### PR TITLE
Revert "[orchestrator] Supports `acloud pull`. (#266)"

### DIFF
--- a/frontend/host/packages/cuttlefish-orchestration/etc/sudoers.d/cuttlefish-orchestration
+++ b/frontend/host/packages/cuttlefish-orchestration/etc/sudoers.d/cuttlefish-orchestration
@@ -1,6 +1,2 @@
 # Allow `_cutf-operator` to run cvd commands as `_cvd-executor` using sudo without password.
 _cutf-operator ALL=(_cvd-executor) NOPASSWD:ALL
-# Allow `_cutf-operator` to run cvd commands as `vsoc-01` using sudo without password.
-#   Required for supporting `acloud CLI` backwards compatibility
-#   TODO: Remove once acloud is deprecated.
-_cutf-operator ALL=(vsoc-01) NOPASSWD:ALL

--- a/frontend/src/host_orchestrator/orchestrator/instancemanager.go
+++ b/frontend/src/host_orchestrator/orchestrator/instancemanager.go
@@ -223,10 +223,6 @@ func (m *CVDToolInstanceManager) launchCVD(req apiv1.CreateCVDRequest, op apiv1.
 		log.Printf("failed to launch cvd with error: %v", err)
 		return
 	}
-	// TODO: Remove once `acloud CLI` gets deprecated.
-	if cvd.Name == "cvd-1" {
-		runAcloudSetup(m.paths.RuntimesRootDir)
-	}
 	result = OperationResult{Value: cvd}
 }
 
@@ -855,19 +851,4 @@ func downloadArtifactToFile(buildAPI BuildAPI, filename, artifactName, buildID, 
 	}()
 	downloadErr = buildAPI.DownloadArtifact(artifactName, buildID, target, f)
 	return downloadErr
-}
-
-// Acloud only works with the first instance: cvd-1
-func runAcloudSetup(runtimesRootDir string) {
-	const acloudUser = "vsoc-01"
-	// Creates symlink for runtime directory for `acloud pull`
-	target := runtimesRootDir + "/cvd-1/cuttlefish_runtime"
-	cmd := exec.Command("sudo", "-u", acloudUser, "ln", "-s", target, "/home/"+acloudUser)
-	var b bytes.Buffer
-	cmd.Stdout = &b
-	cmd.Stderr = &b
-	err := cmd.Run()
-	if err != nil {
-		log.Println("runAcloudSetup failed with error: " + b.String())
-	}
 }


### PR DESCRIPTION
This reverts commit 108dd22b67202659f84a192b8246707c7ff40322.

Reason: Acloud compatibility setup will be handled in the cloud orchestrator.