### PR TITLE
Added ebtables as a dependency in base/debian/control

### DIFF
--- a/base/debian/control
+++ b/base/debian/control
@@ -30,6 +30,7 @@ Depends: adduser,
          net-tools,
          python3,
          qemu-user-static [arm64],
+         ebtables-legacy | ebtables,
          ${misc:Depends},
          ${shlibs:Depends}
 Pre-Depends: ${misc:Pre-Depends}


### PR DESCRIPTION
Added ebtables as an explicit dependency in base/debian/control.
It bothered me that cuttlefish-base.cuttlefish-host-resources.init mentioned it as a dependency, but it was not explicitly listed in the control file.