### PR TITLE
Remove websocket support

### DIFF
--- a/host/frontend/host-orchestrator/go.mod
+++ b/host/frontend/host-orchestrator/go.mod
@@ -9,5 +9,3 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 )
-
-require github.com/gorilla/websocket v1.4.2 // indirect

--- a/host/frontend/host-orchestrator/go.sum
+++ b/host/frontend/host-orchestrator/go.sum
@@ -2,5 +2,3 @@ github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
-github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/host/frontend/host-orchestrator/main.go
+++ b/host/frontend/host-orchestrator/main.go
@@ -134,7 +134,7 @@ func main() {
 		err := deviceServerLoop()
 		log.Fatal("Error with device endpoint: ", err)
 	}()
-	r := operator.CreateHttpHandlers(pool, polledSet, config, maybeIntercept, true /*acceptsWS*/)
+	r := operator.CreateHttpHandlers(pool, polledSet, config, maybeIntercept)
 	orchestrator.SetupInstanceManagement(r, im, om)
 	// The host orchestrator currently has no use for this, since clients won't connect
 	// to it directly, however they probably will once the multi-device feature matures.

--- a/host/frontend/liboperator/go.mod
+++ b/host/frontend/liboperator/go.mod
@@ -5,5 +5,4 @@ go 1.17
 require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
-	github.com/gorilla/websocket v1.4.2
 )

--- a/host/frontend/liboperator/go.sum
+++ b/host/frontend/liboperator/go.sum
@@ -2,5 +2,3 @@ github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
-github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/host/frontend/liboperator/operator/clients.go
+++ b/host/frontend/liboperator/operator/clients.go
@@ -28,23 +28,6 @@ type Client interface {
 	OnDeviceDisconnected()
 }
 
-// Implements the client interface using a websocket connection
-type WsClient struct {
-	ws *JSONWs
-}
-
-func NewWsClient(ws *JSONWs) *WsClient {
-	return &WsClient{ws: ws}
-}
-
-// From IClient
-func (c *WsClient) Send(msg interface{}) error {
-	return c.ws.Send(msg)
-}
-func (c *WsClient) OnDeviceDisconnected() {
-	// Do nothing
-}
-
 // Implements the client interface using a polled connection
 type PolledClient struct {
 	// The polled connection id
@@ -101,8 +84,7 @@ func (c *PolledClient) ClientId() int {
 	return c.clientId
 }
 
-// Basically a map of polled clients by id. This is necessary because polled
-// connections are not handled in an exclusive thread like those based on websockets.
+// Basically a map of polled clients by id.
 type PolledSet struct {
 	connections map[string]*PolledClient
 	mapMtx      sync.Mutex

--- a/host/frontend/liboperator/operator/jsonservers.go
+++ b/host/frontend/liboperator/operator/jsonservers.go
@@ -18,49 +18,11 @@ import (
 	"encoding/json"
 	"log"
 	"net"
-	"net/http"
 	"sync"
 	"syscall"
-
-	"github.com/gorilla/websocket"
 )
 
-// A websocket connection that can send and receive JSON objects.
-// Only one thread should call Recv() at a time, Send() and Close() are thread safe
-type JSONWs struct {
-	conn     *websocket.Conn
-	writeMtx sync.Mutex
-}
-
-var upgrader = websocket.Upgrader{} // default options
-
-func NewJSONWs(w http.ResponseWriter, r *http.Request) *JSONWs {
-	conn, err := upgrader.Upgrade(w, r, nil)
-	if err != nil {
-		log.Println(err)
-		return nil
-	}
-	return &JSONWs{conn: conn}
-}
-
-func (ws *JSONWs) Send(val interface{}) error {
-	ws.writeMtx.Lock()
-	defer ws.writeMtx.Unlock()
-	return ws.conn.WriteJSON(val)
-}
-
-func (ws *JSONWs) Recv(val interface{}) error {
-	return ws.conn.ReadJSON(val)
-}
-
-func (ws *JSONWs) Close() {
-	ws.writeMtx.Lock()
-	defer ws.writeMtx.Unlock()
-	ws.conn.WriteMessage(websocket.CloseMessage, []byte{})
-	ws.conn.Close()
-}
-
-// A Unix socket connection (as returned by Accept) that can send recieve JSON objects.
+// A Unix socket connection (as returned by Accept) that can send and receive JSON objects.
 // Only one thread should call Recv() at a time, Send and Close are thread safe
 type JSONUnix struct {
 	conn     *net.UnixConn

--- a/host/frontend/operator/go.mod
+++ b/host/frontend/operator/go.mod
@@ -8,5 +8,3 @@ require (
 	cuttlefish/liboperator v0.0.0-unpublished
 	github.com/gorilla/mux v1.8.0
 )
-
-require github.com/gorilla/websocket v1.4.2 // indirect

--- a/host/frontend/operator/go.sum
+++ b/host/frontend/operator/go.sum
@@ -1,4 +1,2 @@
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
-github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/host/frontend/operator/main.go
+++ b/host/frontend/operator/main.go
@@ -101,7 +101,7 @@ func main() {
 		},
 	}
 
-	r := operator.CreateHttpHandlers(pool, polledSet, config, maybeIntercept, true /*acceptsWS*/)
+	r := operator.CreateHttpHandlers(pool, polledSet, config, maybeIntercept)
 	fs := http.FileServer(http.Dir(DefaultStaticFilesDir))
 	r.PathPrefix("/").Handler(fs)
 	http.Handle("/", r)


### PR DESCRIPTION
The websocket library we're using doesn't currently have a maintainer, so its future is uncertain.
The HTTP polling connector works in all cases, unlike the websocket one which is know to be unreliable through proxies and is hard to make it work on a multi-server setup.
There won't be an incompatibility with clients since the server_connector.js hides the websocket logic from the client and is provided by the server.
