### PR TITLE
Remove Debian adb package

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,8 +3,9 @@ cuttlefish-common (0.9.8) UNRELEASED; urgency=medium
   * Changes to enable arm builds
   * Fix dependencies for buster
   * Add qemu-user-static on non-amd64
+  * Remove Debian adb package
 
- -- Greg Hartman <ghartman@google.com>  Thu, 02 May 2019 17:43:13 -0700
+ -- Greg Hartman <ghartman@google.com>  Wed, 26 Jun 2019 11:18:47 -0700
 
 cuttlefish-common (0.9.6) stable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,6 @@ Package: cuttlefish-common
 Architecture: any
 Depends:
  acl,
- adb,
  binutils,
  bridge-utils,
  device-tree-compiler,
@@ -57,7 +56,6 @@ Description: Cuttlefish Android Virtual Device companion package.
 Package: cuttlefish-integration
 Architecture: any
 Depends:
- adb,
  cuttlefish-common,
  libc6,
  ${misc:Depends}


### PR DESCRIPTION
adb on Debian has bugs and doesn't appear to be actively maintained.
With this change users will have to invoke /home/vsoc-*/bin/adb to
access the device.

Note: if the versions of the various /home/vsoc-*/bin/adb executables
don't match then adb will drop all of its connections each time that an
incompatible version is run.

Change-Id: I46253bfcdf805449cda9ba574dcd5574905052c8