### PR TITLE
frontend: debian: control: add libprotobuf-dev to Build-Depends

### DIFF
--- a/frontend/debian/control
+++ b/frontend/debian/control
@@ -6,6 +6,7 @@ Build-Depends: config-package-dev,
                curl,
                debhelper-compat (= 12),
                golang (>= 2:1.13~) | golang-1.13,
+               libprotobuf-dev,
                protobuf-compiler,
 Standards-Version: 4.5.0
 


### PR DESCRIPTION
Without libprotobuf-dev, when building the package, we got
  google/protobuf/empty.proto: File not found.
  example.proto:24:1: Import "google/protobuf/empty.proto

It is because libprotobuf-dev is just a Recommends of protobuf-compiler. And it is not guaranteed to be installed by current Build-Depends. So we add libprotobuf-dev to Build-Depends to solve the build failure.