### PR TITLE
Add binutils for kernel decompresson on crosvm boots

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cuttlefish-common (0.9.4) stable; urgency=medium
+
+  * Add binutils for kernel decompresson on crosvm boots
+
+ -- Greg Hartman <ghartman@google.com>  Fri, 29 Mar 2019 08:46:22 -0700
+
 cuttlefish-common (0.9.3) stable; urgency=medium
 
   [ Cody Schuffelen ]

--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,7 @@ Architecture: amd64
 Depends:
  acl,
  adb,
+ binutils,
  bridge-utils,
  device-tree-compiler,
  hostapd,


### PR DESCRIPTION
BUG: 128878093
Test: launch_cvd -vm_manager crosvm
Change-Id: I4932a80dc5bc3c3fe8b38db626c6059a5ee6a968