### PR TITLE
Do not call t.Fatal in a goroutine.

### DIFF
--- a/frontend/src/host_orchestrator/orchestrator/instancemanager_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/instancemanager_test.go
@@ -108,10 +108,10 @@ func TestAndroidCICVDDownloaderDownloadMultipleTimesSucceeds(t *testing.T) {
 			for _, name := range []string{outCVD, outFetchCVD} {
 				exists, err := fileExist(name)
 				if err != nil {
-					t.Fatal(err)
+					t.Error(err)
 				}
 				if exists != true {
-					t.Errorf("expected true")
+					t.Error("expected true")
 				}
 			}
 		}()


### PR DESCRIPTION
- https://staticcheck.dev/docs/checks#SA2002