### PR TITLE
Host orchestrator reverse proxies to operator

### DIFF
--- a/frontend/debian/changelog
+++ b/frontend/debian/changelog
@@ -1,5 +1,7 @@
 cuttlefish-frontend (0.9.28) UNRELEASED; urgency=medium
 
+  * Replace operator functionality with reverse proxy in host operator
+
  -- Jorge Moreira <jemoreira@google.com>  Wed, 13 Sep 2023 11:59:23 -0700
 
 cuttlefish-frontend (0.9.27) unstable; urgency=medium

--- a/frontend/debian/changelog
+++ b/frontend/debian/changelog
@@ -1,10 +1,14 @@
-cuttlefish-frontend (0.9.27) UNRELEASED; urgency=medium
+cuttlefish-frontend (0.9.28) UNRELEASED; urgency=medium
+
+ -- Jorge Moreira <jemoreira@google.com>  Wed, 13 Sep 2023 11:59:23 -0700
+
+cuttlefish-frontend (0.9.27) unstable; urgency=medium
 
   * Increase nofile soft limit to support passthrough GPU modes
 
  -- Jason Macnak <natsu@google.com>  Tue, 23 May 2023 08:58:58 -0700
 
-cuttlefish-frontend (0.9.26) UNRELEASED; urgency=medium
+cuttlefish-frontend (0.9.26) unstable; urgency=medium
 
   * Change operator's web UI to tile UI
 

--- a/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.default
+++ b/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.default
@@ -30,4 +30,7 @@ orchestrator_https_port=1443
 # If it isn't empty, the application uses web UI from the url,
 # else, it uses web pages which is generated during the build
 # Defaults to ""
-# orchestrator_webui_url=
+# operator_webui_url=
+#
+# The port where the operator is to listen on.
+operator_http_port=2080

--- a/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.init
+++ b/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.init
@@ -39,9 +39,11 @@ orchestrator_tls_cert_dir=${orchestrator_tls_cert_dir:-"/etc/cuttlefish-common/h
 orchestrator_cvd_artifacts_dir=${orchestrator_cvd_artifacts_dir:-"/var/lib/cuttlefish-common"}
 
 RUN_DIR="/run/cuttlefish"
-ASSET_DIR="/usr/share/cuttlefish-common/host_orchestrator"
-DAEMON="/usr/lib/cuttlefish-common/bin/host_orchestrator"
-PIDFILE="${RUN_DIR}"/host_orchestrator.pid
+ORCHESTRATOR_BIN="/usr/lib/cuttlefish-common/bin/host_orchestrator"
+ORCHESTRATOR_PIDFILE="${RUN_DIR}"/host_orchestrator.pid
+ASSET_DIR="/usr/share/cuttlefish-common/operator"
+OPERATOR_BIN="/usr/lib/cuttlefish-common/bin/operator"
+OPERATOR_PIDFILE="${RUN_DIR}"/operator.pid
 
 gen_cert() {
   CERT_FILE="${orchestrator_tls_cert_dir}/cert.pem"
@@ -84,24 +86,38 @@ start() {
   eval $(set_config_expr ORCHESTRATOR_CVDBIN_ANDROID_BUILD_ID orchestrator_cvdbin_android_build_id)
   eval $(set_config_expr ORCHESTRATOR_CVDBIN_ANDROID_BUILD_TARGET orchestrator_cvdbin_android_build_target)
   eval $(set_config_expr ORCHESTRATOR_CVD_ARTIFACTS_DIR orchestrator_cvd_artifacts_dir)
-  eval $(set_config_expr ORCHESTRATOR_WEBUI_URL orchestrator_webui_url)
+  eval $(set_config_expr OPERATOR_WEBUI_URL operator_webui_url)
+  eval $(set_config_expr OPERATOR_HTTP_PORT operator_http_port)
 
-  ORCHESTRATOR_SOCKET_PATH="${RUN_DIR}"/operator \
+  OPERATOR_SOCKET_PATH="${RUN_DIR}"/operator \
+  start-stop-daemon --start \
+    --pidfile "${OPERATOR_PIDFILE}" \
+    --chdir "${ASSET_DIR}" \
+    --background --no-close \
+    --make-pidfile \
+    --exec "${OPERATOR_BIN}"
+
   ORCHESTRATOR_CVD_USER="_cvd-executor" \
   start-stop-daemon --start \
-    --pidfile "${PIDFILE}" \
+    --pidfile "${ORCHESTRATOR_PIDFILE}" \
     --chuid _cutf-operator:cvdnetwork \
     --chdir "${ASSET_DIR}" \
     --background --no-close \
     --make-pidfile \
-    --exec "${DAEMON}"
+    --exec "${ORCHESTRATOR_BIN}"
 }
 
 stop() {
   start-stop-daemon --stop \
-    --pidfile "${PIDFILE}" \
+    --pidfile "${ORCHESTRATOR_PIDFILE}" \
     --remove-pidfile \
-    --exec "${DAEMON}"
+    --exec "${ORCHESTRATOR_BIN}"
+
+  start-stop-daemon --stop \
+    --pidfile "${OPERATOR_PIDFILE}" \
+    --remove-pidfile \
+    --exec "${OPERATOR_BIN}"
+
   # The presence of the socket will cause devices to try to connect to it
   # instead of starting their own signaling servers, so it needs to be removed
   # once the service isn't running.
@@ -114,9 +130,9 @@ status() {
   #   1 if daemon is dead and pid file exists
   #   3 if daemon is not running
   #   4 if daemon status is unknown
-  start-stop-daemon --start --quiet --pidfile "${PIDFILE}" --exec ${DAEMON} --test > /dev/null
+  start-stop-daemon --start --quiet --pidfile "${ORCHESTRATOR_PIDFILE}" --exec ${ORCHESTRATOR_BIN} --test > /dev/null
   case "${?}" in
-    0) [ -e "${PIDFILE}" ] && return 1 ; return 3 ;;
+    0) [ -e "${ORCHESTRATOR_PIDFILE}" ] && return 1 ; return 3 ;;
     1) return 0 ;;
     *) return 4 ;;
   esac

