### PR TITLE
changes in docker container for AOSP and/or cuttlefish developers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # important when we map the (container) user's home directory as a docker volume.
 
 ARG UID
+ARG DO_BUILD_ANDROID
 
 USER root
 WORKDIR /root
@@ -50,6 +51,9 @@ RUN if test $(uname -m) == aarch64; then \
 	    && apt-get install --no-install-recommends -y qemu qemu-user qemu-user-static binfmt-support; \
     fi
 
+# to share X with the local docker host
+RUN apt-get install -y xterm
+
 COPY . android-cuttlefish/
 
 RUN cd /root/android-cuttlefish \
@@ -61,6 +65,14 @@ RUN cd /root/android-cuttlefish \
     && rm -rvf android-cuttlefish
 
 RUN apt-get install -y curl wget unzip
+RUN if echo $DO_BUILD_ANDROID | grep "true" > /dev/null 2>&1; then \
+       apt-get install -y libncurses5 libncurses5-dev zip subversion rsync; \
+       mkdir /repo-bin; \
+       curl https://storage.googleapis.com/git-repo-downloads/repo > /repo-bin/repo; \
+       chmod a+x /repo-bin/repo; \
+    fi
+
+ENV PATH=$PATH:/repo-bin
 
 RUN apt-get clean
 
@@ -76,6 +88,7 @@ RUN sed -i -r -e 's/^#{0,1}\s*PasswordAuthentication\s+(yes|no)/PasswordAuthenti
 WORKDIR /home/vsoc-01
 
 COPY --chown=vsoc-01 download-aosp.sh .
+COPY run_in_CMD.sh /root
 
 VOLUME [ "/home/vsoc-01" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,6 @@ RUN sed -i -r -e 's/^#{0,1}\s*PasswordAuthentication\s+(yes|no)/PasswordAuthenti
 WORKDIR /home/vsoc-01
 
 COPY --chown=vsoc-01 download-aosp.sh .
-COPY run_in_CMD.sh /root
 
 VOLUME [ "/home/vsoc-01" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,9 @@ RUN if test $(uname -m) == aarch64; then \
 # to share X with the local docker host
 RUN apt-get install -y xterm
 
+# to run cuttlefish docker in foreground, and test via webrtc/VNC
+RUN apt-get install -y tigervnc-viewer firefox-esr
+
 COPY . android-cuttlefish/
 
 RUN cd /root/android-cuttlefish \

--- a/setup.sh
+++ b/setup.sh
@@ -25,10 +25,26 @@ function cvd_docker_list {
   docker ps -a --filter="ancestor=cuttlefish"
 }
 
+function help_on_container_create {
+  echo "   cvd_docker_create <options> [NAME] # by default names 'cuttlefish'"
+  echo "     Options:"
+  echo "       -n | --name jellyfish  : override default name"
+  echo "                              : for backward compat, [NAME] will override this"
+  echo "       -f | --foreground      : run the container in foreground"
+  echo "                              : otherwise, the container is created as a daemon"
+  echo "       -x | --with_host_x     : run the container in foreground and"
+  echo "                              : share X of the docker host"
+  echo "       -m | --share_home dir1 : share subdirectories of the host user's home"
+  echo "                              : -m dir1 -m dir2 -m dir3 for multiple directories"
+  echo "                              : dir1 should be an absolute path or relative path"
+  echo "                              : to $HOME. $HOME itself is not allowed."
+  echo "        -h | --help           : print this help message"
+  echo "        The optional [NAME] will override -n option for backward compatibility"
+}
+
 function help_on_sourcing {
   echo "Create a cuttlefish container:"
-  echo "   cvd_docker_create # by default names 'cuttlefish'"
-  echo "   cvd_docker_create name # name is 'name'"
+  help_on_container_create
 
   echo "To list existing Cuttlefish containers:"
   echo "   cvd_docker_list"
@@ -51,9 +67,84 @@ function help_on_container_start {
   [[ "${name}" != 'cuttlefish' ]] && echo "    cvd_docker_rm ${name}"
 }
 
+function is_absolute_path {
+  local sub=$1
+  if [[ -n ${sub:0:1} ]] && [[ "${sub:0:1}" == "/" ]]; then
+    return 0
+  fi
+  return 1
+}
+
 function cvd_docker_create {
-  local name="$(cvd_get_id $1)"
-  local container="$(cvd_exists $1)"
+  local OPTIND
+  local op
+  local val
+  local OPTARG
+
+  local name_=""
+  local foreground="false"
+  local with_host_x="false"
+  local need_help="false"
+  local share_home="false"
+  local -a shared_home_subdirs=()
+
+  while getopts ":m:n:-:hfx" op; do
+    # n | --name=cuttlefish | --name jellyfish
+    # f | --foreground
+    # x | --with_host_x
+    # m | --share_home dir1
+    # h | --help
+    if [[ $op == '-' ]]; then
+      case "${OPTARG}" in
+        *=* )
+          val=${OPTARG#*=}
+          op=${OPTARG%=$val}
+          OPTARG=${val}
+          ;;
+        *)
+          op=${OPTARG}
+          val=${!OPTIND}
+          if [[ -n $val ]] && [[ ${val:0:1} != '-' ]]; then
+            OPTARG=${val}
+            OPTIND=$(( OPTIND + 1 ))
+            echo $op
+            echo $OPTARG
+          fi
+          ;;
+      esac
+    fi
+    case "$op" in
+      n | name ) name_=${OPTARG}
+        ;;
+      f | foreground ) foreground="true"
+        ;;
+      x | with_host_x )
+        with_host_x="true"
+        foreground="true"
+        ;;
+      m | share_home )
+        share_home="true"
+        shared_home_subdirs+=("${OPTARG}")
+        ;;
+      h | help ) need_help="true"
+        ;;
+      ? ) need_help="true"
+        ;;
+    esac
+  done
+
+  if [[ "${need_help}" == "true" ]]; then
+    help_on_container_create
+    return
+  fi
+
+  # for backward compatibility:
+  [[ -n ${!OPTIND} ]] && name_="${!OPTIND}"
+
+  local name="$(cvd_get_id $name_)"
+  local container="$(cvd_exists $name_)"
+
+  local -a home_volume=()
   if [[ -z "${container}" ]]; then
     echo "Container ${name} does not exist.";
     echo "Starting container ${name} from image cuttlefish.";
