### PR TITLE
Host Orchestrator accepts build API credentials in create CVD requests

### DIFF
--- a/frontend/src/host_orchestrator/main.go
+++ b/frontend/src/host_orchestrator/main.go
@@ -141,8 +141,10 @@ func main() {
 		UserArtifactsDirResolver: uam,
 		CVDExecTimeout:           5 * time.Minute,
 		HostValidator:            &orchestrator.HostValidator{ExecContext: exec.Command},
-		BuildAPI:                 orchestrator.NewAndroidCIBuildAPI(http.DefaultClient, abURL),
-		UUIDGen:                  func() string { return uuid.New().String() },
+		BuildAPIFactory: func(credentials string) orchestrator.BuildAPI {
+			return orchestrator.NewAndroidCIBuildAPI(http.DefaultClient, abURL, credentials)
+		},
+		UUIDGen: func() string { return uuid.New().String() },
 	}
 	im := orchestrator.NewCVDToolInstanceManager(&opts)
 	debugStaticVars := debug.StaticVariables{

--- a/frontend/src/host_orchestrator/orchestrator/artifactsmanager.go
+++ b/frontend/src/host_orchestrator/orchestrator/artifactsmanager.go
@@ -1,0 +1,131 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Downloads and organizes the Build artifacts.
+//
+// Artifacts will be organized the following way:
+//  1. $ROOT_DIR/<BUILD_ID>_<TARGET>__cvd will store a full download.
+//  2. $ROOT_DIR/<BUILD_ID>_<TARGET>__kernel will store kernel artifacts only.
+type ArtifactsManager struct {
+	rootDir  string
+	uuidGen  func() string
+	map_     map[string]*downloadArtifactsMapEntry
+	mapMutex sync.Mutex
+}
+
+func NewArtifactsManager(rootDir string, uuidGen func() string) *ArtifactsManager {
+	return &ArtifactsManager{
+		rootDir: rootDir,
+		uuidGen: uuidGen,
+		map_:    make(map[string]*downloadArtifactsMapEntry),
+	}
+}
+
+type ExtraCVDOptions struct {
+	SystemImgBuildID string
+	SystemImgTarget  string
+}
+
+type ArtifactsFetcher interface {
+	// Fetches all artifacts necessary to launch a CVD. It support downloading a system
+	// image from a different build if the extraOptions is provided.
+	FetchCVD(outDir, buildID, target string, extraOptions *ExtraCVDOptions) error
+	// Fetches specific artifacts from the build API.
+	FetchArtifacts(outDir, buildID, target string, artifacts ...string) error
+}
+
+type downloadArtifactsResult struct {
+	OutDir string
+	Error  error
+}
+
+type downloadArtifactsMapEntry struct {
+	mutex  sync.Mutex
+	result *downloadArtifactsResult
+}
+
+func (h *ArtifactsManager) GetCVDBundle(buildID, target string, extraOptions *ExtraCVDOptions, fetcher ArtifactsFetcher) (string, error) {
+	outDir := fmt.Sprintf("%s/%s_%s__cvd", h.rootDir, buildID, target)
+	f := func() (string, error) {
+		if extraOptions != nil {
+			// A custom cvd bundle puts artifacts from different builds into the final directory so it can only be reused
+			// if the same arguments are used.
+			outDir = fmt.Sprintf("%s/%s__custom_cvd", h.rootDir, h.uuidGen())
+		}
+		if err := fetcher.FetchCVD(outDir, buildID, target, extraOptions); err != nil {
+			return "", err
+		}
+		return outDir, nil
+	}
+	return h.syncDownload(outDir, f)
+}
+
+func (h *ArtifactsManager) GetKernelBundle(buildID, target string, fetcher ArtifactsFetcher) (string, error) {
+	f := func() (string, error) {
+		outDir := fmt.Sprintf("%s/%s_%s__kernel", h.rootDir, buildID, target)
+		if err := createDir(outDir); err != nil {
+			return "", err
+		}
+		if err := fetcher.FetchArtifacts(outDir, buildID, target, "bzImage"); err != nil {
+			return "", err
+		}
+		return outDir, nil
+	}
+	return h.syncDownload(buildID+target+"kernel", f)
+}
+
+func (h *ArtifactsManager) GetBootloaderBundle(buildID, target string, fetcher ArtifactsFetcher) (string, error) {
+	f := func() (string, error) {
+		outDir := fmt.Sprintf("%s/%s_%s__bootloader", h.rootDir, buildID, target)
+		if err := createDir(outDir); err != nil {
+			return "", err
+		}
+		if err := fetcher.FetchArtifacts(outDir, buildID, target, "u-boot.rom"); err != nil {
+			return "", err
+		}
+		return outDir, nil
+	}
+	return h.syncDownload(buildID+target+"bootloader", f)
+}
+
+// Synchronizes downloads to avoid downloading same bundle more than once.
+func (h *ArtifactsManager) syncDownload(key string, downloadFunc func() (string, error)) (string, error) {
+	entry := h.getMapEntry(key)
+	entry.mutex.Lock()
+	defer entry.mutex.Unlock()
+	if entry.result != nil {
+		return entry.result.OutDir, entry.result.Error
+	}
+	entry.result = &downloadArtifactsResult{}
+	entry.result.OutDir, entry.result.Error = downloadFunc()
+	return entry.result.OutDir, entry.result.Error
+}
+
+func (h *ArtifactsManager) getMapEntry(key string) *downloadArtifactsMapEntry {
+	h.mapMutex.Lock()
+	defer h.mapMutex.Unlock()
+	entry := h.map_[key]
+	if entry == nil {
+		entry = &downloadArtifactsMapEntry{}
+		h.map_[key] = entry
+	}
+	return entry
+}

--- a/frontend/src/host_orchestrator/orchestrator/instancemanager.go
+++ b/frontend/src/host_orchestrator/orchestrator/instancemanager.go
@@ -483,15 +483,6 @@ type downloadArtifactsMapEntry struct {
 	result *downloadArtifactsResult
 }
 
-type bundleType int
-
-const (
-	cvdBundleType bundleType = iota
-	kernelBundleType
-	bootloaderBundleType
-	systemImgBundleType
-)
-
 func (h *artifactsManager) DownloadCVDBundle(buildID, target string) (string, error) {
 	f := func() (string, error) {
 		outDir := fmt.Sprintf("%s/%s_%s__cvd", h.rootDir, buildID, target)

--- a/frontend/src/host_orchestrator/orchestrator/instancemanager_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/instancemanager_test.go
@@ -321,7 +321,7 @@ func TestCreateCVDVerifyStartCVDCmdArgs(t *testing.T) {
 				},
 				OperationManager: om,
 				HostValidator:    &AlwaysSucceedsValidator{},
-				BuildAPI:         &fakeBuildAPI{},
+				BuildAPIFactory:  func(_ string) BuildAPI { return &fakeBuildAPI{} },
 				UUIDGen:          fakeUUIDGen,
 			}
 			im := NewCVDToolInstanceManager(&opts)
@@ -399,7 +399,7 @@ func TestCreateCVDWithUserBuildSucceeds(t *testing.T) {
 		OperationManager:         om,
 		HostValidator:            &AlwaysSucceedsValidator{},
 		UserArtifactsDirResolver: &fakeUADirRes{dir},
-		BuildAPI:                 &fakeBuildAPI{},
+		BuildAPIFactory:          func(_ string) BuildAPI { return &fakeBuildAPI{} },
 	}
 	im := NewCVDToolInstanceManager(&opts)
 	buildSource := &apiv1.BuildSource{UserBuildSource: &apiv1.UserBuildSource{ArtifactsDir: "baz"}}
@@ -454,7 +454,7 @@ func TestCreateCVDFailsDueTimeout(t *testing.T) {
 		OperationManager: om,
 		CVDExecTimeout:   testFakeBinaryDelayMs - (50 * time.Millisecond),
 		HostValidator:    &AlwaysSucceedsValidator{},
-		BuildAPI:         &fakeBuildAPI{},
+		BuildAPIFactory:  func(_ string) BuildAPI { return &fakeBuildAPI{} },
 	}
 	im := NewCVDToolInstanceManager(&opts)
 	r := apiv1.CreateCVDRequest{CVD: &apiv1.CVD{BuildSource: androidCISource("1", "foo")}}
@@ -490,6 +490,7 @@ func TestCreateCVDFailsDueInvalidHost(t *testing.T) {
 		Paths:            paths,
 		OperationManager: om,
 		HostValidator:    &AlwaysFailsValidator{},
+		BuildAPIFactory:  func(_ string) BuildAPI { return &fakeBuildAPI{} },
 	}
 	im := NewCVDToolInstanceManager(&opts)
 	r := apiv1.CreateCVDRequest{CVD: &apiv1.CVD{BuildSource: androidCISource("1", "foo")}}
@@ -577,7 +578,7 @@ func newCVDToolIm(execContext ExecContext,
 		Paths:            paths,
 		OperationManager: om,
 		HostValidator:    &AlwaysSucceedsValidator{},
-		BuildAPI:         &fakeBuildAPI{},
+		BuildAPIFactory:  func(_ string) BuildAPI { return &fakeBuildAPI{} },
 	}
 	return NewCVDToolInstanceManager(&opts)
 }

--- a/frontend/src/liboperator/api/v1/messages.go
+++ b/frontend/src/liboperator/api/v1/messages.go
@@ -86,6 +86,8 @@ type AndroidCIBuildSource struct {
 	BootloaderBuild *AndroidCIBuild `json:"bootloader_build,omitempty"`
 	// Uses this specific system image build target if set.
 	SystemImageBuild *AndroidCIBuild `json:"system_image_build,omitempty"`
+	// Credentials to use when connecting to the build API
+	Credentials string `json:"credentials,omitempty"`
 }
 
 // Represents a user build.

--- a/frontend/src/liboperator/operator/devices.go
+++ b/frontend/src/liboperator/operator/devices.go
@@ -133,7 +133,7 @@ func (p *DevicePool) DeviceIds() []string {
 	p.devicesMtx.Lock()
 	defer p.devicesMtx.Unlock()
 	ret := make([]string, 0, len(p.devices))
-	for key, _ := range p.devices {
+	for key := range p.devices {
 		ret = append(ret, key)
 	}
 	return ret

--- a/frontend/src/operator/main.go
+++ b/frontend/src/operator/main.go
@@ -102,7 +102,7 @@ func main() {
 	config := apiv1.InfraConfig{
 		Type: "config",
 		IceServers: []apiv1.IceServer{
-			apiv1.IceServer{URLs: []string{"stun:stun.l.google.com:19302"}},
+			{URLs: []string{"stun:stun.l.google.com:19302"}},
 		},
 	}
 


### PR DESCRIPTION
The credentials field is optional. If provided it will use it to directly access the build API or will pass it to `cvd fetch`.