### PR TITLE
Let the user know that using WebRTC requires socat

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -311,3 +311,5 @@ connect (on the same machine as the docker container) by pointing your browser
 at https://localhost:8443/
 
 WebRTC allows you to control cuttlefish inside the docker container without ssh tunnel.
+
+Using WebRTC requires installing `socat` binary to the host.


### PR DESCRIPTION
I do not yet know how to install the binary, but after cvd_publish I get constant errors where nohup socat fails to run, so I assume socat is required.

```
petri@test-petri:~/android-cuttlefish$ cvd_publish_cuttlefish 0
[1]   Exit 127                nohup socat tcp4-listen:"$1",fork TCP:"$2":"$3" > /dev/null 2>&1
[2]   Exit 127                nohup socat tcp4-listen:"$1",fork TCP:"$2":"$3" > /dev/null 2>&1
```