### PR TITLE
Use fetch_cvd instead of cvd fetch in the host orchestrator

### DIFF
--- a/frontend/src/host_orchestrator/main.go
+++ b/frontend/src/host_orchestrator/main.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -103,8 +104,8 @@ func main() {
 	httpsPort := fromEnvOrDefault("ORCHESTRATOR_HTTPS_PORT", DefaultHttpsPort)
 	tlsCertDir := fromEnvOrDefault("ORCHESTRATOR_TLS_CERT_DIR", DefaultTLSCertDir)
 	webUIUrlStr := fromEnvOrDefault("ORCHESTRATOR_WEBUI_URL", DefaultWebUIUrl)
-	certPath := tlsCertDir + "/cert.pem"
-	keyPath := tlsCertDir + "/key.pem"
+	certPath := filepath.Join(tlsCertDir, "cert.pem")
+	keyPath := filepath.Join(tlsCertDir, "key.pem")
 
 	pool := operator.NewDevicePool()
 	polledSet := operator.NewPolledSet()
@@ -120,19 +121,19 @@ func main() {
 	imRootDir := fromEnvOrDefault("ORCHESTRATOR_CVD_ARTIFACTS_DIR", defaultCVDArtifactsDir)
 	imPaths := orchestrator.IMPaths{
 		RootDir:          imRootDir,
-		CVDBin:           imRootDir + "/cvd",
-		ArtifactsRootDir: imRootDir + "/artifacts",
-		RuntimesRootDir:  imRootDir + "/runtimes",
+		CVDToolsDir:      imRootDir,
+		ArtifactsRootDir: filepath.Join(imRootDir, "artifacts"),
+		RuntimesRootDir:  filepath.Join(imRootDir, "runtimes"),
 	}
 	om := orchestrator.NewMapOM()
 	uamOpts := orchestrator.UserArtifactsManagerOpts{
-		RootDir:     imRootDir + "/user_artifacs",
+		RootDir:     filepath.Join(imRootDir, "user_artifacs"),
 		NameFactory: func() string { return uuid.New().String() },
 	}
 	uam := orchestrator.NewUserArtifactsManagerImpl(uamOpts)
 	opts := orchestrator.CVDToolInstanceManagerOpts{
 		ExecContext: exec.CommandContext,
-		CVDBinAB: orchestrator.AndroidBuild{
+		CVDToolsVersion: orchestrator.AndroidBuild{
 			ID:     cvdBinAndroidBuildID,
 			Target: cvdBinAndroidBuildTarget,
 		},
@@ -148,8 +149,8 @@ func main() {
 	}
 	im := orchestrator.NewCVDToolInstanceManager(&opts)
 	debugStaticVars := debug.StaticVariables{
-		InitialCVDBinAndroidBuildID:     opts.CVDBinAB.ID,
-		InitialCVDBinAndroidBuildTarget: opts.CVDBinAB.Target,
+		InitialCVDBinAndroidBuildID:     opts.CVDToolsVersion.ID,
+		InitialCVDBinAndroidBuildTarget: opts.CVDToolsVersion.Target,
 	}
 	debugVarsManager := debug.NewVariablesManager(debugStaticVars)
 	deviceServerLoop := operator.SetupDeviceEndpoint(pool, config, socketPath)

--- a/frontend/src/host_orchestrator/main.go
+++ b/frontend/src/host_orchestrator/main.go
@@ -131,7 +131,7 @@ func main() {
 	}
 	uam := orchestrator.NewUserArtifactsManagerImpl(uamOpts)
 	opts := orchestrator.CVDToolInstanceManagerOpts{
-		ExecContext: exec.Command,
+		ExecContext: exec.CommandContext,
 		CVDBinAB: orchestrator.AndroidBuild{
 			ID:     cvdBinAndroidBuildID,
 			Target: cvdBinAndroidBuildTarget,
@@ -140,7 +140,7 @@ func main() {
 		OperationManager:         om,
 		UserArtifactsDirResolver: uam,
 		CVDExecTimeout:           5 * time.Minute,
-		HostValidator:            &orchestrator.HostValidator{ExecContext: exec.Command},
+		HostValidator:            &orchestrator.HostValidator{ExecContext: exec.CommandContext},
 		BuildAPIFactory: func(credentials string) orchestrator.BuildAPI {
 			return orchestrator.NewAndroidCIBuildAPI(http.DefaultClient, abURL, credentials)
 		},

--- a/frontend/src/host_orchestrator/orchestrator/instancemanager.go
+++ b/frontend/src/host_orchestrator/orchestrator/instancemanager.go
@@ -539,9 +539,10 @@ func createCredentialsFile(content string) (*os.File, error) {
 	}
 	go func(f *os.File) {
 		defer f.Close()
-		_, err = f.Write([]byte(content))
-		log.Printf("Failed to write credentials to file: %v\n", err)
-		// Can't return this error without risking a deadlock when the pipe buffer fills up.
+		if _, err := f.Write([]byte(content)); err != nil {
+			log.Printf("Failed to write credentials to file: %v\n", err)
+			// Can't return this error without risking a deadlock when the pipe buffer fills up.
+		}
 	}(p2)
 	return p1, nil
 }

--- a/frontend/src/host_orchestrator/orchestrator/instancemanager.go
+++ b/frontend/src/host_orchestrator/orchestrator/instancemanager.go
@@ -397,6 +397,9 @@ func untarCVDHostPackage(dir string) error {
 }
 
 func validateRequest(r *apiv1.CreateCVDRequest) error {
+	if r.CVD == nil {
+		return EmptyFieldError("CVD")
+	}
 	if r.CVD.BuildSource == nil {
 		return EmptyFieldError("BuildSource")
 	}

--- a/frontend/src/host_orchestrator/orchestrator/instancemanager_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/instancemanager_test.go
@@ -15,6 +15,7 @@
 package orchestrator
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -110,7 +111,7 @@ func TestCreateCVDSameTargetArtifactsIsDownloadedOnce(t *testing.T) {
 	dir := tempDir(t)
 	defer removeDir(t, dir)
 	fetchCVDExecCounter := 0
-	execContext := func(name string, args ...string) *exec.Cmd {
+	execContext := func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		if contains(args, "fetch") {
 			fetchCVDExecCounter += 1
 		}
@@ -303,7 +304,7 @@ func TestCreateCVDVerifyStartCVDCmdArgs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var usedCmdName string
 			var usedCmdArgs []string
-			execContext := func(name string, args ...string) *exec.Cmd {
+			execContext := func(cxt context.Context, name string, args ...string) *exec.Cmd {
 				if contains(args, "start") {
 					usedCmdName = name
 					usedCmdArgs = args
@@ -523,7 +524,7 @@ func TestListCVDsSucceeds(t *testing.T) {
           }
   ]
 ]`
-	execContext := func(name string, args ...string) *exec.Cmd {
+	execContext := func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		cmd := exec.Command("true")
 		if path.Base(args[len(args)-1]) == "fleet" {
 			cmd = exec.Command("echo", strings.TrimSpace(output))
@@ -602,11 +603,11 @@ func removeDir(t *testing.T, name string) {
 	}
 }
 
-func execCtxAlwaysSucceeds(name string, args ...string) *exec.Cmd {
+func execCtxAlwaysSucceeds(ctx context.Context, name string, args ...string) *exec.Cmd {
 	return exec.Command("true")
 }
 
-func execCtxSubcmdFails(name string, args ...string) *exec.Cmd {
+func execCtxSubcmdFails(ctx context.Context, name string, args ...string) *exec.Cmd {
 	cmd := "false"
 	// Do not fail when executing cvd only as it is not a cvd subcommand.
 	if path.Base(args[len(args)-1]) == "cvd" {
@@ -617,7 +618,7 @@ func execCtxSubcmdFails(name string, args ...string) *exec.Cmd {
 
 const testFakeBinaryDelayMs = 100 * time.Millisecond
 
-func execCtxSubcmdDelays(name string, args ...string) *exec.Cmd {
+func execCtxSubcmdDelays(ctx context.Context, name string, args ...string) *exec.Cmd {
 	cmd := fmt.Sprintf("sleep %f", float64(testFakeBinaryDelayMs)/1000_000_000)
 	// Do not wait when executing cvd only as it is not a cvd subcommand.
 	if path.Base(args[len(args)-1]) == "cvd" {


### PR DESCRIPTION
`cvd fetch` doesn't do the fetch itself but instead sends a request to the cvd server for it to do it. That request unfortunately doesn't include all open file descriptors, which makes passing the credentials file to the command as `/proc/self/fd/<n>` impossible.

`fetch_cvd` on the other hand behaves as expected.