### PR TITLE
Added -v and an option to skip Google Chrome download in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN if test $(uname -m) == aarch64; then \
 	    && apt-get install --no-install-recommends -y qemu qemu-user qemu-user-static binfmt-support; \
     fi
 
+# host packages and google-chrome (google-chrome*.deb)
 COPY ./out/*.deb ./android-cuttlefish/out/
 
 RUN cd /root/android-cuttlefish/out \
@@ -58,13 +59,14 @@ RUN cd /root/android-cuttlefish/out \
 
 # to share X with the local docker host
 RUN apt-get install -y xterm
-
 RUN apt-get install -y curl wget unzip
 
 # to run cuttlefish docker in foreground, and test via webrtc/VNC
 RUN apt-get install -y tigervnc-viewer
-RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-RUN apt-get install -y ./google-chrome-stable_current_amd64.deb && rm -f ./google-chrome-stable_current_amd64.deb
+RUN cd /root/android-cuttlefish/out \
+    && apt-get install -y ./google-chrome*.deb \
+    && rm -f ./google-chrome-stable_current_amd64.deb \
+    && cd /root
 
 RUN apt-get clean
 

--- a/utils.sh
+++ b/utils.sh
@@ -206,3 +206,26 @@ set -o errexit
     done
   done
 }
+
+# return if this is exactly Debian Linux
+function is_debian {
+  if [[ -f /etc/debian_version ]]; then
+      return 0
+  fi
+  if ls -1 /etc/*release | egrep -i "(debian)" > /dev/null 2>&1; then
+    return 0
+  fi
+  return 1
+}
+
+# tell if the distro is Debian series
+function is_debian_series {
+  if is_debian; then
+    return 0
+  fi
+  # if ever not Debian, use the whitelists
+  if ls -1 /etc/*release | egrep -i "(debian|buntu|mint)" > /dev/null 2>&1; then
+      return 0
+  fi
+  return 1
+}


### PR DESCRIPTION
The change is for cuttlefish docker container developers. Google Chrome
is downloaded offline, and copied into the image during docker build.
The dowload can be skipped optionally.

Also, added -v option for verbose. --noverbose will run build.sh silently
except any output to stderr.