### PR TITLE
 Add partial implementation of host orchestrator

### DIFF
--- a/host/frontend/host-orchestrator/clients.go
+++ b/host/frontend/host-orchestrator/clients.go
@@ -23,7 +23,7 @@ import (
 
 type Client interface {
 	// Send a message to the device
-	Send(msg interface{}) bool
+	Send(msg interface{}) error
 	// Provides an oportunity for the client to react to the device being disconnected
 	OnDeviceDisconnected()
 }
@@ -38,7 +38,7 @@ func NewWsClient(ws *JsonWs) *WsClient {
 }
 
 // From IClient
-func (c *WsClient) Send(msg interface{}) bool {
+func (c *WsClient) Send(msg interface{}) error {
 	return c.ws.Send(msg)
 }
 func (c *WsClient) OnDeviceDisconnected() {
@@ -60,11 +60,11 @@ type PolledClient struct {
 }
 
 // From IClient
-func (c *PolledClient) Send(msg interface{}) bool {
+func (c *PolledClient) Send(msg interface{}) error {
 	c.msgMtx.Lock()
 	defer c.msgMtx.Unlock()
 	c.messages = append(c.messages, msg)
-	return true
+	return nil
 }
 func (c *PolledClient) OnDeviceDisconnected() {
 	// This object is useless when the device disconnects, release all resourcess associated to it
@@ -72,7 +72,7 @@ func (c *PolledClient) OnDeviceDisconnected() {
 }
 
 // Sends a message to the device
-func (c *PolledClient) ToDevice(msg interface{}) bool {
+func (c *PolledClient) ToDevice(msg interface{}) error {
 	return c.device.Send(msg)
 }
 

--- a/host/frontend/host-orchestrator/clients.go
+++ b/host/frontend/host-orchestrator/clients.go
@@ -1,0 +1,141 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+//     Unless required by applicable law or agreed to in writing, software
+//     distributed under the License is distributed on an "AS IS" BASIS,
+//     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+//     limitations under the License.
+
+package main
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// Implements the client interface using a websocket connection
+type WsClient struct {
+	ws *JsonWs
+}
+
+func NewWsClient(ws *JsonWs) *WsClient {
+	return &WsClient{ws: ws}
+}
+
+// From IClient
+func (c *WsClient) Send(msg interface{}) bool {
+	return c.ws.Send(msg)
+}
+func (c *WsClient) OnDeviceDisconnected() {
+	// Do nothing
+}
+
+// Implements the client interface using a polled connection
+type PolledClient struct {
+	// The polled connection id
+	id       string
+	device   *Device
+	messages []interface{}
+	// Synchronizes access to the messages list
+	msgMtx sync.Mutex
+	// The id given to this client by the device
+	clientId int
+	// A reference to the polled set to clean up when the device disconnects
+	set *PolledSet
+}
+
+// From IClient
+func (c *PolledClient) Send(msg interface{}) bool {
+	c.msgMtx.Lock()
+	defer c.msgMtx.Unlock()
+	c.messages = append(c.messages, msg)
+	return true
+}
+func (c *PolledClient) OnDeviceDisconnected() {
+	// This object is useless when the device disconnects, release all resourcess associated to it
+	c.set.Destroy(c.id)
+}
+
+// Sends a message to the device
+func (c *PolledClient) ToDevice(msg interface{}) bool {
+	return c.device.Send(msg)
+}
+
+// Gets count messages from the device, skipping the first start messages
+func (c *PolledClient) GetMessages(start int, count int) []interface{} {
+	c.msgMtx.Lock()
+	defer c.msgMtx.Unlock()
+	if count < 0 {
+		count = len(c.messages) - start
+	}
+	end := start + count
+	if end > len(c.messages) {
+		end = len(c.messages)
+	}
+	// Safe to return slice because c.messages is never shrunk
+	return c.messages[start:end]
+}
+
+func (c *PolledClient) Id() string {
+	return c.id
+}
+
+func (c *PolledClient) ClientId() int {
+	return c.clientId
+}
+
+// Basically a map of polled clients by id. This is necessary because polled
+// connections are not handled in an exclusive thread like those based on websockets.
+type PolledSet struct {
+	connections map[string]*PolledClient
+	mapMtx      sync.Mutex
+}
+
+func (s *PolledSet) NewConnection(d *Device) *PolledClient {
+	s.mapMtx.Lock()
+	defer s.mapMtx.Unlock()
+	for {
+		id := randStr(64)
+		if _, ok := s.connections[id]; !ok {
+			conn := &PolledClient{id: id, device: d, messages: make([]interface{}, 0), set: s}
+			s.connections[id] = conn
+			conn.clientId = d.Register(conn)
+			return conn
+		}
+	}
+}
+
+func (s *PolledSet) GetConnection(id string) *PolledClient {
+	s.mapMtx.Lock()
+	defer s.mapMtx.Unlock()
+	return s.connections[id]
+}
+
+func (s *PolledSet) Destroy(id string) {
+	s.mapMtx.Lock()
+	defer s.mapMtx.Unlock()
+	delete(s.connections, id)
+}
+
+func NewPolledSet() *PolledSet {
+	rand.Seed(time.Now().UnixNano())
+	return &PolledSet{connections: make(map[string]*PolledClient)}
+}
+
+// The available characters for the connection ids
+const runes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+func randStr(l int) string {
+	s := make([]byte, l)
+	for i := range s {
+		s[i] = runes[rand.Intn(len(runes))]
+	}
+	return string(s)
+}

--- a/host/frontend/host-orchestrator/clients_test.go
+++ b/host/frontend/host-orchestrator/clients_test.go
@@ -1,0 +1,100 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+//     Unless required by applicable law or agreed to in writing, software
+//     distributed under the License is distributed on an "AS IS" BASIS,
+//     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+//     limitations under the License.
+
+package main
+
+import (
+	"testing"
+)
+
+func TestNewPolledConnection(t *testing.T) {
+	ps := NewPolledSet()
+	c1 := ps.NewConnection(NewDevice(nil, 0, ""))
+	if c1 == nil {
+		t.Error("Failed to create polled connection")
+	}
+	c2 := ps.NewConnection(NewDevice(nil, 0, ""))
+	if c2 == nil {
+		t.Error("Failed to create polled connection")
+	}
+	if c1.Id() == c2.Id() {
+		t.Error("Polled connections have the same id")
+	}
+}
+
+func TestGetConnection(t *testing.T) {
+	ps := NewPolledSet()
+	c1 := ps.NewConnection(NewDevice(nil, 0, ""))
+	if ps.GetConnection(c1.Id()) != c1 {
+		t.Error("Failed to get connection by id")
+	}
+	if ps.GetConnection(c1.Id()+"some suffix") == c1 {
+		t.Error("Returned connection with wrong id")
+	}
+	c2 := ps.NewConnection(NewDevice(nil, 0, ""))
+	if ps.GetConnection(c1.Id()) == c2 || ps.GetConnection(c2.Id()) == c1 {
+		t.Error("Returned the wrong connection")
+	}
+	ps.Destroy(c2.Id())
+	if ps.GetConnection(c2.Id()) != nil {
+		t.Error("Returned unregistered connection")
+	}
+	// should have no effect
+	ps.Destroy(c2.Id())
+	if ps.GetConnection(c1.Id()) != c1 {
+		t.Error("Failed to get connection after destruction of another")
+	}
+}
+
+func TestMessages(t *testing.T) {
+	ps := NewPolledSet()
+	c := ps.NewConnection(NewDevice(nil, 0, ""))
+	msgs := c.GetMessages(0, -1)
+	if len(msgs) != 0 {
+		t.Error("Returned messages")
+	}
+	c.Send("msg1")
+	c.Send("msg2")
+	c.Send("msg3")
+	msgs = c.GetMessages(0, -1)
+	if len(msgs) != 3 || msgs[0] != "msg1" || msgs[2] != "msg3" {
+		t.Error("Failed to return all messages: ", msgs)
+	}
+	msgs = c.GetMessages(1, 1)
+	if len(msgs) != 1 && msgs[0] != "msg2" {
+		t.Error("Failed to return message range: ", msgs)
+	}
+}
+
+func TestDestroy(t *testing.T) {
+	ps := NewPolledSet()
+	c := ps.NewConnection(NewDevice(nil, 0, ""))
+	c.OnDeviceDisconnected()
+	if ps.GetConnection(c.Id()) != nil {
+		t.Error("connection was not destroyed after device disconnect")
+	}
+}
+
+func TestRandStr(t *testing.T) {
+	s1 := randStr(1)
+	if len(s1) != 1 {
+		t.Error("Returned string of wrong length")
+	}
+	s1 = randStr(100)
+	s2 := randStr(100)
+	if s1 == s2 {
+		// The probability of this happening without a bug is 1 in 62^100
+		t.Error("randStr returned two equal strings of len 100")
+	}
+}

--- a/host/frontend/host-orchestrator/clients_test.go
+++ b/host/frontend/host-orchestrator/clients_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"math/rand"
 	"testing"
 )
 
@@ -87,6 +88,7 @@ func TestDestroy(t *testing.T) {
 }
 
 func TestRandStr(t *testing.T) {
+	rand.Seed(1)
 	s1 := randStr(1)
 	if len(s1) != 1 {
 		t.Error("Returned string of wrong length")

--- a/host/frontend/host-orchestrator/devices.go
+++ b/host/frontend/host-orchestrator/devices.go
@@ -23,7 +23,6 @@ import (
 )
 
 type Device struct {
-	id   string
 	info interface{}
 	ws   *JsonWs
 	// Reverse proxy to the client files
@@ -35,7 +34,7 @@ type Device struct {
 	clientCount int
 }
 
-func NewDevice(ws *JsonWs, id string, port int, info interface{}) *Device {
+func NewDevice(ws *JsonWs, port int, info interface{}) *Device {
 	url, err := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", port))
 	if err != nil {
 		// This should not happen
@@ -43,7 +42,7 @@ func NewDevice(ws *JsonWs, id string, port int, info interface{}) *Device {
 		return nil
 	}
 	proxy := httputil.NewSingleHostReverseProxy(url)
-	return &Device{id: id, ws: ws, Proxy: proxy, info: info, clients: make(map[int]Client), clientCount: 0}
+	return &Device{ws: ws, Proxy: proxy, info: info, clients: make(map[int]Client), clientCount: 0}
 }
 
 // Sends a message to the device

--- a/host/frontend/host-orchestrator/devices.go
+++ b/host/frontend/host-orchestrator/devices.go
@@ -22,13 +22,6 @@ import (
 	"sync"
 )
 
-type Client interface {
-	// Send a message to the device
-	Send(msg interface{}) bool
-	// Provides an oportunity for the client to react to the device being disconnected
-	OnDeviceDisconnected()
-}
-
 type Device struct {
 	id   string
 	info interface{}

--- a/host/frontend/host-orchestrator/devices.go
+++ b/host/frontend/host-orchestrator/devices.go
@@ -68,7 +68,10 @@ func (d *Device) Unregister(id int) {
 // Notify the clients that the device has disconnected
 func (d *Device) DisconnectClients() {
 	d.clientsMtx.Lock()
-	clientsCopy := d.clients
+	clientsCopy := make([]Client, 0, len(d.clients))
+	for _, client := range d.clients {
+		clientsCopy = append(clientsCopy, client)
+	}
 	d.clientsMtx.Unlock()
 	for _, client := range clientsCopy {
 		client.OnDeviceDisconnected()

--- a/host/frontend/host-orchestrator/devices.go
+++ b/host/frontend/host-orchestrator/devices.go
@@ -1,0 +1,143 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+//     Unless required by applicable law or agreed to in writing, software
+//     distributed under the License is distributed on an "AS IS" BASIS,
+//     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+//     limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http/httputil"
+	"net/url"
+	"sync"
+)
+
+type Client interface {
+	// Send a message to the device
+	Send(msg interface{}) bool
+	// Provides an oportunity for the client to react to the device being disconnected
+	OnDeviceDisconnected()
+}
+
+type Device struct {
+	id   string
+	info interface{}
+	ws   *JsonWs
+	// Reverse proxy to the client files
+	Proxy *httputil.ReverseProxy
+	// Synchronizes access to the client list and the client count
+	clientsMtx sync.Mutex
+	clients    map[int]Client
+	// Historical client count, it doesn't decrease when clients unregister. It's used to generate client ids.
+	clientCount int
+}
+
+func NewDevice(ws *JsonWs, id string, port int, info interface{}) *Device {
+	url, err := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", port))
+	if err != nil {
+		// This should not happen
+		log.Fatal("Unable to parse hard coded url: ", err)
+		return nil
+	}
+	proxy := httputil.NewSingleHostReverseProxy(url)
+	return &Device{id: id, ws: ws, Proxy: proxy, info: info, clients: make(map[int]Client), clientCount: 0}
+}
+
+// Sends a message to the device
+func (d *Device) Send(msg interface{}) bool {
+	return d.ws.Send(msg)
+}
+
+func (d *Device) Register(c Client) int {
+	d.clientsMtx.Lock()
+	defer d.clientsMtx.Unlock()
+	d.clientCount += 1
+	d.clients[d.clientCount] = c
+	return d.clientCount
+}
+
+func (d *Device) Unregister(id int) {
+	d.clientsMtx.Lock()
+	defer d.clientsMtx.Unlock()
+	delete(d.clients, id)
+}
+
+// Notify the clients that the device has disconnected
+func (d *Device) DisconnectClients() {
+	d.clientsMtx.Lock()
+	defer d.clientsMtx.Unlock()
+	for _, client := range d.clients {
+		client.OnDeviceDisconnected()
+	}
+}
+
+// Send a message to the client
+func (d *Device) ToClient(id int, msg interface{}) bool {
+	d.clientsMtx.Lock()
+	client, ok := d.clients[id]
+	d.clientsMtx.Unlock()
+	if !ok {
+		return false
+	}
+	return client.Send(msg)
+}
+
+// Keeps track of the registered devices.
+type DevicePool struct {
+	devicesMtx sync.Mutex
+	devices    map[string]*Device
+}
+
+func NewDevicePool() *DevicePool {
+	return &DevicePool{
+		devices: make(map[string]*Device),
+	}
+}
+
+// Register a new device, returns false if a device with that id already exists
+func (p *DevicePool) Register(d *Device, id string) bool {
+	p.devicesMtx.Lock()
+	defer p.devicesMtx.Unlock()
+	_, ok := p.devices[id]
+	if ok {
+		return false
+	}
+	p.devices[id] = d
+	return true
+}
+
+func (p *DevicePool) Unregister(id string) {
+	p.devicesMtx.Lock()
+	defer p.devicesMtx.Unlock()
+	if d, ok := p.devices[id]; ok {
+		d.DisconnectClients()
+		delete(p.devices, id)
+	}
+}
+
+func (p *DevicePool) GetDevice(id string) *Device {
+	p.devicesMtx.Lock()
+	defer p.devicesMtx.Unlock()
+	return p.devices[id]
+}
+
+// List the registered devices' ids
+func (p *DevicePool) DeviceIds() []string {
+	p.devicesMtx.Lock()
+	defer p.devicesMtx.Unlock()
+	ret := make([]string, 0, len(p.devices))
+	for key, _ := range p.devices {
+		ret = append(ret, key)
+	}
+	return ret
+}

--- a/host/frontend/host-orchestrator/devices_test.go
+++ b/host/frontend/host-orchestrator/devices_test.go
@@ -1,0 +1,158 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+//     Unless required by applicable law or agreed to in writing, software
+//     distributed under the License is distributed on an "AS IS" BASIS,
+//     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+//     limitations under the License.
+
+package main
+
+import (
+	"testing"
+)
+
+func TestNewDevice(t *testing.T) {
+	d := NewDevice(nil, 0, "info")
+	if d == nil {
+		t.Error("null device")
+	}
+}
+
+type MockClient struct {
+	sendCount       int
+	disconnectCount int
+}
+
+func (c *MockClient) Send(msg interface{}) bool {
+	c.sendCount++
+	return true
+}
+
+func (c *MockClient) OnDeviceDisconnected() {
+	c.disconnectCount++
+}
+
+func TestDeviceRegister(t *testing.T) {
+	d := NewDevice(nil, 0, "info")
+	// Unregistering unexisting client has no effect
+	d.Unregister(9)
+	// Register a client
+	c1 := &MockClient{}
+	c2 := &MockClient{}
+	id1 := d.Register(c1)
+	if id1 == -1 {
+		t.Error("-1 client id")
+	}
+	id2 := d.Register(c2)
+	if id2 == -1 {
+		t.Error("-1 client id")
+	}
+	if id1 == id2 {
+		t.Error("Same id for different clients")
+	}
+	if !d.ToClient(id1, "msg") {
+		t.Error("Failed to send to registered device")
+	}
+	if !d.ToClient(id2, "msg") {
+		t.Error("Failed to send to registered device")
+	}
+	if d.ToClient(-1, "msg") {
+		t.Error("Succeeded in sending to unexisting client")
+	}
+
+	d.Unregister(id1)
+	d.DisconnectClients()
+
+	if d.ToClient(id1, "msg") {
+		t.Error("Succeeded sending to unregistered client")
+	}
+
+	if c1.sendCount != 1 {
+		t.Error("Did not send on c1")
+	}
+	if c2.sendCount != 1 {
+		t.Error("Did not send on c2")
+	}
+	if c1.disconnectCount != 0 {
+		t.Error("Disconnected on unregistered device")
+	}
+	if c2.disconnectCount != 1 {
+		t.Error("Did not disconnect on registered device")
+	}
+}
+
+func TestPoolRegister(t *testing.T) {
+	p := NewDevicePool()
+	// Unregistering wrong device has no effect
+	p.Unregister("id1")
+	d := NewDevice(nil, 0, "info1")
+	if p.GetDevice("id1") != nil {
+		t.Error("Empty pool returned device")
+	}
+	if !p.Register(d, "id1") {
+		t.Error("Failed to register new device")
+	}
+	if p.GetDevice("id1") != d {
+		t.Error("Failed to get registered device")
+	}
+	if p.GetDevice("id2") == d {
+		t.Error("Returned wrong device")
+	}
+	// Register with the same id
+	if p.Register(d, "id1") {
+		t.Error("Didn't fail with same device id")
+	}
+	if !p.Register(d, "id2") {
+		t.Error("Failed to register with different id")
+	}
+	// Try to get device after unregistering another
+	p.Unregister("id2")
+	if p.GetDevice("id1") != d {
+		t.Error("Failed to get registered device")
+	}
+	p.Unregister("id1")
+	if p.GetDevice("id1") != nil {
+		t.Error("Returned unregistered device")
+	}
+}
+
+func TestListDevices(t *testing.T) {
+	p := NewDevicePool()
+	d1 := NewDevice(nil, 0, "info1")
+	d2 := NewDevice(nil, 0, "info2")
+	if len(p.DeviceIds()) != 0 {
+		t.Error("Empty pool listed devices")
+	}
+	p.Register(d1, "1")
+	l := p.DeviceIds()
+	if len(l) != 1 || l[0] != "1" {
+		t.Error("Error listing after 1 device registration: ", l)
+	}
+	p.Register(d2, "2")
+	l = p.DeviceIds()
+	if len(l) != 2 || l[0] != "1" && l[0] != "2" || l[1] != "1" && l[1] != "2" || l[0] == l[1] {
+		t.Error("Error listing after 2 device restrations: ", l)
+	}
+	p.Unregister("1")
+	l = p.DeviceIds()
+	if len(l) != 1 || l[0] != "2" {
+		t.Error("Error listing after 2 device registrations and 1 unregistration: ", l)
+	}
+	// Should have no effect
+	p.Unregister("1")
+	if len(l) != 1 || l[0] != "2" {
+		t.Error("Error listing after 2 device registrations, 1 unregistration and 1 failed unregistration: ", l)
+	}
+	p.Unregister("2")
+	l = p.DeviceIds()
+	if len(p.DeviceIds()) != 0 {
+		t.Error("Empty pool listed devices")
+	}
+}

--- a/host/frontend/host-orchestrator/devices_test.go
+++ b/host/frontend/host-orchestrator/devices_test.go
@@ -30,9 +30,9 @@ type MockClient struct {
 	disconnectCount int
 }
 
-func (c *MockClient) Send(msg interface{}) bool {
+func (c *MockClient) Send(msg interface{}) error {
 	c.sendCount++
-	return true
+	return nil
 }
 
 func (c *MockClient) OnDeviceDisconnected() {
@@ -57,20 +57,20 @@ func TestDeviceRegister(t *testing.T) {
 	if id1 == id2 {
 		t.Error("Same id for different clients")
 	}
-	if !d.ToClient(id1, "msg") {
-		t.Error("Failed to send to registered device")
+	if err := d.ToClient(id1, "msg"); err != nil {
+		t.Error("Failed to send to registered device: ", err)
 	}
-	if !d.ToClient(id2, "msg") {
-		t.Error("Failed to send to registered device")
+	if err := d.ToClient(id2, "msg"); err != nil {
+		t.Error("Failed to send to registered device: ", err)
 	}
-	if d.ToClient(-1, "msg") {
+	if d.ToClient(-1, "msg") == nil {
 		t.Error("Succeeded in sending to unexisting client")
 	}
 
 	d.Unregister(id1)
 	d.DisconnectClients()
 
-	if d.ToClient(id1, "msg") {
+	if d.ToClient(id1, "msg") == nil {
 		t.Error("Succeeded sending to unregistered client")
 	}
 

--- a/host/frontend/host-orchestrator/go.mod
+++ b/host/frontend/host-orchestrator/go.mod
@@ -1,0 +1,8 @@
+module cuttlefish/host-orchestrator
+
+go 1.17
+
+require (
+	github.com/gorilla/mux v1.8.0
+	github.com/gorilla/websocket v1.4.2
+)

--- a/host/frontend/host-orchestrator/go.sum
+++ b/host/frontend/host-orchestrator/go.sum
@@ -1,0 +1,4 @@
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/host/frontend/host-orchestrator/intercept/js/server_connector.js
+++ b/host/frontend/host-orchestrator/intercept/js/server_connector.js
@@ -1,0 +1,282 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// The public elements in this file implement the Server Connector Interface,
+// part of the contract between the signaling server and the webrtc client.
+// No changes that break backward compatibility are allowed here. Any new
+// features must be added as a new function/class in the interface. Any
+// additions to the interface must be checked for existence by the client before
+// using it.
+
+// The id of the device the client is supposed to connect to.
+// The List Devices page in the signaling server may choose any way to pass the
+// device id to the client page, this function retrieves that information once
+// the client loaded.
+// In this case the device id is passed as a parameter in the url.
+export function deviceId() {
+  const urlParams = new URLSearchParams(window.location.search);
+  return urlParams.get('deviceId');
+}
+
+// Creates a connector capable of communicating with the signaling server.
+export async function createConnector() {
+  try {
+    let ws = await connectWs();
+    console.debug(`Connected to ${ws.url}`);
+    return new WebsocketConnector(ws);
+  } catch (e) {
+    console.error('WebSocket error:', e);
+  }
+  console.warn('Failed to connect websocket, trying polling instead');
+
+  return new PollingConnector();
+}
+
+// A connector object provides high level functions for communicating with the
+// signaling server, while hiding away implementation details.
+// This class is an interface and shouldn't be instantiated direclty.
+// Only the public methods present in this class form part of the Server
+// Connector Interface, any implementations of the interface are considered
+// internal and not accessible to client code.
+class Connector {
+  constructor() {
+    if (this.constructor == Connector) {
+      throw new Error('Connector is an abstract class');
+    }
+  }
+
+  // Selects a particular device in the signaling server and opens the signaling
+  // channel with it (but doesn't send any message to the device). Returns a
+  // promise to an object with the following properties:
+  // - deviceInfo: The info object provided by the device when it registered
+  // with the server.
+  // - infraConfig: The server's infrastructure configuration (mainly STUN and
+  // TURN servers)
+  // The promise may take a long time to resolve if, for example, the server
+  // decides to wait for a device with the provided id to register with it. The
+  // promise may be rejected if there are connectivity issues, a device with
+  // that id doesn't exist or this client doesn't have rights to access that
+  // device.
+  async requestDevice(deviceId) {
+    throw 'Not implemented!';
+  }
+
+  // Sends a message to the device selected with requestDevice. It's an error to
+  // call this function before the promise from requestDevice() has resolved.
+  // Returns an empty promise that is rejected when the message can not be
+  // delivered, either because the device has not been requested yet or because
+  // of connectivity issues.
+  async sendToDevice(msg) {
+    throw 'Not implemented!';
+  }
+}
+
+// End of Server Connector Interface.
+
+// The following code is internal and shouldn't be accessed outside this file.
+
+function httpUrl(path) {
+  return location.protocol + '//' + location.host + '/' + path;
+}
+
+function websocketUrl(path) {
+  return ((location.protocol == 'http:') ? 'ws://' : 'wss://') + location.host +
+      '/' + path;
+}
+
+async function connectWs() {
+  return new Promise((resolve, reject) => {
+    let url = websocketUrl('connect_client');
+    let ws = new WebSocket(url);
+    ws.onopen = () => {
+      resolve(ws);
+    };
+    ws.onerror = evt => {
+      reject(evt);
+    };
+  });
+}
+
+async function ajaxPostJson(url, data) {
+  const response = await fetch(url, {
+    method: 'POST',
+    cache: 'no-cache',
+    headers: {'Content-Type': 'application/json'},
+    redirect: 'follow',
+    body: JSON.stringify(data),
+  });
+  return response.json();
+}
+
+// Implementation of the connector interface using websockets
+class WebsocketConnector extends Connector {
+  #websocket;
+  #futures = {};
+  #onDeviceMsgCb = msg =>
+      console.error('Received device message without registered listener');
+
+  onDeviceMsg(cb) {
+    this.#onDeviceMsgCb = cb;
+  }
+
+  constructor(ws) {
+    super();
+    ws.onmessage = e => {
+      let data = JSON.parse(e.data);
+      this.#onWebsocketMessage(data);
+    };
+    this.#websocket = ws;
+  }
+
+  async requestDevice(deviceId) {
+    return new Promise((resolve, reject) => {
+      this.#futures.onDeviceAvailable = (device) => resolve(device);
+      this.#futures.onConnectionFailed = (error) => reject(error);
+      this.#wsSendJson({
+        message_type: 'connect',
+        device_id: deviceId,
+      });
+    });
+  }
+
+  async sendToDevice(msg) {
+    return this.#wsSendJson({message_type: 'forward', payload: msg});
+  }
+
+  #onWebsocketMessage(message) {
+    const type = message.message_type;
+    if (message.error) {
+      console.error(message.error);
+      this.#futures.onConnectionFailed(message.error);
+      return;
+    }
+    switch (type) {
+      case 'config':
+        this.#futures.infraConfig = message;
+        break;
+      case 'device_info':
+        if (this.#futures.onDeviceAvailable) {
+          this.#futures.onDeviceAvailable({
+            deviceInfo: message.device_info,
+            infraConfig: this.#futures.infraConfig,
+          });
+          delete this.#futures.onDeviceAvailable;
+        } else {
+          console.error('Received unsolicited device info');
+        }
+        break;
+      case 'device_msg':
+        this.#onDeviceMsgCb(message.payload);
+        break;
+      default:
+        console.error('Unrecognized message type from server: ', type);
+        this.#futures.onConnectionFailed(
+            'Unrecognized message type from server: ' + type);
+        console.error(message);
+    }
+  }
+
+  async #wsSendJson(obj) {
+    return this.#websocket.send(JSON.stringify(obj));
+  }
+}
+
+// Implementation of the Connector interface using HTTP long polling
+class PollingConnector extends Connector {
+  #configUrl = httpUrl('infra_config');
+  #connectUrl = httpUrl('polled_connections');
+  #forwardUrl;
+  #messagesUrl;
+  #config = undefined;
+  #messagesReceived = 0;
+  #pollerSchedule;
+  #onDeviceMsgCb = msg =>
+      console.error('Received device message without registered listener');
+
+  onDeviceMsg(cb) {
+    this.#onDeviceMsgCb = cb;
+  }
+
+  constructor() {
+    super();
+  }
+
+  async requestDevice(deviceId) {
+    let config = await this.#getConfig();
+    let response = await ajaxPostJson(this.#connectUrl, {device_id: deviceId});
+    let connId = response.connection_id;
+    this.#forwardUrl = httpUrl(`polled_connections/${connId}/:forward`);
+    this.#messagesUrl = httpUrl(`polled_connections/${connId}/messages`);
+
+    this.#startPolling();
+
+    return {
+      deviceInfo: response.device_info,
+      infraConfig: config,
+    };
+  }
+
+  async sendToDevice(msg) {
+    return await ajaxPostJson(this.#forwardUrl, {
+      payload: msg,
+    });
+  }
+
+  async #getConfig() {
+    if (this.#config === undefined) {
+      this.#config = await (await fetch(this.#configUrl, {
+                       method: 'GET',
+                       redirect: 'follow',
+                     })).json();
+    }
+    return this.#config;
+  }
+
+  async #pollMessages() {
+    let r = await fetch(
+        this.#messagesUrl + `?start=${this.#messagesReceived}`, {
+          method: 'GET',
+          redirect: 'follow',
+        })
+    let arr = await r.json();
+    this.#messagesReceived += arr.length;
+    return arr;
+  }
+
+  #startPolling() {
+    if (this.#pollerSchedule !== undefined) {
+      return;
+    }
+
+    let currentPollDelay = 1000;
+    let pollerRoutine = async () => {
+      let messages = await this.#pollMessages();
+
+      // Do exponential backoff on the polling up to 60 seconds
+      currentPollDelay = Math.min(60000, 2 * currentPollDelay);
+      for (const message of messages) {
+        this.#onDeviceMsgCb(message.payload);
+        // There is at least one message, poll sooner
+        currentPollDelay = 1000;
+      }
+      this.#pollerSchedule = setTimeout(pollerRoutine, currentPollDelay);
+    };
+
+    this.#pollerSchedule = setTimeout(pollerRoutine, currentPollDelay);
+  }
+}

--- a/host/frontend/host-orchestrator/jsonws.go
+++ b/host/frontend/host-orchestrator/jsonws.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
-	"time"
+	"sync"
 
 	"github.com/gorilla/websocket"
 )
@@ -26,13 +26,13 @@ import (
 // A websocket connection that can send and receive json objects.
 // Using websockets requires some boilerplate code, even using gorilla, which is
 // encapsulated behind this object.
-// All methods in this struct are thread safe.
+// Only one thread should call Recv() at a time, Send() and Close() are thread safe
 type JsonWs struct {
-	send chan []byte
-	recv chan []byte
-	cl   chan bool
-	conn *websocket.Conn
+	conn     *websocket.Conn
+	writeMtx sync.Mutex
 }
+
+var upgrader = websocket.Upgrader{} // default options
 
 func NewJsonWs(w http.ResponseWriter, r *http.Request) *JsonWs {
 	conn, err := upgrader.Upgrade(w, r, nil)
@@ -40,120 +40,45 @@ func NewJsonWs(w http.ResponseWriter, r *http.Request) *JsonWs {
 		log.Println(err)
 		return nil
 	}
-	send, recv, cl := make(chan []byte, 100), make(chan []byte, 100), make(chan bool)
-	go writePump(conn, send)
-	go readPump(conn, recv, cl)
-	return &JsonWs{send: send, recv: recv, cl: cl, conn: conn}
+	return &JsonWs{conn: conn}
 }
 
 func (ws *JsonWs) Send(val interface{}) bool {
-	select {
-	case _, _ = <-ws.cl:
-		// Activity on this channel means the ws is closed
-		return false
-	default:
-		// Do nothing
-	}
 	msg, err := json.Marshal(val)
 	if err != nil {
 		log.Println(err)
 		return false
 	}
-	ws.send <- msg
+
+	ws.writeMtx.Lock()
+	defer ws.writeMtx.Unlock()
+
+	err = ws.conn.WriteMessage(websocket.TextMessage, msg)
+	if err != nil {
+		return false
+	}
+
 	return true
 }
 
 func (ws *JsonWs) Recv(val interface{}) bool {
-	msg, ok := <-ws.recv
-	if !ok {
+	_, msg, err := ws.conn.ReadMessage()
+	if err != nil {
+		if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+			log.Printf("error: %v", err)
+		}
 		return false
 	}
 	if err := json.Unmarshal(msg, &val); err != nil {
 		log.Println(err)
 		return false
 	}
-
 	return true
 }
 
 func (ws *JsonWs) Close() {
-	close(ws.send)
-}
-
-const (
-	// Time allowed to write a message to the peer.
-	writeWait = 10 * time.Second
-
-	// Time allowed to read the next pong message from the peer.
-	pongWait = 60 * time.Second
-
-	// Send pings to peer with this period. Must be less than pongWait.
-	pingPeriod = (pongWait * 9) / 10
-
-	// Maximum message size allowed from peer.
-	maxMessageSize = 10240
-)
-
-var upgrader = websocket.Upgrader{
-	ReadBufferSize:  20480,
-	WriteBufferSize: 20480,
-}
-
-func readPump(conn *websocket.Conn, ch chan []byte, cl chan bool) {
-	defer func() {
-		close(ch)
-		close(cl)
-	}()
-	conn.SetReadLimit(maxMessageSize)
-	conn.SetReadDeadline(time.Now().Add(pongWait))
-	conn.SetPongHandler(func(string) error { conn.SetReadDeadline(time.Now().Add(pongWait)); return nil })
-	for {
-		_, msg, err := conn.ReadMessage()
-		if err != nil {
-			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
-				log.Printf("error: %v", err)
-			}
-			break
-		}
-		ch <- msg
-	}
-}
-
-func writePump(conn *websocket.Conn, ch chan []byte) {
-	ticker := time.NewTicker(pingPeriod)
-	defer ticker.Stop()
-	for {
-		select {
-		case msg, ok := <-ch:
-			conn.SetWriteDeadline(time.Now().Add(writeWait))
-			if !ok {
-				conn.WriteMessage(websocket.CloseMessage, []byte{})
-				conn.Close()
-				return
-			}
-			w, err := conn.NextWriter(websocket.TextMessage)
-			if err != nil {
-				conn.Close()
-				// The writer won't return until the send channel is
-				// closed to avoid blocking an application thread
-				continue
-			}
-			w.Write(msg)
-
-			if err := w.Close(); err != nil {
-				conn.Close()
-				// The writer won't return until the send channel is
-				// closed to avoid blocking an application thread
-				continue
-			}
-		case <-ticker.C:
-			conn.SetWriteDeadline(time.Now().Add(writeWait))
-			if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
-				conn.Close()
-				// The writer won't return until the send channel is
-				// closed to avoid blocking an application thread
-				continue
-			}
-		}
-	}
+	ws.writeMtx.Lock()
+	defer ws.writeMtx.Unlock()
+	ws.conn.WriteMessage(websocket.CloseMessage, []byte{})
+	ws.conn.Close()
 }

--- a/host/frontend/host-orchestrator/jsonws.go
+++ b/host/frontend/host-orchestrator/jsonws.go
@@ -24,8 +24,6 @@ import (
 )
 
 // A websocket connection that can send and receive json objects.
-// Using websockets requires some boilerplate code, even using gorilla, which is
-// encapsulated behind this object.
 // Only one thread should call Recv() at a time, Send() and Close() are thread safe
 type JsonWs struct {
 	conn     *websocket.Conn

--- a/host/frontend/host-orchestrator/jsonws.go
+++ b/host/frontend/host-orchestrator/jsonws.go
@@ -49,7 +49,7 @@ func NewJsonWs(w http.ResponseWriter, r *http.Request) *JsonWs {
 func (ws *JsonWs) Send(val interface{}) bool {
 	select {
 	case _, _ = <-ws.cl:
-		// A message on this channel means the ws is closed
+		// Activity on this channel means the ws is closed
 		return false
 	default:
 		// Do nothing

--- a/host/frontend/host-orchestrator/jsonws.go
+++ b/host/frontend/host-orchestrator/jsonws.go
@@ -1,0 +1,159 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+//     Unless required by applicable law or agreed to in writing, software
+//     distributed under the License is distributed on an "AS IS" BASIS,
+//     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+//     limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// A websocket connection that can send and receive json objects.
+// Using websockets requires some boilerplate code, even using gorilla, which is
+// encapsulated behind this object.
+// All methods in this struct are thread safe.
+type JsonWs struct {
+	send chan []byte
+	recv chan []byte
+	cl   chan bool
+	conn *websocket.Conn
+}
+
+func NewJsonWs(w http.ResponseWriter, r *http.Request) *JsonWs {
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Println(err)
+		return nil
+	}
+	send, recv, cl := make(chan []byte, 100), make(chan []byte, 100), make(chan bool)
+	go writePump(conn, send)
+	go readPump(conn, recv, cl)
+	return &JsonWs{send: send, recv: recv, cl: cl, conn: conn}
+}
+
+func (ws *JsonWs) Send(val interface{}) bool {
+	select {
+	case _, _ = <-ws.cl:
+		// A message on this channel means the ws is closed
+		return false
+	default:
+		// Do nothing
+	}
+	msg, err := json.Marshal(val)
+	if err != nil {
+		log.Println(err)
+		return false
+	}
+	ws.send <- msg
+	return true
+}
+
+func (ws *JsonWs) Recv(val interface{}) bool {
+	msg, ok := <-ws.recv
+	if !ok {
+		return false
+	}
+	if err := json.Unmarshal(msg, &val); err != nil {
+		log.Println(err)
+		return false
+	}
+
+	return true
+}
+
+func (ws *JsonWs) Close() {
+	close(ws.send)
+}
+
+const (
+	// Time allowed to write a message to the peer.
+	writeWait = 10 * time.Second
+
+	// Time allowed to read the next pong message from the peer.
+	pongWait = 60 * time.Second
+
+	// Send pings to peer with this period. Must be less than pongWait.
+	pingPeriod = (pongWait * 9) / 10
+
+	// Maximum message size allowed from peer.
+	maxMessageSize = 10240
+)
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  20480,
+	WriteBufferSize: 20480,
+}
+
+func readPump(conn *websocket.Conn, ch chan []byte, cl chan bool) {
+	defer func() {
+		close(ch)
+		close(cl)
+	}()
+	conn.SetReadLimit(maxMessageSize)
+	conn.SetReadDeadline(time.Now().Add(pongWait))
+	conn.SetPongHandler(func(string) error { conn.SetReadDeadline(time.Now().Add(pongWait)); return nil })
+	for {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+				log.Printf("error: %v", err)
+			}
+			break
+		}
+		ch <- msg
+	}
+}
+
+func writePump(conn *websocket.Conn, ch chan []byte) {
+	ticker := time.NewTicker(pingPeriod)
+	defer ticker.Stop()
+	for {
+		select {
+		case msg, ok := <-ch:
+			conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if !ok {
+				conn.WriteMessage(websocket.CloseMessage, []byte{})
+				conn.Close()
+				return
+			}
+			w, err := conn.NextWriter(websocket.TextMessage)
+			if err != nil {
+				conn.Close()
+				// The writer won't return until the send channel is
+				// closed to avoid blocking an application thread
+				continue
+			}
+			w.Write(msg)
+
+			if err := w.Close(); err != nil {
+				conn.Close()
+				// The writer won't return until the send channel is
+				// closed to avoid blocking an application thread
+				continue
+			}
+		case <-ticker.C:
+			conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				conn.Close()
+				// The writer won't return until the send channel is
+				// closed to avoid blocking an application thread
+				continue
+			}
+		}
+	}
+}

--- a/host/frontend/host-orchestrator/operator.go
+++ b/host/frontend/host-orchestrator/operator.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-        "math/rand"
+	"math/rand"
 	"net/http"
 	"strconv"
 	"time"
@@ -249,10 +249,10 @@ func clientWs(w http.ResponseWriter, r *http.Request, pool *DevicePool, config I
 				wsReplyError(ws, "Client forward message missing payload")
 				return
 			}
-			cMsg := map[string]interface{}{
-				"message_type": "client_msg",
-				"client_id":    id,
-				"payload":      payload,
+			cMsg := ClientMsg{
+				Type:     "client_msg",
+				ClientId: id,
+				Payload:  payload,
 			}
 			if err := device.Send(cMsg); err != nil {
 				wsReplyError(ws, "Device disconnected")
@@ -296,10 +296,10 @@ func forward(w http.ResponseWriter, r *http.Request, polledSet *PolledSet) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	cMsg := map[string]interface{}{
-		"message_type": "client_msg",
-		"client_id":    conn.ClientId(),
-		"payload":      msg.Payload,
+	cMsg := ClientMsg{
+		Type:     "client_msg",
+		ClientId: conn.ClientId(),
+		Payload:  msg.Payload,
 	}
 	if err := conn.ToDevice(cMsg); err != nil {
 		log.Println("Failed to send message to device: ", err)
@@ -357,6 +357,12 @@ type ForwardMsg struct {
 	Payload interface{} `json:"payload"`
 	// This is used by the device message and ignored by the client
 	ClientId int `json:"client_id"`
+}
+
+type ClientMsg struct {
+	Type     string      `json:"message_type"`
+	ClientId int         `json:"client_id"`
+	Payload  interface{} `json:"payload"`
 }
 
 type ErrorMsg struct {

--- a/host/frontend/host-orchestrator/operator.go
+++ b/host/frontend/host-orchestrator/operator.go
@@ -121,7 +121,7 @@ func deviceWs(w http.ResponseWriter, r *http.Request, pool *DevicePool, config I
 			info = make(map[string]interface{})
 		}
 		port := msg.Port
-		device := NewDevice(ws, id, port, info)
+		device := NewDevice(ws, port, info)
 		if !pool.Register(device, id) {
 			wsReplyError(ws, fmt.Sprintln("Device id already taken: ", id))
 			return

--- a/host/frontend/host-orchestrator/operator.go
+++ b/host/frontend/host-orchestrator/operator.go
@@ -1,0 +1,400 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+//     Unless required by applicable law or agreed to in writing, software
+//     distributed under the License is distributed on an "AS IS" BASIS,
+//     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+//     limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/gorilla/mux"
+)
+
+func main() {
+	pool := NewDevicePool()
+	polledSet := NewPolledSet()
+	var config interface{}
+	err := json.Unmarshal([]byte("{\"ice_servers\":[{\"urls\":[\"stun:stun.l.google.com:19302\"]}],\"message_type\":\"config\"}"), &config)
+	if err != nil {
+		log.Fatal("Malformed config string")
+	}
+
+	setupDeviceEndpoint(pool, config)
+	r := setupServerRoutes(pool, polledSet, config)
+
+	http.Handle("/", r)
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatal("ListenAndServe client: ", err)
+	}
+}
+
+func setupDeviceEndpoint(pool *DevicePool, config interface{}) {
+	devMux := http.NewServeMux()
+	if devMux == nil {
+		log.Fatal("Failed to allocate ServeMux")
+	}
+	// http.HandleFunc("/", serveHome)
+	devMux.HandleFunc("/register_device", func(w http.ResponseWriter, r *http.Request) {
+		deviceWs(w, r, pool, config)
+	})
+	// Serve the register_device endpoint in a different thread
+	go func() {
+		err := http.ListenAndServe("127.0.0.1:8081", devMux)
+		if err != nil {
+			log.Fatal("ListenAndServe device: ", err)
+		}
+	}()
+}
+
+func setupServerRoutes(pool *DevicePool, polledSet *PolledSet, config interface{}) *mux.Router {
+	router := mux.NewRouter()
+	http.HandleFunc("/connect_client", func(w http.ResponseWriter, r *http.Request) {
+		clientWs(w, r, pool, config)
+	})
+	// The path parameter needs to include the leading '/'
+	router.HandleFunc("/devices/{deviceId}/files{path:/.+}", func(w http.ResponseWriter, r *http.Request) {
+		deviceFiles(w, r, pool)
+	}).Methods("GET")
+	router.HandleFunc("/devices", func(w http.ResponseWriter, r *http.Request) {
+		listDevices(w, r, pool)
+	}).Methods("GET")
+	router.HandleFunc("/polled_connections/{connId}/:forward", func(w http.ResponseWriter, r *http.Request) {
+		forward(w, r, polledSet)
+	}).Methods("POST")
+	router.HandleFunc("/polled_connections/{connId}/messages", func(w http.ResponseWriter, r *http.Request) {
+		messages(w, r, polledSet)
+	}).Methods("GET")
+	router.HandleFunc("/polled_connections", func(w http.ResponseWriter, r *http.Request) {
+		createPolledConnection(w, r, pool, polledSet)
+	}).Methods("POST")
+	router.HandleFunc("/infra_config", func(w http.ResponseWriter, r *http.Request) {
+		replyJSON(w, config)
+	}).Methods("GET")
+	fs := http.FileServer(http.Dir("static"))
+	router.PathPrefix("/").Handler(fs)
+	return router
+}
+
+// Device endpoint
+func deviceWs(w http.ResponseWriter, r *http.Request, pool *DevicePool, config interface{}) {
+	log.Println(r.URL)
+	ws := NewJsonWs(w, r)
+	if ws == nil {
+		return
+	}
+	// Serve the websocket in its own thread
+	go func() {
+		defer ws.Close()
+		var msg RegisterMsg
+		ok := ws.Recv(&msg)
+		if !ok {
+			wsReplyError(ws, "Websocket closed unexpectedly")
+			return
+		}
+		if msg.Type != "register" {
+			wsReplyError(ws, "First device message must be the registration")
+			return
+		}
+		id := msg.DeviceId
+		if id == "" {
+			wsReplyError(ws, "Missing device_id")
+			return
+		}
+		info := msg.Info
+		if info == nil {
+			log.Println("No device info provided by: ", id)
+			info = make(map[string]interface{})
+		}
+		port := msg.Port
+		device := NewDevice(ws, id, port, info)
+		if !pool.Register(device, id) {
+			wsReplyError(ws, fmt.Sprintln("Device id already taken: ", id))
+			return
+		}
+		defer pool.Unregister(id)
+		if !device.Send(config) {
+			log.Println("Failed to send config to device")
+			return
+		}
+		for {
+			var msg ForwardMsg
+			ok := ws.Recv(&msg)
+			if !ok {
+				log.Println("Device websocket closed")
+				return
+			}
+			if msg.Type != "forward" {
+				wsReplyError(ws, fmt.Sprintln("Unrecognized message type: ", msg.Type))
+				return
+			}
+			clientId := msg.ClientId
+			if clientId == 0 {
+				wsReplyError(ws, "Device forward message missing client id")
+				return
+			}
+			payload := msg.Payload
+			if payload == nil {
+				wsReplyError(ws, "Device forward message missing payload")
+				return
+			}
+			dMsg := map[string]interface{}{
+				"message_type": "device_msg",
+				"payload":      payload,
+			}
+			if !device.ToClient(clientId, dMsg) {
+				log.Println(ws, "Missing client ", int(clientId), " for device ", id)
+				wsReplyError(ws, fmt.Sprintln("Client disconnected: ", clientId))
+			}
+		}
+	}()
+}
+
+// General client endpoints
+
+func listDevices(w http.ResponseWriter, r *http.Request, pool *DevicePool) {
+	if err := replyJSON(w, pool.DeviceIds()); err != nil {
+		log.Println(err)
+	}
+}
+
+func deviceFiles(w http.ResponseWriter, r *http.Request, pool *DevicePool) {
+	vars := mux.Vars(r)
+	devId := vars["deviceId"]
+	dev := pool.GetDevice(devId)
+	if dev == nil {
+		http.NotFound(w, r)
+		return
+	}
+	path := vars["path"]
+	if shouldIntercept(path) {
+		http.ServeFile(w, r, fmt.Sprintf("intercept%s", path))
+	} else {
+		r.URL.Path = path
+		dev.Proxy.ServeHTTP(w, r)
+	}
+}
+
+// Client websocket endpoint
+
+func clientWs(w http.ResponseWriter, r *http.Request, pool *DevicePool, config interface{}) {
+	log.Println(r.URL)
+	ws := NewJsonWs(w, r)
+	if ws == nil {
+		return
+	}
+	// Serve the websocket in its own thread
+	go func() {
+		defer ws.Close()
+		var msg ConnectMsg
+		ok := ws.Recv(&msg)
+		if !ok {
+			log.Println("Websocket closed unexpectedly")
+			return
+		}
+		if msg.Type != "connect" {
+			wsReplyError(ws, "First client message must be 'connect'")
+			return
+		}
+		deviceId := msg.DeviceId
+		if deviceId == "" {
+			wsReplyError(ws, "Missing or invalid device_id")
+			return
+		}
+		device := pool.GetDevice(deviceId)
+		if device == nil {
+			wsReplyError(ws, fmt.Sprintln("Unknown device id: ", deviceId))
+			return
+		}
+		client := NewWsClient(ws)
+		id := device.Register(client)
+		defer device.Unregister(id)
+		if !client.Send(config) {
+			log.Println("Failed to send config to client")
+			return
+		}
+		infoMsg := make(map[string]interface{})
+		infoMsg["message_type"] = "device_info"
+		infoMsg["device_info"] = device.info
+		if !client.Send(infoMsg) {
+			log.Println("Failed to send device info to client")
+			return
+		}
+		for {
+			var msg ForwardMsg
+			ok := ws.Recv(&msg)
+			if !ok {
+				log.Println("Client websocket closed")
+				return
+			}
+			if msg.Type != "forward" {
+				wsReplyError(ws, fmt.Sprintln("Unrecognized message type: ", msg.Type))
+				return
+			}
+			payload := msg.Payload
+			if payload == nil {
+				wsReplyError(ws, "Client forward message missing payload")
+				return
+			}
+			cMsg := map[string]interface{}{
+				"message_type": "client_msg",
+				"client_id":    id,
+				"payload":      payload,
+			}
+			if !device.Send(cMsg) {
+				wsReplyError(ws, "Device disconnected")
+			}
+		}
+	}()
+}
+
+// Http long polling client endpoints
+
+func createPolledConnection(w http.ResponseWriter, r *http.Request, pool *DevicePool, polledSet *PolledSet) {
+	var msg NewConnMsg
+	err := json.NewDecoder(r.Body).Decode(&msg)
+	if err != nil {
+		log.Println("Failed to parse json from client: ", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	log.Println("id: ", msg.DeviceId)
+	device := pool.GetDevice(msg.DeviceId)
+	if device == nil {
+		http.Error(w, "Device not found", http.StatusNotFound)
+		return
+	}
+	conn := polledSet.NewConnection(device)
+	reply := NewConnReply{ConnId: conn.Id(), DeviceInfo: device.info}
+	replyJSON(w, reply)
+}
+
+func forward(w http.ResponseWriter, r *http.Request, polledSet *PolledSet) {
+	id := mux.Vars(r)["connId"]
+	conn := polledSet.GetConnection(id)
+	if conn == nil {
+		http.NotFound(w, r)
+		return
+	}
+	var msg ForwardMsg
+	err := json.NewDecoder(r.Body).Decode(&msg)
+	if err != nil {
+		log.Println("Failed to parse json from client: ", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	cMsg := map[string]interface{}{
+		"message_type": "client_msg",
+		"client_id":    conn.ClientId(),
+		"payload":      msg.Payload,
+	}
+	if !conn.ToDevice(cMsg) {
+		http.Error(w, "Device disconnected", http.StatusNotFound)
+	}
+	replyJSON(w, "ok")
+}
+
+func messages(w http.ResponseWriter, r *http.Request, polledSet *PolledSet) {
+	id := mux.Vars(r)["connId"]
+	conn := polledSet.GetConnection(id)
+	if conn == nil {
+		http.NotFound(w, r)
+		return
+	}
+	start := 0
+	count := -1 // All messages
+	if sStr := r.FormValue("start"); sStr != "" {
+		i, err := strconv.Atoi(sStr)
+		if err != nil {
+			log.Println("Invalid start value: ", sStr)
+			http.Error(w, "Invalid value for start field", http.StatusBadRequest)
+			return
+		}
+		start = i
+	}
+	if cStr := r.FormValue("count"); cStr != "" {
+		i, err := strconv.Atoi(cStr)
+		if err != nil {
+			log.Println("Invalid count value: ", cStr)
+			http.Error(w, "Invalid value for count field", http.StatusBadRequest)
+			return
+		}
+		count = i
+	}
+	replyJSON(w, conn.GetMessages(start, count))
+}
+
+// JSON objects schema
+
+type RegisterMsg struct {
+	Type     string      `json:"message_type"`
+	DeviceId string      `json:"device_id"`
+	Port     int         `json:"device_port"`
+	Info     interface{} `json:"device_info"`
+}
+
+type ConnectMsg struct {
+	Type     string `json:"message_type"`
+	DeviceId string `json:"device_id"`
+}
+
+type ForwardMsg struct {
+	Type    string      `json:"message_type"`
+	Payload interface{} `json:"payload"`
+	// This is used by the device message and ignored by the client
+	ClientId int `json:"client_id"`
+}
+
+type ErrorMsg struct {
+	Error string `json:"error"`
+}
+
+type NewConnMsg struct {
+	DeviceId string `json:"device_id"`
+}
+
+type NewConnReply struct {
+	ConnId     string      `json:"connection_id"`
+	DeviceInfo interface{} `json:"device_info"`
+}
+
+// Utility functions
+
+// Log and reply with an error over a websocket
+func wsReplyError(ws *JsonWs, msg string) {
+	log.Println(msg)
+	ws.Send(ErrorMsg{Error: msg})
+}
+
+// Send a JSON http response to the client
+func replyJSON(w http.ResponseWriter, obj interface{}) error {
+	w.Header().Set("Content-Type", "application/json")
+	encoder := json.NewEncoder(w)
+	return encoder.Encode(obj)
+}
+
+// Whether a device file request should be intercepted and served from the signaling server instead
+func shouldIntercept(path string) bool {
+	_, err := os.Stat(fmt.Sprintf("intercept/%s", path))
+	if err != nil && os.IsNotExist(err) {
+		return false
+	}
+	if err != nil {
+		log.Println("Error accessing intercepted file: ", err)
+	}
+	return true
+}

--- a/host/frontend/host-orchestrator/static/index.html
+++ b/host/frontend/host-orchestrator/static/index.html
@@ -1,0 +1,32 @@
+<?--
+ Copyright (C) 2019 The Android Open Source Project
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+
+<html>
+    <head>
+        <title>My Virtual Device Playground</title>
+
+        <link rel="stylesheet" type="text/css" href="styles/index.css" >
+        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    </head>
+
+    <body>
+      <section id='device-selector'>
+        <h1>Available devices <span id='refresh-list'>&#8635;</span></h1>
+        <ul id="device-list"></ul>
+      </section>
+      <script src="js/index.js"></script>
+    </body>
+</html>

--- a/host/frontend/host-orchestrator/static/js/index.js
+++ b/host/frontend/host-orchestrator/static/js/index.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+class DeviceListApp {
+  #url;
+  #selectDeviceCb;
+
+  constructor({url, selectDeviceCb}) {
+    this.#url = url;
+    this.#selectDeviceCb = selectDeviceCb;
+  }
+
+  start() {
+    // Get any devices that are already connected
+    this.#UpdateDeviceList();
+
+    // Update the list at the user's request
+    document.getElementById('refresh-list')
+        .addEventListener('click', evt => this.#UpdateDeviceList());
+  }
+
+  async #UpdateDeviceList() {
+    try {
+      const device_ids = await fetch(this.#url, {
+        method: 'GET',
+        cache: 'no-cache',
+        redirect: 'follow',
+      });
+      this.#ShowNewDeviceList(await device_ids.json());
+    } catch (e) {
+      console.error('Error getting list of device ids: ', e);
+    }
+  }
+
+  #ShowNewDeviceList(device_ids) {
+    let ul = document.getElementById('device-list');
+    ul.innerHTML = '';
+    let count = 1;
+    let device_to_button_map = {};
+    for (const devId of device_ids) {
+      const buttonId = 'connect_' + count++;
+      let entry = this.#createDeviceEntry(devId, buttonId);
+      ul.appendChild(entry);
+      device_to_button_map[devId] = buttonId;
+    }
+
+    for (const [devId, buttonId] of Object.entries(device_to_button_map)) {
+      let button = document.getElementById(buttonId);
+      button.addEventListener('click', evt => {
+        this.#selectDeviceCb(devId);
+      });
+    }
+  }
+
+  #createDeviceEntry(devId, buttonId) {
+    let li = document.createElement('li');
+    li.className = 'device_entry';
+    li.title = 'Connect to ' + devId;
+    let div = document.createElement('div');
+    let span = document.createElement('span');
+    span.appendChild(document.createTextNode(devId));
+    let button = document.createElement('button');
+    button.id = buttonId;
+    button.appendChild(document.createTextNode('Connect'));
+    div.appendChild(span);
+    div.appendChild(button);
+    li.appendChild(div);
+    return li;
+  }
+}  // DeviceListApp
+
+window.addEventListener('load', e => {
+  let listDevicesUrl = '/devices';
+  let selectDeviceCb = deviceId => {
+    return new Promise((resolve, reject) => {
+      let client = window.open(
+          `/devices/${deviceId}/files/client.html?deviceId=${deviceId}`,
+          deviceId);
+      client.addEventListener('load', evt => {
+        console.log('loaded');
+        resolve();
+      });
+    });
+  };
+  let deviceListApp = new DeviceListApp({url: listDevicesUrl, selectDeviceCb});
+  deviceListApp.start();
+});

--- a/host/frontend/host-orchestrator/static/styles/index.css
+++ b/host/frontend/host-orchestrator/static/styles/index.css
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+body {
+  background-color:black;
+  margin: 0;
+}
+
+#device-selector {
+  color: whitesmoke;
+}
+
+#device-selector li.device-entry {
+  cursor: pointer;
+}
+
+#refresh-list {
+  cursor: pointer;
+}
+
+#device-list .device-entry button {
+  margin-left: 10px;
+}
+


### PR DESCRIPTION
This only adds the code to our repo, but it doesn't build as part of any debian package yet. It also still doesn't use a unix socket endpoint for the device, it uses a websocket instead so it can be easily tested with the current cuttlefish code.

To test you can do:
```
cd host/frontend/host-orchestrator
go get cuttlefish/host-orchestrator
go build
./host-orchestrator
```
The last command starts a server listening for devices in port 8081 and for clients in port 8080, so you can register a device with
```
launch_cvd --nostart_webrtc_sig_server --nowebrtc_sig_server_secure --webrtc_sig_server_port=8081
```
Then simply direct your browser to http://localhost:8080