@@ -62,8 +153,6 @@ function cvd_docker_create {
     # build environment is correctly configured.  We further assume
     # that there is a valid $ANDROID_HOST_OUT/cvd-host_package.tar.gz
     # and a set of Android images under $ANDROID_PRODUCT_OUT/*.img.
-
-    local -a home_volume=()
 
     if [[ -v ANDROID_BUILD_TOP ]]; then
       local home="$(mktemp -d)"
@@ -75,17 +164,43 @@ function cvd_docker_create {
       home_volume+=("-v ${home}:/home/vsoc-01:rw")
     fi
 
-    docker run -d \
-            --name "${name}" -h "${name}" \
-            --privileged \
-            -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-            ${home_volume[@]} \
-            cuttlefish
+    if [[ $share_home == "true" ]]; then
+      local user_home=$(realpath $HOME)
+      for sub in "${shared_home_subdirs[@]}"; do
+        local subdir=${sub}
+        if ! is_absolute_path ${subdir}; then
+          subdir=${user_home}/${subdir}
+        fi
+        # mount /home/user/X to /home/vsoc-01/X
+        local dstdir=${subdir#$user_home/}
+        home_volume+=("-v ${subdir}:/home/vsoc-01/${dstdir}:rw")
+      done
+    fi
+
+    local -a as_host_x=()
+    if [[ "$with_host_x" == "true" ]]; then
+      as_host_x+=("-e DISPLAY=$DISPLAY")
+      as_host_x+=("-v /tmp/.X11-unix:/tmp/.X11-unix")
+    fi
+
+    docker run -d ${as_host_x[@]} \
+           --name "${name}" -h "${name}" \
+           --privileged \
+           -v /sys/fs/cgroup:/sys/fs/cgroup:ro ${home_volume[@]} \
+           cuttlefish
 
     __gen_funcs ${name}
+
+    if [[ "$foreground" == "true" ]]; then
+        docker exec -it --user vsoc-01 ${name} /bin/bash
+        cvd_docker_rm ${name}
+        return
+    fi
+
     help_on_container_start ${name}
     echo
     help_on_sourcing
+
   else
     echo "Container ${name} exists";
     if [ $(docker inspect -f "{{.State.Running}}" ${name}) != 'true' ]; then


### PR DESCRIPTION
It seems that it would be helpful if we could use a docker container to build AOSP from the source, and run cuttlefish. The current container seems to be missing a few mandated software package like rsync, etc. 

Besides, from my personal preference, which might be shared by some other developers out there, it would be good to have an option to run the container in foreground, optionally sharing the docker host X server and/or some subdirectories of the host user's home where the AOSP tree is repo-sync'ed. 

These changes have been tested on Gentoo on amd64. I was able to build Android, and run cuttlefish with VNC and webrtc. All of these were done with no gpu support. 

Regarding the GPU support, for now, the implicit assumption is that the host and guest use the same package management system: e.g. both should use dpkg/apt . Thus, we may need to warn users to disable --detect_gpu when that's not the case. 