### PR TITLE
Add Ethernet bridge

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cuttlefish-common (0.9.17) stable; urgency=medium
+
+  [ Alistair Delva ]
+  * Networking improvements to support Ethernet interfaces
+
+ -- Alistair Delva <adelva@google.com>  Tue, 10 Nov 2020 09:03:37 -0700
+
 cuttlefish-common (0.9.16) stable; urgency=medium
 
   [ Ram Muthiah ]

--- a/debian/cuttlefish-common.default
+++ b/debian/cuttlefish-common.default
@@ -3,14 +3,15 @@
 # Maximum number of concurrent CVDs runnable on this machine.
 #num_cvd_accounts=10
 
-# Network bridge to use with the cuttlefish wifi tap devices. By default,
-# we will create and destroy a managed bridge called 'cvd-wbr' but all
-# interfaces comprising this bridge will be NAT'ed, and IPv6 will not
-# be configured. Setting a preconfigured bridge interface here (usually
-# with just one physical ethernet controller in it) suppresses bridge
-# management, and instead adds the cuttlefish wifi tap devices the
-# specified bridge. By specifying a network interface here, you can
-# disable IPv4 or IPv6 bridging with 'ipv4_bridge' and 'ipv6_bridge'.
+# Network bridge to use with the cuttlefish wifi and ethernet tap devices.
+# By default, we will create and destroy managed bridges called 'cvd-wbr'
+# and 'cvd-ebr' but all interfaces comprising these bridges will be
+# NAT'ed, and IPv6 will not be configured. Setting a preconfigured bridge
+# interface here (usually with just one physical ethernet controller in it)
+# suppresses bridge management, and instead adds the cuttlefish wifi and
+# ethernet tap devices to the specified bridge. By specifying a network
+# interface here, you can disable IPv4 or IPv6 bridging with 'ipv4_bridge'
+# and 'ipv6_bridge'.
 #bridge_interface=
 
 # IPv4 bridging. Defaults on. Requires 'bridge_interface' to be set,

--- a/debian/cuttlefish-common.init
+++ b/debian/cuttlefish-common.init
@@ -34,23 +34,16 @@ if [ -f /etc/default/cuttlefish-common ]; then
     . /etc/default/cuttlefish-common
 fi
 
-if [ -z "${num_cvd_accounts}" ]; then
-    num_cvd_accounts=10
-fi
-if [ -z "${bridge_interface}" ]; then
-    bridge_interface=cvd-wbr
-fi
-if [ -z "${ipv4_bridge}" ]; then
-    ipv4_bridge=1
-fi
-if [ -z "${ipv6_bridge}" ]; then
-    ipv6_bridge=1
-fi
-if [ -z "${dns_servers}" ]; then
-    dns_servers="8.8.8.8,8.8.4.4"
-fi
-if [ -z "${dns6_servers}" ]; then
-    dns6_servers="2001:4860:4860::8888,2001:4860:4860::8844"
+num_cvd_accounts=${num_cvd_accounts:-10}
+wifi_bridge_interface=${bridge_interface:-cvd-wbr}
+ethernet_bridge_interface=${bridge_interface:-cvd-ebr}
+ipv4_bridge=${ipv4_bridge:-1}
+ipv6_bridge=${ipv4_bridge:-1}
+dns_servers=${dns_servers:-8.8.8.8,8.8.4.4}
+dns6_servers=${dns6_servers:-2001:4860:4860::8888,2001:4860:4860::8844}
+
+if [ -z ${bridge_interface} ]; then
+  create_bridges=1
 fi
 
 # Newer distros prefer nft, but broute is not supported, so use
@@ -134,19 +127,20 @@ destroy_mobile_interface() {
     destroy_tap "${tap}"
 }
 
-# Create many wireless tap devices on a single bridge
+# Create many tap devices on a single bridge (wifi or ethernet)
 # $1 = ip address base ("a.b.c")
