### PR TITLE
Fix cvd name after `cvd` version update.

### DIFF
--- a/frontend/src/host_orchestrator/orchestrator/listcvdsaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/listcvdsaction.go
@@ -48,7 +48,7 @@ func (a *ListCVDsAction) Run() (*apiv1.ListCVDsResponse, error) {
 	if err := a.cvdDownloader.Download(a.cvdToolsVersion, a.paths.CVDBin(), a.paths.FetchCVDBin()); err != nil {
 		return nil, err
 	}
-	fleet, err := cvdFleet(a.execContext, a.paths.CVDBin())
+	fleet, err := getCVDFleet(a.execContext, a.paths.CVDBin())
 	if err != nil {
 		return nil, err
 	}

--- a/frontend/src/host_orchestrator/orchestrator/listcvdsaction_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/listcvdsaction_test.go
@@ -81,7 +81,7 @@ func TestListCVDsSucceeds(t *testing.T) {
 
 	want := &apiv1.ListCVDsResponse{CVDs: []*apiv1.CVD{
 		{
-			Name:        "1",
+			Name:        "cvd-1",
 			BuildSource: &apiv1.BuildSource{},
 			Status:      "Running",
 			Displays:    []string{"720 x 1280 ( 320 )"},


### PR DESCRIPTION
- After bumping `cvd` version in commit#497d7f09eb161cb095fb66b8be104f6bd75412de returned cvd names changed from `cvd-1` to `1`, which breaks compatibility with names used in `GET /devices` API.