### PR TITLE
Downgrade defaultCVDBinAndroidBuildID for arm64

### DIFF
--- a/frontend/src/host_orchestrator/constants_arm64.go
+++ b/frontend/src/host_orchestrator/constants_arm64.go
@@ -18,6 +18,6 @@
 package main
 
 const (
-	defaultCVDBinAndroidBuildID     = "11125998"
+	defaultCVDBinAndroidBuildID     = "10797123"
 	defaultCVDBinAndroidBuildTarget = "aosp_cf_arm64_only_phone-trunk_staging-userdebug"
 )


### PR DESCRIPTION
Discussed in:
https://github.com/google/android-cuttlefish/pull/385#discussion_r1401426598