### PR TITLE
Fix Dockerfile for aarch64

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # This file is based on https://hub.docker.com/r/jrei/systemd-debian/.
 
-FROM debian:buster-slim AS cuttlefish-softgpu
+FROM debian:stable-20211011 AS cuttlefish-softgpu
 
 ENV container docker
 ENV LC_ALL C
@@ -46,7 +46,7 @@ RUN if test $(uname -m) == aarch64; then \
 	    dpkg --add-architecture amd64 \
 	    && apt-get update \
 	    && apt-get install --no-install-recommends -y libc6:amd64 \
-	    && apt-get install --no-install-recommends -y qemu qemu-user qemu-user-static binfmt-support; \
+	    && apt-get install --no-install-recommends -y qemu-system-arm qemu-user qemu-user-static binfmt-support; \
     fi
 
 # host packages and google-chrome (google-chrome*.deb)


### PR DESCRIPTION
Building the Dockerfile from the provided Docker scripts fails due to dependency issues (see below). This PR fixes that.

The libc6 library provided in buster is `2.28-10+deb10u2`, while cuttlefish requires versions `>= 2.34`, causing the build to fail.
Switching the debian version to match the version seen in the builder solves this. (also the qemu package is renamed because the package is dummy package and no longer exists in later debian versions like bookworm, see [here](https://packages.debian.org/buster/qemu)).

A complete log of the error fixed can be found in the attached file: [err.txt](https://github.com/google/android-cuttlefish/files/11801528/err.txt)
