### PR TITLE
Load nvidia-modeset kernel module in cuttlefish-common.init

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,7 +3,10 @@ cuttlefish-common (0.9.11) UNRELEASED; urgency=medium
   [ Jorge E. Moreira ]
   * Explicitly depend on iptables
 
- -- Jorge E. Moreira <jemoreira@google.com> Thu, 06 Feb 2020 16:52:24 -0800
+  [ Jason Macnak ]
+  * Load nvidia-modeset kernel module in cuttlefish-common.init
+
+ -- Jason Macnak <natsu@google.com> Tue, 11 Feb 2020 14:56:24 -0800
 
 cuttlefish-common (0.9.10) UNRELEASED; urgency=medium
 

--- a/debian/cuttlefish-common.init
+++ b/debian/cuttlefish-common.init
@@ -158,6 +158,8 @@ start() {
       chmod ug+rw /dev/kvm
       chmod ug+rw /dev/vhost-vsock
     fi
+    # Try to preload the Nvidia modeset kernel module.
+    /usr/bin/nvidia-modprobe --modeset || /bin/true
 }
 
 stop() {


### PR DESCRIPTION
Running `launch_cvd --gpu_mode=drm_virgl` will fail on the first
invocation on a fresh GCE instance because Nvidia's EGL library
will fork to run the nvidia-modprobe command and then crosvm will
abort after receiving the child subprocess's exit signal which is
interpreted as a failure.

This change makes the init script run the nvidia-modprobe command
to ensure that the modeset kernel driver is already loaded so that
the EGL library does not need to fork and load it in Crosvm.