### PR TITLE
[orchestrator] Fixes group name.

### DIFF
--- a/frontend/src/host_orchestrator/orchestrator/instancemanager.go
+++ b/frontend/src/host_orchestrator/orchestrator/instancemanager.go
@@ -624,6 +624,7 @@ const (
 	daemonArg = "--daemon"
 	// TODO(b/242599859): Add report_anonymous_usage_stats as a parameter to the Create CVD API.
 	reportAnonymousUsageStatsArg = "--report_anonymous_usage_stats=y"
+	groupNameArg                 = "--group_name=cvd"
 )
 
 type startCVDHandler struct {
@@ -650,8 +651,9 @@ func (h *startCVDHandler) Start(p startCVDParams) error {
 		androidHostOut: p.MainArtifactsDir,
 		home:           p.RuntimeDir,
 		cvdBin:         h.CVDBin,
-		args:           []string{"start", daemonArg, reportAnonymousUsageStatsArg, instanceNumArg, imgDirArg},
-		timeout:        h.Timeout,
+		args: []string{groupNameArg, "start",
+			daemonArg, reportAnonymousUsageStatsArg, instanceNumArg, imgDirArg},
+		timeout: h.Timeout,
 	}
 	if p.KernelDir != "" {
 		cvdCmd.args = append(cvdCmd.args, fmt.Sprintf("--kernel_path=%s/bzImage", p.KernelDir))

--- a/frontend/src/host_orchestrator/orchestrator/instancemanager_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/instancemanager_test.go
@@ -201,7 +201,7 @@ func TestCreateCVDVerifyStartCVDCmdArgs(t *testing.T) {
 	dir := tempDir(t)
 	defer removeDir(t, dir)
 	goldenPrefixFmt := fmt.Sprintf("sudo -u _cvd-executor HOME=%[1]s/runtimes/cvd-1 "+
-		"ANDROID_HOST_OUT=%[1]s/artifacts/%%[1]s "+"%[1]s/cvd start --daemon --report_anonymous_usage_stats=y"+
+		"ANDROID_HOST_OUT=%[1]s/artifacts/%%[1]s "+"%[1]s/cvd --group_name=cvd start --daemon --report_anonymous_usage_stats=y"+
 		" --base_instance_num=1 --system_image_dir=%[1]s/artifacts/%%[1]s", dir)
 	tests := []struct {
 		name string


### PR DESCRIPTION
- After bumping to cvd version 9802869 in https://github.com/google/android-cuttlefish/pull/261 cvd instances were returning an unexpected name, i.e cvd_1-1, cvd_2-1 and so on. The reason is that with the introduction of group instances, the default group name "cvd" when using a custom HOME value did not apply, hece the group names "cvd_1" and "cvd_2". In this PR we fix the group name to "cvd" so it does not longer depends on the default value.