### PR TITLE
Fix dependencies for buster and add qemu-user-static on arm

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+cuttlefish-common (0.9.8) UNRELEASED; urgency=medium
+
+  * Changes to enable arm builds
+  * Fix dependencies for buster
+  * Add qemu-user-static on non-amd64
+
+ -- Greg Hartman <ghartman@google.com>  Thu, 02 May 2019 17:43:13 -0700
+
 cuttlefish-common (0.9.6) stable; urgency=medium
 
   * Add missing dependency on dnsmasq.

--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Build-Depends:
  libnl-genl-3-dev
 
 Package: cuttlefish-common
-Architecture: all
+Architecture: any
 Depends:
  acl,
  adb,
@@ -28,7 +28,8 @@ Depends:
  device-tree-compiler,
  dnsmasq-base,
  hostapd,
- simg2img,
+ simg2img [amd64],
+ simg2img:amd64 [!amd64],
  iptables,
  libarchive-tools | bsdtar,
  libc6,
@@ -40,7 +41,8 @@ Depends:
  lzop,
  psmisc,
  python,
- qemu-kvm (>= 2.8.0),
+ libc6:amd64 [!amd64],
+ qemu-user-static [!amd64],
  qemu-system-common (>= 2.8.0),
  qemu-system-x86 (>= 2.8.0),
  qemu-utils (>= 2.8.0),


### PR DESCRIPTION
Non-amd64 hosts need to use qemu-user-static to launch. This forces
cuttlefish-common to be 'any' rather than 'all'.

qemu-kvm is not available on buster. Cuttlefish never depended on
/usr/bin/kvm, so it's safe to drop it.

Change-Id: I99bbca5893090023c58582724ce72757ddc320e7