### PR TITLE
Steve/wrapper

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -87,12 +87,48 @@ Say, the source is downloaded to $HOME/android-src. The following
 command will build the Android and Cuttlefish from the source.
 
 ```bash
-./build-android-with-docker.sh --android-src_mntptr "$HOME/android-src:/home/vsoc-01/build"
+./build-android-with-docker.sh --android_src_mnt "$HOME/android-src:/home/vsoc-01/build"
 ```
 
 For more detail:
 ```bash
 ./build-android-with-docker.sh --help
+```
+
+The build-android-with-docker.sh script also allows:
+1. running a docker guest command with arguments
+2. mounting a host script at docker container to run it with arguments
+3. passing another set of arguments to docker run at the same time
+4. as a showcase, just init, sync, and build with default
+   configurations
+
+Note that if arguments should be passed to the guest command or the
+host script, it should be done like this:
+```bash
+./build-android-with-docker.sh --android_src_mnt "$HOME/android-src:/home/vsoc-01/build" \
+    --op_mode=guest guest_program -- -a -b -c and more arguments
+
+```
+-- makes the following arguments like -a, -b, -c, arguments, rather
+than options to the ./build-android-with-docker script. Without --,
+getopt that internally implements cmdline parsing will be confused.
+
+Also, for --docker_run_opts, spaces are not allowed. Thus, for a short
+docker option with optional parameter, you should do as follows:
+```
+-vVALUE1:VALUE2
+```
+
+For a long docker run option with optional parameter, you should do
+like this:
+```
+--name=MYNAME
+```
+
+In summary, a docker_run_opts looks like:
+```bash
+--docker_run_opts="-vV1:V2,--name=MYNAME,--privileged,-a,-b"
+
 ```
 
 Although the command will build Android and Cuttlefish, the docker

--- a/android-builder-docker/Dockerfile.builder
+++ b/android-builder-docker/Dockerfile.builder
@@ -23,7 +23,7 @@ RUN chmod a+x /repo-bin/repo
 ENV PATH=$PATH:/repo-bin
 
 RUN apt-get install --no-install-recommends -y apt-utils sudo vim dpkg-dev devscripts gawk coreutils
-RUN apt-get install -y openssh-server openssh-client
+RUN apt-get install -y procps
 SHELL ["/bin/bash", "-c"]
 RUN if test $(uname -m) == aarch64; then \
 	    dpkg --add-architecture amd64 \
@@ -36,13 +36,14 @@ RUN useradd -ms /bin/bash vsoc-01 -d /home/vsoc-01 -u $UID \
     && passwd -d vsoc-01 \
     && echo 'vsoc-01 ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
 
-RUN sed -i -r -e 's/^#{0,1}\s*PasswordAuthentication\s+(yes|no)/PasswordAuthentication yes/g' /etc/ssh/sshd_config \
-    && sed -i -r -e 's/^#{0,1}\s*PermitEmptyPasswords\s+(yes|no)/PermitEmptyPasswords yes/g' /etc/ssh/sshd_config \
-    && sed -i -r -e 's/^#{0,1}\s*ChallengeResponseAuthentication\s+(yes|no)/ChallengeResponseAuthentication no/g' /etc/ssh/sshd_config \
-    && sed -i -r -e 's/^#{0,1}\s*UsePAM\s+(yes|no)/UsePAM no/g' /etc/ssh/sshd_config
-
 WORKDIR /home/vsoc-01
