### PR TITLE
Use bash in cuttlefish-host_orchestrator.init.

### DIFF
--- a/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.init
+++ b/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.init
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 ### BEGIN INIT INFO
 # Provides: cuttlefish-host_orchestrator


### PR DESCRIPTION
- The script fails with error `/etc/init.d/cuttlefish-host_orchestrator: 80: Syntax error: "(" unexpected (expecting "}")` when using the `dash` shell as arrays are not part of POSIX specifications for the shell.