### PR TITLE
Removed x86_64 libc which is no longer needed

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -32,7 +32,6 @@ Depends: adduser,
          openssl,
          python3,
          qemu-user-static [arm64],
-         libc6:amd64 [arm64],
          ${misc:Depends},
          ${shlibs:Depends}
 Pre-Depends: ${misc:Pre-Depends}


### PR DESCRIPTION
mkenvimage relied on this package. Since that dep has been removed this line can be dropped.