### PR TITLE
Add an option to use web UI outside the package instead of static asset included in the package

### DIFF
--- a/debian/cuttlefish-orchestration.cuttlefish-host-orchestrator.default
+++ b/debian/cuttlefish-orchestration.cuttlefish-host-orchestrator.default
@@ -26,8 +26,8 @@
 # Defaults to "/var/lib/cuttlefish-common"
 # orchestrator_cvd_artifacts_dir=
 #
-# Whether a web application is served by `ng serve`.
-# If true, it uses web pages served by `ng serve`,
-# else, it uses built web pages.
-# Defaults to false
-# orchestrator_use_ng_serve=
+# Where web UI in the application is from
+# If it isn't empty, the application uses web UI from the url,
+# else, it uses web pages which is generated during the build
+# Defaults to ""
+# orchestrator_webui_url=

--- a/debian/cuttlefish-orchestration.cuttlefish-host-orchestrator.default
+++ b/debian/cuttlefish-orchestration.cuttlefish-host-orchestrator.default
@@ -25,3 +25,9 @@
 # Directory used to store the CVD artifacts.
 # Defaults to "/var/lib/cuttlefish-common"
 # orchestrator_cvd_artifacts_dir=
+#
+# Whether a web application is served by `ng serve`.
+# If true, it uses web pages served by `ng serve`,
+# else, it uses built web pages.
+# Defaults to false
+# orchestrator_use_ng_serve=

