### PR TITLE
Create /var/emtpy after installing cuttlefish-base

### DIFF
--- a/base/debian/cuttlefish-base.postinst
+++ b/base/debian/cuttlefish-base.postinst
@@ -4,6 +4,7 @@ set -e
 
 case "$1" in
     (configure)
+    mkdir -p /var/empty
     if ! getent group cvdnetwork > /dev/null 2>&1
     then
         addgroup --system cvdnetwork


### PR DESCRIPTION
The directory is needed to run crosvm in sandbox mode