### PR TITLE
Add udev rules for /dev/tpm* devices for cuttlefish-integration.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,7 +3,10 @@ cuttlefish-common (0.9.17) stable; urgency=medium
   [ Alistair Delva ]
   * Networking improvements to support Ethernet interfaces
 
- -- Alistair Delva <adelva@google.com>  Tue, 10 Nov 2020 09:03:37 -0700
+  [ A. Cody Schuffelen ]
+  * Grant access to /dev/tpm for the secure environment code
+
+ -- Cody Schuffelen <schuffelen@google.com>  Fri, 13 Nov 2020 13:35:59 -0800
 
 cuttlefish-common (0.9.16) stable; urgency=medium
 

--- a/debian/cuttlefish-integration.udev
+++ b/debian/cuttlefish-integration.udev
@@ -1,0 +1,2 @@
+KERNEL=="tpm[0-9]*", MODE="0660", OWNER="tss", GROUP="cvdnetwork"
+KERNEL=="tpmrm[0-9]*", MODE="0660", OWNER="tss", GROUP="cvdnetwork"


### PR DESCRIPTION
This will likely conflict with desktop / workstation use cases, so the change is made to cuttlefish-integration (cloud environment) rather than cuttlefish-common (cloud environment + local environment).

Test: device/google/cuttlefish/tools/create_base_image.sh , `ls -l /dev/tpm0`