--- a/frontend/debian/cuttlefish-orchestration.install
+++ b/frontend/debian/cuttlefish-orchestration.install
@@ -1,4 +1,5 @@
 host/packages/cuttlefish-orchestration/* /
 src/host_orchestrator/host_orchestrator /usr/lib/cuttlefish-common/bin/
-src/operator/webui/dist/static /usr/share/cuttlefish-common/host_orchestrator/
-src/operator/intercept /usr/share/cuttlefish-common/host_orchestrator/
+src/operator/operator /usr/lib/cuttlefish-common/bin/
+src/operator/webui/dist/static /usr/share/cuttlefish-common/operator/
+src/operator/intercept /usr/share/cuttlefish-common/operator/

--- a/frontend/debian/cuttlefish-user.cuttlefish-operator.default
+++ b/frontend/debian/cuttlefish-user.cuttlefish-operator.default
@@ -1,5 +1,9 @@
 # defaults for cuttlefish-operator
 
+# The network address to listen on for both HTTP and HTTPS.
+# Defaults to all ip addresses.
+operator_listen_address=0.0.0.0
+#
 # The port on which the operator server should listen on for plain HTTP.
 # Defaults to 1080.
 # operator_http_port=

--- a/frontend/debian/cuttlefish-user.cuttlefish-operator.default
+++ b/frontend/debian/cuttlefish-user.cuttlefish-operator.default
@@ -5,8 +5,8 @@
 # operator_http_port=
 #
 # The port on which the operator server should listen on for HTTPS.
-# Defaults to 1443.
-# operator_https_port=
+# Serve over http only when not provided.
+operator_https_port=1443
 #
 # The directory where the TLS certificate needed to establish the HTTPS
 # communication lives.

--- a/frontend/debian/cuttlefish-user.cuttlefish-operator.init
+++ b/frontend/debian/cuttlefish-user.cuttlefish-operator.init
@@ -76,6 +76,7 @@ start() {
   OPERATOR_TLS_CERT_DIR="${operator_tls_cert_dir}" \
   OPERATOR_SOCKET_PATH="${RUN_DIR}"/operator \
   OPERATOR_WEBUI_URL="${operator_webui_url}" \
+  OPERATOR_LISTEN_ADDRESS="${operator_listen_address}" \
   start-stop-daemon --start \
     --pidfile "${PIDFILE}" \
     --chuid _cutf-operator:cvdnetwork \

--- a/frontend/debian/rules
+++ b/frontend/debian/rules
@@ -40,4 +40,5 @@ override_dh_installinit:
 
 override_dh_auto_clean:
 	rm -f $(ORCHESTRATOR_SOURCE_DIR)/host_orchestrator
+	rm -f $(OPERATOR_SOURCE_DIR)/operator
 	dh_auto_clean

--- a/frontend/src/operator/main.go
+++ b/frontend/src/operator/main.go
@@ -30,7 +30,6 @@ import (
 const (
 	DefaultSocketPath     = "/run/cuttlefish/operator"
 	DefaultHttpPort       = "1080"
-	DefaultHttpsPort      = "1443"
 	DefaultTLSCertDir     = "/etc/cuttlefish-common/operator/cert"
 	DefaultStaticFilesDir = "static"    // relative path
 	DefaultInterceptDir   = "intercept" // relative path
@@ -90,7 +89,7 @@ func start(starters []func() error) {
 func main() {
 	socketPath := fromEnvOrDefault("OPERATOR_SOCKET_PATH", DefaultSocketPath)
 	httpPort := fromEnvOrDefault("OPERATOR_HTTP_PORT", DefaultHttpPort)
-	httpsPort := fromEnvOrDefault("OPERATOR_HTTPS_PORT", DefaultHttpsPort)
+	httpsPort := fromEnvOrDefault("OPERATOR_HTTPS_PORT", "")
 	tlsCertDir := fromEnvOrDefault("OPERATOR_TLS_CERT_DIR", DefaultTLSCertDir)
 	webUiUrlStr := fromEnvOrDefault("OPERATOR_WEBUI_URL", DefaultWebUIUrl)
 
@@ -119,8 +118,10 @@ func main() {
 
 	starters := []func() error{
 		func() error { return operator.SetupDeviceEndpoint(pool, config, socketPath)() },
-		func() error { return startHttpsServer(httpsPort, certPath, keyPath) },
 		func() error { return startHttpServer(httpPort) },
+	}
+	if httpPort != "" {
+		starters = append(starters, func() error { return startHttpsServer(httpsPort, certPath, keyPath) })
 	}
 	start(starters)
 }


### PR DESCRIPTION
Eliminates the redundancy between host-orchestrator and operator by having the signaling server features only in the operator.
Allows having and executing both binaries simultaneously, which is required for the orchestration UI to support local use cases.
The host orchestrator service now starts both the host_orchestrator and the operator daemons, with the operator listening only on localhost:2080 and the orchestrator on its regular ports.