### PR TITLE
Support tap devices for 128 CF instances, and add cvd-wifiap

### DIFF
--- a/base/debian/cuttlefish-base.cuttlefish-host-resources.init
+++ b/base/debian/cuttlefish-base.cuttlefish-host-resources.init
@@ -105,7 +105,7 @@ destroy_tap() {
     ip link delete "${1}"
 }
 
-# Create a mobile tap interface
+# Create a tap interface
 # The tap device will have the IP address and DHCP server running on it, and
 # it will be added to a bridge with no address (for routing).
 # $1 = tap interface name
@@ -129,7 +129,7 @@ create_interface() {
     iptables -t nat -A POSTROUTING -s "${network}" -j MASQUERADE
 }
 
-# Destroy a mobile tap interface
+# Destroy a tap interface
 # $1 = tap interface name
 # $2 = ip address base ("a.b.c")
 # $3 = interface index within ip address base
@@ -244,11 +244,14 @@ start() {
     echo 1 > /proc/sys/net/ipv6/conf/all/forwarding
 
     # Ethernet
+    # 192.168.98.X for cvd-ebr and cvd-etap-XX
     create_bridged_interfaces \
       192.168.98 "${ethernet_bridge_interface}" cvd-etap \
       "${ethernet_ipv6_prefix}" "${ethernet_ipv6_prefix_length}"
 
     # Mobile Network
+    # 192.168.97.X from cvd-mtap-01 to cvd-mtap-64
+    # 192.168.93.X from cvd-mtap-65 to cvd-mtap-128
     for i in $(seq ${num_cvd_accounts}); do
         tap="$(printf cvd-mtap-%02d $i)"
         if [ $i -lt 65 ]; then
@@ -259,6 +262,12 @@ start() {
     done
 
     # Wireless Network
+    # cvd-wbr and cvd-wtap-XX for legacy wireless network without distinguished
+    # subnet between tap interfaces, cvd-wifiap-XX with distinguished subnet for
+    # running several OpenWRT instances simultaneously.
+    # 192.168.96.X for cvd-wbr and cvd-wtap-XX
+    # 192.168.94.X from cvd-wifiap-01 to cvd-wifiap-64
+    # 192.168.95.X from cvd-wifiap-65 to cvd-wifiap-128
     create_bridged_interfaces \
       192.168.96 "${wifi_bridge_interface}" cvd-wtap \
       "${wifi_ipv6_prefix}" "${wifi_ipv6_prefix_length}"

--- a/base/debian/cuttlefish-base.cuttlefish-host-resources.init
+++ b/base/debian/cuttlefish-base.cuttlefish-host-resources.init
@@ -108,31 +108,46 @@ destroy_tap() {
 # Create a mobile tap interface
 # The tap device will have the IP address and DHCP server running on it, and
 # it will be added to a bridge with no address (for routing).
-# $1 = interface number
+# $1 = tap interface name
 # $2 = ip address base ("a.b.c")
-create_mobile_interface() {
-    tap="$(printf cvd-mtap-%02d $1)"
-    gateway="${2}.$((4*$1 - 3))"
+# $3 = interface index within ip address base
+# $4 = IPv6 prefix ("a:b::")
+# $5 = IPv6 prefix length
+create_interface() {
+    tap="${1}"
+    gateway="${2}.$((4*$3 - 3))"
     netmask="/30"
-    network="${2}.$((4*$1 - 4))${netmask}"
-    dhcp_range="${2}.$((4*$1 - 2)),${2}.$((4*$1 - 2))"
+    network="${2}.$((4*$3 - 4))${netmask}"
+    ipv6_prefix="${4}"
+    ipv6_prefix_length="${5}"
 
     create_tap "${tap}"
     ip addr add "${gateway}${netmask}" broadcast + dev "${tap}"
+    if [ -n "${ipv6_prefix}" -a -n "${ipv6_prefix_length}" ]; then
+        ip -6 addr add "${ipv6_prefix}1/${ipv6_prefix_length}" dev "${tap}"
+    fi
     iptables -t nat -A POSTROUTING -s "${network}" -j MASQUERADE
 }
 
 # Destroy a mobile tap interface
-# $1 = interface number
+# $1 = tap interface name
 # $2 = ip address base ("a.b.c")
-destroy_mobile_interface() {
-    tap="$(printf cvd-mtap-%02d $1)"
-    gateway="${2}.$((4*$1 - 3))"
+# $3 = interface index within ip address base
+# $4 = IPv6 prefix ("a:b::")
+# $5 = IPv6 prefix length
+destroy_interface() {
+    tap="${1}"
+    gateway="${2}.$((4*$3 - 3))"
     netmask="/30"
-    network="${2}.$((4*$1 - 4))${netmask}"
+    network="${2}.$((4*$3 - 4))${netmask}"
+    ipv6_prefix="${4}"
+    ipv6_prefix_length="${5}"
 
     iptables -t nat -D POSTROUTING -s "${network}" -j MASQUERADE
     ip addr del "${gateway}${netmask}" dev "${tap}"
+    if [ -n "${ipv6_prefix}" -a -n "${ipv6_prefix_length}" ]; then
+        ip -6 addr del "${ipv6_prefix}1/${ipv6_prefix_length}" dev "${tap}"
+    fi
     destroy_tap "${tap}"
 }
 
@@ -228,15 +243,33 @@ start() {
     echo 1 > /proc/sys/net/ipv4/ip_forward
     echo 1 > /proc/sys/net/ipv6/conf/all/forwarding
 
+    # Ethernet
+    create_bridged_interfaces \
+      192.168.98 "${ethernet_bridge_interface}" cvd-etap \
+      "${ethernet_ipv6_prefix}" "${ethernet_ipv6_prefix_length}"
+
+    # Mobile Network
+    for i in $(seq ${num_cvd_accounts}); do
+        tap="$(printf cvd-mtap-%02d $i)"
+        if [ $i -lt 65 ]; then
+            create_interface $tap 192.168.97 $i
+        elif [ $i -lt 129 ]; then
+            create_interface $tap 192.168.93 $(($i - 64))
+        fi
+    done
+
+    # Wireless Network
     create_bridged_interfaces \
       192.168.96 "${wifi_bridge_interface}" cvd-wtap \
       "${wifi_ipv6_prefix}" "${wifi_ipv6_prefix_length}"
     for i in $(seq ${num_cvd_accounts}); do
-        create_mobile_interface $i 192.168.97
+        tap="$(printf cvd-wifiap-%02d $i)"
+        if [ $i -lt 65 ]; then
+            create_interface $tap 192.168.94 $i
+        elif [ $i -lt 129 ]; then
+            create_interface $tap 192.168.95 $(($i - 64))
+        fi
     done
-    create_bridged_interfaces \
-      192.168.98 "${ethernet_bridge_interface}" cvd-etap \
-      "${ethernet_ipv6_prefix}" "${ethernet_ipv6_prefix_length}"
 
     # When running inside a privileged container, set the ownership and access
     # of these device nodes.
@@ -254,16 +287,33 @@ start() {
 }
 
 stop() {
+    # Ethernet
     destroy_bridged_interfaces \
       192.168.98 "${ethernet_bridge_interface}" cvd-etap \
       "${ethernet_ipv6_prefix}" "${ethernet_ipv6_prefix_length}"
 
+    # Mobile Network
     for i in $(seq ${num_cvd_accounts}); do
-        destroy_mobile_interface $i 192.168.97
+        tap="$(printf cvd-mtap-%02d $i)"
+        if [ $i -lt 65 ]; then
+            destroy_interface $tap 192.168.97 $i
+        elif [ $i -lt 129 ]; then
+            destroy_interface $tap 192.168.93 $(($i - 64))
+        fi
     done
+
+    # Wireless Network
     destroy_bridged_interfaces \
       192.168.96 "${wifi_bridge_interface}" cvd-wtap \
       "${wifi_ipv6_prefix}" "${wifi_ipv6_prefix_length}"
+    for i in $(seq ${num_cvd_accounts}); do
+        tap="$(printf cvd-wifiap-%02d $i)"
+        if [ $i -lt 65 ]; then
+            destroy_interface $tap 192.168.94 $i
+        elif [ $i -lt 129 ]; then
+            destroy_interface $tap 192.168.95 $(($i - 64))
+        fi
+    done
 }
 
 usage() {


### PR DESCRIPTION
According to [go/cf-new-tap-device](http://goto.google.com/cf-new-tap-device), there would be several changes about tap devices.

- Support tap device for mobile network(`cvd-mtap`) from 65th to 128th CF instance in `192.168.93.X`.
- Support tap device for wireless network with distinguished subnet(`cvd-wifiap`) from 1st to 128th CF instance in `192.168.94.X` and `192.168.95.X`.
- Like before, `cvd-etap` and `cvd-wtap` with bridge device will support tap devices for 128 CF instances.