### PR TITLE
Fix dependencies for cuttlefish-common

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,13 +16,15 @@ Build-Depends:
  dh-buildinfo,
  config-package-dev (>= 4.5~),
  libnl-3-dev,
- libnl-genl-3-dev
+ libnl-genl-3-dev,
+ gcc
 
 Package: cuttlefish-common
 Architecture: any
 Depends:
  acl,
  binutils,
+ binfmt-support [!amd64],
  bridge-utils,
  device-tree-compiler,
  dnsmasq-base,
@@ -33,18 +35,23 @@ Depends:
  libarchive-tools | bsdtar,
  libdrm2,
  libc6,
+ libc6:amd64 [!amd64],
+ libfdt1,
  libgoogle-glog0v5 | libgoogle-glog0,
  libnl-genl-3-200,
  libstdc++6,
  libudev1,
  libwayland-client0,
  libwayland-server0,
+ libx11-6,
+ libxext6,
  libxml2,
  lzop,
  psmisc,
  python,
  libc6:amd64 [!amd64],
  qemu-user-binfmt [!amd64],
+ qemu-user-static [!amd64],
  qemu-system-common (>= 2.8.0),
  qemu-system-x86 (>= 2.8.0),
  qemu-utils (>= 2.8.0),

--- a/debian/control
+++ b/debian/control
@@ -4,60 +4,26 @@ Section: misc
 Priority: optional
 Standards-Version: 3.9.2
 Build-Depends:
- clang-3.8,
- debhelper (>= 9),
- libgflags-dev,
- libgoogle-glog-dev,
- libudev-dev,
- libxml2-dev,
- libjsoncpp-dev,
  cdbs,
- debhelper,
- dh-buildinfo,
  config-package-dev (>= 4.5~),
- libnl-3-dev,
- libnl-genl-3-dev,
+ debhelper (>= 9),
  gcc
 
 Package: cuttlefish-common
 Architecture: any
 Depends:
- acl,
- binutils,
  binfmt-support [!amd64],
  bridge-utils,
- device-tree-compiler,
- dnsmasq-base,
- hostapd,
- simg2img [amd64],
- simg2img:amd64 [!amd64],
- iptables,
  libarchive-tools | bsdtar,
- libdrm2,
  libc6,
  libc6:amd64 [!amd64],
+ libdrm2,
  libfdt1,
- libgoogle-glog0v5 | libgoogle-glog0,
- libnl-genl-3-200,
- libstdc++6,
- libudev1,
  libwayland-client0,
- libwayland-server0,
  libx11-6,
  libxext6,
- libxml2,
- lzop,
- psmisc,
  python,
- libc6:amd64 [!amd64],
- qemu-user-binfmt [!amd64],
  qemu-user-static [!amd64],
- qemu-system-common (>= 2.8.0),
- qemu-system-x86 (>= 2.8.0),
- qemu-utils (>= 2.8.0),
- rsync,
- socat,
- vde2,
  ${misc:Depends}
 Description: Cuttlefish Android Virtual Device companion package.
  Contains set of tools and binaries required to boot up and manage

--- a/host/deploy/capability_query.py
+++ b/host/deploy/capability_query.py
@@ -24,7 +24,7 @@ comparing the version numbers.
 import sys
 
 def main():
-    capabilities = {"capability_check", "qemu_cli", "vde", "vsock"}
+    capabilities = {"capability_check", "qemu_cli", "vsock"}
     if len(sys.argv) == 1:
         # Print all capabilities
         print('\n'.join(capabilities))


### PR DESCRIPTION
Remove superfluous dependencies for cuttlefish-common

Add in required dependencies for all platforms:
  gcc
  libfdt1
  libx11-6
  libxext6

Add in dependencies for arm64:
  binfmt-support
  libc6:amd64
  qemu-user-static