### PR TITLE
Update default number of cvd account to 10

### DIFF
--- a/debian/cuttlefish-common.init
+++ b/debian/cuttlefish-common.init
@@ -30,7 +30,7 @@
 
 . /lib/lsb/init-functions
 
-num_cvd_accounts=8
+num_cvd_accounts=10
 
 create_legacy_interface() {
   printf '<network>\n'


### PR DESCRIPTION
Our typical usage is usually 10 (rather than 8). Updating the default to match that number.

Don't foresee needing more than that.