### PR TITLE
Build host-orchestrator with cuttlefish-common

### DIFF
--- a/.github/workflows/test_build_deb.yaml
+++ b/.github/workflows/test_build_deb.yaml
@@ -11,7 +11,7 @@ jobs:
     - name: setup apt
       run: apt update -y && apt upgrade -y
     - name: install debuild dependencies
-      run: apt install -y git devscripts config-package-dev debhelper-compat
+      run: apt install -y git devscripts config-package-dev debhelper-compat golang
     - name: checkout repository
       uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 /debian/*.debhelper
 /debian/debhelper-build-stamp
 
+/host/frontend/host-orchestrator/host-orchestrator
+
 equivs.txt
 deps.txt
 ignore-depends-for-*.txt

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cuttlefish-common (0.9.21) UNRELEASED; urgency=medium
+
+  * Initial version of host-orchestrator
+
+ -- Jorge Moreira Broche <jemoreira@google.com>  Wed, 01 Dec 2021 15:03:04 -0800
+
 cuttlefish-common (0.9.20) stable; urgency=medium
 
   [ Ram Muthiah ]

--- a/debian/control
+++ b/debian/control
@@ -3,12 +3,14 @@ Maintainer: Cuttlefish Team
 Section: misc
 Priority: optional
 Build-Depends: config-package-dev,
-               debhelper-compat (= 12)
+               debhelper-compat (= 12),
+               golang
 Standards-Version: 4.5.0
 
 Package: cuttlefish-common
 Architecture: any
-Depends: binfmt-support [arm64],
+Depends: adduser,
+         binfmt-support [arm64],
          bridge-utils,
          dnsmasq-base,
          e2fsprogs,

--- a/debian/cuttlefish-common.cuttlefish-host-orchestrator.init
+++ b/debian/cuttlefish-common.cuttlefish-host-orchestrator.init
@@ -98,14 +98,11 @@ else
         start|stop|status)
             "$1"
             ;;
-        restart)
+        restart|force-reload|condrestart|try-restart)
             stop && start
             ;;
-        condrestart|try-restart)
-            stop && start
-            ;;
-        reload|force-reload)
-            # Nothing to do; we reread configuration on each invocation
+        reload)
+            # Nothing to do
             ;;
         shutdown)
             stop

--- a/debian/cuttlefish-common.cuttlefish-host-orchestrator.init
+++ b/debian/cuttlefish-common.cuttlefish-host-orchestrator.init
@@ -1,0 +1,118 @@
+#!/bin/sh
+#
+### BEGIN INIT INFO
+# Provides: cuttlefish-host-orchestrator
+# Required-Start: $network $remote_fs
+# Required-Stop: $network $remote_fs
+# Default-Start:
+# Default-Stop: 0 1 2 3 4 5 6
+# Short-Description: Cuttlefish Host Orchestrator service
+# Description: The Host Orchestrator service provides the signaling
+#              server used by all cuttlefish instances running in this
+#              host as well as orchestration capabilities.
+### END INIT INFO
+#
+# Copyright (C) 2021 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Make sure calls to this script get redirected to systemctl when
+# using systemd
+
+. /lib/lsb/init-functions
+
+if [ -f /etc/default/cuttlefish-common ]; then
+    . /etc/default/cuttlefish-common
+fi
+orchestrator_port=${orchestrator_port:-1080}
+
+RUN_DIR="/run/cuttlefish"
+ASSET_DIR="/usr/share/cuttlefish-common/host-orchestrator"
+DAEMON="/usr/lib/cuttlefish-common/bin/host-orchestrator"
+PIDFILE="${RUN_DIR}"/host-orchestrator.pid
+
+start() {
+  mkdir -p "${RUN_DIR}"
+  chown _cutf-operator:cvdnetwork "${RUN_DIR}"
+  chmod 775 "${RUN_DIR}"
+
+  ORCHESTRATOR_PORT="${orchestrator_port}" \
+  ORCHESTRATOR_SOCKET_PATH="${RUN_DIR}"/operator \
+  start-stop-daemon --start \
+    --pidfile "${PIDFILE}" \
+    --chuid _cutf-operator:cvdnetwork \
+    --chdir "${ASSET_DIR}" \
+    --background --no-close \
+    --output "${RUN_DIR}"/host-orchestrator.log \
+    --make-pidfile \
+    --exec "${DAEMON}"
+
+}
+
+stop() {
+  start-stop-daemon --stop \
+    --pidfile "${PIDFILE}" \
+    --remove-pidfile \
+    --exec "${DAEMON}"
+  # The presence of the socket will cause devices to try to connect to it
+  # instead of starting their own signaling servers, so it needs to be removed
+  # once the service isn't running.
+  unlink "${RUN_DIR}"/operator
+}
+
+status() {
+  # Return
+  #   0 if daemon is running
+  #   1 if daemon is dead and pid file exists
+  #   3 if daemon is not running
+  #   4 if daemon status is unknown
+  start-stop-daemon --start --quiet --pidfile "${PIDFILE}" --exec ${DAEMON} --test > /dev/null
+  case "${?}" in
+    0) [ -e "${PIDFILE}" ] && return 1 ; return 3 ;;
+    1) return 0 ;;
+    *) return 4 ;;
+  esac
+}
+
+usage() {
+    echo $0: start\|stop\|status
+}
+
+if test $# != 1; then
+    usage
+else
+    case "$1" in
+        --help)
+            usage 0
+            ;;
+        start|stop|status)
+            "$1"
+            ;;
+        restart)
+            stop && start
+            ;;
+        condrestart|try-restart)
+            stop && start
+            ;;
+        reload|force-reload)
+            # Nothing to do; we reread configuration on each invocation
+            ;;
+        shutdown)
+            stop
+            ;;
+        *)
+            usage
+            ;;
+    esac
+fi
+exit 0

--- a/debian/cuttlefish-common.default
+++ b/debian/cuttlefish-common.default
@@ -36,3 +36,7 @@
 #wifi_ipv6_prefix_length=
 #ethernet_ipv6_prefix=
 #ethernet_ipv6_prefix_length=
+
+# The port on which the orchestrator server should listen on for plain HTTP.
+# Defaults to 1080.
+# orchestrator_port=

--- a/debian/cuttlefish-common.install
+++ b/debian/cuttlefish-common.install
@@ -1,4 +1,7 @@
 host/deploy/install_zip.sh /usr/bin/
 host/deploy/unpack_boot_image.py /usr/lib/cuttlefish-common/bin/
 host/deploy/capability_query.py /usr/lib/cuttlefish-common/bin/
+host/frontend/host-orchestrator/host-orchestrator /usr/lib/cuttlefish-common/bin/
+host/frontend/host-orchestrator/static /usr/share/cuttlefish-common/host-orchestrator/
+host/frontend/host-orchestrator/intercept /usr/share/cuttlefish-common/host-orchestrator/
 host/packages/cuttlefish-common/* /

--- a/debian/cuttlefish-common.postinst
+++ b/debian/cuttlefish-common.postinst
@@ -8,6 +8,11 @@ case "$1" in
     then
         addgroup --system cvdnetwork
     fi
+    if ! getent passwd _cutf-operator > /dev/null 2>&1
+    then
+        adduser --system --disabled-password --disabled-login --home /var/empty \
+                --no-create-home --quiet --force-badname --ingroup cvdnetwork _cutf-operator
+    fi
 
     # Create the kvm group when running inside a docker container.
     if test -f /.dockerenv && ( ! getent group kvm > /dev/null 2>&1 )

--- a/debian/rules
+++ b/debian/rules
@@ -15,3 +15,16 @@ include /usr/share/dpkg/buildflags.mk
 
 %:
 	dh $@ --with=config-package
+
+SOURCE_DIR := host/frontend/host-orchestrator
+override_dh_auto_build:
+	$(SOURCE_DIR)/build
+
+override_dh_installinit:
+	dh_installinit --name=cuttlefish-host-orchestrator
+	dh_installinit
+
+override_dh_auto_clean:
+	-rm -f $(SOURCE_DIR)/host-orchestrator
+	dh_auto_clean
+

--- a/host/frontend/host-orchestrator/build
+++ b/host/frontend/host-orchestrator/build
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+cd $(dirname $0)
+
+go build -v
+
+go test
+

--- a/host/frontend/host-orchestrator/operator.go
+++ b/host/frontend/host-orchestrator/operator.go
@@ -48,6 +48,7 @@ func main() {
 	r := setupServerRoutes(pool, polledSet, config)
 
 	http.Handle("/", r)
+	log.Println("Client endpoint created")
 	if err := http.ListenAndServe(fmt.Sprint(":", port), nil); err != nil {
 		log.Fatal("ListenAndServe client: ", err)
 	}
@@ -66,6 +67,7 @@ func setupDeviceEndpoint(pool *DevicePool, config InfraConfig, path string) {
 	if err != nil {
 		log.Fatal("Failed to create unix socket: ", err)
 	}
+	log.Println("Device endpoint created")
 	// Serve the register_device endpoint in a background thread
 	go func() {
 		defer sock.Close()

--- a/host/frontend/host-orchestrator/operator.go
+++ b/host/frontend/host-orchestrator/operator.go
@@ -67,6 +67,11 @@ func setupDeviceEndpoint(pool *DevicePool, config InfraConfig, path string) {
 	if err != nil {
 		log.Fatal("Failed to create unix socket: ", err)
 	}
+	// Make sure the socket is only accessible by owner and group
+	if err := os.Chmod(path, 0770); err != nil {
+		// This shouldn't happen since the creation of the socket just succeeded
+		log.Println("Failed to change permissions on socket file: ", err)
+	}
 	log.Println("Device endpoint created")
 	// Serve the register_device endpoint in a background thread
 	go func() {


### PR DESCRIPTION
It just builds it and packages it, but doesn't start it at boot like it does with the cuttlefish-common service.

To test this you need to:
```
sudo service cuttlefish-host-orchestrator start
```
And then just launch_cvd from a recent master build, the device will be accessible in port 1080 over HTTP instead of port 8443 over HTTPS.