### PR TITLE
Remove use of t.TempDir().

### DIFF
--- a/host/frontend/host-orchestrator/go.mod
+++ b/host/frontend/host-orchestrator/go.mod
@@ -5,8 +5,7 @@ go 1.19
 replace cuttlefish/liboperator v0.0.0-unpublished => ../liboperator
 
 require (
-	cuttlefish/liboperator v0.0.0-unpublished // indirect
-	github.com/google/uuid v1.3.0 // indirect
-	github.com/gorilla/mux v1.8.0 // indirect
-	github.com/gorilla/websocket v1.4.2 // indirect
+	cuttlefish/liboperator v0.0.0-unpublished
+	github.com/google/uuid v1.3.0
+	github.com/gorilla/mux v1.8.0
 )

--- a/host/frontend/host-orchestrator/orchestrator/instancemanager_test.go
+++ b/host/frontend/host-orchestrator/orchestrator/instancemanager_test.go
@@ -17,6 +17,7 @@ package orchestrator
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -28,6 +29,7 @@ import (
 
 	apiv1 "cuttlefish/liboperator/api/v1"
 	"cuttlefish/liboperator/operator"
+	"github.com/google/uuid"
 )
 
 func TestCreateCVDInvalidRequestsEmptyFields(t *testing.T) {
@@ -291,8 +293,7 @@ func TestLaunchCVDProcedureBuilder(t *testing.T) {
 }
 
 func TestStageDownloadCVDDownloadFails(t *testing.T) {
-	dir := t.TempDir()
-	cvdBin := dir + "/cvd"
+	cvdBin := "/tmp/cvd"
 	expectedErr := errors.New("error")
 	s := StageDownloadCVD{
 		CVDBin:     cvdBin,
@@ -308,7 +309,8 @@ func TestStageDownloadCVDDownloadFails(t *testing.T) {
 }
 
 func TestStageDownloadCVD(t *testing.T) {
-	dir := t.TempDir()
+	dir := tempDir(t)
+	defer removeDir(t, dir)
 	cvdBin := dir + "/cvd"
 	cvdBinContent := "foo"
 	ad := &FakeArtifactDownloader{
@@ -334,7 +336,9 @@ func TestStageDownloadCVD(t *testing.T) {
 }
 
 func TestStageCreateDirIfNotExist(t *testing.T) {
-	dir := t.TempDir() + "/foo"
+	tmpDir := tempDir(t)
+	defer removeDir(t, tmpDir)
+	dir := tmpDir + "/foo"
 	s := StageCreateDirIfNotExist{Dir: dir}
 
 	err := s.Run()
@@ -351,7 +355,9 @@ func TestStageCreateDirIfNotExist(t *testing.T) {
 }
 
 func TestStageCreateDirIfNotExistAndDirectoryExists(t *testing.T) {
-	dir := t.TempDir() + "/foo"
+	tmpDir := tempDir(t)
+	defer removeDir(t, tmpDir)
+	dir := tmpDir + "/foo"
 	s := StageCreateDirIfNotExist{Dir: dir}
 
 	err := s.Run()
@@ -393,7 +399,8 @@ func (d *FakeArtifactDownloader) Download(dst io.Writer, _ AndroidBuild, name st
 
 func TestCVDDownloaderDownloadBinaryAlreadyExist(t *testing.T) {
 	const fetchCVDContent = "bar"
-	dir := t.TempDir()
+	dir := tempDir(t)
+	defer removeDir(t, dir)
 	filename := dir + "/cvd"
 	f, err := os.Create(filename)
 	if err != nil {
@@ -423,7 +430,8 @@ func TestCVDDownloaderDownloadBinaryAlreadyExist(t *testing.T) {
 }
 
 func TestCVDDownloaderDownload(t *testing.T) {
-	dir := t.TempDir()
+	dir := tempDir(t)
+	defer removeDir(t, dir)
 	filename := dir + "/cvd"
 	ad := &FakeArtifactDownloader{t, "foo"}
 	cd := NewCVDDownloader(ad)
@@ -439,7 +447,8 @@ func TestCVDDownloaderDownload(t *testing.T) {
 }
 
 func TestCVDDownloaderDownload0750FileAccessIsSet(t *testing.T) {
-	dir := t.TempDir()
+	dir := tempDir(t)
+	defer removeDir(t, dir)
 	filename := dir + "/cvd"
 	ad := &FakeArtifactDownloader{t, "foo"}
 	cd := NewCVDDownloader(ad)
@@ -454,7 +463,8 @@ func TestCVDDownloaderDownload0750FileAccessIsSet(t *testing.T) {
 }
 
 func TestCVDDownloaderDownloadSettingFileAccessFails(t *testing.T) {
-	dir := t.TempDir()
+	dir := tempDir(t)
+	defer removeDir(t, dir)
 	filename := dir + "/cvd"
 	ad := &FakeArtifactDownloader{t, "foo"}
 	cd := NewCVDDownloader(ad)
@@ -479,7 +489,8 @@ func (d *AlwaysFailsArtifactDownloader) Download(_ io.Writer, _ AndroidBuild, _ 
 }
 
 func TestCVDDownloaderDownloadingFails(t *testing.T) {
-	dir := t.TempDir()
+	dir := tempDir(t)
+	defer removeDir(t, dir)
 	filename := dir + "/cvd"
 	expectedErr := errors.New("error")
 	cd := NewCVDDownloader(&AlwaysFailsArtifactDownloader{err: expectedErr})
@@ -700,6 +711,26 @@ func TestBuildGetSignedURL(t *testing.T) {
 			t.Errorf("expected <<%q>>, got %q", expected, actual)
 		}
 	})
+}
+
+// Creates a temporary directory for the test to use returning its path.
+// Each subsequent call creates a unique directory; if the directory creation
+// fails, `tempDir` terminates the test by calling Fatal.
+func tempDir(t *testing.T) string {
+	name := fmt.Sprintf("%s/cuttlefishTestDir-%s", os.TempDir(), uuid.New().String())
+	err := os.Mkdir(name, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return name
+}
+
+// Removes the directory at the passed path.
+// If deletion fails, `removeDir` terminates the test by calling Fatal.
+func removeDir(t *testing.T, name string) {
+	if err := os.RemoveAll(name); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // Creates a new exec.Cmd, which will call the `TestMockGoTestCmdHelperFunction`

--- a/host/frontend/host-orchestrator/orchestrator/instancemanager_test.go
+++ b/host/frontend/host-orchestrator/orchestrator/instancemanager_test.go
@@ -17,7 +17,6 @@ package orchestrator
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -29,7 +28,6 @@ import (
 
 	apiv1 "cuttlefish/liboperator/api/v1"
 	"cuttlefish/liboperator/operator"
-	"github.com/google/uuid"
 )
 
 func TestCreateCVDInvalidRequestsEmptyFields(t *testing.T) {
@@ -293,7 +291,7 @@ func TestLaunchCVDProcedureBuilder(t *testing.T) {
 }
 
 func TestStageDownloadCVDDownloadFails(t *testing.T) {
-	cvdBin := "/tmp/cvd"
+	cvdBin := os.TempDir() + "/cvd"
 	expectedErr := errors.New("error")
 	s := StageDownloadCVD{
 		CVDBin:     cvdBin,
@@ -717,8 +715,7 @@ func TestBuildGetSignedURL(t *testing.T) {
 // Each subsequent call creates a unique directory; if the directory creation
 // fails, `tempDir` terminates the test by calling Fatal.
 func tempDir(t *testing.T) string {
-	name := fmt.Sprintf("%s/cuttlefishTestDir-%s", os.TempDir(), uuid.New().String())
-	err := os.Mkdir(name, 0700)
+	name, err := ioutil.TempDir("", "cuttlefishTestDir")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- t.TempDir() was introduced in go1.15 and host orchestrator should
  support go1.13.
- go.mod changed in sync with go1.13.15