### PR TITLE
Steve/new cuttlefish docker

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -41,7 +41,7 @@ To list the Cuttlefish containers:
 cvd_docker_list
 ```
 
-There are two ways to provision a container (that is, to install the Cuttlefish
+There are three ways to provision a container (that is, to install the Cuttlefish
 and Android images on it.)
 
 If cvd_docker_create detects an [Android build
@@ -51,7 +51,31 @@ binary artifacts.  Assuming you have downloaded, set up, and built a Cuttlefish
 device and Android from the sources, and you call cvd_docker_create in the same
 terminal, you can jump ahead to launching Cuttlefish.
 
-If you either don't have the Android build environment or you want to provision
+If you do not have the Android build environment, alternatively, you
+can build Android and Cuttlefish with another docker container. We are
+offering a wrapper script for that. Say, the source is downloaded to
+$HOME/android-src, we can run these to commands to build Android from
+the source:
+```bash
+./build-android-with-docker.sh --help
+./build-android-with-docker.sh --android-src-mntptr "$HOME/android-src:/home/vsoc-01/build"
+```
+
+That does build Android and Cuttlefish, and save them where you
+downloaded the source. It does not, however, allow you to automatically jump ahead to launching
+Cuttlefish. We are improving the process but for now, these commands
+will prepare for running Cuttlefish with a container:
+```bash
+export ANDROID_BUILD_TOP=$HOME/android-src
+export ANDROID_PRODUCT_OUT=$(dirname `find $ANDROID_BUILD_TOP/out |
+egrep "*/boot\.img$"`)
+export ANDROID_HOST_OUT=$(dirname `find $ANDROID_BUILD_TOP/out/host/ |
+egrep "/bin/launch_cvd$")
+```
+After those commands, you can run the docker image and run the
+container.
+
+If you you want to provision
 the container with a prebuilt cuttlefish image for example, from [AOSP
 CI](htts://ci.android.com), you can follow the steps to [obtain a prebuilt image
 of Cuttlefish](https://android.googlesource.com/device/google/cuttlefish/)

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,15 @@ RUN cd /root/android-cuttlefish \
     && cd .. \
     && rm -rvf android-cuttlefish
 
+# to share X with the local docker host
+RUN apt-get install -y xterm
+
 RUN apt-get install -y curl wget unzip
+
+# to run cuttlefish docker in foreground, and test via webrtc/VNC
+RUN apt-get install -y tigervnc-viewer
+RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+RUN apt-get install -y ./google-chrome-stable_current_amd64.deb && rm -f ./google-chrome-stable_current_amd64.deb
 
 RUN apt-get clean
 

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,0 +1,48 @@
+FROM debian:buster-slim AS cuttlefish-android-builder
+
+ENV container docker
+ENV LC_ALL C
+ENV DEBIAN_FRONTEND noninteractive
+
+# Set up the user have the same UID as user creating the container.  This is
+# important when we map the (container) user's home directory as a docker volume.
+
+ARG UID
+
+USER root
+WORKDIR /root
+
+RUN set -x
+
+RUN apt-get update -y
+RUN apt-get install -y python python3 wget curl git build-essential libncurses5 libncurses5-dev zip subversion rsync
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+RUN mkdir /repo-bin && curl https://storage.googleapis.com/git-repo-downloads/repo > /repo-bin/repo
+RUN chmod a+x /repo-bin/repo
+
+ENV PATH=$PATH:/repo-bin
+
+RUN apt-get install --no-install-recommends -y apt-utils sudo vim dpkg-dev devscripts gawk coreutils
+RUN apt-get install -y openssh-server openssh-client
+SHELL ["/bin/bash", "-c"]
+RUN if test $(uname -m) == aarch64; then \
+	    dpkg --add-architecture amd64 \
+	    && apt-get update \
+	    && apt-get install --no-install-recommends -y libc6:amd64 \
+	    && apt-get install --no-install-recommends -y qemu qemu-user qemu-user-static binfmt-support; \
+    fi
+
+RUN useradd -ms /bin/bash vsoc-01 -d /home/vsoc-01 -u $UID \
+    && passwd -d vsoc-01 \
+    && echo 'vsoc-01 ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+
+RUN sed -i -r -e 's/^#{0,1}\s*PasswordAuthentication\s+(yes|no)/PasswordAuthentication yes/g' /etc/ssh/sshd_config \
+    && sed -i -r -e 's/^#{0,1}\s*PermitEmptyPasswords\s+(yes|no)/PermitEmptyPasswords yes/g' /etc/ssh/sshd_config \
+    && sed -i -r -e 's/^#{0,1}\s*ChallengeResponseAuthentication\s+(yes|no)/ChallengeResponseAuthentication no/g' /etc/ssh/sshd_config \
+    && sed -i -r -e 's/^#{0,1}\s*UsePAM\s+(yes|no)/UsePAM no/g' /etc/ssh/sshd_config
+
+WORKDIR /home/vsoc-01
+# use sudo if root privilege is needed
+USER vsoc-01
+VOLUME [ "/home/vsoc-01" ]
+

--- a/build-android-with-docker.sh
+++ b/build-android-with-docker.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+
+# for now, the script will build docker image as needed
+# and gives a bash shell inside the container, so that
+# the user can run source, lunch & m commands to build
+#
+# TODO: support commands like
+#   intrinsic commands: init, sync, build, img_build
+#   running a host script inside docker container
+#   running a guest command inside docker container
+
+# to print multi-lined helper for shflags
+function multiline_helper {
+    local aligner=''
+    for cnt in `seq 0 $1`; do
+        aligner+=' '
+    done
+
+    local -n msgs=$2
+    echo ${msgs[0]}
+    for msg in "${msgs[@]:1}"; do
+        echo "${aligner}""$msg"
+    done
+}
+
+script_name=$(basename $0)
+
+# android_src_mnt helper message that is multi-lined
+android_src_mnt_helper=("src_dir:mount_point | src_dir | :mount_point | <an empty string>")
+android_src_mnt_helper+=("  src_dir on the host will be mounted mount_pointer on the docker container")
+android_src_mnt_helper+=("    e.g. /home/$USER/aosp03:/home/vsoc-01/aosp")
+android_src_mnt_helper+=("    This will mount /home/$USER/aosp03 to /home/vsoc-01/aosp in the container")
+android_src_mnt_helper+=("  if mount_point is missing, it is the src_dir with $HOME if any being replaced with /home/vsoc-01")
+android_src_mnt_helper+=("  if src_dir is missing, it should be given in the environment variable ANDROID_BUILD_TOP.")
+
+source "shflags"
+
+DEFINE_boolean rebuild_docker_img false "Rebuild cuttlefish-android-builder image" ""
+DEFINE_boolean share_gitconfig true "Allow the docker container to use the host gitconfig"
+DEFINE_string android_src_mntptr \
+              "" \
+              "$(multiline_helper 24 android_src_mnt_helper)" \
+
+FLAGS "$@" || exit 1
+eval set -- "${FLAGS_ARGV}"
+
+# As FLAGS_ARGV is not the best for us to process, we convert it into a bash array
+# Especially, iterating over or passing FLAGS_ARGV may not work as expected for
+# an argument surrounded by "" and has space(s) inside: "a b c"
+arg_list=()
+function parse_cmds() {
+    # a finite state machine
+    # say, 'XXX' is a token. "${FLAGS_ARGV}" is a set of tokens
+    # separated by spaces
+    # we want the vector of the tokens, arg_list without ''
+    local state="skip" # and 'record'
+    local as_str="${FLAGS_ARGV}"
+    local word=""
+    for i in $(seq 1 ${#as_str}); do
+        local input="${as_str:i-1:1}"
+        case $input in
+            [[:space:]] )
+                case $state in
+                    "skip") ;;
+                    "record") word+="$input" ;;
+                esac
+                ;;
+            \')
+                case $state in
+                    "skip") state="record" ;;
+                    *) # record
+                        state="skip"
+                        arg_list+=( "$word" )
+                        word=""
+                        ;;
+                esac
+                ;;
+            *)  word+="$input"
+                ;;
+        esac
+    done
+}
+
+parse_cmds
+# "${arg_list[@]}" is ready to be used
+
+# pick up src dir and its mnt point
+android_src_host_dir=""
+android_src_mnt_dir=""
+
+# util func used by calc_mnt_point
+function no_src_dir2mount() {
+    >&2 echo "Error: --android_src_mntptr should be given and indicate at least source directory. try:"
+    >&2 echo "       $0 -h"
+    >&2 echo "       Alternatively, set ANDROID_BUILD_TOP to the root of the Android source directory."
+    exit 10
+}
+
+#util func used by calc_mnt_point
+function default_mnt_dir() {
+    local srcdir="$(realpath $1)"
+    local home=$(echo $HOME | sed -e 's/\//\\\//g')
+    echo ${srcdir} | sed -e "s/$home/\/home\/vsoc-01/g"
+}
+
+# output: android_src_{host,mnt}_dir
+# input: FLAGS_android_src_mntptr and/or ANDROID_BUILD_TOP env variable
+function calc_mnt_point() {
+    local arg=${FLAGS_android_src_mntptr}
+    local tk0=""
+    local tk1=""
+    if echo ${arg} | egrep ':' > /dev/null 2>&1; then
+        # "src:mnt", "src:", ":mnt", ":"
+        tk0="$(echo ${arg} | cut -d ':' -f1)"
+        tk1="$(echo ${arg} | cut -d ':' -f2-)"
+    else
+        if test -n ${arg}; then
+            # "src"
+            tk0="${arg}"
+        fi
+    fi
+
+    if test -z "${tk0}"; then
+        tk0="${ANDROID_BUILD_TOP}"
+        if test -z "${tk0}"; then
+            no_src_dir2mount
+        fi
+    fi
+    android_src_host_dir="$(realpath ${tk0})"
+    if test -z ${tk1}; then
+        tk1=$(default_mnt_dir "${android_src_host_dir}")
+    fi
+    android_src_mnt_dir="${tk1}"
+
+    if [[ "${android_src_mnt_dir}" == "/home/vsoc-01" ]]; then
+        >&2 echo "Error: We don't allow the source to be mounted exactly at /home/vsoc-01"
+        >&2 echo "       Please consider to mount it at a subdirectory of /home/vsoc-01"
+        exit 9
+    fi
+}
+calc_mnt_point
+
+# Output
+cf_builder_img_name="cuttlefish-android-builder"
+cf_builder_img_tag="latest"
+
+# see Dockerfile.builder, the target name must match
+cf_builder_img_target="cuttlefish-android-builder"
+
+# build docker image when required
+function is_rebuild_docker() {
+    local cnt="$(docker images -q ${cf_builder_img_name}:${cf_builder_img_tag} | wc -l)"
+    if (( cnt != 0 )); then
+        if [[ ${FLAGS_rebuild_docker_img} -ne ${FLAGS_TRUE} ]]; then
+            return 1
+        fi
+    fi
+    return 0
+}
+
+function build_image() {
+    docker build -f Dockerfile.builder \
+           --target ${cf_builder_img_target} \
+           -t ${cf_builder_img_name}:${cf_builder_img_tag} \
+           ${PWD} --build-arg UID=`id -u`
+}
+
+function run_cf_builder() {
+    echo "args taken: " "$@"
+    set -x
+
+    local mount_volumes=()
+    mount_volumes+=("-v" "${android_src_host_dir}:${android_src_mnt_dir}")
+    if [[ ${FLAGS_share_gitconfig} == ${FLAGS_TRUE} ]]; then
+        mount_volumes+=("-v" "$HOME/.gitconfig:/home/vsoc-01/.gitconfig")
+    fi
+
+    docker run --name cf_builder --privileged --rm \
+           "${mount_volumes[@]}" "$@" \
+           -it ${cf_builder_img_name}:${cf_builder_img_tag} \
+           /bin/bash
+}
+
+
+# main routine starts frome here
+if [ ${FLAGS_help} -eq ${FLAGS_TRUE} ]; then
+    exit 0
+fi
+
+# when needed, create the image first
+if is_rebuild_docker; then
+    build_image
+else
+    echo "not building docker img"
+fi
+
+run_cf_builder "${arg_list[@]}"

