### PR TITLE
Rename go modules to allow importing from other projects

### DIFF
--- a/frontend/src/host_orchestrator/go.mod
+++ b/frontend/src/host_orchestrator/go.mod
@@ -1,11 +1,11 @@
-module cuttlefish/host_orchestrator
+module github.com/google/android-cuttlefish/frontend/src/host_orchestrator
 
 go 1.19
 
-replace cuttlefish/liboperator v0.0.0-unpublished => ../liboperator
+replace github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-unpublished => ../liboperator
 
 require (
-	cuttlefish/liboperator v0.0.0-unpublished
+	github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-unpublished
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 )

--- a/frontend/src/host_orchestrator/main.go
+++ b/frontend/src/host_orchestrator/main.go
@@ -23,9 +23,9 @@ import (
 	"os"
 	"sync"
 
-	"cuttlefish/host_orchestrator/orchestrator"
-	apiv1 "cuttlefish/liboperator/api/v1"
-	"cuttlefish/liboperator/operator"
+	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator"
+	apiv1 "github.com/google/android-cuttlefish/frontend/src/liboperator/api/v1"
+	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
 )
 
 const (

--- a/frontend/src/host_orchestrator/orchestrator/instancemanager.go
+++ b/frontend/src/host_orchestrator/orchestrator/instancemanager.go
@@ -26,8 +26,8 @@ import (
 	"sync"
 	"sync/atomic"
 
-	apiv1 "cuttlefish/liboperator/api/v1"
-	"cuttlefish/liboperator/operator"
+	apiv1 "github.com/google/android-cuttlefish/frontend/src/liboperator/api/v1"
+	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
 )
 
 type EmptyFieldError string

--- a/frontend/src/host_orchestrator/orchestrator/instancemanager_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/instancemanager_test.go
@@ -28,8 +28,8 @@ import (
 	"strings"
 	"testing"
 
-	apiv1 "cuttlefish/liboperator/api/v1"
-	"cuttlefish/liboperator/operator"
+	apiv1 "github.com/google/android-cuttlefish/frontend/src/liboperator/api/v1"
+	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
 )
 
 func TestCreateCVDInvalidRequestsEmptyFields(t *testing.T) {

--- a/frontend/src/host_orchestrator/orchestrator/orchestrator.go
+++ b/frontend/src/host_orchestrator/orchestrator/orchestrator.go
@@ -18,8 +18,8 @@ import (
 	"encoding/json"
 	"net/http"
 
-	apiv1 "cuttlefish/liboperator/api/v1"
-	"cuttlefish/liboperator/operator"
+	apiv1 "github.com/google/android-cuttlefish/frontend/src/liboperator/api/v1"
+	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
 
 	"github.com/gorilla/mux"
 )

--- a/frontend/src/liboperator/go.mod
+++ b/frontend/src/liboperator/go.mod
@@ -1,4 +1,4 @@
-module cuttlefish/liboperator
+module github.com/google/android-cuttlefish/frontend/src/liboperator
 
 go 1.17
 

--- a/frontend/src/liboperator/operator/errors.go
+++ b/frontend/src/liboperator/operator/errors.go
@@ -17,7 +17,7 @@ package operator
 import (
 	"net/http"
 
-	apiv1 "cuttlefish/liboperator/api/v1"
+	apiv1 "github.com/google/android-cuttlefish/frontend/src/liboperator/api/v1"
 )
 
 type AppError struct {

--- a/frontend/src/liboperator/operator/operator.go
+++ b/frontend/src/liboperator/operator/operator.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"strconv"
 
-	apiv1 "cuttlefish/liboperator/api/v1"
+	apiv1 "github.com/google/android-cuttlefish/frontend/src/liboperator/api/v1"
 
 	"github.com/gorilla/mux"
 )

--- a/frontend/src/liboperator/operator/utils.go
+++ b/frontend/src/liboperator/operator/utils.go
@@ -20,7 +20,7 @@ import (
 	"log"
 	"net/http"
 
-	apiv1 "cuttlefish/liboperator/api/v1"
+	apiv1 "github.com/google/android-cuttlefish/frontend/src/liboperator/api/v1"
 )
 
 // Interface implemented by any connection capable of sending in JSON format

--- a/frontend/src/operator/go.mod
+++ b/frontend/src/operator/go.mod
@@ -1,10 +1,10 @@
-module cuttlefish/operator
+module github.com/google/android-cuttlefish/frontend/src/operator
 
 go 1.19
 
-replace cuttlefish/liboperator v0.0.0-unpublished => ../liboperator
+replace github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-unpublished => ../liboperator
 
 require (
-	cuttlefish/liboperator v0.0.0-unpublished
+	github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-unpublished
 	github.com/gorilla/mux v1.8.0
 )

--- a/frontend/src/operator/main.go
+++ b/frontend/src/operator/main.go
@@ -23,8 +23,8 @@ import (
 	"os"
 	"sync"
 
-	apiv1 "cuttlefish/liboperator/api/v1"
-	"cuttlefish/liboperator/operator"
+	apiv1 "github.com/google/android-cuttlefish/frontend/src/liboperator/api/v1"
+	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
 )
 
 const (


### PR DESCRIPTION
The module's name needs to match it github URL