### PR TITLE
Add `/devices/{deviceId}` API & WebUI service method for getting device info

### DIFF
--- a/host/frontend/liboperator/api/v1/messages.go
+++ b/host/frontend/liboperator/api/v1/messages.go
@@ -89,3 +89,8 @@ type Operation struct {
 type OperationResult struct {
 	Error *ErrorMsg `json:"error,omitempty"`
 }
+
+type DeviceInfoReply struct {
+	DeviceId string `json:"device_id"`
+	RegistrationInfo interface{} `json:"registration_info"`
+}

--- a/host/frontend/liboperator/operator/operator.go
+++ b/host/frontend/liboperator/operator/operator.go
@@ -187,7 +187,7 @@ func deviceInfo(w http.ResponseWriter, r *http.Request, pool *DevicePool) {
 		http.NotFound(w, r)
 		return
 	}
-	ReplyJSONOK(w, dev.info)
+	ReplyJSONOK(w, apiv1.DeviceInfoReply {DeviceId: devId, RegistrationInfo: dev.info})
 }
 
 func deviceFiles(w http.ResponseWriter, r *http.Request, pool *DevicePool, maybeIntercept func(string) *string) {

--- a/host/frontend/operator/webui/src/app/device-info-interface.ts
+++ b/host/frontend/operator/webui/src/app/device-info-interface.ts
@@ -4,6 +4,11 @@ export interface DisplayInfo {
   y_res: number;
 }
 
-export interface DeviceInfo {
+export interface RegistrationInfo {
   displays: DisplayInfo[];
+}
+
+export interface DeviceInfo {
+  device_id: string;
+  registration_info: RegistrationInfo;
 }

--- a/host/frontend/operator/webui/src/app/device-info-interface.ts
+++ b/host/frontend/operator/webui/src/app/device-info-interface.ts
@@ -1,0 +1,9 @@
+export interface DisplayInfo {
+  dpi: number;
+  x_res: number;
+  y_res: number;
+}
+
+export interface DeviceInfo {
+  displays: DisplayInfo[];
+}

--- a/host/frontend/operator/webui/src/app/device.service.ts
+++ b/host/frontend/operator/webui/src/app/device.service.ts
@@ -2,6 +2,7 @@ import {Injectable, SecurityContext} from '@angular/core';
 import {map, ReplaySubject, Subject} from 'rxjs';
 import {HttpClient} from '@angular/common/http';
 import {Device} from './device-interface';
+import {DeviceInfo} from './device-info-interface';
 import {DomSanitizer} from '@angular/platform-browser';
 
 @Injectable({
@@ -43,5 +44,11 @@ export class DeviceService {
   getDevices() {
     this.refresh();
     return this.devicesObservable;
+  }
+
+  getDeviceInfo(deviceId: string) {
+    return this.httpClient
+      .get('./devices/' + deviceId)
+      .pipe(map(res => res as DeviceInfo));
   }
 }

--- a/host/frontend/operator/webui/src/app/device.service.ts
+++ b/host/frontend/operator/webui/src/app/device.service.ts
@@ -1,5 +1,5 @@
 import {Injectable, SecurityContext} from '@angular/core';
-import {map, ReplaySubject, Subject} from 'rxjs';
+import {map, Observable, ReplaySubject, Subject} from 'rxjs';
 import {HttpClient} from '@angular/common/http';
 import {Device} from './device-interface';
 import {DeviceInfo} from './device-info-interface';
@@ -46,7 +46,7 @@ export class DeviceService {
     return this.devicesObservable;
   }
 
-  getDeviceInfo(deviceId: string) {
+  getDeviceInfo(deviceId: string) : Observable<DeviceInfo> {
     return this.httpClient
       .get('./devices/' + deviceId)
       .pipe(map(res => res as DeviceInfo));


### PR DESCRIPTION
To determine initial view size at Web UI, it needs to get display info of a device.

Add API for getting specific device's info, and also add API client at DeviceService of web UI.