### PR TITLE
Separated .deb build from the cuttlefish docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ deps.txt
 ignore-depends-for-*.txt
 */*/driver-deps
 */*/driver.txt
+
+!out/.gitkeep

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,12 +34,11 @@ VOLUME [ "/sys/fs/cgroup" ]
 
 CMD ["/lib/systemd/systemd"]
 
+# TODO: remove packages that were required solely by building .deb files
 RUN apt-get update \
-    && apt-get install --no-install-recommends -y apt-utils sudo vim dpkg-dev devscripts gawk coreutils \
+    && apt-get install --no-install-recommends -y apt-utils sudo vim gawk coreutils \
        openssh-server openssh-client psmisc iptables iproute2 dnsmasq \
-       net-tools rsyslog equivs # qemu-system-x86
-
-RUN apt-get install --no-install-recommends -y dialog
+       net-tools rsyslog equivs equivs devscripts dpkg-dev dialog # qemu-system-x86
 
 SHELL ["/bin/bash", "-c"]
 
@@ -50,15 +49,12 @@ RUN if test $(uname -m) == aarch64; then \
 	    && apt-get install --no-install-recommends -y qemu qemu-user qemu-user-static binfmt-support; \
     fi
 
-COPY . android-cuttlefish/
+COPY ./out/*.deb ./android-cuttlefish/out/
 
-RUN cd /root/android-cuttlefish \
-    && yes | sudo mk-build-deps -i -r -B \
-    && dpkg-buildpackage -uc -us \
-    && apt-get install --no-install-recommends -y -f ../cuttlefish-common_*.deb \
-    && rm -rvf ../cuttlefish-common_*.deb \
-    && cd .. \
-    && rm -rvf android-cuttlefish
+RUN cd /root/android-cuttlefish/out \
+    && apt-get install --no-install-recommends -y -f ./cuttlefish-common_*.deb \
+    && rm -rvf ./cuttlefish-common_*.deb \
+    && cd /root
 
 # to share X with the local docker host
 RUN apt-get install -y xterm

--- a/build-android-with-docker.sh
+++ b/build-android-with-docker.sh
@@ -81,7 +81,6 @@ docker_run_opts_helper=("passing arguments to docker run, not the guest/host scr
 docker_run_opts_helper+=("  comma separated, and no space is allowed.")
 docker_run_opts_helper+=("  e.g. --rm,--privileged,-eENV,-vSRC:DIR,--name=MYNAME")
 
-
 source "shflags"
 
 DEFINE_boolean rebuild_docker_img false "Rebuild cuttlefish-android-builder image" "" "f"

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 source "shflags"
 
 DEFINE_boolean detect_gpu true "Attempt to detect the GPU vendor"
-DEFINE_boolean rebuild_debs false "Forcefully rebuild deb packages. If false, builds only when missing."
+DEFINE_boolean rebuild_debs true "Rebuild deb packages. If false, builds only when any .deb is missing in ./out/"
 
 FLAGS "$@" || exit 1
 
@@ -137,6 +137,9 @@ function is_rebuild_debs() {
 }
 
 if is_rebuild_debs; then
-    ./debs-builder-docker/build-debs-with-docker.sh
+    echo "###"
+    echo "### Building ,deb Host packages"
+    echo "###"
+    ./debs-builder-docker/build-debs-with-docker.sh --noverbose
 fi
 build_docker_image $*

--- a/debs-builder-docker/Dockerfile.debbld
+++ b/debs-builder-docker/Dockerfile.debbld
@@ -29,3 +29,4 @@ RUN useradd -ms /bin/bash vsoc-01 -d /home/vsoc-01 -u $UID \
     && passwd -d vsoc-01 \
     && echo 'vsoc-01 ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
 
+RUN mkdir -p /home/vsoc-01/host/android-cuttlefish && chown -R vsoc-01 /home/vsoc-01

--- a/debs-builder-docker/Dockerfile.debbld
+++ b/debs-builder-docker/Dockerfile.debbld
@@ -1,0 +1,31 @@
+# This file is based on https://hub.docker.com/r/jrei/systemd-debian/.
+
+FROM debian:buster-slim AS cuttlefish-hostpkg-builder
+
+ENV container docker
+ENV LC_ALL C
+ENV DEBIAN_FRONTEND noninteractive
+
+# Set up the user have the same UID as user creating the container.  This is
+# important when we map the (container) user's home directory as a docker volume.
+
+ARG UID
+
+USER root
+WORKDIR /root
+
+RUN set -x
+
+RUN apt-get update
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y apt-utils sudo vim dpkg-dev devscripts gawk coreutils equivs
+
+SHELL ["/bin/bash", "-c"]
+
+RUN useradd -ms /bin/bash vsoc-01 -d /home/vsoc-01 -u $UID \
+    && passwd -d vsoc-01 \
+    && echo 'vsoc-01 ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+

--- a/debs-builder-docker/build-debs-with-docker.sh
+++ b/debs-builder-docker/build-debs-with-docker.sh
@@ -3,11 +3,22 @@
 # at /path/to/android-cuttlefish, run like this:
 #  ./debs-builder-docker/build-debs-docker.sh
 #
-resource_subdir=debs-builder-docker
+
+source "shflags"
+
+DEFINE_boolean verbose "true" "show the stdout/stderr from the sub-tools" "v"
+
+FLAGS "$@" || exit 1
+
+if [ ${FLAGS_help} -eq ${FLAGS_TRUE} ]; then
+    exit 0
+fi
+
 # 1: host package builder's docker image tag
 # 2: host out dir where debian packages would be stored
 function build_host_debian_pkg {
   local builder_tag="$1"
+  local resource_subdir=debs-builder-docker
   docker build \
       --target "cuttlefish-hostpkg-builder" \
       -t "$builder_tag" \
@@ -20,31 +31,58 @@ function build_host_debian_pkg {
   shift 2
 
   # in guest:
-  #  build:
-  #    - android-cuttlefish (src)
-  #    - out
+  #  host:
+  #   - android-cuttlefish (copy of the host android-cuttlefish)
+  #   - out (mounted host out dir)
   # host 2 guest maps:
-  #  PWD -> build/androd-cuttlefish
-  #  PWD/out -> build/out
+  #  PWD -> host/androd-cuttlefish
+  #  PWD/out -> host/out
   #
   local guest_home="/home/vsoc-01"
-  local build_dir_on_guest="$guest_home/build"
-  local src_on_guest="$build_dir_on_guest/android-cuttlefish"
-  local script_on_guest="$src_on_guest/$resource_subdir/build-hostpkg.sh"
-  local out_on_guest="$build_dir_on_guest/out"
+  local host_dir_on_guest="$guest_home/host"
+  local src_on_guest="$host_dir_on_guest/android-cuttlefish"
+  local out_on_guest="$host_dir_on_guest/out"
+
+  local container_name="meow_yumi"
+  if ! docker run -d \
+       --rm --privileged \
+       --user="vsoc-01" -w "$guest_home" \
+       --name=$container_name \
+       -v $PWD/out:$out_on_guest \
+       -i \
+       $builder_tag; then
+      >&2 echo "fail to start the docker container, $container_name, to build deb packages"
+      exit 1
+  fi
+
+  if ! docker cp . $container_name:$src_on_guest > /dev/null 2>&1; then
+      >&2 echo "fail to copy android-cuttlefish/* to the container, $container_name"
+      exit 2
+  fi
 
   # run the script inside the guest
   # the script figures out its location in the guest file system
   # then, it does cd to the location, cd .., and run commands
-  docker run \
-         --rm --privileged \
-         --user="vsoc-01" -w "$guest_home" \
-         -v $PWD:$src_on_guest \
-         -v $PWD/out:$out_on_guest \
-         -t $hostpkg_builder \
-         $script_on_guest $out_on_guest
+  local script_on_guest="$src_on_guest/$resource_subdir/build-hostpkg.sh"
+  if ! docker exec \
+       --privileged \
+       --user="vsoc-01" -w "$guest_home" \
+       $container_name $script_on_guest $out_on_guest; then
+      >&2 echo "fail to exec/attach to the container, $container_name, running in background"
+      exit 3
+  fi
+
+  if ! docker rm -f $container_name > /dev/null 2>&1; then
+      >&2 echo "fail to clean up to the container"
+      exit 4
+  fi
 }
 
 hostpkg_builder="cuttlefish-deb-builder"
 hostpkg_out_dir="$PWD/out"
-build_host_debian_pkg $hostpkg_builder $hostpkg_out_dir
+if [ ${FLAGS_verbose} -eq ${FLAGS_TRUE} ]; then
+    build_host_debian_pkg $hostpkg_builder $hostpkg_out_dir
+else
+    build_host_debian_pkg $hostpkg_builder $hostpkg_out_dir > /dev/null 2>&1
+fi
+

--- a/debs-builder-docker/build-debs-with-docker.sh
+++ b/debs-builder-docker/build-debs-with-docker.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# at /path/to/android-cuttlefish, run like this:
+#  ./debs-builder-docker/build-debs-docker.sh
+#
+resource_subdir=debs-builder-docker
+# 1: host package builder's docker image tag
+# 2: host out dir where debian packages would be stored
+function build_host_debian_pkg {
+  local builder_tag="$1"
+  docker build \
+      --target "cuttlefish-hostpkg-builder" \
+      -t "$builder_tag" \
+      -f $resource_subdir/Dockerfile.debbld \
+      $PWD \
+       --build-arg UID="${UID}" \
+       --build-arg OEM="${OEM}"
+
+  local out_on_host="$2"
+  shift 2
+
+  # in guest:
+  #  build:
+  #    - android-cuttlefish (src)
+  #    - out
+  # host 2 guest maps:
+  #  PWD -> build/androd-cuttlefish
+  #  PWD/out -> build/out
+  #
+  local guest_home="/home/vsoc-01"
+  local build_dir_on_guest="$guest_home/build"
+  local src_on_guest="$build_dir_on_guest/android-cuttlefish"
+  local script_on_guest="$src_on_guest/$resource_subdir/build-hostpkg.sh"
+  local out_on_guest="$build_dir_on_guest/out"
+
+  # run the script inside the guest
+  # the script figures out its location in the guest file system
+  # then, it does cd to the location, cd .., and run commands
+  docker run \
+         --rm --privileged \
+         --user="vsoc-01" -w "$guest_home" \
+         -v $PWD:$src_on_guest \
+         -v $PWD/out:$out_on_guest \
+         -t $hostpkg_builder \
+         $script_on_guest $out_on_guest
+}
+
+hostpkg_builder="cuttlefish-deb-builder"
+hostpkg_out_dir="$PWD/out"
+build_host_debian_pkg $hostpkg_builder $hostpkg_out_dir

--- a/debs-builder-docker/build-hostpkg.sh
+++ b/debs-builder-docker/build-hostpkg.sh
@@ -34,4 +34,3 @@ function build() {
 
 build
 [[ $is_mv_debs == "true" ]] && cp -f $cuttlefish_root/../*.deb ${outdir}/
-

--- a/debs-builder-docker/build-hostpkg.sh
+++ b/debs-builder-docker/build-hostpkg.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# start preparation
+script_location=`realpath -s $(dirname ${BASH_SOURCE[0]})`
+cuttlefish_root=$(realpath -s $script_location/..)
+
+# intended to make "path/ to path"
+# while leaving "path" or "/" as is
+function remove_trailing_slash() {
+    local outdir="$1"
+    if [[ "$1" == "/" ]]; then
+        echo "${outdir}"
+    else
+        echo "${outdir%/}"
+    fi
+}
+
+outdir=$(remove_trailing_slash $1)
+shift 1
+
+is_mv_debs="true"
+[[ "$outdir" == "" ]] && is_mv_debs="false"
+
+#end of preparation
+
+function build() {
+    pushd $cuttlefish_root > /dev/null 2>&1
+    yes | sudo mk-build-deps -i -r -B \
+        && sudo dpkg-buildpackage -uc -us \
+        && sudo chown $(id -u) ../*.deb
+    popd > /dev/null 2>&1
+}
+#sudo apt-get install --no-install-recommends -y -f ${outdir}/cuttlefish-common_*.deb
+
+build
+[[ $is_mv_debs == "true" ]] && cp -f $cuttlefish_root/../*.deb ${outdir}/
+


### PR DESCRIPTION
So far, when it comes to build the host .deb packages, we have had slightly different instructions here and there. For example, the commands in the Dockerfile here is different from what we have in device/google/cuttlefish at the AOSP. 

Now, it can be done by git clone & run the script where docker build & run is available. 

The existing build.sh is either build the .deb files, or re-use those that are already available. If the files are not available or --rebuild_debs is given, then, build.sh (re)builds the .deb files.