### PR TITLE
Turn on detailed logging in ssh

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cuttlefish-common (0.9.5) UNRELEASED; urgency=medium
+
+  * No need to displace instance_configs.cfg.template
+  * Turn on detailed logging in ssh
+
+ -- Greg Hartman <ghartman@google.com>  Tue, 02 Apr 2019 17:48:43 -0700
+
 cuttlefish-common (0.9.4) stable; urgency=medium
 
   * Add binutils for kernel decompresson on crosvm boots

--- a/debian/control
+++ b/debian/control
@@ -48,8 +48,6 @@ Depends:
  socat,
  vde2,
  ${misc:Depends}
-Provides: ${diverted-files}
-Conflicts: ${diverted-files}
 Description: Cuttlefish Android Virtual Device companion package.
  Contains set of tools and binaries required to boot up and manage
  Cuttlefish Android Virtual Device that are used in all deployments.

--- a/debian/cuttlefish-integration.postinst
+++ b/debian/cuttlefish-integration.postinst
@@ -23,6 +23,14 @@ case "$1" in
           -G "${cvd_account_groups}" -s /usr/bin/adbshell
       fi
     done
+    # Update the installed version of the diverted file with the
+    # desired configuration.
+    # We can't use the traditional transform approach here because
+    # sshd_config doesn't have a registered md5sum in older versions.
+    cat /etc/ssh/sshd_config - >/etc/ssh/sshd_config.cuttlefish <<EOF
+SyslogFacility LOCAL1
+LogLevel DEBUG1
+EOF
     ;;
 esac
 

--- a/debian/rules
+++ b/debian/rules
@@ -8,6 +8,8 @@
 # export DH_VERBOSE=1
 
 DEB_DISPLACE_EXTENSION = .cuttlefish
+DEB_DISPLACE_FILES_cuttlefish-integration += \
+	/etc/ssh/sshd_config
 
 build:
 	make -C host/commands/adbshell

--- a/debian/rules
+++ b/debian/rules
@@ -8,8 +8,6 @@
 # export DH_VERBOSE=1
 
 DEB_DISPLACE_EXTENSION = .cuttlefish
-DEB_DISPLACE_FILES_cuttlefish-integration += \
-        /etc/default/instance_configs.cfg.template.cuttlefish
 
 build:
 	make -C host/commands/adbshell

--- a/host/packages/cuttlefish-integration/etc/rsyslog.d/91-cuttlefish.conf
+++ b/host/packages/cuttlefish-integration/etc/rsyslog.d/91-cuttlefish.conf
@@ -1,0 +1,5 @@
+# Cuttlefish logging configuration
+#
+# Send local1 to the console so it appears in serial port output
+#
+local1.* /dev/console


### PR DESCRIPTION
Log every connection and also every attempt to open a channel
(aka connect through a tunnel) on the console. These messages
will then appear on the first serial port, making them available
on TreeHugger.

BUG: 113671281
Test: Built image, logs appear
Change-Id: If3759ee98b86c757b7ad954705af351f4be1a466