### PR TITLE
Use new resource path `/cvds` for instance management.

### DIFF
--- a/frontend/src/host-orchestrator/orchestrator/orchestrator.go
+++ b/frontend/src/host-orchestrator/orchestrator/orchestrator.go
@@ -25,7 +25,7 @@ import (
 )
 
 func SetupInstanceManagement(router *mux.Router, im *InstanceManager, om OperationManager) {
-	router.HandleFunc("/devices", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/instances", func(w http.ResponseWriter, r *http.Request) {
 		createDevices(w, r, im)
 	}).Methods("POST")
 	router.HandleFunc("/operations/{name}", func(w http.ResponseWriter, r *http.Request) {

--- a/frontend/src/host-orchestrator/orchestrator/orchestrator.go
+++ b/frontend/src/host-orchestrator/orchestrator/orchestrator.go
@@ -25,7 +25,7 @@ import (
 )
 
 func SetupInstanceManagement(router *mux.Router, im *InstanceManager, om OperationManager) {
-	router.HandleFunc("/instances", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/cvds", func(w http.ResponseWriter, r *http.Request) {
 		createDevices(w, r, im)
 	}).Methods("POST")
 	router.HandleFunc("/operations/{name}", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
- Path `/cvds` is already taken for webrtc streaming functionalities.