### PR TITLE
[orcestrator] Use `/:wait` in wait operation endpoint to denote it's an action

### DIFF
--- a/frontend/src/host_orchestrator/orchestrator/controller.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller.go
@@ -43,7 +43,7 @@ func (c *Controller) AddRoutes(router *mux.Router) {
 	// Same as `/operations/{name}/result but waits for the specified operation to be DONE or for the request
 	// to approach the specified deadline, `503 Service Unavailable` error will be returned if the deadline is
 	// reached. Be prepared to retry if the deadline was reached.
-	router.Handle("/operations/{name}/wait",
+	router.Handle("/operations/{name}/:wait",
 		&waitOperationHandler{c.OperationManager, c.WaitOperationDuration}).Methods("POST")
 }
 

--- a/frontend/src/host_orchestrator/orchestrator/controller_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller_test.go
@@ -111,7 +111,7 @@ func TestGetOperationResultIsHandled(t *testing.T) {
 
 func TestWaitOperationIsHandled(t *testing.T) {
 	rr := httptest.NewRecorder()
-	req, err := http.NewRequest("POST", "/operations/foo/wait", strings.NewReader(""))
+	req, err := http.NewRequest("POST", "/operations/foo/:wait", strings.NewReader(""))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,7 +126,7 @@ func TestWaitOperationIsHandled(t *testing.T) {
 
 func TestWaitOperationNotFound(t *testing.T) {
 	rr := httptest.NewRecorder()
-	req, err := http.NewRequest("POST", "/operations/foo/wait", strings.NewReader(""))
+	req, err := http.NewRequest("POST", "/operations/foo/:wait", strings.NewReader(""))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,7 +145,7 @@ func TestWaitOperationTimeout(t *testing.T) {
 	dt := 100 * time.Millisecond
 	om := NewMapOM()
 	op := om.New()
-	req, err := http.NewRequest("POST", "/operations/"+op.Name+"/wait", strings.NewReader(""))
+	req, err := http.NewRequest("POST", "/operations/"+op.Name+"/:wait", strings.NewReader(""))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +169,7 @@ func TestWaitOperationOperationIsDone(t *testing.T) {
 	om := NewMapOM()
 	op := om.New()
 	om.Complete(op.Name, &OperationResult{Value: "foo"})
-	req, err := http.NewRequest("POST", "/operations/"+op.Name+"/wait", strings.NewReader(""))
+	req, err := http.NewRequest("POST", "/operations/"+op.Name+"/:wait", strings.NewReader(""))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
action.