### PR TITLE
cuttlefish-user was missing in building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,10 @@ COPY ./out/*.deb ./android-cuttlefish/out/
 
 RUN cd /root/android-cuttlefish/out \
     && apt-get install --no-install-recommends -y -f ./cuttlefish-base_*.deb \
-    && rm -rvf ./cuttlefish-base_*.deb \
+    && apt-get install --no-install-recommends -y -f ./cuttlefish-user_*.deb \
     && apt-get install --no-install-recommends -y -f ./cuttlefish-common_*.deb \
+    && rm -rvf ./cuttlefish-base_*.deb \
+    && rm -rvf ./cuttlefish-user_*.deb \
     && rm -rvf ./cuttlefish-common_*.deb \
     && cd /root
 

--- a/build.sh
+++ b/build.sh
@@ -168,6 +168,7 @@ function build_docker_image {
 
 function is_rebuild_debs() {
   local -a required_packages=("cuttlefish-base" \
+                              "cuttlefish-user" \
                               "cuttlefish-common" \
                               "cuttlefish-integration" \
                               "cuttlefish-integration-dbgsym")


### PR DESCRIPTION
cuttlefish-user package was missing in build.sh. Also, missing
in Dockerfile. Thus, ./build.sh did not build correctly.