### PR TITLE
[orchestrator] Change Operation response type to string.

### DIFF
--- a/frontend/src/host_orchestrator/go.mod
+++ b/frontend/src/host_orchestrator/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-unpublished
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
+	github.com/google/go-cmp v0.5.9
 )

--- a/frontend/src/host_orchestrator/go.sum
+++ b/frontend/src/host_orchestrator/go.sum
@@ -1,3 +1,5 @@
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=

--- a/frontend/src/liboperator/api/v1/messages.go
+++ b/frontend/src/liboperator/api/v1/messages.go
@@ -89,8 +89,9 @@ type OperationResult struct {
 	// The expected response of the operation in case of success.  If the original
 	// method returns no data on success, such as `Delete`, this field will be
 	// empty, hence omitted. If the original method is standard:
-	// `Get`/`Create`/`Update`, the response should be the relevant resource.
-	Response interface{} `json:"response,omitempty"`
+	// `Get`/`Create`/`Update`, the response should be the relevant resource
+	// encoded in JSON format.
+	Response string `json:"response,omitempty"`
 }
 
 type CVD struct {


### PR DESCRIPTION
- Use string to properly encode the embedded objects.