### PR TITLE
Run fetch_cvd with the orchestrator uid

### DIFF
--- a/frontend/src/host_orchestrator/orchestrator/instancemanager_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/instancemanager_test.go
@@ -113,11 +113,8 @@ func TestCreateCVDSameTargetArtifactsIsDownloadedOnce(t *testing.T) {
 	defer removeDir(t, dir)
 	fetchCVDExecCounter := 0
 	execContext := func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		for _, arg := range args {
-			if filepath.Base(arg) == "fetch_cvd" {
-				fetchCVDExecCounter += 1
-				break
-			}
+		if filepath.Base(name) == "fetch_cvd" {
+			fetchCVDExecCounter += 1
 		}
 		return exec.Command("true")
 	}
@@ -142,7 +139,7 @@ func TestCreateCVDSameTargetArtifactsIsDownloadedOnce(t *testing.T) {
 		t.Error("`fetch_cvd` was never executed")
 	}
 	if fetchCVDExecCounter > 1 {
-		t.Errorf("`fetch_cvd` was downloaded more than once, it was <<%d>> times", fetchCVDExecCounter)
+		t.Errorf("`fetch_cvd` was executed more than once, it was <<%d>> times", fetchCVDExecCounter)
 	}
 }
 


### PR DESCRIPTION
Instead of as _cvd-executor. Running as a different user requires sudo, which prevents file descriptors to be inherited by the child process, which in turn is needed to pass credentials securely to fetch_cvd.

Downloading with the orchestrator user also allows us to give the executor read-only access to the artifacts, which is a more robust approach when we want to be able to reuse those artifacts. Unfortunately we can't take advantage of that fact at the moment because of a bug in cuttlefish that causes it to write to one of the images.