### PR TITLE
[Web UI] Sort device ID with instance number

### DIFF
--- a/frontend/src/operator/webui/src/app/device.service.ts
+++ b/frontend/src/operator/webui/src/app/device.service.ts
@@ -18,12 +18,21 @@ export class DeviceService {
     private sanitizer: DomSanitizer
   ) {}
 
+  compareDeviceId(x: string, y: string): number {
+    let reg: RegExp = new RegExp('cvd-[0-9]+');
+    if (reg.test(x) && reg.test(y)) {
+      return parseInt(x.substring(4)) - parseInt(y.substring(4));
+    } else {
+      return x > y ? 1 : -1;
+    }
+  }
+
   refresh(): void {
     this.httpClient
       .get<string[]>('./devices')
       .pipe(
         map((deviceIds: string[]) =>
-          deviceIds.sort().map(this.createDevice.bind(this))
+          deviceIds.sort(this.compareDeviceId).map(this.createDevice.bind(this))
         )
       )
       .subscribe((devices: Device[]) => this.devicesSubject.next(devices));

--- a/frontend/src/operator/webui/src/app/device.service.ts
+++ b/frontend/src/operator/webui/src/app/device.service.ts
@@ -18,21 +18,12 @@ export class DeviceService {
     private sanitizer: DomSanitizer
   ) {}
 
-  compareDeviceId(x: string, y: string): number {
-    let reg: RegExp = new RegExp('cvd-[0-9]+');
-    if (reg.test(x) && reg.test(y)) {
-      return parseInt(x.substring(4)) - parseInt(y.substring(4));
-    } else {
-      return x > y ? 1 : -1;
-    }
-  }
-
   refresh(): void {
     this.httpClient
       .get<string[]>('./devices')
       .pipe(
         map((deviceIds: string[]) =>
-          deviceIds.sort(this.compareDeviceId).map(this.createDevice.bind(this))
+          deviceIds.sort((a, b) => a.localeCompare(b, undefined, { numeric: true })).map(this.createDevice.bind(this))
         )
       )
       .subscribe((devices: Device[]) => this.devicesSubject.next(devices));


### PR DESCRIPTION
Currently device ID is sorted by default rule for string type.

Newly added function compares instance number instead when having a prefix `cvd-`.