### PR TITLE
Use bash for cuttlefish-user.cuttlefish-operator.init

### DIFF
--- a/frontend/debian/cuttlefish-user.cuttlefish-operator.init
+++ b/frontend/debian/cuttlefish-user.cuttlefish-operator.init
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 ### BEGIN INIT INFO
 # Provides: cuttlefish-operator


### PR DESCRIPTION
Switch shell from "sh" to "bash". The script now uses arrays which require true bash:

args=()
args+=(...)