### PR TITLE
Steve/new aosp builder

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -41,7 +41,7 @@ To list the Cuttlefish containers:
 cvd_docker_list
 ```
 
-There are two ways to provision a container (that is, to install the Cuttlefish
+There are three ways to provision a container (that is, to install the Cuttlefish
 and Android images on it.)
 
 If cvd_docker_create detects an [Android build
@@ -51,7 +51,31 @@ binary artifacts.  Assuming you have downloaded, set up, and built a Cuttlefish
 device and Android from the sources, and you call cvd_docker_create in the same
 terminal, you can jump ahead to launching Cuttlefish.
 
-If you either don't have the Android build environment or you want to provision
+If you do not have the Android build environment, alternatively, you
+can build Android and Cuttlefish with another docker container. We are
+offering a wrapper script for that. Say, the source is downloaded to
+$HOME/android-src, we can run these to commands to build Android from
+the source:
+```bash
+./build-android-with-docker.sh --help
+./build-android-with-docker.sh --android-src-mntptr "$HOME/android-src:/home/vsoc-01/build"
+```
+
+That does build Android and Cuttlefish, and save them where you
+downloaded the source. It does not, however, allow you to automatically jump ahead to launching
+Cuttlefish. We are improving the process but for now, these commands
+will prepare for running Cuttlefish with a container:
+```bash
+export ANDROID_BUILD_TOP=$HOME/android-src
+export ANDROID_PRODUCT_OUT=$(dirname `find $ANDROID_BUILD_TOP/out |
+egrep "*/boot\.img$"`)
+export ANDROID_HOST_OUT=$(dirname `find $ANDROID_BUILD_TOP/out/host/ |
+egrep "/bin/launch_cvd$")
+```
+After those commands, you can run the docker image and run the
+container.
+
+If you you want to provision
 the container with a prebuilt cuttlefish image for example, from [AOSP
 CI](htts://ci.android.com), you can follow the steps to [obtain a prebuilt image
 of Cuttlefish](https://android.googlesource.com/device/google/cuttlefish/)

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,0 +1,47 @@
+FROM debian:buster-slim AS cuttlefish-android-builder
+
+ENV container docker
+ENV LC_ALL C
+ENV DEBIAN_FRONTEND noninteractive
+
+# Set up the user have the same UID as user creating the container.  This is
+# important when we map the (container) user's home directory as a docker volume.
+
+ARG UID
+
+USER root
+WORKDIR /root
+
+RUN set -x
+
+RUN apt-get update -y
+RUN apt-get install -y python python3 wget curl git build-essential libncurses5 libncurses5-dev zip subversion rsync
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+RUN mkdir /repo-bin && curl https://storage.googleapis.com/git-repo-downloads/repo > /repo-bin/repo
+RUN chmod a+x /repo-bin/repo
+
+ENV PATH=$PATH:/repo-bin
+
+RUN apt-get install --no-install-recommends -y apt-utils sudo vim dpkg-dev devscripts gawk coreutils
+RUN apt-get install -y openssh-server openssh-client
+RUN if test $(uname -m) == aarch64; then \
+	    dpkg --add-architecture amd64 \
+	    && apt-get update \
+	    && apt-get install --no-install-recommends -y libc6:amd64 \
+	    && apt-get install --no-install-recommends -y qemu qemu-user qemu-user-static binfmt-support; \
+    fi
+
+RUN useradd -ms /bin/bash vsoc-01 -d /home/vsoc-01 -u $UID \
+    && passwd -d vsoc-01 \
+    && echo 'vsoc-01 ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+
+RUN sed -i -r -e 's/^#{0,1}\s*PasswordAuthentication\s+(yes|no)/PasswordAuthentication yes/g' /etc/ssh/sshd_config \
+    && sed -i -r -e 's/^#{0,1}\s*PermitEmptyPasswords\s+(yes|no)/PermitEmptyPasswords yes/g' /etc/ssh/sshd_config \
+    && sed -i -r -e 's/^#{0,1}\s*ChallengeResponseAuthentication\s+(yes|no)/ChallengeResponseAuthentication no/g' /etc/ssh/sshd_config \
+    && sed -i -r -e 's/^#{0,1}\s*UsePAM\s+(yes|no)/UsePAM no/g' /etc/ssh/sshd_config
+
+WORKDIR /home/vsoc-01
+# use sudo if root privilege is needed
+USER vsoc-01
+VOLUME [ "/home/vsoc-01" ]
+

--- a/build-android-with-docker.sh
+++ b/build-android-with-docker.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+
+# for now, the script will build docker image as needed
+# and gives a bash shell inside the container, so that
+# the user can run source, lunch & m commands to build
+#
+# TODO: support commands like
+#   intrinsic commands: init, sync, build, img_build
+#   running a host script inside docker container
+#   running a guest command inside docker container
+
+# to print multi-lined helper for shflags
+function multiline_helper {
+    local aligner=''
+    for cnt in `seq 0 $1`; do
+        aligner+=' '
+    done
+
+    local -n msgs=$2
+    echo ${msgs[0]}
+    for msg in "${msgs[@]:1}"; do
+        echo "${aligner}""$msg"
+    done
+}
+
+script_name=$(basename $0)
+
+# android_src_mnt helper message that is multi-lined
+android_src_mnt_helper=("src_dir:mount_point")
+android_src_mnt_helper+=("src_dir on the host will be mounted mount_pointer on the docker container")
+android_src_mnt_helper=("e.g. /home/$USER/aosp03:/home/vsoc-01/aosp")
+android_src_mnt_helper+=("This will mount /home/$USER/aosp03 to /home/vsoc-01/aosp in the container")
+android_src_mnt_helper+=("An empty src_dir is allowed only when ANDROID_BUILD_TOP is set")
+android_src_mnt_helper+=("e.g. /home/$USER/aosp03")
+android_src_mnt_helper+=("an empty dst_dir will be regarded as a default mount point for it")
+android_src_mnt_helper+=("That is, realpath of src dir while home replaced with /home/vsoc-01/aosp03")
+
+source "shflags"
+
+DEFINE_boolean rebuild_docker_img false "Rebuild cuttlefish-android-builder image" ""
+DEFINE_boolean share_gitconfig true "Allow the docker container to use the host gitconfig"
+DEFINE_string android_src_mntptr \
+              "" \
+              "$(multiline_helper 24 android_src_mnt_helper)" \
+
+FLAGS "$@" || exit 1
+eval set -- "${FLAGS_ARGV}"
+
+# As FLAGS_ARGV is not the best for us to process, we convert it into a bash array
+# Especially, iterating over or passing FLAGS_ARGV may not work as expected for
+# an argument surrounded by "" and has space(s) inside: "a b c"
+arg_list=()
+function parse_cmds() {
+    # a finite state machine
+    # say, 'XXX' is a token. "${FLAGS_ARGV}" is a set of tokens
+    # separated by spaces
+    # we want the vector of the tokens, arg_list without ''
+    local state="skip" # and 'record'
+    local as_str="${FLAGS_ARGV}"
+    local word=""
+    for i in $(seq 1 ${#as_str}); do
+        local input="${as_str:i-1:1}"
+        case $input in
+            [[:space:]] )
+                case $state in
+                    "skip") ;;
+                    "record") word+="$input" ;;
+                esac
+                ;;
+            \')
+                case $state in
+                    "skip") state="record" ;;
+                    *) # record
+                        state="skip"
+                        arg_list+=( "$word" )
+                        word=""
+                        ;;
+                esac
+                ;;
+            *)  word+="$input"
+                ;;
+        esac
+    done
+}
+
+parse_cmds
+# "${arg_list[@]}" is ready to be used
+
+# pick up src dir and its mnt point
+android_src_host_dir=""
+android_src_mnt_dir=""
+
+# util func used by calc_mnt_point
+function no_src_dir2mount() {
+    >&2 echo "Error: --android_src_mntptr should be given and indicate at least source directory. try:"
+    >&2 echo "       $0 -h"
+    >&2 echo "       Alternatively, set ANDROID_BUILD_TOP to the root of the Android source directory."
+    exit 10
+}
+
+#util func used by calc_mnt_point
+function default_mnt_dir() {
+    local srcdir="$(realpath $1)"
+    local home=$(echo $HOME | sed -e 's/\//\\\//g')
+    echo ${srcdir} | sed -e "s/$home/\/home\/vsoc-01/g"
+}
+
+# output: android_src_{host,mnt}_dir
+# input: FLAGS_android_src_mntptr and/or ANDROID_BUILD_TOP env variable
+function calc_mnt_point() {
+    local arg=${FLAGS_android_src_mntptr}
+    local tk0=""
+    local tk1=""
+    if echo ${arg} | egrep ':' > /dev/null 2>&1; then
+        # "src:mnt", "src:", ":mnt", ":"
+        tk0="$(echo ${arg} | cut -d ':' -f1)"
+        tk1="$(echo ${arg} | cut -d ':' -f2-)"
+    else
+        if test -n ${arg}; then
+            # "src"
+            tk0="${arg}"
+        fi
+    fi
+
+    if test -z "${tk0}"; then
+        tk0="${ANDROID_BUILD_TOP}"
+        if test -z "${tk0}"; then
+            no_src_dir2mount
+        fi
+    fi
+    android_src_host_dir="$(realpath ${tk0})"
+    if test -z ${tk1}; then
+        tk1=$(default_mnt_dir "${android_src_host_dir}")
+    fi
+    android_src_mnt_dir="${tk1}"
+
+    if [[ "${android_src_mnt_dir}" == "/home/vsoc-01" ]]; then
+        >&2 echo "Error: We don't allow the source to be mounted exactly at /home/vsoc-01"
+        >&2 echo "       Please consider to mount it at a subdirectory of /home/vsoc-01"
+        exit 9
+    fi
+}
+calc_mnt_point
+
+# Output
+cf_builder_img_name="cuttlefish-android-builder"
+cf_builder_img_tag="latest"
+
+# see Dockerfile.builder, the target name must match
+cf_builder_img_target="cuttlefish-android-builder"
+
+# build docker image when required
+function is_rebuild_docker() {
+    local cnt="$(docker images -q ${cf_builder_img_name}:${cf_builder_img_tag} | wc -l)"
+    if (( cnt != 0 )); then
+        if [[ ${FLAGS_rebuild_docker_img} -ne ${FLAGS_TRUE} ]]; then
+            return 1
+        fi
+    fi
+    return 0
+}
+
+function build_image() {
+    docker build -f Dockerfile.builder \
+           --target ${cf_builder_img_target} \
+           -t ${cf_builder_img_name}:${cf_builder_img_tag} \
+           ${PWD} --build-arg UID=`id -u`
+}
+
+function run_cf_builder() {
+    echo "args taken: " "$@"
+    set -x
+
+    local mount_volumes=()
+    mount_volumes+=("-v" "${android_src_host_dir}:${android_src_mnt_dir}")
+    if [[ ${FLAGS_share_gitconfig} == ${FLAGS_TRUE} ]]; then
+        mount_volumes+=("-v" "$HOME/.gitconfig:/home/vsoc-01/.gitconfig")
+    fi
+
+    docker run --name cf_builder --privileged --rm \
+           "${mount_volumes[@]}" "$@" \
+           -it ${cf_builder_img_name}:${cf_builder_img_tag} \
+           /bin/bash
+}
+
+
+# main routine starts frome here
+if [ ${FLAGS_help} -eq ${FLAGS_TRUE} ]; then
+    exit 0
+fi
+
+# when needed, create the image first
+if is_rebuild_docker; then
+    build_image
+else
+    echo "not building docker img"
+fi
+
+run_cf_builder "${arg_list[@]}"


### PR DESCRIPTION
Added the docker image to build Android from the source. This is for now intended to offer a bash shell that has all the required environment to build. 

Modifided BUILD.md for now in order to encourage the users to set up these three variables manually if they want to build from the source with the new docker container:
 ANDROID_HOST_OUT
 ANDROID_PRODUCT_OUT
 ANDROID_BUILD_TOP

With that, the existing container can detect *.img, host packages, etc, and run Cuttlefish inside the docker container. 