### PR TITLE
install_zip.sh: do not fail when files_to_extract does not match

### DIFF
--- a/host/deploy/install_zip.sh
+++ b/host/deploy/install_zip.sh
@@ -51,7 +51,11 @@ case $# in
 esac
 
 mkdir -p "${destdir}"
-bsdtar -x -C "${destdir}" -f "${source}" ${sparse} ${files_to_extract}
+if ! bsdtar -x -C "${destdir}" -f "${source}" ${sparse} ${files_to_extract}; then
+    echo "WARNING: extraction failed: very likely a file to be extracted was"
+    echo "         requested that was not part of the archive."
+    echo "         See above error log for details."
+fi
 
 if [[ " ${files_to_extract[*]} " == *" boot.img "* ]]; then
     /usr/lib/cuttlefish-common/bin/unpack_boot_image.py -boot_img "${destdir}/boot.img" -dest "${destdir}"


### PR DESCRIPTION
Files passed as arguments to install_zip.sh might not exist in a
particular archive. In that case, warn the user and proceed.

Bug: 129743198
Signed-off-by: Matthias Maennich <maennich@google.com>