### PR TITLE
Remove nofile hard limit change

### DIFF
--- a/base/host/packages/cuttlefish-base/etc/security/limits.d/1_cuttlefish.conf
+++ b/base/host/packages/cuttlefish-base/etc/security/limits.d/1_cuttlefish.conf
@@ -1,4 +1,3 @@
 # Cuttlefish with GPU passthrough will use additional file descriptors on the
 # host for Gralloc buffers.
-@cvdnetwork hard nofile 4096
 @cvdnetwork soft nofile 4096


### PR DESCRIPTION
... previously from https://github.com/google/android-cuttlefish/pull/280.

With an empty `/etc/security/limits.d/1_cuttlefish.conf`:

```
$ ulimit -n -S
1024
$ ulimit -n -H
1048576
```

With https://github.com/google/android-cuttlefish/pull/280,

```
$ ulimit -n -S
4096
$ ulimit -n -H
4096
```

which bumps up the soft limit for (which is what affected accelerated GPU mode) but then this prevent Crosvm from bumping up it's soft limit to 32768 (as the hard limit was set to 4096) which it does in sandboxed modes (guest swiftshader).

We want the soft limit bumped up to get a nice default for accelerated GPU modes and to not touch the hard limit (so that it stays the large value) so that Crosvm can adjust itself as needed. With this change,

```
$ ulimit -n -S
4096
$ ulimit -n -H
1048576
```

Bug: b/281897851
Test: m create_base_image
Test: create_base_image --launch_instance=natsu-test
Test: ./device/google/cuttlefish/tools/upload_to_gce_and_run.py -instance=natsu-test
Test: ./bin/cvd start --gpu_mode=guest_swiftshader
Test: ./bin/cvd start --gpu_mode=gfxstream
Test: ./bin/cvd start --gpu_mode=gfxstream_guest_angle_host_swiftshader