+
+RUN mkdir -p /home/vsoc-01/intrinsic_shells/bin
+COPY ./common_intrinsic.sh /home/vsoc-01/intrinsic_shells/bin/
+COPY ./run.sh /home/vsoc-01/intrinsic_shells/bin/
+
+RUN chmod +x /home/vsoc-01/intrinsic_shells/bin/*.sh
+
 # use sudo if root privilege is needed
 USER vsoc-01
 VOLUME [ "/home/vsoc-01" ]
-

--- a/android-builder-docker/common_intrinsic.sh
+++ b/android-builder-docker/common_intrinsic.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# 1: mode
+# 2: android_build_top
+#
+mode=$1
+
+function calc_n() {
+    if cat /proc/cpuinfo | \
+            egrep "processor[[:space:]:]+[0-9]+$" | \
+            tail -1 > /dev/null 2>&1; then
+        local n=$(cat /proc/cpuinfo  | \
+                      egrep "processor[[:space:]:]+[0-9]+$" | tail -1 | \
+                      cut -d ':' -f 2- | egrep -o "[0-9]+")
+        echo $(( n + 1 ))
+        return
+    fi
+    echo 2 # default value when there's no /proc/cpuinfo
+}
+
+if cat /proc/cpuinfo  | egrep "processor[[:space:]:]+[0-9]+$" > /dev/null 2>&1; then
+    n_parallel=$(calc_n)
+fi
+
+if (( N_PARALLEL > 0 )); then
+    n_parallel=${N_PARALLEL}
+fi
+
+echo "cd to $2"
+case $mode in
+    init)
+        echo "running repo init -u $REPO_SRC"
+        (cd $2; repo init -u $REPO_SRC; cd -)
+        ;;
+    sync)
+        echo "running repo sync -j $n_parallel"
+        (cd $2; repo sync -j $n_parallel; cd -)
+        ;;
+    build)
+        echo "running source ./build/envsetup.sh"
+        echo "        lunch $LUNCH_TARGET"
+        echo "        m -j $n_parallel"
+        cd $2
+        source ./build/envsetup.sh
+        lunch $LUNCH_TARGET
+        m -j $n_parallel
+        ;;
+    *)
+        >&2 echo "unsupported operation"
+        exit 10
+        ;;
+esac

--- a/android-builder-docker/run.sh
+++ b/android-builder-docker/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+dst_dir=$1
+prog=$2
+shift 2
+this_dir=$PWD
+cd $dst_dir
+$prog "$@"
+cd $this_dir

--- a/build-android-with-docker.sh
+++ b/build-android-with-docker.sh
@@ -23,23 +23,97 @@ function multiline_helper {
     done
 }
 
+function get_default_lunch_target {
+    local def_lunch_target=""
+    case "$(uname -m)" in
+        x86_64|i386|x86|amd64) def_lunch_target="aosp_cf_x86_phone-userdebug" ;;
+        aarch64|arm64) def_lunch_target="aosp_cf_arm64_phone-userdebug" ;;
+        *)
+            >&2 echo "unsupported architecture $(uname -m)"
+            exit 10
+            ;;
+    esac
+    echo $def_lunch_target
+}
+
 script_name=$(basename $0)
 
-# android_src_mnt helper message that is multi-lined
-android_src_mnt_helper=("src_dir:mount_point | src_dir | :mount_point | <an empty string>")
-android_src_mnt_helper+=("  src_dir on the host will be mounted mount_pointer on the docker container")
+default_lunch_target="$LUNCH_TARGET"
+if [[ -z "$LUNCH_TARGET" ]]; then
+    default_lunch_target="$(get_default_lunch_target)"
+fi
+
+default_repo_src="$REPO_SRC"
+if [[ -z "$REPO_SRC" ]]; then
+    default_repo_src="https://android.googlesource.com/platform/manifest"
+fi
+
+# android_src_mnt helper message
+android_src_mnt_helper=("src_dir:mnt_ptr | src_dir | :mnt_ptr | <an empty string>")
+android_src_mnt_helper+=("  src_dir on the host will be mounted mnt_ptrer on the docker container")
 android_src_mnt_helper+=("    e.g. /home/$USER/aosp03:/home/vsoc-01/aosp")
 android_src_mnt_helper+=("    This will mount /home/$USER/aosp03 to /home/vsoc-01/aosp in the container")
-android_src_mnt_helper+=("  if mount_point is missing, it is the src_dir with $HOME if any being replaced with /home/vsoc-01")
+android_src_mnt_helper+=("  if mnt_ptr is missing, it is the src_dir with $HOME if any being replaced with /home/vsoc-01")
 android_src_mnt_helper+=("  if src_dir is missing, it should be given in the environment variable ANDROID_BUILD_TOP.")
+
+# op_mode help message
+supported_op_modes=("bash | host | guest | image_build | intrinsic")
+op_mode_helper=("$supported_op_modes")
+op_mode_helper+=("  determine the mode in which $script_name operates.")
+op_mode_helper+=("    bash mode:")
+op_mode_helper+=("      gives a bash shell inside the docker container.")
+op_mode_helper+=("      e.g. $0 <options> --op_mode=bash -- optional bash args if any")
+op_mode_helper+=("    host mode:")
+op_mode_helper+=("      mount the host script to the corresponding location.")
+op_mode_helper+=("        i.e. host script path --> realpath -s --> replace $HOME")
+op_mode_helper+=("      and run it in the mnt_ptr of the src_dir.")
+op_mode_helper+=("        see --android_src_mnt.")
+op_mode_helper+=("    guest mode:")
+op_mode_helper+=("      run guest commands with optional arguments followed by --")
+op_mode_helper+=("      e.g. $0 <options> --op_mode=guest -- ls -l /home")
+op_mode_helper+=("    image_build mode:")
+op_mode_helper+=("      only (re)build the docker image.")
+op_mode_helper+=("    intrinsic mode:")
+op_mode_helper+=("      regards args as an intrinsic command that could be:")
+op_mode_helper+=("        init, sync, and build")
+op_mode_helper+=("      this is a showcase operation mode.")
+op_mode_helper+=("      ${script_name} reads REPO_SRC, LUNCH_TARGET.")
+op_mode_helper+=("      Following that, it does repo init, sync, or m -j N in the mnt_ptr.")
+op_mode_helper+=("        see --android_src_mnt")
+op_mode_helper+=("      if REPO_SRC and LUNCH_TARGET is not set, the defaults are:")
+op_mode_helper+=("        REPO_SRC=$default_repo_src")
+op_mode_helper+=("        LUNCH_TARGET=$default_lunch_target")
+
+# docker_run_opts help message
+docker_run_opts_helper=("passing arguments to docker run, not the guest/host scripts or bash")
+docker_run_opts_helper+=("  comma separated, and no space is allowed.")
+docker_run_opts_helper+=("  e.g. --rm,--privileged,-eENV,-vSRC:DIR,--name=MYNAME")
+
 
 source "shflags"
 
 DEFINE_boolean rebuild_docker_img false "Rebuild cuttlefish-android-builder image" ""
 DEFINE_boolean share_gitconfig true "Allow the docker container to use the host gitconfig"
-DEFINE_string android_src_mntptr \
+DEFINE_boolean rm true "Pass --rm to docker run"
+DEFINE_string android_src_mnt \
               "" \
-              "$(multiline_helper 24 android_src_mnt_helper)" \
+              "$(multiline_helper 21 android_src_mnt_helper)"
+DEFINE_string op_mode \
+              "bash" \
+              "$(multiline_helper 13 op_mode_helper)"
+DEFINE_string lunch_target \
+              "$default_lunch_target" \
+              "default lunch target used by the --op_mode=intrinsic only"
+DEFINE_string repo_src \
+              "$default_repo_src" \
+              "default Android Repo source used by the --op_mode=intrinsic only"
+DEFINE_integer n_parallel "0" \
+               "default N for m/repo sync -j N. we use /proc/cpuinfo if 0"
+DEFINE_string instance_name \
+              "cf_builder" \
+              "default name of the docker container that builds Android"
+DEFINE_string docker_run_opts "" \
+              "$(multiline_helper 21 android_src_mnt_helper)"
 
 FLAGS "$@" || exit 1
 eval set -- "${FLAGS_ARGV}"
@@ -77,9 +151,24 @@ function parse_cmds() {
         esac
     done
 }
-
+# "${arg_list[@]}" is ready to be used after the following call
 parse_cmds
-# "${arg_list[@]}" is ready to be used
+
+if [ ${FLAGS_help} -eq ${FLAGS_TRUE} ]; then
+    exit 0
+fi
+
+# global util function
+# 1: src dir, either symlink or dir
+# 2: to replace
+# 3: to be replaced
+# echo the absolute path with $2 being replaced $3
+function calc_dst_dir() {
+    local srcdir="$(realpath -s $1)"
+    local to_go=$(echo $2 | sed -e 's/\//\\\//g')
+    local to_come=$(echo $3 | sed -e 's/\//\\\//g')
+    echo ${srcdir} | sed -e "s/$to_go/$to_come/g"
+}
 
 # pick up src dir and its mnt point
 android_src_host_dir=""
@@ -87,7 +176,7 @@ android_src_mnt_dir=""
 
 # util func used by calc_mnt_point
 function no_src_dir2mount() {
-    >&2 echo "Error: --android_src_mntptr should be given and indicate at least source directory. try:"
+    >&2 echo "Error: --android_src_mnt should be given and indicate at least source directory. try:"
     >&2 echo "       $0 -h"
     >&2 echo "       Alternatively, set ANDROID_BUILD_TOP to the root of the Android source directory."
     exit 10
@@ -95,15 +184,13 @@ function no_src_dir2mount() {
 
 #util func used by calc_mnt_point
 function default_mnt_dir() {
-    local srcdir="$(realpath $1)"
-    local home=$(echo $HOME | sed -e 's/\//\\\//g')
-    echo ${srcdir} | sed -e "s/$home/\/home\/vsoc-01/g"
+    echo "$(calc_dst_dir $1 $HOME /home/vsoc-01)"
 }
 
 # output: android_src_{host,mnt}_dir
-# input: FLAGS_android_src_mntptr and/or ANDROID_BUILD_TOP env variable
+# input: FLAGS_android_src_mnt and/or ANDROID_BUILD_TOP env variable
 function calc_mnt_point() {
-    local arg=${FLAGS_android_src_mntptr}
+    local arg=${FLAGS_android_src_mnt}
     local tk0=""
     local tk1=""
     if echo ${arg} | egrep ':' > /dev/null 2>&1; then
@@ -125,7 +212,7 @@ function calc_mnt_point() {
     fi
     android_src_host_dir="$(realpath ${tk0})"
     if test -z ${tk1}; then
-        tk1=$(default_mnt_dir "${android_src_host_dir}")
+        tk1=$(default_mnt_dir "$(realpath -s ${tk0})")
     fi
     android_src_mnt_dir="${tk1}"
 
@@ -135,14 +222,23 @@ function calc_mnt_point() {
         exit 9
     fi
 }
-calc_mnt_point
 
-# Output
-cf_builder_img_name="cuttlefish-android-builder"
-cf_builder_img_tag="latest"
-
-# see Dockerfile.builder, the target name must match
-cf_builder_img_target="cuttlefish-android-builder"
+# util to parse docker run options
+# 1: string to parse
+# 2: reference to array
+# 3: optional delimiter
+#
+# don't pass an empty ${FLAGS_string}
+function string_to_array() {
+    local what2parse="$1"
+    local -n result=$2
+    local delim=${3:-','}
+    local IFS=$delim
+    echo $what2parse
+    for opt in "$what2parse"; do
+        result+=("$opt")
+    done
+}
 
 # build docker image when required
 function is_rebuild_docker() {
@@ -155,40 +251,141 @@ function is_rebuild_docker() {
     return 0
 }
 
+# Output
+cf_builder_img_name="cuttlefish-android-builder"
+cf_builder_img_tag="latest"
+
+# see Dockerfile.builder, the target name must match
+cf_builder_img_target="cuttlefish-android-builder"
+
 function build_image() {
+    pushd ./android-builder-docker > /dev/null 2>&1
+    if cat Dockerfile.builder | egrep "AS[[:space:]]+$cf_builder_img_target" \
+                                      > /dev/null 2>&1; then
+        >&2 echo "The target name in Dockerfile.builder must match $cf_builder_img_target"
+    fi
     docker build -f Dockerfile.builder \
            --target ${cf_builder_img_target} \
            -t ${cf_builder_img_name}:${cf_builder_img_tag} \
            ${PWD} --build-arg UID=`id -u`
+    popd > /dev/null 2>&1
+    err_code=$?
+    if (( err_code != 0)); then
+        >&2 echo "image build failed"
+        exit $err_code
+    fi
+}
+
+function verify_intrinsic_mode() {
+    if (( $# != 1 )); then
+        >&2 echo "--op_mode=intrinsic takes only one args, one of these:"
+        >&2 echo "  <$supported_op_modes>"
+        exit 40
+    fi
+    case $1 in
+        init)
+        ;;
+        sync)
+        ;;
+        build)
+        ;;
+        *)
+            >&2 echo "unsupported value for --op_mode=intrinsic"
+            exit 41
+            ;;
+    esac
+    return 0 # return success
 }
 
 function run_cf_builder() {
-    echo "args taken: " "$@"
-    set -x
+    local -a parms=( "$@" )
 
-    local mount_volumes=()
+    case "${FLAGS_op_mode}" in
+        image_build)
+            build_image
+            return
+            ;;
+        *)
+            ;; # keep going
+    esac
+
+    local -a mount_volumes=()
+    calc_mnt_point
     mount_volumes+=("-v" "${android_src_host_dir}:${android_src_mnt_dir}")
     if [[ ${FLAGS_share_gitconfig} == ${FLAGS_TRUE} ]]; then
         mount_volumes+=("-v" "$HOME/.gitconfig:/home/vsoc-01/.gitconfig")
     fi
 
-    docker run --name cf_builder --privileged --rm \
-           "${mount_volumes[@]}" "$@" \
+    local cmd_to_docker="/bin/bash"
+
+    local -a env_variables=()
+    export N_PARALLEL=${FLAGS_n_parallel}
+    env_variables+=("-e" "N_PARALLEL")
+
+    # a script change dir to $1, and run $2 "shift-2'ed $@"
+    local chdirer="/home/vsoc-01/intrinsic_shells/bin/run.sh"
+
+    case "${FLAGS_op_mode}" in
+        intrinsic)
+            env_variables+=("-e" "LUNCH_TARGET")
+            env_variables+=("-e" "REPO_SRC")
+            export LUNCH_TARGET="${FLAGS_lunch_target}"
+            export REPO_SRC="${FLAGS_repo_src}"
+            if ! verify_intrinsic_mode "${parms[@]}"; then
+                exit 40
+            fi
+            local intrinsic_cmd="/home/vsoc-01/intrinsic_shells/bin/common_intrinsic.sh"
+            cmd_to_docker="$intrinsic_cmd"
+            parms=("${parms[@]}" "$android_src_mnt_dir")
+            echo ${parms[@]}
+            echo $cmd_to_docker
+            ;;
+        bash)
+            ;;
+        guest)
+            cmd_to_docker=$chdirer
+            parms=("$android_src_mnt_dir" "${parms[@]}")
+            ;;
+        host)
+            local host_script_path="$(realpath -s ${parms[0]})"
+            local host_script="$(realpath $host_script_path)"
+            local guest_script="$(calc_dst_dir $host_script_path $HOME /home/vsoc-01)"
+            mount_volumes+=("-v" "${host_script}:${guest_script}")
+            parms=("$android_src_mnt_dir" "$guest_script" "${parms[@]:1}")
+            cmd_to_docker=$chdirer
+            ;;
+        image_build)
+            >&2 echo "control shouldn't reach here"
+            exit 9
+            ;;
+        *)
+            >&2 echo "unsupported --op_mode"
+            exit 10
+            ;;
+    esac
+
+    # when needed, create the image first
+    if is_rebuild_docker; then
+        build_image
+    else
+        echo "not building docker img"
+    fi
+
+    local -a opt_rm=()
+    if [ ${FLAGS_rm} -eq ${FLAGS_TRUE} ]; then
+        opt_rm+=("--rm")
+    fi
+
+    set -x
+    local -a dck_usr_opts=()
+    if [[ "${FLAGS_docker_run_opts}" != "" ]]; then
+        string_to_array "${FLAGS_docker_run_opts}" dck_usr_opts ','
+    fi
+    docker run --name="${FLAGS_instance_name}" \
+           --privileged "${opt_rm[@]}" "${env_variables[@]}" \
+           "${mount_volumes[@]}" "${dck_opts[@]}" \
            -it ${cf_builder_img_name}:${cf_builder_img_tag} \
-           /bin/bash
+           ${cmd_to_docker} "${parms[@]}" # all parameters are passed to cmd_to_docker
 }
-
-
-# main routine starts frome here
-if [ ${FLAGS_help} -eq ${FLAGS_TRUE} ]; then
-    exit 0
-fi
-
-# when needed, create the image first
-if is_rebuild_docker; then
-    build_image
-else
-    echo "not building docker img"
-fi
 
 run_cf_builder "${arg_list[@]}"

--- a/setup.sh
+++ b/setup.sh
@@ -247,7 +247,10 @@ function cvd_docker_create {
 	    fi
 
         if [[ $share_dir == "true" ]]; then
-            local host_pwd=$(realpath "$PWD")
+            # mount host_dir to guest_dir
+            # if host_dir is symlink, use the symlink path to calculate guest_dir
+            # however, mount the host actual target directory to the guest_dir
+            local host_pwd=$(realpath -s "$PWD")
             local guest_home="/home/vsoc-01"
             for sub in "${shared_dir_pairs[@]}"; do
                 if ! echo ${sub} | egrep ":" > /dev/null; then
@@ -263,6 +266,7 @@ function cvd_docker_create {
                 if ! is_absolute_path ${guest_dir}; then
                     guest_dir="${guest_home}/${guest_dir}"
                 fi
+                host_dir=${realpath $host_dir} # resolve symbolic link only on the host side
                 volumes+=("-v ${host_dir}:${guest_dir}")
             done
         fi


### PR DESCRIPTION
This implements the wrapper for docker that builds Android from the source. It's about 400 lines of code. 

Basically, the user could do:
 1. get a bash shell with all set up
 2. run a guest command with options
 3. mount a host script, and run it inside the container with options
 4. add another set of options to "docker run" at the same time
 5. simple intrinsic functionality such as init, sync, build
 6. mount useful directories and files to the container: e.g. the ssh public key, .gitconfig, etc. 
