### PR TITLE
Make sure IPv6 is enabled for bridge interfaces to enable IPv6 for cuttlefish-specific intrefaces inside docker container

### DIFF
--- a/base/debian/cuttlefish-base.cuttlefish-host-resources.init
+++ b/base/debian/cuttlefish-base.cuttlefish-host-resources.init
@@ -162,6 +162,7 @@ create_bridged_interfaces() {
         ip link add name "${2}" type bridge forward_delay 0 stp_state 0
         ip link set dev "${2}" up
 
+        echo 0 > /proc/sys/net/ipv6/conf/${2}/disable_ipv6
         echo 0 > /proc/sys/net/ipv6/conf/${2}/addr_gen_mode
         echo 1 > /proc/sys/net/ipv6/conf/${2}/autoconf
     fi


### PR DESCRIPTION
Make sure IPv6 link-local address is generated inside docker container to ensure fastboot will work with oxygen and other docker-centered flows.

Bug: b/270040723