--- a/setup.sh
+++ b/setup.sh
@@ -25,14 +25,35 @@ function cvd_docker_list {
   docker ps -a --filter="ancestor=cuttlefish"
 }
 
+function help_on_container_create {
+  echo "   cvd_docker_create <options> [NAME] # by default names 'cuttlefish'"
+  echo "     Options:"
+  echo "       -n | --name jellyfish        : override default name"
+  echo "                                    : for backward compat, [NAME] will override this"
+  echo "       -f | --foreground            : run the container in foreground"
+  echo "                                    : otherwise, the container is created as a daemon"
+  echo "       -x | --with_host_x           : run the container in foreground and"
+  echo "                                    : share X of the docker host"
+  echo "       -a | --android_build_top dir : equivalent as setting ANDROID_BUILD_TOP"
+  echo "                                    : if ANDROID_BUILD_TOP is already set, the option is ignored"
+  echo "                                    : dir should be the level directory of android tree"
+  echo "       -m | --share_dir dir1:dir2   : mount a host directory dir1 at dir2 of docker container"
+  echo "                                    : dir1 should be an absolute path or relative path to $PWD"
+  echo "                                    : dir2 should be an absolute path or relative path to /home/vsoc-01/"
+  echo "                                    : $HOME is not allowed as dir1"
+  echo "                                    : /home/vsoc-01 is not allowed as dir2"
+  echo "                                    : For multiple mounts, use multiple -m options per pair"
+  echo "       -h | --help                  : print this help message"
+  echo "        The optional [NAME] will override -n option for backward compatibility"
+}
+
 function help_on_sourcing {
   echo "Create a cuttlefish container:"
-  echo "   cvd_docker_create # by default names 'cuttlefish'"
-  echo "   cvd_docker_create name # name is 'name'"
-
+  help_on_container_create
+  echo ""
   echo "To list existing Cuttlefish containers:"
   echo "   cvd_docker_list"
-
+  echo ""
   echo "Existing Cuttlefish containers:"
   cvd_docker_list
 }
