### PR TITLE
Add grub-efi dependency to cuttlefish-common

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -18,7 +18,10 @@ cuttlefish-common (0.9.18) UNRELEASED; urgency=medium
   [ A. Cody Schuffelen ]
   * Enable nested virtualization for cuttlefish-integration.
 
- -- A. Cody Schuffelen <schuffelen@google.com>  Mon, 08 Mar 2021 18:00:53 -0800
+  [ Alistair Delva ]
+  * Add grub-efi dependency to cuttlefish-common
+
+ -- Alistair Delva <adelva@google.com>  Tue, 09 Mar 2021 08:01:20 -0800
 
 cuttlefish-common (0.9.17) stable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -8,10 +8,12 @@ Standards-Version: 4.5.0
 
 Package: cuttlefish-common
 Architecture: any
-Depends: binfmt-support [!amd64],
+Depends: binfmt-support [arm64],
          bridge-utils,
          dnsmasq-base,
          f2fs-tools,
+         grub-efi-arm64-bin [arm64],
+         grub-efi-ia32-bin [!arm64],
          iptables,
          libarchive-tools | bsdtar,
          libdrm2,
@@ -25,8 +27,8 @@ Depends: binfmt-support [!amd64],
          lsb-base,
          net-tools,
          python2.7,
-         qemu-user-static [!amd64],
-         libc6:amd64 [!amd64],
+         qemu-user-static [arm64],
+         libc6:amd64 [arm64],
          ${misc:Depends},
          ${shlibs:Depends}
 Pre-Depends: ${misc:Pre-Depends}


### PR DESCRIPTION
Ensure that at least the bootloader binaries for the native architecture
are installed, so that Other OS mode can work. For cases where
non-native targets are supported (such as QEMU TCG) the user will have
to install the extra needed bootloader binaries manually.

This inverts some checks for '!amd64' to be 'arm64', though in practice
it shouldn't matter too much as cuttlefish cannot run on 32-bit arm or
32-bit x86 presently.