### PR TITLE
Revert "frontend: debian: control: add libprotobuf-dev to Build-Depends"

### DIFF
--- a/frontend/debian/control
+++ b/frontend/debian/control
@@ -6,7 +6,6 @@ Build-Depends: config-package-dev,
                curl,
                debhelper-compat (= 12),
                golang (>= 2:1.13~) | golang-1.13,
-               libprotobuf-dev,
                protobuf-compiler,
 Standards-Version: 4.5.0
 


### PR DESCRIPTION
Reverts google/android-cuttlefish#316

It breaks docker build, and we don't build protobuf during build for now.