@@ -51,41 +72,203 @@ function help_on_container_start {
   [[ "${name}" != 'cuttlefish' ]] && echo "    cvd_docker_rm ${name}"
 }
 
+function is_absolute_path {
+  local sub=$1
+  if [[ -n ${sub:0:1} ]] && [[ "${sub:0:1}" == "/" ]]; then
+    return 0
+  fi
+  return 1
+}
+
+# set up android_prod_out_dir, android_host_out_dir,
+# and android_build_top_dir
+#
+# based on the android_build_top_dir, the routine figures out
+# the rest, using find and egrep
+function setup_android_build_envs {
+  local -n android_build_top_dir_=$1
+  local -n android_host_out_dir_=$2
+  local -n android_prod_out_dir_=$3
+  android_build_top_dir_="$(realpath $4)"
+
+  local host_pkg_file=
+  if ! host_pkg_file="$(find "$android_build_top_dir_"/out/ -type f | egrep "/cvd-host_package\.tar\.gz$" | tail -1 2> /dev/null)"; then
+      echo "failed to search ANDROID_HOST_OUT directory"
+      echo "try to set it up manually"
+      exit 1
+  fi
+  android_host_out_dir_="$(dirname $host_pkg_file)"
+  android_host_out_dir_="$(realpath $android_host_out_dir_)"
+  local boot_img_file=
+  if ! boot_img_file="$(find "$android_build_top_dir_"/out/ -type f | egrep "/boot\.img$"  | tail -1 2> /dev/null)"; then
+      echo "failed to search ANDROID_PRODUCT_OUT directory"
+      echo "try to set it up manually"
+      exit 1
+  fi
+  android_prod_out_dir_="$(dirname $boot_img_file)"
+  android_prod_out_dir_="$(realpath $android_prod_out_dir_)"
+}
+
 function cvd_docker_create {
-  local name="$(cvd_get_id $1)"
-  local container="$(cvd_exists $1)"
+  local OPTIND
+  local op
+  local val
+  local OPTARG
+
+  local name_=""
+  local foreground="false"
+  local with_host_x="false"
+  local need_help="false"
+  local share_dir="false"
+  local -a shared_dir_pairs=()
+  local android_build_top="false"
+  local to_build_top_dir="${ANDROID_BUILD_TOP}"
+
+  while getopts ":m:a:n:-:hfx" op; do
+    # n | --name=cuttlefish | --name jellyfish
+    # f | --foreground
+    # x | --with_host_x
+    # m | --share_dir dir1:dir2
+    # h | --help
+    # a | --android_build_top dir
+    if [[ $op == '-' ]]; then
+      case "${OPTARG}" in
+        *=* )
+          val=${OPTARG#*=}
+          op=${OPTARG%=$val}
+          OPTARG=${val}
+          ;;
+        *)
+          op=${OPTARG}
+          val=${!OPTIND}
+          if [[ -n $val ]] && [[ ${val:0:1} != '-' ]]; then
+            OPTARG=${val}
+            OPTIND=$(( OPTIND + 1 ))
+            echo $op
+            echo $OPTARG
+          fi
+          ;;
+      esac
+    fi
+    case "$op" in
+      n | name ) name_=${OPTARG}
+        ;;
+      f | foreground ) foreground="true"
+        ;;
+      x | with_host_x )
+        with_host_x="true"
+        foreground="true"
+        ;;
+      m | share_dir )
+        share_dir="true"
+        shared_dir_pairs+=("${OPTARG}")
+        ;;
+      a | android_build_top )
+        if [[ -z ${ANDROID_BUILD_TOP} ]]; then
+            android_build_top="true"
+            to_build_top_dir="${OPTARG}"
+        fi
+        ;;
+      h | help ) need_help="true"
+        ;;
+      ? ) need_help="true"
+        ;;
+    esac
+  done
+
+  if [[ "${need_help}" == "true" ]]; then
+    help_on_container_create
+    return
+  fi
+
+  local android_build_top_dir="${ANDROID_BUILD_TOP}"
+  local android_host_out_dir="${ANDROID_HOST_OUT}"
+  local android_prod_out_dir="${ANDROID_PRODUCT_OUT}"
+  if [[ "${android_build_top}" == "true" ]]; then
+      setup_android_build_envs \
+          android_build_top_dir \
+          android_host_out_dir \
+          android_prod_out_dir \
+          ${to_build_top_dir}
+  fi
+
+  echo "android_host_out_dir is $android_host_out_dir"
+  echo "android_prod_out_dir is $android_prod_out_dir"
+  echo "android_build_top_dir is $android_build_top_dir"
+
+  # for backward compatibility:
+  [[ -n ${!OPTIND} ]] && name_="${!OPTIND}"
+
+  local name="$(cvd_get_id $name_)"
+  local container="$(cvd_exists $name_)"
+
+  local -a volumes=()
   if [[ -z "${container}" ]]; then
     echo "Container ${name} does not exist.";
     echo "Starting container ${name} from image cuttlefish.";
 
