### PR TITLE
[HO] Use latest green build id.

### DIFF
--- a/frontend/src/host_orchestrator/orchestrator/controller.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller.go
@@ -147,6 +147,7 @@ func (h *fetchArtifactsHandler) Handle(r *http.Request) (interface{}, error) {
 		CVDToolsVersion:  h.Config.CVDToolsVersion,
 		CVDDownloader:    cvdDwnl,
 		OperationManager: h.OM,
+		BuildAPI:         buildAPI,
 		CVDBundleFetcher: cvdBundleFetcher,
 		ArtifactsFetcher: artifactsFetcher,
 	}


### PR DESCRIPTION
- When client provides branch and target only the host orchestrator will use the latest green build id.