-create_wireless_interfaces() {
-    if [ "${bridge_interface}" = "cvd-wbr" ]; then
-        ip link add name "${bridge_interface}" \
-          type bridge forward_delay 0 stp_state 0
-        ip link set dev "${bridge_interface}" up
+# $2 = bridge interface name
+# $3 = tap base name
+create_bridged_interfaces() {
+    if [ "${create_bridges}" = "1" ]; then
+        ip link add name "${2}" type bridge forward_delay 0 stp_state 0
+        ip link set dev "${2}" up
     fi
     for i in $(seq ${num_cvd_accounts}); do
-        tap="$(printf cvd-wtap-%02d $i)"
+        tap="$(printf ${3}-%02d $i)"
         create_tap "${tap}"
-        ip link set dev "${tap}" master "${bridge_interface}"
-        if [ "${bridge_interface}" != "cvd-wbr" ]; then
+        ip link set dev "${tap}" master "${2}"
+        if [ "${create_bridges}" != "1" ]; then
             if [ "$ipv4_bridge" != "1" ]; then
                 $ebtables -t broute -A BROUTING -p ipv4 --in-if  "${tap}" -j DROP
                 $ebtables -t filter -A FORWARD  -p ipv4 --out-if "${tap}" -j DROP
@@ -157,31 +151,33 @@ create_wireless_interfaces() {
             fi
         fi
     done
-    if [ "${bridge_interface}" = "cvd-wbr" ]; then
+    if [ "${create_bridges}" = "1" ]; then
         gateway="${1}.1"
         netmask="/24"
         network="${1}.0${netmask}"
         dhcp_range="${1}.2,${1}.255"
-        ip addr add "${gateway}${netmask}" broadcast + dev "${bridge_interface}"
-        start_dnsmasq "${bridge_interface}" "${gateway}" "${dhcp_range}"
+        ip addr add "${gateway}${netmask}" broadcast + dev "${2}"
+        start_dnsmasq "${2}" "${gateway}" "${dhcp_range}"
         iptables -t nat -A POSTROUTING -s "${network}" -j MASQUERADE
     fi
 }
 
-# Destroy many wireless tap devices and a single bridge
+# Destroy many tap devices and a single bridge (wifi or ethernet)
 # $1 = ip address base ("a.b.c")
-destroy_wireless_interfaces() {
-    if [ "${bridge_interface}" = "cvd-wbr" ]; then
+# $2 = bridge interface name
+# $3 = tap base name
+destroy_bridged_interfaces() {
+    if [ "${create_bridges}" = "1" ]; then
         gateway="${1}.1"
         netmask="/24"
         network="${1}.0${netmask}"
         iptables -t nat -D POSTROUTING -s "${network}" -j MASQUERADE
-        stop_dnsmasq "${bridge_interface}"
-        ip addr del "${gateway}${netmask}" dev "${bridge_interface}"
+        stop_dnsmasq "${2}"
+        ip addr del "${gateway}${netmask}" dev "${2}"
     fi
     for i in $(seq ${num_cvd_accounts}); do
-        tap="$(printf cvd-wtap-%02d $i)"
-        if [ "${bridge_interface}" != "cvd-wbr" ]; then
+        tap="$(printf ${3}-%02d $i)"
+        if [ "${create_bridges}" != "1" ]; then
             if [ "$ipv4_bridge" != "1" ]; then
                 $ebtables -t filter -D FORWARD  -p ipv4 --out-if "${tap}" -j DROP
                 $ebtables -t broute -D BROUTING -p ipv4 --in-if  "${tap}" -j DROP
@@ -193,9 +189,9 @@ destroy_wireless_interfaces() {
         fi
         destroy_tap "${tap}"
     done
-    if [ "${bridge_interface}" = "cvd-wbr" ]; then
-        ip link set dev "${bridge_interface}" down
-        ip link delete "${bridge_interface}"
+    if [ "${create_bridges}" = "1" ]; then
+        ip link set dev "${2}" down
+        ip link delete "${2}"
     fi
 }
 
@@ -203,10 +199,11 @@ start() {
     # Enable ip forwarding
     echo 1 >/proc/sys/net/ipv4/ip_forward
 
-    create_wireless_interfaces 192.168.96
+    create_bridged_interfaces 192.168.96 ${wifi_bridge_interface} cvd-wtap
     for i in $(seq ${num_cvd_accounts}); do
         create_mobile_interface $i 192.168.97
     done
+    create_bridged_interfaces 192.168.98 ${ethernet_bridge_interface} cvd-etap
 
     # When running inside a privileged container, set the ownership and access
     # of these device nodes.
@@ -224,10 +221,11 @@ start() {
 }
 
 stop() {
+    destroy_bridged_interfaces 192.168.98 ${ethernet_bridge_interface} cvd-etap
     for i in $(seq ${num_cvd_accounts}); do
         destroy_mobile_interface $i 192.168.97
     done
-    destroy_wireless_interfaces 192.168.96
+    destroy_bridged_interfaces 192.168.96 ${wifi_bridge_interface} cvd-wtap
 }
 
 usage() {


### PR DESCRIPTION
Create an Ethernet bridge ("cvd-ebr") alongside the existing wifi bridge
("cvd-wbr") and corresponding tap devices ("cvd-etap-X") for each
instance. This enables a wired ethernet connection to be assigned to
each virtual device and for the networks to be isolated on the host.

If the user wants to bridge with an existing interface, the wifi and
ethernet are bridged together for simplicity, and there is no network
isolation.

Signed-off-by: Alistair Delva <adelva@google.com>