### PR TITLE
Add support for NVIDIA GPUs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,19 @@ RUN if test $(uname -m) == aarch64; then \
 	    && apt install -y qemu qemu-user qemu-user-static binfmt-support; \
     fi
 
+RUN if test $(uname -m) == x86_64; then \
+	apt install -y pciutils; \
+	if test $(lspci | grep -i vga | grep -icw nvidia) -gt 0; then \
+		apt install -y software-properties-common; \
+		apt-add-repository contrib; \
+		apt-add-repository non-free; \
+		apt update; \
+		apt install -y nvidia-detect; \
+		nvidia-detect; \
+		apt install -y nvidia-driver; \
+	fi; \
+    fi
+
 COPY . /root/android-cuttlefish/
 
 RUN cd /root/android-cuttlefish \


### PR DESCRIPTION
Install nvidia-driver if the container is running on an x86_64 machine
and lspci reports a VGA-compatible NVIDIA controller.

With this, you can launch cuttlefish to use a physical NVIDIA GPU.
Assuming you have set up and built Android:

	source start.sh

	ssh vsoc-01@$CF -- 'tar xzvf -' < \
		$ANDROID_HOST_OUT/cvd-host_package.tar.gz

	scp $ANDROID_PRODUCT_OUT/*.img vsoc-01@$CF:~/

	ssh vsoc-01@$CF \
		-L6444:localhost:6444 -L6520:localhost:6520 -- \
		bin/launch_cvd -gpu_mode=drm_virgl

Signed-off-by: Iliyan Malchev <malchev@google.com>