### PR TITLE
Fixing docker android 14

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y apt-utils sudo vim gawk coreutils \
        openssh-server openssh-client psmisc iptables iproute2 dnsmasq \
        net-tools rsyslog equivs equivs devscripts dpkg-dev dialog \
-       protobuf-compiler # qemu-system-x86
+       protobuf-compiler libegl1 libegl-dev # qemu-system-x86
 
 SHELL ["/bin/bash", "-c"]
 

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -356,7 +356,6 @@ function cf_docker_create {
 
 	    if [[ -f "${cuttlefish}" ]]; then
 		    local home="$(mktemp -d)"
-		    echo "home=$home"
 		    echo "Setting up Cuttlefish host image from ${cuttlefish} in ${home}."
 		    tar xz -C "${home}" -f "${cuttlefish}"
 	    fi
@@ -404,7 +403,6 @@ function cf_docker_create {
 	    fi
 
         echo "Starting container ${name} (id ${cf_instance}) from image cuttlefish.";
-#        echo "-v /sys/fs/cgroup:/sys/fs/cgroup:rw ${volumes[@]}"
 	    docker run -d ${as_host_x[@]} \
 		        --cgroupns=host \
 		        --name "${name}" -h "${name}" \
@@ -547,15 +545,13 @@ function $(__gen_login_func_name ${name}) {
   if [[ -n "\$@" ]]; then
 	_cmd="\$@"
   fi
-  echo "Executing: docker exec -it  --user vsoc-01 ${name} \${_cmd}"
-  docker exec -it  --user vsoc-01 "${name}" \${_cmd}
+  docker exec -it --user vsoc-01 "${name}" \${_cmd}
 }
 EOF
 
 read -r -d '' start_func <<EOF
 function $(__gen_start_func_name ${name}) {
-  echo "Starting ./bin/launch_cvd  \$@"
-  $(__gen_login_func_name ${name}) ./bin/launch_cvd  "\$@"
+  $(__gen_login_func_name ${name}) ./bin/launch_cvd "${vcid_opt}" "\$@"
 }
 EOF
 

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -362,15 +362,15 @@ function cf_docker_create {
 	    if [[ -d "${android}" ]]; then
 		    echo "Setting up Android images from ${android} in ${home}."
 		    if [[ $(compgen -G "${android}"/*.img) != "${android}/*.img" ]]; then
-				for f in "${android}"/*.img; do
-					cp "${f}" "${home}"
-				done
+			    for f in "${android}"/*.img; do
+				    cp "${f}" "${home}"
+			    done
 		    else
 			    echo "WARNING: No Android images in ${android}."
 		    fi
-            if [ -f "${android}/bootloader" ]; then
-		cp ${android}/bootloader ${home}
-            fi
+		    if [ -f "${android}/bootloader" ]; then
+	    	    	    cp ${android}/bootloader ${home}
+            	    fi
 	    fi
 	    if [[ -f "${cuttlefish}" || -d "${android}" ]]; then
 		    volumes+=("-v ${home}:/home/vsoc-01:rw")


### PR DESCRIPTION
Android 14 behaves differently to Android 13 in that when cuttlefish runs, it needs to create a new super.img file over the original image. It does this by re-naming super.img.raw to super.img. However in docker if you use the --android parameter, this file is mounted directly rather than mounting a containing directory. This means that the inode of the file would change, and docker does not allow this. The end result is the following output after running cf_start_<name>:

```
assemble_cvd D 10-19 07:46:14   474   474 subprocess.cpp:335] --out
assemble_cvd D 10-19 07:46:14   474   474 subprocess.cpp:335] /tmp/nfrzwE
Failed to load library: libEGL.so
Failed to load library: libEGL.so.1
Failed to load library: libEGL.so
Failed to load library: libEGL.so.1
Failed to load vk
GPU auto mode: did not detect prerequisites for accelerated rendering support, enabling --gpu_mode=guest_swiftshader.
GPU auto mode: did not detect prerequisites for accelerated rendering support, enabling --gpu_mode=guest_swiftshader.
Requested resuming a previous session (the default behavior) but the base images have changed under the overlay, making the overlay incompatible. Wiping the overlay files.
Path for instance UDS: /tmp/cf_avd_1005
/bin/mv: cannot move '/home/vsoc-01/super.img.raw' to '/home/vsoc-01/super.img': Device or resource busy
Unable to replace original sparse image 1
launch_cvd E 10-19 07:46:15   448   448 subprocess.cpp:162] Subprocess 474 was interrupted by a signal: 6
launch_cvd E 10-19 07:46:15   448   448 main.cc:391] assemble_cvd returned -1
```

This commit changes the method of mounting the image files, so that they are copied to the same tmp directory as the cuttlefish files. Then the whole directory is mounted, so that the files inside can be tweaked at will. This allows the running of cuttlefish inside the docker container for android 14.

(NOTE: This is not an issue if you create the container without specifying cuttlefish/android files, and then manually ssh them inside once created. e.g.
```
cf_docker_create cf1
ssh vsoc-01@$(cf_get_ip cf1) -- 'tar xzvf -' < AOSP_IMAGE_FILES.tar.gz
ssh vsoc-01@$(cf_get_ip cf1) -- 'tar xzvf -' < cvd-host_package.tar.gz
```
works fine, but

```
cf_docker_create --android=aosp/out/target/product/vsoc_x86_64 --cuttlefish=aosp/out/host/linux-x86/cvd-host_package.tar.gz cf1
```

will not.

The Docker file has also been changed so that it now installs libegl1 and libegl-dev which resolves the library loading error messages

```
Failed to load library: libEGL.so
Failed to load library: libEGL.so.1
Failed to load library: libEGL.so
Failed to load library: libEGL.so.1
```

(I could not see any immediate issue with this error, but felt like it would probably be useful to fix the error at the same time as pushing this fix)

This was tested on cuttlefish built on branches android-13.0.0_r45 and android-14.0.0_r1, both of which seem to start-up as expected, and are connectable via adb.