### PR TITLE
Add missing libusb-1.0-0 dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+cuttlefish-common (0.9.10) UNRELEASED; urgency=medium
+
+  [ Tristan Muntsinger ]
+  * Add in required dependencies for arm64 buster
+  * Remove superfluous dependencies for cuttlefish-common
+  * Add in net-tools dependency
+
+  [ A. Cody Schuffelen ]
+  * Add missing libusb-1.0-0 dependency
+
+ -- Cody Schuffelen <schuffelen@google.com>  Mon, 04 Nov 2019 18:54:57 -0800
+
 cuttlefish-common (0.9.9) stable; urgency=medium
 
   * Added missing dependencies for crosvm and rockpi4

--- a/debian/control
+++ b/debian/control
@@ -19,6 +19,7 @@ Depends:
  libc6:amd64 [!amd64],
  libdrm2,
  libfdt1,
+ libusb-1.0-0,
  libwayland-client0,
  libx11-6,
  libxext6,


### PR DESCRIPTION
This is loaded by crosvm at runtime, and a system with only cuttlefish-common doesn't otherwise necessarily have this package.

May be obsoleted by b/140963307 in the future.

Originally reported by malchev@.