### PR TITLE
Add psmisc dependency for fuser.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -7,8 +7,9 @@ cuttlefish-common (0.9.10) UNRELEASED; urgency=medium
 
   [ A. Cody Schuffelen ]
   * Add missing libusb-1.0-0 dependency
+  * Add psmisc dependency for fuser.
 
- -- Cody Schuffelen <schuffelen@google.com>  Mon, 04 Nov 2019 18:54:57 -0800
+ -- Cody Schuffelen <schuffelen@google.com>  Tue, 05 Nov 2019 15:26:55 -0800
 
 cuttlefish-common (0.9.9) stable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -24,6 +24,7 @@ Depends:
  libx11-6,
  libxext6,
  net-tools,
+ psmisc,
  python,
  qemu-user-static [!amd64],
  ${misc:Depends}


### PR DESCRIPTION
fuser is used by stop_cvd.

Reported by malchev@.

Change-Id: I98b3b6c6a6e9892aee6049483a620503cd631b64