### PR TITLE
Set execute permission to fetch_cvd.

### DIFF
--- a/host/frontend/host-orchestrator/instancemanager.go
+++ b/host/frontend/host-orchestrator/instancemanager.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"log"
 	"net/http"
 	"net/url"
@@ -93,7 +92,7 @@ type FetchCVDHandler struct {
 	dir                string
 	fetchCVDDownloader FetchCVDDownloader
 	mutex              sync.Mutex
-	osChmod            func(string, fs.FileMode) error
+	osChmod            func(string, os.FileMode) error
 }
 
 func NewFetchCVDHandler(dir string, fetchCVDDownloader FetchCVDDownloader) *FetchCVDHandler {

--- a/host/frontend/host-orchestrator/instancemanager.go
+++ b/host/frontend/host-orchestrator/instancemanager.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"net/http"
 	"net/url"
@@ -92,10 +93,11 @@ type FetchCVDHandler struct {
 	dir                string
 	fetchCVDDownloader FetchCVDDownloader
 	mutex              sync.Mutex
+	osChmod            func(string, fs.FileMode) error
 }
 
 func NewFetchCVDHandler(dir string, fetchCVDDownloader FetchCVDDownloader) *FetchCVDHandler {
-	return &FetchCVDHandler{dir, fetchCVDDownloader, sync.Mutex{}}
+	return &FetchCVDHandler{dir, fetchCVDDownloader, sync.Mutex{}, os.Chmod}
 }
 
 func (h *FetchCVDHandler) Download(buildID string) error {
@@ -120,7 +122,7 @@ func (h *FetchCVDHandler) Download(buildID string) error {
 		}
 		return err
 	}
-	return nil
+	return h.osChmod(fileName, 0750)
 }
 
 func (h *FetchCVDHandler) exist(buildID string) (bool, error) {

--- a/host/frontend/host-orchestrator/instancemanager_test.go
+++ b/host/frontend/host-orchestrator/instancemanager_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -156,7 +155,7 @@ func TestFetchCVDHandlerDownload0750FileAccessIsSet(t *testing.T) {
 	h.Download("1")
 
 	stats, _ := os.Stat(BuildFetchCVDFileName(dir, "1"))
-	var expected fs.FileMode = 0750
+	var expected os.FileMode = 0750
 	if stats.Mode() != expected {
 		t.Errorf("expected <<%+v>>, got %+v", expected, stats.Mode())
 	}
@@ -167,7 +166,7 @@ func TestFetchCVDHandlerDownloadSettingFileAccessFails(t *testing.T) {
 	downloader := &FakeFetchCVDDownloader{t, "foo"}
 	h := NewFetchCVDHandler(dir, downloader)
 	expectedErr := errors.New("error")
-	h.osChmod = func(_ string, _ fs.FileMode) error {
+	h.osChmod = func(_ string, _ os.FileMode) error {
 		return expectedErr
 	}
 

--- a/host/frontend/host-orchestrator/instancemanager_test.go
+++ b/host/frontend/host-orchestrator/instancemanager_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -102,53 +103,79 @@ func (d *FakeFetchCVDDownloader) Download(dst io.Writer, buildID string) error {
 	return nil
 }
 
-func TestFetchCVDHandler(t *testing.T) {
+func TestFetchCVDHandlerBinaryAlreadyExist(t *testing.T) {
 	dir := t.TempDir()
 	f, err := os.Create(BuildFetchCVDFileName(dir, "1"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer f.Close()
-	_, err = f.Write([]byte(string("000")))
+	_, err = f.Write([]byte(string("bar")))
 	if err != nil {
 		t.Fatal(err)
 	}
-	downloader := &FakeFetchCVDDownloader{
-		t:       t,
-		content: "111",
+	downloader := &FakeFetchCVDDownloader{t, "foo"}
+	h := NewFetchCVDHandler(dir, downloader)
+
+	err = h.Download("1")
+
+	if err != nil {
+		t.Errorf("epected <<nil>> error, got %#v", err)
+	}
+	content, err := ioutil.ReadFile(BuildFetchCVDFileName(dir, "1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual := string(content)
+	expected := "bar"
+	if actual != expected {
+		t.Errorf("expected <<%q>>, got %q", expected, actual)
+	}
+}
+
+func TestFetchCVDHandlerBinaryIsDownloaded(t *testing.T) {
+	dir := t.TempDir()
+	downloader := &FakeFetchCVDDownloader{t, "foo"}
+	h := NewFetchCVDHandler(dir, downloader)
+
+	h.Download("1")
+
+	content, _ := ioutil.ReadFile(BuildFetchCVDFileName(dir, "1"))
+	actual := string(content)
+	expected := "foo"
+	if actual != expected {
+		t.Errorf("expected <<%q>>, got %q", expected, actual)
+	}
+}
+
+func TestFetchCVDHandler0750FileAccessIsSet(t *testing.T) {
+	dir := t.TempDir()
+	downloader := &FakeFetchCVDDownloader{t, "foo"}
+	h := NewFetchCVDHandler(dir, downloader)
+
+	h.Download("1")
+
+	stats, _ := os.Stat(BuildFetchCVDFileName(dir, "1"))
+	var expected fs.FileMode = 0750
+	if stats.Mode() != expected {
+		t.Errorf("expected <<%+v>>, got %+v", expected, stats.Mode())
+	}
+}
+
+func TestFetchCVDHandlerSettingFileAccessFails(t *testing.T) {
+	dir := t.TempDir()
+	downloader := &FakeFetchCVDDownloader{t, "foo"}
+	h := NewFetchCVDHandler(dir, downloader)
+	expectedErr := errors.New("error")
+	h.osChmod = func(_ string, _ fs.FileMode) error {
+		return expectedErr
 	}
 
-	t.Run("binary is not downloaded as it already exists", func(t *testing.T) {
-		h := NewFetchCVDHandler(dir, downloader)
+	err := h.Download("1")
 
-		err := h.Download("1")
-
-		if err != nil {
-			t.Errorf("epected <<nil>> error, got %#v", err)
-		}
-		content, err := ioutil.ReadFile(BuildFetchCVDFileName(dir, "1"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		actual := string(content)
-		expected := "000"
-		if actual != expected {
-			t.Errorf("expected <<%q>>, got %q", expected, actual)
-		}
-	})
-
-	t.Run("binary is downloaded", func(t *testing.T) {
-		h := NewFetchCVDHandler(dir, downloader)
-
-		h.Download("2")
-
-		content, _ := ioutil.ReadFile(BuildFetchCVDFileName(dir, "2"))
-		actual := string(content)
-		expected := "111"
-		if actual != expected {
-			t.Errorf("expected <<%q>>, got %q", expected, actual)
-		}
-	})
+	if err != expectedErr {
+		t.Errorf("expected <<%+v>>, got %+v", expectedErr, err)
+	}
 }
 
 type AlwaysFailsFetchCVDDownloader struct{}

--- a/host/frontend/host-orchestrator/instancemanager_test.go
+++ b/host/frontend/host-orchestrator/instancemanager_test.go
@@ -103,13 +103,14 @@ func (d *FakeFetchCVDDownloader) Download(dst io.Writer, buildID string) error {
 }
 
 func TestFetchCVDHandlerDownloadBinaryAlreadyExist(t *testing.T) {
+	const fetchCVDContent = "bar"
 	dir := t.TempDir()
 	f, err := os.Create(BuildFetchCVDFileName(dir, "1"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer f.Close()
-	_, err = f.Write([]byte(string("bar")))
+	_, err = f.Write([]byte(fetchCVDContent))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,9 +127,8 @@ func TestFetchCVDHandlerDownloadBinaryAlreadyExist(t *testing.T) {
 		t.Fatal(err)
 	}
 	actual := string(content)
-	expected := "bar"
-	if actual != expected {
-		t.Errorf("expected <<%q>>, got %q", expected, actual)
+	if actual != fetchCVDContent {
+		t.Errorf("expected <<%q>>, got %q", fetchCVDContent, actual)
 	}
 }
 
@@ -172,7 +172,7 @@ func TestFetchCVDHandlerDownloadSettingFileAccessFails(t *testing.T) {
 
 	err := h.Download("1")
 
-	if err != expectedErr {
+	if !errors.Is(err, expectedErr) {
 		t.Errorf("expected <<%+v>>, got %+v", expectedErr, err)
 	}
 }

--- a/host/frontend/host-orchestrator/instancemanager_test.go
+++ b/host/frontend/host-orchestrator/instancemanager_test.go
@@ -103,7 +103,7 @@ func (d *FakeFetchCVDDownloader) Download(dst io.Writer, buildID string) error {
 	return nil
 }
 
-func TestFetchCVDHandlerBinaryAlreadyExist(t *testing.T) {
+func TestFetchCVDHandlerDownloadBinaryAlreadyExist(t *testing.T) {
 	dir := t.TempDir()
 	f, err := os.Create(BuildFetchCVDFileName(dir, "1"))
 	if err != nil {
@@ -133,7 +133,7 @@ func TestFetchCVDHandlerBinaryAlreadyExist(t *testing.T) {
 	}
 }
 
-func TestFetchCVDHandlerBinaryIsDownloaded(t *testing.T) {
+func TestFetchCVDHandlerDownload(t *testing.T) {
 	dir := t.TempDir()
 	downloader := &FakeFetchCVDDownloader{t, "foo"}
 	h := NewFetchCVDHandler(dir, downloader)
@@ -148,7 +148,7 @@ func TestFetchCVDHandlerBinaryIsDownloaded(t *testing.T) {
 	}
 }
 
-func TestFetchCVDHandler0750FileAccessIsSet(t *testing.T) {
+func TestFetchCVDHandlerDownload0750FileAccessIsSet(t *testing.T) {
 	dir := t.TempDir()
 	downloader := &FakeFetchCVDDownloader{t, "foo"}
 	h := NewFetchCVDHandler(dir, downloader)
@@ -162,7 +162,7 @@ func TestFetchCVDHandler0750FileAccessIsSet(t *testing.T) {
 	}
 }
 
-func TestFetchCVDHandlerSettingFileAccessFails(t *testing.T) {
+func TestFetchCVDHandlerDownloadSettingFileAccessFails(t *testing.T) {
 	dir := t.TempDir()
 	downloader := &FakeFetchCVDDownloader{t, "foo"}
 	h := NewFetchCVDHandler(dir, downloader)


### PR DESCRIPTION
- Remove the use of `t.Run` in FetchCVDHandler unit tests as its forcing
  keeping track of already used filenames.