### PR TITLE
Make the variable 'args' be local in start_operator and start_orchestrator

### DIFF
--- a/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.init
+++ b/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.init
@@ -77,7 +77,7 @@ prepare_run_dir() {
 }
 
 start_operator() {
-  args=()
+  local args=()
 
   if [[ -n "${operator_http_port}" ]]; then
     args+=("--http_port=${operator_http_port}")
@@ -99,7 +99,7 @@ start_orchestrator() {
   mkdir -p  "${orchestrator_cvd_artifacts_dir}"
   chown _cutf-operator:cvdnetwork "${orchestrator_cvd_artifacts_dir}"
 
-  orhcestrator_args=()
+  local args=()
 
   if [[ -n "${orchestrator_http_port}" ]]; then
     args+=("--http_port=${orchestrator_http_port}")


### PR DESCRIPTION
We had a problem for running HO in local machine because of initialization of args. Restrict the scope of the variable.