### PR TITLE
BUILDING.md should change accordingly to the new download-aosp script

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -176,15 +176,18 @@ scp *.img vsoc-01@${ip_cuttlefish}:~/
 As an aid, if you would like to fetch the latest Cuttlefish build from AOSP:
 
 ```bash
-ssh vsoc-01@${ip_cuttlefish} -- './download-aosp $(uname -m)'
+ssh vsoc-01@${ip_cuttlefish} -- './download-aosp -A -C -a $(uname -m)'
 ```
 
+-A and -C respectively enable the download of Android images and the
+host package. -a indicates the architecture.
+
 Note that if you want to run Cuttlefish built for x86, you will probably have to
-invoke ./download-aosp with the argument 'x86', since your machine will most
+invoke ./download-aosp with the arguments -a 'x86', since your machine will most
 likely be 'x86_64':
 
 ```bash
-ssh vsoc-01@${ip_cuttlefish} -- './download-aosp x86'
+ssh vsoc-01@${ip_cuttlefish} -- './download-aosp  -A -C -a x86'
 ```
 
 # Launching Cuttlefish inside a container


### PR DESCRIPTION
Iliyan changed the arguments formats of the download-aosp script. xargs egrep shows that BUILDING.md is the only file that refers the name. BUILDING.md file has, however, the old usage of the script. Should change. 