### PR TITLE
Changes cvd binary BuildID config value to tested value "8687975".

### DIFF
--- a/debian/cuttlefish-orchestration.cuttlefish-host-orchestrator.init
+++ b/debian/cuttlefish-orchestration.cuttlefish-host-orchestrator.init
@@ -39,7 +39,7 @@ orchestrator_https_port=${orchestrator_https_port:-1443}
 orchestrator_tls_cert_dir=${orchestrator_tls_cert_dir:-"/etc/cuttlefish-common/host-orchestrator/cert"}
 orchestrator_instance_manager_enabled=${orchestrator_instance_manager_enabled:-false}
 orchestrator_android_build_url=${orchestrator_android_build_url:-"https://androidbuildinternal.googleapis.com"}
-orchestrator_cvdbin_android_build_id=${orchestrator_cvdbin_android_build_id:-"8817521"}
+orchestrator_cvdbin_android_build_id=${orchestrator_cvdbin_android_build_id:-"8687975"}
 orchestrator_cvdbin_android_build_target=${orchestrator_cvdbin_android_build_target:-"aosp_cf_x86_64_phone-userdebug"}
 orchestrator_cvd_artifacts_dir=${orchestrator_cvd_artifacts_dir:-"/var/lib/cuttlefish-common"}
 

--- a/host/frontend/host-orchestrator/main.go
+++ b/host/frontend/host-orchestrator/main.go
@@ -35,7 +35,7 @@ const (
 	DefaultInterceptDir   = "intercept" // relative path
 
 	defaultAndroidBuildURL          = "https://androidbuildinternal.googleapis.com"
-	defaultCVDBinAndroidBuildID     = "8817521"
+	defaultCVDBinAndroidBuildID     = "8687975"
 	defaultCVDBinAndroidBuildTarget = "aosp_cf_x86_64_phone-userdebug"
 	defaultCVDArtifactsDir          = "/var/lib/cuttlefish-common"
 )


### PR DESCRIPTION
- For BuildID 8817521, `cvd fetch` command is fails with error:

"""
exe E 07-28 18:56:05 727612 727612 subprocess.cpp:323] exec of fetch_cvd failed (No such file or directory)\nReceived error response for \"HandleCommand\":\nExited with code 255\nIn client\n at device/google/cuttlefish/host/commands/cvd/main.cc:294\n in Result<void> cuttlefish::(anonymous namespace)::CvdClient::CheckStatus(const cvd::Status &, const std::string &)\nReceived error\n  at device/google/cuttle fish/host/commands/cvd/main.cc:213\n  in Result<void> cuttlefish::(anonymous namespace)::CvdClient::HandleCommand(std::vector<std::string>, std::vector<std::string>)\n  for CF_EXPECT(CheckStatus(response.status(), \"HandleCommand\"))\nReceived error\n  at device/google/cuttlefish  /host/commands/cvd/main.cc:413\n in Result<void> cuttlefish::(anonymous namespace)::CvdMain(int, char **, char **)\n  for CF_EXPECT(client.HandleCommand(args, env))\n
"""