### PR TITLE
[orchestrator] Boilerplate for exposing system variables.

### DIFF
--- a/frontend/src/host_orchestrator/main.go
+++ b/frontend/src/host_orchestrator/main.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator"
+	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/debug"
 	apiv1 "github.com/google/android-cuttlefish/frontend/src/liboperator/api/v1"
 	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
 
@@ -145,6 +146,11 @@ func main() {
 		HostValidator:            &orchestrator.HostValidator{ExecContext: exec.Command},
 	}
 	im := orchestrator.NewCVDToolInstanceManager(&opts)
+	debugStaticVars := debug.StaticVariables{
+		InitialCVDBinAndroidBuildID:     opts.CVDBinAB.ID,
+		InitialCVDBinAndroidBuildTarget: opts.CVDBinAB.Target,
+	}
+	debugVarsManager := debug.NewVariablesManager(debugStaticVars)
 	deviceServerLoop := operator.SetupDeviceEndpoint(pool, config, socketPath)
 	go func() {
 		err := deviceServerLoop()
@@ -156,6 +162,7 @@ func main() {
 		OperationManager:      om,
 		WaitOperationDuration: 2 * time.Minute,
 		UserArtifactsManager:  uam,
+		DebugVariablesManager: debugVarsManager,
 	}
 	imController.AddRoutes(r)
 	// The host orchestrator currently has no use for this, since clients won't connect

--- a/frontend/src/host_orchestrator/orchestrator/controller.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/debug"
 	apiv1 "github.com/google/android-cuttlefish/frontend/src/liboperator/api/v1"
 	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
 
@@ -34,6 +35,7 @@ type Controller struct {
 	OperationManager      OperationManager
 	WaitOperationDuration time.Duration
 	UserArtifactsManager  UserArtifactsManager
+	DebugVariablesManager *debug.VariablesManager
 }
 
 func (c *Controller) AddRoutes(router *mux.Router) {
@@ -57,7 +59,7 @@ func (c *Controller) AddRoutes(router *mux.Router) {
 		httpHandler(&listUploadDirectoriesHandler{c.UserArtifactsManager})).Methods("GET")
 	router.Handle("/userartifacts/{name}",
 		httpHandler(&createUpdateUserArtifactHandler{c.UserArtifactsManager})).Methods("PUT")
-
+	router.Handle("/varz", httpHandler(&getDebugVariablesHandler{c.DebugVariablesManager})).Methods("GET")
 }
 
 type handler interface {
@@ -267,4 +269,12 @@ func (h *createUpdateUserArtifactHandler) Handle(r *http.Request) (interface{}, 
 		File:           f,
 	}
 	return nil, h.m.UpdateArtifact(dir, chunk)
+}
+
+type getDebugVariablesHandler struct {
+	m *debug.VariablesManager
+}
+
+func (h *getDebugVariablesHandler) Handle(r *http.Request) (interface{}, error) {
+	return h.m.GetVariables(), nil
 }

--- a/frontend/src/host_orchestrator/orchestrator/controller.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller.go
@@ -59,7 +59,8 @@ func (c *Controller) AddRoutes(router *mux.Router) {
 		httpHandler(&listUploadDirectoriesHandler{c.UserArtifactsManager})).Methods("GET")
 	router.Handle("/userartifacts/{name}",
 		httpHandler(&createUpdateUserArtifactHandler{c.UserArtifactsManager})).Methods("PUT")
-	router.Handle("/varz", httpHandler(&getDebugVariablesHandler{c.DebugVariablesManager})).Methods("GET")
+	// Debug endpoints.
+	router.Handle("/_debug/varz", httpHandler(&getDebugVariablesHandler{c.DebugVariablesManager})).Methods("GET")
 }
 
 type handler interface {

--- a/frontend/src/host_orchestrator/orchestrator/controller_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller_test.go
@@ -261,7 +261,7 @@ func TestUploadUserArtifactIsHandled(t *testing.T) {
 
 func TestGetDebugVarzIsHandled(t *testing.T) {
 	rr := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/varz", strings.NewReader("{}"))
+	req, err := http.NewRequest("GET", "/_debug/varz", strings.NewReader("{}"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/frontend/src/host_orchestrator/orchestrator/controller_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/debug"
 	apiv1 "github.com/google/android-cuttlefish/frontend/src/liboperator/api/v1"
 
 	"github.com/gorilla/mux"
@@ -250,6 +251,21 @@ func TestUploadUserArtifactIsHandled(t *testing.T) {
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	controller := Controller{UserArtifactsManager: &testUAM{}}
 	rr := httptest.NewRecorder()
+
+	makeRequest(rr, req, &controller)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("request was not handled. This failure implies an API breaking change.")
+	}
+}
+
+func TestGetDebugVarzIsHandled(t *testing.T) {
+	rr := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/varz", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller := Controller{DebugVariablesManager: debug.NewVariablesManager(debug.StaticVariables{})}
 
 	makeRequest(rr, req, &controller)
 

--- a/frontend/src/host_orchestrator/orchestrator/debug/debug.go
+++ b/frontend/src/host_orchestrator/orchestrator/debug/debug.go
@@ -1,0 +1,42 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package debug
+
+type StaticVariables struct {
+	InitialCVDBinAndroidBuildID     string `json:"initial_cvd_bin_android_build_id"`
+	InitialCVDBinAndroidBuildTarget string `json:"initial_cvd_bin_android_build_target"`
+}
+
+type DynamicVariables struct {
+}
+
+type Variables struct {
+	*StaticVariables
+}
+
+type VariablesManager struct {
+	static StaticVariables
+}
+
+func NewVariablesManager(static StaticVariables) *VariablesManager {
+	return &VariablesManager{
+		static: static,
+	}
+}
+
+func (m *VariablesManager) GetVariables() *Variables {
+	static := m.static
+	return &Variables{&static}
+}


### PR DESCRIPTION
- Use /varz endpoint to expose variables that helps with debugging tasks.