### PR TITLE
Work around hosts that use cgroups v2

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -390,12 +390,13 @@ function cvd_docker_create {
 
         echo "Starting container ${name} (id ${cf_instance}) from image cuttlefish.";
 	    docker run -d ${as_host_x[@]} \
+		        --cgroupns=host \
 		        --name "${name}" -h "${name}" \
                 -l "cf_instance=${cf_instance}" \
                 -l "n_cf_instances=${n_cf_instances}" \
                 -l "vsock_guest_cid=${vsock_guest_cid}" \
 		        --privileged \
-		        -v /sys/fs/cgroup:/sys/fs/cgroup:ro ${volumes[@]} \
+		        -v /sys/fs/cgroup:/sys/fs/cgroup:rw ${volumes[@]} \
 		        cuttlefish
 
 	    echo "Waiting for ${name} to boot."


### PR DESCRIPTION
The systemd in the container uses v1; until we move the debian distro
forward, we'll need to have the host adapt.

Requires docker engine version 20.10.0+.  Older docker installs would
need to use dockerd --default-cgroupns-mode=host.

C.f.:
https://serverfault.com/questions/1053187/systemd-fails-to-run-in-a-docker-container-when-using-cgroupv2-cgroupns-priva

Signed-off-by: Iliyan Malchev <malchev@gmail.com>