### PR TITLE
Add QEMU to host package on GCE machines

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cuttlefish-common (0.9.15) stable; urgency=medium
+
+  [ Ram Muthiah ]
+  * Add QEMU to GCE package to enable QEMU CI testing
+
+ -- Ram Muthiah <rammuthiah@google.com>  Mon, 26 Oct 2020 10:53:54 -0700
+
 cuttlefish-common (0.9.14) stable; urgency=medium
 
   [ Jorge E. Moreira ]

--- a/debian/control
+++ b/debian/control
@@ -37,6 +37,8 @@ Description: Cuttlefish Android Virtual Device companion package
 Package: cuttlefish-integration
 Architecture: any
 Depends: cuttlefish-common,
+         qemu-system-arm (>= 2.8.0),
+         qemu-system-x86 (>= 2.8.0),
          ${shlibs:Depends},
          ${misc:Depends}
 Pre-Depends: ${misc:Pre-Depends}


### PR DESCRIPTION
Needed to enable QEMU runs of cuttlefish in CI.