### PR TITLE
install_zip.sh: convert sparse images

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,14 @@
+cuttlefish-common (0.9+nmu5) UNRELEASED; urgency=medium
+
+  * install_zip.sh: exit early in case of errors
+  * install_zip.sh: support partial extraction
+  * install_zip.sh: convert sparse images
+
+ -- Matthias Männich <maennich@google.com>  Mon, 21 Jan 2019 09:27:21 +0000
+
 cuttlefish-common (0.9+nmu4) UNRELEASED; urgency=medium
 
-  * Add support for vsock connections. 
+  * Add support for vsock connections.
 
  -- Cody Schuffelen <schuffelen@google.com>  Fri, 04 Jan 2019 17:06:46 -0800
 

--- a/debian/control
+++ b/debian/control
@@ -26,6 +26,7 @@ Depends:
  adb,
  device-tree-compiler,
  hostapd,
+ simg2img,
  libarchive-tools | bsdtar,
  libc6,
  libgoogle-glog0v5 | libgoogle-glog0,

--- a/host/deploy/install_zip.sh
+++ b/host/deploy/install_zip.sh
@@ -56,6 +56,13 @@ if [[ " ${files_to_extract[*]} " == *" boot.img "* ]]; then
     /usr/lib/cuttlefish-common/bin/unpack_boot_image.py -boot_img "${destdir}/boot.img" -dest "${destdir}"
 fi
 
+find "${destdir}" -name "*.img" -exec sh -c '
+  img="$0"
+  file "$img" | grep "Android sparse image," -q  \
+    && simg2img "$img" "$img.inflated"           \
+    && mv "$img.inflated" "$img"
+' {} ';'
+
 for i in cache.img cmdline kernel ramdisk.img system.img userdata.img vendor.img; do
   # Use setfacl so that libvirt does not lose access to this file if user
   # does anything to this file at any point.


### PR DESCRIPTION
Convert *.img files that are detected as 'sparse' to regular image
files.