### PR TITLE
Add missing dependency on dnsmasq.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cuttlefish-common (0.9.6) stable; urgency=medium
+
+  * Add missing dependency on dnsmasq.
+
+ -- Cody Schuffelen <schuffelen@google.com>  Wed, 10 Apr 2019 16:26:46 -0700
+
 cuttlefish-common (0.9.5) stable; urgency=medium
 
   * No need to displace instance_configs.cfg.template

--- a/debian/control
+++ b/debian/control
@@ -26,6 +26,7 @@ Depends:
  binutils,
  bridge-utils,
  device-tree-compiler,
+ dnsmasq-base,
  hostapd,
  simg2img,
  iptables,

--- a/debian/cuttlefish-common.init
+++ b/debian/cuttlefish-common.init
@@ -85,9 +85,9 @@ create_interface() {
     /sbin/brctl setfd "${bridge}" 0
     /sbin/ifconfig "${bridge}" "${gateway}" netmask "${netmask}" up
 
-    iptables -t nat -A POSTROUTING -s "${network}" -j MASQUERADE
+    /sbin/iptables -t nat -A POSTROUTING -s "${network}" -j MASQUERADE
 
-    dnsmasq \
+    /usr/sbin/dnsmasq \
     --strict-order \
     --except-interface=lo \
     --interface="${bridge}" \


### PR DESCRIPTION
This likely came from an indirect dependency that came with libvirt in
the past.

Bug: 129699085
Change-Id: I08406d9a95dd43ca94c6950bc7b1ab6aec345acc
Test: `systemctl status cuttlefish-common`, check for dnsmasq processes