### PR TITLE
Steve dir fix

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -174,7 +174,7 @@ function is_rebuild_debs() {
                               "cuttlefish-user" \
                               "cuttlefish-common" \
                               "cuttlefish-integration" \
-                              "cuttlefish-integration-dbgsym")
+                              "cuttlefish-orchestration")
   if [[ ${FLAGS_rebuild_debs} -eq ${FLAGS_TRUE} ]]; then
       return 0
   fi

--- a/docker/debs-builder-docker/build-debs-with-docker.sh
+++ b/docker/debs-builder-docker/build-debs-with-docker.sh
@@ -58,7 +58,7 @@ function build_host_debian_pkg {
       exit 1
   fi
 
-  if ! docker cp $android_cuttlefish_on_host $container_name:$host_dir_on_guest > /dev/null 2>&1; then
+  if ! docker cp $android_cuttlefish_on_host/. $container_name:$src_on_guest > /dev/null 2>&1; then
       >&2 echo "fail to copy android-cuttlefish/* to the container, $container_name"
       exit 2
   fi


### PR DESCRIPTION
Two minor bug fixes:

 1. When the repository is cloned to a directory that is not android-cuttlefish, the build.sh fails.
 2. As the set of host deb packages changed and the required package list in is_rebuild_debs() hasn't changed, the host packages were anyway rebuild from the scratch. 