### PR TITLE
Allow webui to be served on a path other than root

### DIFF
--- a/frontend/src/operator/webui/src/app/safe-device-url.pipe.ts
+++ b/frontend/src/operator/webui/src/app/safe-device-url.pipe.ts
@@ -10,7 +10,7 @@ export class SafeDeviceUrlPipe implements PipeTransform {
   transform(deviceId: string) {
     /* eslint-disable */
     // DO NOT FORMAT THIS LINE
-    return this.sanitizer.bypassSecurityTrustResourceUrl(`/devices/${deviceId}/files/client.html`);
+    return this.sanitizer.bypassSecurityTrustResourceUrl(`devices/${deviceId}/files/client.html`);
     /* eslint-enable */
   }
 }

--- a/frontend/src/operator/webui/src/index.html
+++ b/frontend/src/operator/webui/src/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Cloud Android</title>
-    <base href="/" />
+    <base href="." />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link


### PR DESCRIPTION
This allows showing a remote host's web UI through the cloud orchestrator proxying mechanism.