### PR TITLE
Fix operator https not running

### DIFF
--- a/frontend/debian/cuttlefish-user.cuttlefish-operator.default
+++ b/frontend/debian/cuttlefish-user.cuttlefish-operator.default
@@ -14,8 +14,7 @@ operator_https_port=1443
 #
 # The directory where the TLS certificate needed to establish the HTTPS
 # communication lives.
-# Defaults to "/etc/cuttlefish-common/operator/cert".
-# operator_tls_cert_dir=
+operator_tls_cert_dir="/etc/cuttlefish-common/operator/cert"
 #
 # Where web UI in the application is from
 # If it isn't empty, the application uses web UI from the url,

--- a/frontend/src/operator/main.go
+++ b/frontend/src/operator/main.go
@@ -125,7 +125,7 @@ func main() {
 		func() error { return operator.SetupDeviceEndpoint(pool, config, *socketPath)() },
 		func() error { return startHttpServer(*address, *httpPort) },
 	}
-	if *httpPort <= 0 {
+	if *httpsPort <= 0 {
 		starters = append(starters, func() error {
 			return startHttpsServer(*address, *httpsPort, certPath, keyPath)
 		})


### PR DESCRIPTION
1. there is no where to specify operator_tls_cert_dir to create cert files
 *  put this variable on cuttlefish-operator.default

2. call startHttpsServer when httpPort is not available but httpPort has default port, no chance to run HttpsServer