### PR TITLE
Add a dependency on u-boot-tools.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ cuttlefish-common (0.9.8) UNRELEASED; urgency=medium
   * Changes to enable arm builds
   * Fix dependencies for buster
   * Add qemu-user-static on non-amd64
+  * Add dependency on u-boot-tools
 
  -- Greg Hartman <ghartman@google.com>  Thu, 02 May 2019 17:43:13 -0700
 

--- a/debian/control
+++ b/debian/control
@@ -48,6 +48,7 @@ Depends:
  qemu-utils (>= 2.8.0),
  rsync,
  socat,
+ u-boot-tools,
  vde2,
  ${misc:Depends}
 Description: Cuttlefish Android Virtual Device companion package.


### PR DESCRIPTION
This supports running `mkimage -T script` to create u-boot script images
at launch_cvd runtime which can be invoked by u-boot inside the guest.

Bug: 133797099
Change-Id: I186d3f17314ec811eff52a7807b5bd65f3eb2d84