### PR TITLE
--detect_gpu should be allowed for Debian based systems only for now

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,23 @@
 #!/bin/bash
 
+# tell if the distro is Debian
+function is_debian_distro {
+  if [[ -f /etc/debian_version ]]; then
+      return 0
+  fi
+  # debian based distro mostly have /etc/debian_version
+  # if ever not, use the whitelists
+  if ls -1 /etc/*release | egrep "(debian|buntu|mint)" > /dev/null 2>&1; then
+      return 0
+  fi
+  return 1
+}
+
 source "shflags"
 
-DEFINE_boolean detect_gpu true "Attempt to detect the GPU vendor"
+DEFINE_boolean detect_gpu \
+               "$(is_debian_distro && echo true || echo false)" \
+               "Attempt to detect the GPU vendor"
 
 FLAGS "$@" || exit 1
 
@@ -23,17 +38,21 @@ function detect_gpu {
   done
 }
 
-
 OEM=
 if [[ ${FLAGS_detect_gpu} -eq ${FLAGS_TRUE} ]]; then
-  OEM=$(detect_gpu)
-else
+  if is_debian_distro; then
+      OEM=$(detect_gpu)
+  else
+      echo "Warning: --detect_gpu works only on Debian-based systems"
+      echo
+  fi
+fi
+
+if [ -z "${OEM}" ]; then
   echo "###"
   echo "### Building without physical-GPU support"
   echo "###"
-fi
-
-if [ -n "${OEM}" ]; then
+else
   echo "###"
   echo "### GPU is ${OEM}"
   echo "###"


### PR DESCRIPTION
This blocks --detect_gpu when the host is not Debian-based system. Currently, the scripts do not work when it's not.

We are to give the warning message that ignores --detect_gpu unless the host is not based on Debian, and to let it proceed with --nodetec_gpu. 

Also, defaulting --detect_gpu on non-Debian systems might not make sense. Thus, the default value is "true" if it's Debian or its variant, and "false" otherwise.