### PR TITLE
Add a udev rule for vhost-vsock.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cuttlefish-common (0.9.1+nmu1) UNRELEASED; urgency=medium
+
+  * Use udev for vhost-vsock instead of a chmod.
+
+ -- Cody Schuffelen <schuffelen@google.com>  Mon, 04 Feb 2019 16:17:19 -0800
+
 cuttlefish-common (0.9.1) UNRELEASED; urgency=medium
 
   * Add a network dependency on cuttlefish-common

--- a/debian/cuttlefish-common.init
+++ b/debian/cuttlefish-common.init
@@ -138,7 +138,6 @@ destroy_interfaces(){
 start() {
     /sbin/modprobe vhci-hcd
     /sbin/modprobe vhost_vsock
-    chmod 0666 /dev/vhost-vsock
     # This has to be expressed in very basic shell syntax, so we can't
     # use the typical array idiom.
     for i in /sys/devices/platform/vhci_hcd/attach \

--- a/debian/cuttlefish-common.udev
+++ b/debian/cuttlefish-common.udev
@@ -1,0 +1,1 @@
+ACTION=="add", KERNEL=="vhost-vsock", SUBSYSTEM=="misc", MODE="0660", GROUP="cvdnetwork"


### PR DESCRIPTION
The previous use of chmod for /dev/vhost-vsock was unreliable and might
be racing with the modprobe.

I ran debuild -uc -us, and observed lib/udev/rules.d/60-cuttlefish-common.rules
in the output deb with "dpkg-deb -c".
When manually restarting udev with this rules file, it put
/dev/vhost-vsock into the cvdnetwork group, which any cuttlefish user
should already be in.

While udev files normally create symlinks with different permissions,
this is not possible with vhost-vsock as qemu and crosvm hardcode in the
path "/dev/vhost-vsock" so we have to modify the original device node.

https://github.com/qemu/qemu/blob/595123df1d54ed8fbab9e1a73d5a58c5bb71058f/hw/virtio/vhost-vsock.c#L324
https://chromium.googlesource.com/chromiumos/platform/crosvm/+/88f9cba448ff7f1cd61c8bf66e34772132a8663f/vhost/src/vsock.rs#15

Change-Id: Idf449265dd078b7c2e22b3662e06133dd1b05ccb