### PR TITLE
Fixes cuttlefish-host_orchestrator.init script.

### DIFF
--- a/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.init
+++ b/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.init
@@ -64,8 +64,8 @@ gen_cert() {
   fi
 }
 
-set_config() {
-  if [ -v "$2" ]; then export $1="${!2}"; fi
+set_config_expr() {
+  echo "\${$2+"export $1=\$$2"}"
 }
 
 start() {
@@ -77,14 +77,14 @@ start() {
   mkdir -p  "${orchestrator_cvd_artifacts_dir}"
   chown _cutf-operator:cvdnetwork "${orchestrator_cvd_artifacts_dir}"
 
-  set_config ORCHESTRATOR_HTTP_PORT orchestrator_http_port
-  set_config ORCHESTRATOR_HTTPS_PORT orchestrator_https_port
-  set_config ORCHESTRATOR_TLS_CERT_DIR orchestrator_tls_cert_dir
-  set_config ORCHESTRATOR_ANDROID_BUILD_URL orchestrator_android_build_url
-  set_config ORCHESTRATOR_CVDBIN_ANDROID_BUILD_ID orchestrator_cvdbin_android_build_id
-  set_config ORCHESTRATOR_CVDBIN_ANDROID_BUILD_TARGET orchestrator_cvdbin_android_build_target
-  set_config ORCHESTRATOR_CVD_ARTIFACTS_DIR orchestrator_cvd_artifacts_dir
-  set_config ORCHESTRATOR_WEBUI_URL orchestrator_webui_url
+  eval $(set_config_expr ORCHESTRATOR_HTTP_PORT orchestrator_http_port)
+  eval $(set_config_expr ORCHESTRATOR_HTTPS_PORT orchestrator_https_port)
+  eval $(set_config_expr ORCHESTRATOR_TLS_CERT_DIR orchestrator_tls_cert_dir)
+  eval $(set_config_expr ORCHESTRATOR_ANDROID_BUILD_URL orchestrator_android_build_url)
+  eval $(set_config_expr ORCHESTRATOR_CVDBIN_ANDROID_BUILD_ID orchestrator_cvdbin_android_build_id)
+  eval $(set_config_expr ORCHESTRATOR_CVDBIN_ANDROID_BUILD_TARGET orchestrator_cvdbin_android_build_target)
+  eval $(set_config_expr ORCHESTRATOR_CVD_ARTIFACTS_DIR orchestrator_cvd_artifacts_dir)
+  eval $(set_config_expr ORCHESTRATOR_WEBUI_URL orchestrator_webui_url)
 
   ORCHESTRATOR_SOCKET_PATH="${RUN_DIR}"/operator \
   start-stop-daemon --start \


### PR DESCRIPTION
- `[ -v foo` operation is not POSIX compliant.