### PR TITLE
Depend on python2.7 instead of python2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -27,7 +27,7 @@ Depends:
  libx11-6,
  libxext6,
  net-tools,
- python2,
+ python2.7,
  qemu-user-static [!amd64],
  ${misc:Depends}
 Description: Cuttlefish Android Virtual Device companion package.

--- a/host/deploy/capability_query.py
+++ b/host/deploy/capability_query.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python2.7
 #
 # Copyright (C) 2018 The Android Open Source Project
 #

--- a/host/deploy/unpack_boot_image.py
+++ b/host/deploy/unpack_boot_image.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python2.7
 #
 # Copyright (C) 2017 The Android Open Source Project
 #


### PR DESCRIPTION
The python2 package is only available on Debian and the newest Ubuntu
versions. It's not available on older Ubuntus, such as 18.04 LTS.
python2.7 is available on all of the above.