### PR TITLE
Fix init script of host orchestrator to directly set env variables

### DIFF
--- a/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.init
+++ b/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.init
@@ -34,9 +34,14 @@
 if [ -f /etc/default/cuttlefish-host_orchestrator ]; then
     . /etc/default/cuttlefish-host_orchestrator
 fi
-
+orchestrator_http_port=${orchestrator_http_port:-"1080"}
+orchestrator_https_port=${orchestrator_https_port:-"1443"}
 orchestrator_tls_cert_dir=${orchestrator_tls_cert_dir:-"/etc/cuttlefish-common/host_orchestrator/cert"}
+orchestrator_android_build_url=${orchestrator_android_build_url:-"https://androidbuildinternal.googleapis.com"}
+orchestrator_cvdbin_android_build_id=${orchestrator_cvdbin_android_build_id:-""}
+orchestrator_cvdbin_android_build_target=${orchestrator_cvdbin_android_build_target:-""}
 orchestrator_cvd_artifacts_dir=${orchestrator_cvd_artifacts_dir:-"/var/lib/cuttlefish-common"}
+orchestrator_webui_url=${orchestrator_webui_url:-""}
 
 RUN_DIR="/run/cuttlefish"
 ASSET_DIR="/usr/share/cuttlefish-common/host_orchestrator"
@@ -77,16 +82,15 @@ start() {
   mkdir -p  "${orchestrator_cvd_artifacts_dir}"
   chown _cutf-operator:cvdnetwork "${orchestrator_cvd_artifacts_dir}"
 
-  eval $(set_config_expr ORCHESTRATOR_HTTP_PORT orchestrator_http_port)
-  eval $(set_config_expr ORCHESTRATOR_HTTPS_PORT orchestrator_https_port)
-  eval $(set_config_expr ORCHESTRATOR_TLS_CERT_DIR orchestrator_tls_cert_dir)
-  eval $(set_config_expr ORCHESTRATOR_ANDROID_BUILD_URL orchestrator_android_build_url)
-  eval $(set_config_expr ORCHESTRATOR_CVDBIN_ANDROID_BUILD_ID orchestrator_cvdbin_android_build_id)
-  eval $(set_config_expr ORCHESTRATOR_CVDBIN_ANDROID_BUILD_TARGET orchestrator_cvdbin_android_build_target)
-  eval $(set_config_expr ORCHESTRATOR_CVD_ARTIFACTS_DIR orchestrator_cvd_artifacts_dir)
-  eval $(set_config_expr ORCHESTRATOR_WEBUI_URL orchestrator_webui_url)
-
+  ORCHESTRATOR_HTTP_PORT="${orchestrator_http_port}" \
+  ORCHESTRATOR_HTTPS_PORT="${orchestrator_https_port}" \
+  ORCHESTRATOR_TLS_CERT_DIR="${orchestrator_tls_cert_dir}" \
+  ORCHESTRATOR_ANDROID_BUILD_URL="${orchestrator_android_build_url}" \
+  ORCHESTRATOR_CVDBIN_ANDROID_BUILD_ID="${orchestrator_cvdbin_android_build_id}" \
+  ORCHESTRATOR_CVDBIN_ANDROID_BUILD_TARGET="${orchestrator_cvdbin_android_build_target}" \
+  ORCHESTRATOR_CVD_ARTIFACTS_DIR="${orchestrator_cvd_artifacts_dir}" \
   ORCHESTRATOR_SOCKET_PATH="${RUN_DIR}"/operator \
+  ORCHESTRATOR_WEBUI_URL="${orchestrator_webui_url}" \
   start-stop-daemon --start \
     --pidfile "${PIDFILE}" \
     --chuid _cutf-operator:cvdnetwork \


### PR DESCRIPTION
- `set_config_expr` does not set env vars as in `cuttlefish-orchestration.cuttlefish-host_orchestrator.default` 
- Thus here replaces `eval` & `set_config_expr` to direct setting env vars as `cuttlefish-user` does in  `cuttlefish-user.cuttlefish-operator.init`
- Default values are from comments of `cuttlefish-orchestration.cuttlefish-host_orchestrator.default`