### PR TITLE
Support nvidia virtual GPUs

### DIFF
--- a/gpu/nvidia/probe.sh
+++ b/gpu/nvidia/probe.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -r
 
-test $(lspci | grep -i vga | grep -icw nvidia) -gt 0
+test $(lspci | grep -iE '(vga|3D controller)' | grep -icw nvidia) -gt 0


### PR DESCRIPTION
in GCP nvidia GPUs are reported as followed

00:04.0 3D controller: NVIDIA Corporation TU104GL [Tesla T4] (rev a1)

So we fix the probe method to address that