### PR TITLE
Add in net-tools dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,6 +22,7 @@ Depends:
  libwayland-client0,
  libx11-6,
  libxext6,
+ net-tools,
  python,
  qemu-user-static [!amd64],
  ${misc:Depends}


### PR DESCRIPTION
This is required for the interfaces to come up.

BUG: 132114647
TEST: booted on Rock Pi