-    # If ANDROID_BUILD_TOP is set, we assume that the entire Android
-    # build environment is correctly configured.  We further assume
-    # that there is a valid $ANDROID_HOST_OUT/cvd-host_package.tar.gz
-    # and a set of Android images under $ANDROID_PRODUCT_OUT/*.img.
-
-    local -a home_volume=()
-
-    if [[ -v ANDROID_BUILD_TOP ]]; then
+    # if ANDROID_BUILD_TOP is given either via an env variable or commandline option,
+    # we will use the host package and images from there
+    #
+    if [[ -n "${android_build_top_dir}" ]]; then
       local home="$(mktemp -d)"
       echo "Detected Android build environment.  Setting up in ${home}."
-      tar xz -C "${home}" -f "${ANDROID_HOST_OUT}"/cvd-host_package.tar.gz
-      for f in "${ANDROID_PRODUCT_OUT}"/*.img; do
-        home_volume+=("-v ${f}:/home/vsoc-01/$(basename ${f}):rw")
+      tar xz -C "${home}" -f "${android_host_out_dir}"/cvd-host_package.tar.gz
+      for f in "${android_prod_out_dir}"/*.img; do
+        volumes+=("-v ${f}:/home/vsoc-01/$(basename ${f}):rw")
       done
-      home_volume+=("-v ${home}:/home/vsoc-01:rw")
+      volumes+=("-v ${home}:/home/vsoc-01:rw")
     fi
 
-    docker run -d \
-            --name "${name}" -h "${name}" \
-            --privileged \
-            -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-            ${home_volume[@]} \
-            cuttlefish
+    if [[ $share_dir == "true" ]]; then
+      local host_pwd="$(realpath "$PWD")"
+      local guest_home="/home/vsoc-01"
+      for sub in "${shared_dir_pairs[@]}"; do
+        if ! echo ${sub} | egrep ":" > /dev/null; then
+          echo "${sub} is ill-formated. should be host_dir:mnt_dir"
+          echo "try $0 --help"
+          exit 1
+        fi
+        local host_dir="$(echo $sub | cut -d ':' -f 1)"
+        local guest_dir="$(echo $sub | cut -d ':' -f 2)"
+        if ! is_absolute_path ${host_dir}; then
+          host_dir="${host_pwd}/${subdir}"
+        fi
+        if ! is_absolute_path ${guest_dir}; then
+          guest_dir="${guest_home}/${guest_dir}"
+        fi
+        volumes+=("-v ${host_dir}:${guest_dir}")
+      done
+    fi
+
+    local -a as_host_x=()
+    if [[ "$with_host_x" == "true" ]]; then
+      as_host_x+=("-e DISPLAY=$DISPLAY")
+      as_host_x+=("-v /tmp/.X11-unix:/tmp/.X11-unix")
+    fi
+
+    docker run -d ${as_host_x[@]} \
+           --name "${name}" -h "${name}" \
+           --privileged \
+           -v /sys/fs/cgroup:/sys/fs/cgroup:ro ${volumes[@]} \
+           cuttlefish
 
     __gen_funcs ${name}
+
+    # define and export ip_${name} for the ip address
+    local ip_addr_var_name="ip_${name}"
+    declare ${ip_addr_var_name}="$(cvd_get_ip "${name}")"
+    export ${ip_addr_var_name}
+    if [[ "$foreground" == "true" ]]; then
+        docker exec -it --user vsoc-01 ${name} /bin/bash
+        cvd_docker_rm ${name}
+        return
+    fi
+
     help_on_container_start ${name}
     echo
     help_on_sourcing
+
   else
     echo "Container ${name} exists";
     if [ $(docker inspect -f "{{.State.Running}}" ${name}) != 'true' ]; then
@@ -102,6 +285,8 @@ function cvd_docker_create {
 
 function cvd_docker_rm {
   local name=${1:-cuttlefish}
+  local ip_addr_var_name="ip_${name}"
+  unset ${ip_addr_var_name}
 
   if [ -n "$(docker ps -q -a -f name=${name})" ]; then
     homedir=$(docker inspect -f '{{range $mount:=.Mounts}}{{if and (eq .Destination "/home/vsoc-01") (eq .Type "bind")}}{{- printf "%q" $mount.Source}}{{end}}{{end}}' "${name}" | sed 's/"//g')


### PR DESCRIPTION
Please review this branch.

The first two are for the new docker container to build AOSP.

The last one is to improve the existing docker container. It's nearly the same as my former change. Only that:
 -a is added to point to the ANDROID_BUILD_TOP dir, and calculate ANDROID_{HOST,PRODUCT}_OUT with that
 -m to mount a local directory to the docker container: e.g. $HOME/cuttlefish_runtime*, .gitconfig, any_dir_for_custom_logging, etc

Besides, somehow, ip_${name} was not actually set up and exported. Thus, even after cvd_start_${name}, ssh ip_${name} did not work. Fixed the issue here, too.

Still, ssh did not work. Perhaps, there might have been a change in the ssh itself. Or, there might be mis-configuration to fix. That will be fixed later on. 
