### PR TITLE
Add a Dockerfile for running cuttlefish inside a container

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -4,3 +4,43 @@ This code is intended for use with the cuttlefish Android device. A script
 is provided in the AOSP tree:
 
 https://android.googlesource.com/device/google/cuttlefish_common/+/master/tools/create_base_image.sh
+
+The Docker image can be built as follows:
+
+	git clone https://github.com/google/android-cuttlefish.git
+	cd android-cuttlefish
+	docker build -t cuttlefish https://github.com/google/android-cuttlefish.git
+
+To create a container form this image:
+
+	docker run -d --name cuttlefish -h cuttlefish --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro cuttlefish
+
+The container's IP address can be found as follows:
+
+	CF=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' cuttlefish)
+
+You can then provision the container with a cuttlefish image as described, for example, using [these instructions on AOSP](https://android.googlesource.com/device/google/cuttlefish/), you can follow the steps to obtain a prebuilt image of Cuttlefish (start from step #2, since the container already took care of it). Once you've obtained the image at step #8, you can copy it to your container as follows:
+
+```bash
+ssh vsoc-01@$CF -- 'tar xzvf -' < cvd-host_package.tar.gz
+scp *.img vsoc-01@$CF:~/
+```
+
+You can boot Cuttlefish from the container as follows:
+
+	ssh vsoc-01@$CF -L localhost:6520:127.0.0.1:6520 -L localhost:6444:127.0.0.1:6444 -- bin/launch_cvd -cpus 4 -memory_mb 4096
+
+The above example launches Cuttlefish with 4 cores and 4GB of RAM, while also setting up an SSH tunnel that allows you to connect to Cuttlefish via ADB and VNC from outside the container:
+
+```bash
+adb connect localhost:6250
+adb shell
+```
+
+Or from the inside:
+
+	ssh vsoc-01@$CF -- ./bin/adb -e shell
+
+You can see the display using [VNC](https://android.googlesource.com/device/google/cuttlefish/#so-you-want-to-see-cuttlefish) as well. Follow the link to download the VNC viewer. Assuming you've saved it in your current working directory:
+
+	java -jar tightvnc-jviewer.jar -ScalingFactor=50 -Tunneling=no -host=localhost -port=6444

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+# This file is based on https://hub.docker.com/r/jrei/systemd-debian/.
+
+FROM debian:buster
+
+ENV container docker
+ENV LC_ALL C
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update \
+    && apt-get install -y systemd \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && rm -f /var/run/nologin
+
+RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
+    /etc/systemd/system/*.wants/* \
+    /lib/systemd/system/local-fs.target.wants/* \
+    /lib/systemd/system/sockets.target.wants/*udev* \
+    /lib/systemd/system/sockets.target.wants/*initctl* \
+    /lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup* \
+    /lib/systemd/system/systemd-update-utmp*
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/lib/systemd/systemd"]
+
+RUN apt update \
+    && apt install -y apt-utils sudo vim dpkg-dev devscripts gawk coreutils \
+       openssh-server openssh-client psmisc iptables iproute2 dnsmasq \
+       net-tools rsyslog qemu-system-x86 equivs
+
+COPY . /root/android-cuttlefish/
+
+RUN cd /root/android-cuttlefish \
+    && yes | sudo mk-build-deps -i -r -B \
+    && dpkg-buildpackage -uc -us \
+    && apt install -y -f ../cuttlefish-common_*_amd64.deb
+
+RUN apt-get clean \
+    && rm -rf /root/android-cuttlefish
+
+RUN groupadd kvm
+
+RUN useradd -ms /bin/bash vsoc-01 -d /home/vsoc-01 -G kvm,cvdnetwork \
+    && passwd -d vsoc-01 \
+    && echo 'vsoc-01 ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers \
+    && echo 'sudo chmod ug+rw /dev/kvm' >> /home/vsoc-01/.bashrc \
+    && echo 'sudo chmod ug+rw /dev/vhost-vsock' >> /home/vsoc-01/.bashrc \
+    && echo 'sudo chown root.kvm /dev/kvm' >> /home/vsoc-01/.bashrc \
+    && echo 'sudo chown root.cvdnetwork /dev/vhost-vsock' >> /home/vsoc-01/.bashrc
+
+RUN sed -i -r -e 's/^#{0,1}\s*PasswordAuthentication\s+(yes|no)/PasswordAuthentication yes/g' /etc/ssh/sshd_config \
+    && sed -i -r -e 's/^#{0,1}\s*PermitEmptyPasswords\s+(yes|no)/PermitEmptyPasswords yes/g' /etc/ssh/sshd_config \
+    && sed -i -r -e 's/^#{0,1}\s*ChallengeResponseAuthentication\s+(yes|no)/ChallengeResponseAuthentication no/g' /etc/ssh/sshd_config \
+    && sed -i -r -e 's/^#{0,1}\s*UsePAM\s+(yes|no)/UsePAM no/g' /etc/ssh/sshd_config

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Virtual Device for Android host-side utilities
 
-This repository holds source for Debian packages that prepare a host
-to boot cuttlefish, an Android device that is designed to run on Google
-Compute Engine.
+This repository holds source for Debian packages that prepare a host to boot
+[Cuttlefish](https://source.android.com/setup/create/cuttlefish), an Android
+device that is designed to run on Google Compute Engine.
 
 This package can be built directly with dpkg-buildpackage, but it is
 designed to be built with:
@@ -11,3 +11,8 @@ designed to be built with:
 
 [Check out the AOSP tree](https://source.android.com/setup/build/downloading)
 to obtain the script.
+
+This repository also contains a Dockerfile that can be used to construct an
+image for a privileged Docker container, which in turn can boot the cuttlefish
+device.  Such a image allows one to develop for Cuttlefish without having to
+install a number of packages directly on their host machine.


### PR DESCRIPTION
This Dockerfile creates an image based on a systemd-enabled
debian-10-based image.  Containers created from this image have all the
prerequisites needed to run cuttlefish:

-- all necessary debian packages (including cuttlefish-common)
-- ssh setup for password-less nonroot access to the container
-- an empty vsoc-01 account ready to host cuttlefish images

Instructions for building and using are in file BUILDING.md

Signed-off-by: Iliyan Malchev <malchev@google.com>