### PR TITLE
[orchestrator] Supports `acloud pull`.

### DIFF
--- a/frontend/host/packages/cuttlefish-orchestration/etc/sudoers.d/cuttlefish-orchestration
+++ b/frontend/host/packages/cuttlefish-orchestration/etc/sudoers.d/cuttlefish-orchestration
@@ -1,2 +1,6 @@
 # Allow `_cutf-operator` to run cvd commands as `_cvd-executor` using sudo without password.
 _cutf-operator ALL=(_cvd-executor) NOPASSWD:ALL
+# Allow `_cutf-operator` to run cvd commands as `vsoc-01` using sudo without password.
+#   Required for supporting `acloud CLI` backwards compatibility
+#   TODO: Remove once acloud is deprecated.
+_cutf-operator ALL=(vsoc-01) NOPASSWD:ALL


### PR DESCRIPTION
- Allows `acloud pull` to work with cvd instances created with the host orchestrator.