### PR TITLE
POST /cvds to support specify group name & instance names

### DIFF
--- a/frontend/src/host_orchestrator/orchestrator/createcvdaction_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/createcvdaction_test.go
@@ -176,7 +176,7 @@ func TestCreateCVDVerifyStartCVDCmdArgs(t *testing.T) {
 	dir := orchtesting.TempDir(t)
 	defer orchtesting.RemoveDir(t, dir)
 	goldenPrefixFmt := fmt.Sprintf("sudo -u fakecvduser HOME=%[1]s/runtimes "+
-		"ANDROID_HOST_OUT=%[1]s/artifacts/%%[1]s "+"%[1]s/cvd --group_name=cvd start --daemon --report_anonymous_usage_stats=y"+
+		"ANDROID_HOST_OUT=%[1]s/artifacts/%%[1]s "+"%[1]s/cvd -group_name %%[2]s -instance_name %%[3]s start --daemon --report_anonymous_usage_stats=y"+
 		" --base_instance_num=1 --system_image_dir=%[1]s/artifacts/%%[1]s", dir)
 	tests := []struct {
 		name string
@@ -193,7 +193,10 @@ func TestCreateCVDVerifyStartCVDCmdArgs(t *testing.T) {
 				},
 			},
 			exp: fmt.Sprintf(goldenPrefixFmt,
-				fmt.Sprintf("%s_%s__cvd", fakeLatesGreenBuildID, mainBuildDefaultTarget)),
+				fmt.Sprintf("%s_%s__cvd", fakeLatesGreenBuildID, mainBuildDefaultTarget),
+				"default",
+				"cvd-1",
+			),
 		},
 		{
 			name: "android ci build specific main build",
@@ -209,7 +212,7 @@ func TestCreateCVDVerifyStartCVDCmdArgs(t *testing.T) {
 					},
 				},
 			},
-			exp: fmt.Sprintf(goldenPrefixFmt, "1_foo__cvd"),
+			exp: fmt.Sprintf(goldenPrefixFmt, "1_foo__cvd", "default", "cvd-1"),
 		},
 		{
 			name: "android ci build specific kernel build",
@@ -229,7 +232,7 @@ func TestCreateCVDVerifyStartCVDCmdArgs(t *testing.T) {
 					},
 				},
 			},
-			exp: fmt.Sprintf(goldenPrefixFmt, "1_foo__cvd") +
+			exp: fmt.Sprintf(goldenPrefixFmt, "1_foo__cvd", "default", "cvd-1") +
 				" --kernel_path=" + dir + "/artifacts/137_bar__kernel/bzImage" +
 				" --initramfs_path=" + dir + "/artifacts/137_bar__kernel/initramfs.img",
 		},
@@ -251,7 +254,7 @@ func TestCreateCVDVerifyStartCVDCmdArgs(t *testing.T) {
 					},
 				},
 			},
-			exp: fmt.Sprintf(goldenPrefixFmt, "1_foo__cvd") +
+			exp: fmt.Sprintf(goldenPrefixFmt, "1_foo__cvd", "default", "cvd-1") +
 				" --bootloader=" + dir + "/artifacts/137_bar__bootloader/u-boot.rom",
 		},
 		{
@@ -272,7 +275,7 @@ func TestCreateCVDVerifyStartCVDCmdArgs(t *testing.T) {
 					},
 				},
 			},
-			exp: fmt.Sprintf(goldenPrefixFmt, fakeUUID+"__custom_cvd"),
+			exp: fmt.Sprintf(goldenPrefixFmt, fakeUUID+"__custom_cvd", "default", "cvd-1"),
 		},
 	}
 	for _, tc := range tests {
@@ -340,7 +343,7 @@ func TestCreateCVDFromUserBuildVerifyStartCVDCmdArgs(t *testing.T) {
 	tarContent, _ := ioutil.ReadFile(getTestTarFilename())
 	ioutil.WriteFile(dir+"/"+CVDHostPackageName, tarContent, 0755)
 	expected := fmt.Sprintf("sudo -u fakecvduser HOME=%[1]s/runtimes "+
-		"ANDROID_HOST_OUT=%[1]s "+"%[1]s/cvd --group_name=cvd start --daemon --report_anonymous_usage_stats=y"+
+		"ANDROID_HOST_OUT=%[1]s "+"%[1]s/cvd -group_name default -instance_name cvd-1 start --daemon --report_anonymous_usage_stats=y"+
 		" --base_instance_num=1 --system_image_dir=%[1]s", dir)
 	var usedCmdName string
 	var usedCmdArgs []string

--- a/frontend/src/liboperator/api/v1/messages.go
+++ b/frontend/src/liboperator/api/v1/messages.go
@@ -87,10 +87,12 @@ type AndroidCIBundle struct {
 }
 
 type CreateCVDRequest struct {
+	GroupName string `json:"group_name,omitempty"`
 	// REQUIRED.
 	CVD *CVD `json:"cvd"`
 	// Use to create multiple homogeneous instances.
-	AdditionalInstancesNum uint32 `json:"additional_instances_num,omitempty"`
+	AdditionalInstancesNum uint32   `json:"additional_instances_num,omitempty"`
+	InstanceNames          []string `json:"instance_names,omitempty"`
 }
 
 type CreateCVDResponse struct {


### PR DESCRIPTION
### Changes
- `POST /cvds` now accept group name and instance names as body content, thus user can specify the names
- If `group_name` or `instance_names` are not provided, the default group name becomes `default` and instance names become `cvd-1`, `cvd-2`, etc.


- The test request below creates 2 cvds in a group "bar"
```
curl -d  '{ 
    "group_name": "bar",                                                                                                                                                                                                                  
    "cvd": {
        "name": "",
        "build_source": {
            "android_ci_build_source": {
                "branch": "aosp-main",
                "build_id": "10678986",
                "target": "aosp_cf_x86_64_phone-trunk_staging-userdebug"
            }
        },
        "status": "a",
        "displays": []
    },
   "instance_names": ["device1", "device2"]
}' -H "Content-Type: application/json" -k -X POST [http://localhost:1080/cvds](http://localhost:1081/cvds)
```

- The logic to generate instanceNumbers to decide instance names were removed as `instanceCounter` does not have to deal with concurrency as `instanceCounter` is a value on `CreateCVDAction` which is created per request.  


### Limitation
- Multiple `POST /cvds` calls are not possible so far
  - Maintaining `instanceCounter` from `instanceManager` instead of `CreateCVDAction` would make the host orchestrator be aware of the first available instance id
- Creating different specs(target, build id, branch) of cvds is not possible so far as cvd cli (`cvd start`) does not support it