### PR TITLE
Upgrade to Debian Bullseye and install rsync

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # This file is based on https://hub.docker.com/r/jrei/systemd-debian/.
 
-FROM debian:buster-slim AS cuttlefish-softgpu
+FROM debian:bullseye-slim AS cuttlefish-softgpu
 
 ENV container docker
 ENV LC_ALL C
@@ -38,7 +38,7 @@ CMD ["/lib/systemd/systemd"]
 RUN apt-get update \
     && apt-get install --no-install-recommends -y apt-utils sudo vim gawk coreutils \
        openssh-server openssh-client psmisc iptables iproute2 dnsmasq \
-       net-tools rsyslog equivs equivs devscripts dpkg-dev dialog # qemu-system-x86
+       net-tools rsyslog equivs equivs devscripts dpkg-dev dialog rsync # qemu-system-x86
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
The rsync tool can be used to efficiently copy images from an Android build directory into the container by sending only the file differences. rsync needs to be installed on both ends of the transfer. Since super.img and userdata.img are sparse in the build directory it's useful to pass the --sparse --inplace flags so that they end up being sparse in the container as well. Unfortunately there's a bug in older versions of rsync (such as the one in Debian Buster) that causes transfers with these flags to fail. See: https://github.com/WayneD/rsync/issues/53

Buster is already obsolete at this point, so let's upgrade to Bullseye which has a fixed version of rsync and install rsync into the container so that it doesn't need to be installed manually.