### PR TITLE
Do not set `cvdnetwork` as _cvd-executor's primary group.

### DIFF
--- a/frontend/debian/cuttlefish-orchestration.postinst
+++ b/frontend/debian/cuttlefish-orchestration.postinst
@@ -13,8 +13,8 @@ case "$1" in
     if ! getent passwd _cvd-executor > /dev/null 2>&1
     then
         adduser --system --disabled-password --disabled-login --home /var/empty \
-                --no-create-home --quiet --force-badname --ingroup cvdnetwork _cvd-executor
-        usermod -aG kvm _cvd-executor
+                --no-create-home --quiet --force-badname --group _cvd-executor
+        usermod -a -G cvdnetwork,kvm _cvd-executor
     fi
 esac
 


### PR DESCRIPTION
- A new group with the same name will be created and used instead.