### PR TITLE
Removing base_instance_num from cf_start_

### DIFF
--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -528,7 +528,7 @@ function __gen_gethome_func_name {
 function __gen_funcs {
 	local name=$1
 	local instance_id=$(cf_get_instance_id ${name})
-	local vcid_opt="--base_instance_num=${instance_id}"
+	local vcid_opt
 	local login_func
 	local start_func
 	local stop_func

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -52,7 +52,7 @@ function cf_allocate_instance_id {
 	done
 	local sorted;
 	IFS=$'\n' sorted=($(sort -n <<<"${ids[*]}")); unset IFS
-	local prev=0
+	local prev=1
 	for id in ${sorted[@]}; do
 		if [[ "${prev}" -lt "${id}" ]]; then
 			break;
@@ -349,7 +349,7 @@ function cf_docker_create {
 	    echo "Container ${name} does not exist.";
 
         local cf_instance=$(cf_allocate_instance_id)
-        if [ "${cf_instance}" -gt 7 ]; then
+        if [ "${cf_instance}" -gt 8 ]; then
                 echo "Limit is maximum 8 Cuttlefish instances."
                 return
         fi


### PR DESCRIPTION
If you are attempting to do multi-tenancy cuttlefish, the docker script will currently automatically put `--base_instance_num=0` at the start of your start command. 

In the launch_cvd help, it states that this is for labelling the instances, and will begin labelling at this number.

```
-base_instance_num (The instance number of the device created. When
      `-num_instances N` is used, N instance numbers are claimed starting at
      this number.) type: int32 default: 1
```
If we set this value to 0, we are unable to create multi-tenancy cuttlefish instances, regardless of how many instances we pass in with `--num_instances=` parameter. We actually get an error informing us that cuttlefish was unable to interpret 0 as an id.

`run_cvd I 10-19 12:21:01  1549  1549 cuttlefish_config.cpp:55] Failed to interpret "0" as an id, using instance id 1`

This error can be seen in this line of code: https://github.com/luke-ingle/android-cuttlefish/blob/fixing-capability-to-multi-tenancy-cuttlefish/cvd/host/libs/config/cuttlefish_config.cpp#L53 which is doing a check to ensure the instance value is GREATER than 0.

```
  int instance = std::stoi(instance_str);
  if (instance <= 0) {
    LOG(INFO) << "Failed to interpret \"" << instance_str << "\" as an id, "
              << "using instance id " << kDefaultInstance;
    return kDefaultInstance;
  }
```

Doing the change in the PR remedies this problem, and then when you pass in `--num_instances=` parameter, you will create that many instances as expected.