--- a/debian/cuttlefish-orchestration.cuttlefish-host-orchestrator.init
+++ b/debian/cuttlefish-orchestration.cuttlefish-host-orchestrator.init
@@ -42,7 +42,7 @@ orchestrator_android_build_url=${orchestrator_android_build_url:-"https://androi
 orchestrator_cvdbin_android_build_id=${orchestrator_cvdbin_android_build_id:-"8687975"}
 orchestrator_cvdbin_android_build_target=${orchestrator_cvdbin_android_build_target:-"aosp_cf_x86_64_phone-userdebug"}
 orchestrator_cvd_artifacts_dir=${orchestrator_cvd_artifacts_dir:-"/var/lib/cuttlefish-common"}
-orchestrator_use_ng_serve=${orchestrator_use_ng_serve:-false}
+orchestrator_webui_url=${orchestrator_webui_url:-""}
 
 RUN_DIR="/run/cuttlefish"
 ASSET_DIR="/usr/share/cuttlefish-common/host-orchestrator"
@@ -88,7 +88,7 @@ start() {
   ORCHESTRATOR_CVDBIN_ANDROID_BUILD_TARGET="${orchestrator_cvdbin_android_build_target}" \
   ORCHESTRATOR_CVD_ARTIFACTS_DIR="${orchestrator_cvd_artifacts_dir}" \
   ORCHESTRATOR_SOCKET_PATH="${RUN_DIR}"/operator \
-  ORCHESTRATOR_USE_NG_SERVE="${orchestrator_use_ng_serve}" \
+  ORCHESTRATOR_WEBUI_URL="${orchestrator_webui_url}" \
   start-stop-daemon --start \
     --pidfile "${PIDFILE}" \
     --chuid _cutf-operator:cvdnetwork \

--- a/debian/cuttlefish-orchestration.cuttlefish-host-orchestrator.init
+++ b/debian/cuttlefish-orchestration.cuttlefish-host-orchestrator.init
@@ -42,6 +42,7 @@ orchestrator_android_build_url=${orchestrator_android_build_url:-"https://androi
 orchestrator_cvdbin_android_build_id=${orchestrator_cvdbin_android_build_id:-"8687975"}
 orchestrator_cvdbin_android_build_target=${orchestrator_cvdbin_android_build_target:-"aosp_cf_x86_64_phone-userdebug"}
 orchestrator_cvd_artifacts_dir=${orchestrator_cvd_artifacts_dir:-"/var/lib/cuttlefish-common"}
+orchestrator_use_ng_serve=${orchestrator_use_ng_serve:-false}
 
 RUN_DIR="/run/cuttlefish"
 ASSET_DIR="/usr/share/cuttlefish-common/host-orchestrator"
@@ -87,6 +88,7 @@ start() {
   ORCHESTRATOR_CVDBIN_ANDROID_BUILD_TARGET="${orchestrator_cvdbin_android_build_target}" \
   ORCHESTRATOR_CVD_ARTIFACTS_DIR="${orchestrator_cvd_artifacts_dir}" \
   ORCHESTRATOR_SOCKET_PATH="${RUN_DIR}"/operator \
+  ORCHESTRATOR_USE_NG_SERVE="${orchestrator_use_ng_serve}" \
   start-stop-daemon --start \
     --pidfile "${PIDFILE}" \
     --chuid _cutf-operator:cvdnetwork \

--- a/debian/cuttlefish-user.cuttlefish-operator.default
+++ b/debian/cuttlefish-user.cuttlefish-operator.default
@@ -12,3 +12,9 @@
 # communication lives.
 # Defaults to "/etc/cuttlefish-common/operator/cert".
 # operator_tls_cert_dir=
+#
+# Whether a web application is served by `ng serve`.
+# If true, it uses web pages served by `ng serve`,
+# else, it uses built web pages.
+# Defaults to false
+# operator_use_ng_serve=

--- a/debian/cuttlefish-user.cuttlefish-operator.default
+++ b/debian/cuttlefish-user.cuttlefish-operator.default
@@ -13,8 +13,8 @@
 # Defaults to "/etc/cuttlefish-common/operator/cert".
 # operator_tls_cert_dir=
 #
-# Whether a web application is served by `ng serve`.
-# If true, it uses web pages served by `ng serve`,
-# else, it uses built web pages.
-# Defaults to false
-# operator_use_ng_serve=
+# Where web UI in the application is from
+# If it isn't empty, the application uses web UI from the url,
+# else, it uses web pages which is generated during the build
+# Defaults to ""
+# operator_webui_url=

--- a/debian/cuttlefish-user.cuttlefish-operator.init
+++ b/debian/cuttlefish-user.cuttlefish-operator.init
@@ -37,6 +37,7 @@ fi
 operator_http_port=${operator_http_port:-1080}
 operator_https_port=${operator_https_port:-1443}
 operator_tls_cert_dir=${operator_tls_cert_dir:-"/etc/cuttlefish-common/operator/cert"}
+operator_use_ng_serve=${operator_use_ng_serve:-false}
 
 RUN_DIR="/run/cuttlefish"
 ASSET_DIR="/usr/share/cuttlefish-common/operator"
@@ -74,6 +75,7 @@ start() {
   OPERATOR_HTTPS_PORT="${operator_https_port}" \
   OPERATOR_TLS_CERT_DIR="${operator_tls_cert_dir}" \
   OPERATOR_SOCKET_PATH="${RUN_DIR}"/operator \
+  OPERATOR_USE_NG_SERVE="${operator_use_ng_serve}" \
   start-stop-daemon --start \
     --pidfile "${PIDFILE}" \
     --chuid _cutf-operator:cvdnetwork \

--- a/debian/cuttlefish-user.cuttlefish-operator.init
+++ b/debian/cuttlefish-user.cuttlefish-operator.init
@@ -37,7 +37,7 @@ fi
 operator_http_port=${operator_http_port:-1080}
 operator_https_port=${operator_https_port:-1443}
 operator_tls_cert_dir=${operator_tls_cert_dir:-"/etc/cuttlefish-common/operator/cert"}
-operator_use_ng_serve=${operator_use_ng_serve:-false}
+operator_webui_url=${operator_webui_url:-""}
 
 RUN_DIR="/run/cuttlefish"
 ASSET_DIR="/usr/share/cuttlefish-common/operator"
@@ -75,7 +75,7 @@ start() {
   OPERATOR_HTTPS_PORT="${operator_https_port}" \
   OPERATOR_TLS_CERT_DIR="${operator_tls_cert_dir}" \
   OPERATOR_SOCKET_PATH="${RUN_DIR}"/operator \
-  OPERATOR_USE_NG_SERVE="${operator_use_ng_serve}" \
+  OPERATOR_WEBUI_URL="${operator_webui_url}" \
   start-stop-daemon --start \
     --pidfile "${PIDFILE}" \
     --chuid _cutf-operator:cvdnetwork \

--- a/host/frontend/host-orchestrator/main.go
+++ b/host/frontend/host-orchestrator/main.go
@@ -18,7 +18,10 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 	"os"
+	"strconv"
 	"sync"
 
 	"cuttlefish/host-orchestrator/orchestrator"
@@ -33,6 +36,7 @@ const (
 	DefaultTLSCertDir     = "/etc/cuttlefish-common/host-orchestrator/cert"
 	DefaultStaticFilesDir = "static"    // relative path
 	DefaultInterceptDir   = "intercept" // relative path
+	DefaultNgServe        = false
 
 	defaultAndroidBuildURL          = "https://androidbuildinternal.googleapis.com"
 	defaultCVDBinAndroidBuildID     = "8687975"
@@ -67,6 +71,16 @@ func fromEnvOrDefault(key string, def string) string {
 	return val
 }
 
+func fromEnvOrDefaultBool(key string, def bool) bool {
+	val, err := strconv.ParseBool(os.Getenv(key))
+
+	if err != nil {
+		return def
+	}
+
+	return val
+}
+
 // Whether a device file request should be intercepted and served from the signaling server instead
 func maybeIntercept(path string) *string {
 	if path == "/js/server_connector.js" {
@@ -95,6 +109,7 @@ func main() {
 	httpPort := fromEnvOrDefault("ORCHESTRATOR_HTTP_PORT", DefaultHttpPort)
 	httpsPort := fromEnvOrDefault("ORCHESTRATOR_HTTPS_PORT", DefaultHttpsPort)
 	tlsCertDir := fromEnvOrDefault("ORCHESTRATOR_TLS_CERT_DIR", DefaultTLSCertDir)
+	use_ng_serve := fromEnvOrDefaultBool("ORCHESTRATOR_USE_NG_SERVE", DefaultNgServe)
 	certPath := tlsCertDir + "/cert.pem"
 	keyPath := tlsCertDir + "/key.pem"
 
@@ -138,8 +153,14 @@ func main() {
 	orchestrator.SetupInstanceManagement(r, im, om)
 	// The host orchestrator currently has no use for this, since clients won't connect
 	// to it directly, however they probably will once the multi-device feature matures.
-	fs := http.FileServer(http.Dir(DefaultStaticFilesDir))
-	r.PathPrefix("/").Handler(fs)
+	if use_ng_serve {
+		angularUrl, _ := url.Parse("http://localhost:4200")
+		proxy := httputil.NewSingleHostReverseProxy(angularUrl)
+		r.PathPrefix("/").Handler(proxy)
+	} else {
+		fs := http.FileServer(http.Dir(DefaultStaticFilesDir))
+		r.PathPrefix("/").Handler(fs)
+	}
 	http.Handle("/", r)
 
 	starters := []func() error{


### PR DESCRIPTION
It is inconvenient to build whole deb packages to develop only web ui.
So added operator_use_ng_serve/orchestrator_use_ng_serve to reverse-proxy 4200 port (which is used from ng seve) for web ui.

By this, we can boost dev cycle for web ui.