### PR TITLE
Do not manage cuttlefish HOME directory.

### DIFF
--- a/frontend/src/host_orchestrator/constants_arm64.go
+++ b/frontend/src/host_orchestrator/constants_arm64.go
@@ -18,6 +18,6 @@
 package main
 
 const (
-	defaultCVDBinAndroidBuildID     = "10797123"
+	defaultCVDBinAndroidBuildID     = "11219993"
 	defaultCVDBinAndroidBuildTarget = "aosp_cf_arm64_only_phone-trunk_staging-userdebug"
 )

--- a/frontend/src/host_orchestrator/constants_x86_64.go
+++ b/frontend/src/host_orchestrator/constants_x86_64.go
@@ -18,6 +18,6 @@
 package main
 
 const (
-	defaultCVDBinAndroidBuildID     = "10796991"
+	defaultCVDBinAndroidBuildID     = "11219993"
 	defaultCVDBinAndroidBuildTarget = "aosp_cf_x86_64_phone-trunk_staging-userdebug"
 )

--- a/frontend/src/host_orchestrator/main.go
+++ b/frontend/src/host_orchestrator/main.go
@@ -36,9 +36,9 @@ import (
 )
 
 const (
-	defaultTLSCertDir               = "/etc/cuttlefish-common/host_orchestrator/cert"
-	defaultAndroidBuildURL          = "https://androidbuildinternal.googleapis.com"
-	DefaultListenAddress            = "127.0.0.1"
+	defaultTLSCertDir      = "/etc/cuttlefish-common/host_orchestrator/cert"
+	defaultAndroidBuildURL = "https://androidbuildinternal.googleapis.com"
+	DefaultListenAddress   = "127.0.0.1"
 )
 
 func defaultCVDArtifactsDir() string {
@@ -125,7 +125,6 @@ func main() {
 		RootDir:          *imRootDir,
 		CVDToolsDir:      *imRootDir,
 		ArtifactsRootDir: filepath.Join(*imRootDir, "artifacts"),
-		RuntimesRootDir:  filepath.Join(*imRootDir, "runtimes"),
 	}
 	om := orchestrator.NewMapOM()
 	uamOpts := orchestrator.UserArtifactsManagerOpts{

--- a/frontend/src/host_orchestrator/orchestrator/createcvdaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/createcvdaction.go
@@ -16,7 +16,6 @@ package orchestrator
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -112,9 +111,6 @@ func (a *CreateCVDAction) Run() (apiv1.Operation, error) {
 	}
 	if err := createDir(a.paths.ArtifactsRootDir); err != nil {
 		return apiv1.Operation{}, err
-	}
-	if err := createRuntimesRootDir(a.paths.RuntimesRootDir); err != nil {
-		return apiv1.Operation{}, fmt.Errorf("failed creating cuttlefish runtime directory: %w", err)
 	}
 	if err := a.cvdDownloader.Download(a.cvdToolsVersion, a.paths.CVDBin(), a.paths.FetchCVDBin()); err != nil {
 		return apiv1.Operation{}, err
@@ -285,7 +281,6 @@ func (a *CreateCVDAction) launchFromAndroidCI(
 	startParams := startCVDParams{
 		InstanceNumbers:  a.newInstanceNumbers(instancesCount),
 		MainArtifactsDir: mainBuildDir,
-		RuntimeDir:       a.paths.RuntimesRootDir,
 		KernelDir:        kernelBuildDir,
 		BootloaderDir:    bootloaderBuildDir,
 	}
@@ -294,7 +289,7 @@ func (a *CreateCVDAction) launchFromAndroidCI(
 	}
 	// TODO: Remove once `acloud CLI` gets deprecated.
 	if contains(startParams.InstanceNumbers, 1) {
-		go runAcloudSetup(a.execContext, a.paths.ArtifactsRootDir, mainBuildDir, a.paths.RuntimesRootDir)
+		go runAcloudSetup(a.execContext, a.paths.ArtifactsRootDir, mainBuildDir)
 	}
 	return startParams.InstanceNumbers, nil
 }
@@ -308,14 +303,13 @@ func (a *CreateCVDAction) launchFromUserBuild(
 	startParams := startCVDParams{
 		InstanceNumbers:  a.newInstanceNumbers(instancesCount),
 		MainArtifactsDir: artifactsDir,
-		RuntimeDir:       a.paths.RuntimesRootDir,
 	}
 	if err := a.startCVDHandler.Start(startParams); err != nil {
 		return nil, err
 	}
 	// TODO: Remove once `acloud CLI` gets deprecated.
 	if contains(startParams.InstanceNumbers, 1) {
-		go runAcloudSetup(a.execContext, a.paths.ArtifactsRootDir, artifactsDir, a.paths.RuntimesRootDir)
+		go runAcloudSetup(a.execContext, a.paths.ArtifactsRootDir, artifactsDir)
 	}
 	return startParams.InstanceNumbers, nil
 }

--- a/frontend/src/host_orchestrator/orchestrator/createcvdaction_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/createcvdaction_test.go
@@ -96,7 +96,6 @@ func TestCreateCVDSameTargetArtifactsIsDownloadedOnce(t *testing.T) {
 	paths := IMPaths{
 		CVDToolsDir:      dir,
 		ArtifactsRootDir: dir + "/artifacts",
-		RuntimesRootDir:  dir + "/runtimes",
 	}
 	om := NewMapOM()
 	buildAPI := &fakeBuildAPI{}
@@ -138,7 +137,6 @@ func TestCreateCVDVerifyRootDirectoriesAreCreated(t *testing.T) {
 	paths := IMPaths{
 		CVDToolsDir:      dir,
 		ArtifactsRootDir: dir + "/artifacts",
-		RuntimesRootDir:  dir + "/runtimes",
 	}
 	om := NewMapOM()
 	buildAPI := &fakeBuildAPI{}
@@ -166,16 +164,12 @@ func TestCreateCVDVerifyRootDirectoriesAreCreated(t *testing.T) {
 	if diff := cmp.Diff("drwxrwxr--", stats.Mode().String()); diff != "" {
 		t.Errorf("mode mismatch (-want +got):\n%s", diff)
 	}
-	stats, _ = os.Stat(paths.RuntimesRootDir)
-	if diff := cmp.Diff("dgrwxrwxr--", stats.Mode().String()); diff != "" {
-		t.Errorf("mode mismatch (-want +got):\n%s", diff)
-	}
 }
 
 func TestCreateCVDVerifyStartCVDCmdArgs(t *testing.T) {
 	dir := orchtesting.TempDir(t)
 	defer orchtesting.RemoveDir(t, dir)
-	goldenPrefixFmt := fmt.Sprintf("sudo -u fakecvduser HOME=%[1]s/runtimes "+
+	goldenPrefixFmt := fmt.Sprintf("sudo -u fakecvduser "+
 		"ANDROID_HOST_OUT=%[1]s/artifacts/%%[1]s "+"%[1]s/cvd --group_name=cvd start --daemon --report_anonymous_usage_stats=y"+
 		" --base_instance_num=1 --system_image_dir=%[1]s/artifacts/%%[1]s", dir)
 	tests := []struct {
@@ -289,7 +283,6 @@ func TestCreateCVDVerifyStartCVDCmdArgs(t *testing.T) {
 			paths := IMPaths{
 				CVDToolsDir:      dir,
 				ArtifactsRootDir: dir + "/artifacts",
-				RuntimesRootDir:  dir + "/runtimes",
 			}
 			om := NewMapOM()
 			buildAPI := &fakeBuildAPI{}
@@ -339,7 +332,7 @@ func TestCreateCVDFromUserBuildVerifyStartCVDCmdArgs(t *testing.T) {
 	defer orchtesting.RemoveDir(t, dir)
 	tarContent, _ := ioutil.ReadFile(getTestTarFilename())
 	ioutil.WriteFile(dir+"/"+CVDHostPackageName, tarContent, 0755)
-	expected := fmt.Sprintf("sudo -u fakecvduser HOME=%[1]s/runtimes "+
+	expected := fmt.Sprintf("sudo -u fakecvduser "+
 		"ANDROID_HOST_OUT=%[1]s "+"%[1]s/cvd --group_name=cvd start --daemon --report_anonymous_usage_stats=y"+
 		" --base_instance_num=1 --system_image_dir=%[1]s", dir)
 	var usedCmdName string
@@ -354,7 +347,6 @@ func TestCreateCVDFromUserBuildVerifyStartCVDCmdArgs(t *testing.T) {
 	paths := IMPaths{
 		CVDToolsDir:      dir,
 		ArtifactsRootDir: dir + "/artifacts",
-		RuntimesRootDir:  dir + "/runtimes",
 	}
 	om := NewMapOM()
 	buildAPI := &fakeBuildAPI{}
@@ -407,7 +399,6 @@ func TestCreateCVDFailsDueCVDSubCommandExecution(t *testing.T) {
 	paths := IMPaths{
 		CVDToolsDir:      dir,
 		ArtifactsRootDir: dir + "/artifacts",
-		RuntimesRootDir:  dir + "/runtimes",
 	}
 	om := NewMapOM()
 	buildAPI := &fakeBuildAPI{}
@@ -444,7 +435,6 @@ func TestCreateCVDFailsDueTimeout(t *testing.T) {
 	paths := IMPaths{
 		CVDToolsDir:      dir,
 		ArtifactsRootDir: dir + "/artifacts",
-		RuntimesRootDir:  dir + "/runtimes",
 	}
 	om := NewMapOM()
 	buildAPI := &fakeBuildAPI{}
@@ -488,7 +478,6 @@ func TestCreateCVDFailsDueInvalidHost(t *testing.T) {
 	paths := IMPaths{
 		CVDToolsDir:      dir,
 		ArtifactsRootDir: dir + "/artifacts",
-		RuntimesRootDir:  dir + "/runtimes",
 	}
 	om := NewMapOM()
 	opts := CreateCVDActionOpts{

--- a/frontend/src/host_orchestrator/orchestrator/cvd/cvd.go
+++ b/frontend/src/host_orchestrator/orchestrator/cvd/cvd.go
@@ -33,7 +33,6 @@ const CVDCommandDefaultTimeout = 30 * time.Second
 
 const (
 	envVarAndroidHostOut = "ANDROID_HOST_OUT"
-	envVarHome           = "HOME"
 )
 
 type CommandOpts struct {
@@ -88,7 +87,7 @@ func (c *Command) Run() error {
 	}
 	// TODO: Use `context.WithTimeout` if upgrading to go 1.19 as `exec.Cmd` adds the `Cancel` function field,
 	// so the cancel logic could be customized to continue sending the SIGINT signal.
-	cmd := c.execContext(context.TODO(), cvdEnv(c.opts.AndroidHostOut, c.opts.Home), c.cvdBin, c.args...)
+	cmd := c.execContext(context.TODO(), cvdEnv(c.opts.AndroidHostOut), c.cvdBin, c.args...)
 	stderr := &bytes.Buffer{}
 	cmd.Stdout = c.opts.Stdout
 	cmd.Stderr = stderr
@@ -123,7 +122,7 @@ func (c *Command) Run() error {
 }
 
 func (c *Command) startCVDServer() error {
-	cmd := c.execContext(context.TODO(), cvdEnv("", ""), c.cvdBin)
+	cmd := c.execContext(context.TODO(), cvdEnv(""), c.cvdBin)
 	// NOTE: Stdout and Stderr should be nil so Run connects the corresponding
 	// file descriptor to the null device (os.DevNull).
 	// Otherwhise, `Run` will never complete. Why? a pipe will be created to handle
@@ -135,8 +134,8 @@ func (c *Command) startCVDServer() error {
 	return cmd.Run()
 }
 
-func cvdEnv(androidHostOut, home string) []string {
-	env := []string{envVarHome + "=" + home}
+func cvdEnv(androidHostOut string) []string {
+	env := []string{}
 	if androidHostOut != "" {
 		env = append(env, envVarAndroidHostOut+"="+androidHostOut)
 	}

--- a/frontend/src/host_orchestrator/orchestrator/instancemanager.go
+++ b/frontend/src/host_orchestrator/orchestrator/instancemanager.go
@@ -56,7 +56,6 @@ type IMPaths struct {
 	RootDir          string
 	CVDToolsDir      string
 	ArtifactsRootDir string
-	RuntimesRootDir  string
 }
 
 func (p *IMPaths) CVDBin() string {
@@ -169,10 +168,13 @@ func HostBugReport(ctx cvd.CVDExecContext, paths IMPaths, out string) error {
 	if len(fleet) == 0 {
 		return operator.NewNotFoundError("no artifacts found", nil)
 	}
-	opts := cvd.CommandOpts{
-		Home: paths.RuntimesRootDir,
-	}
-	return cvd.NewCommand(ctx, paths.CVDBin(), []string{"host_bugreport", "--output=" + out}, opts).Run()
+	cmd := cvd.NewCommand(
+		ctx,
+		paths.CVDBin(),
+		[]string{"host_bugreport", "--output=" + out},
+		cvd.CommandOpts{},
+	)
+	return cmd.Run()
 }
 
 const (
@@ -524,7 +526,7 @@ func (s cvdInstances) findByName(name string) (bool, *cvdInstance) {
 	return false, &cvdInstance{}
 }
 
-func runAcloudSetup(execContext cvd.CVDExecContext, artifactsRootDir, artifactsDir, runtimeDir string) {
+func runAcloudSetup(execContext cvd.CVDExecContext, artifactsRootDir, artifactsDir string) {
 	run := func(cmd *exec.Cmd) {
 		var b bytes.Buffer
 		cmd.Stdout = &b

--- a/frontend/src/host_orchestrator/orchestrator/listcvdsaction_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/listcvdsaction_test.go
@@ -66,7 +66,6 @@ func TestListCVDsSucceeds(t *testing.T) {
 	paths := IMPaths{
 		CVDToolsDir:      dir,
 		ArtifactsRootDir: dir + "/artifacts",
-		RuntimesRootDir:  dir + "/runtimes",
 	}
 	opts := ListCVDsActionOpts{
 		Paths:           paths,


### PR DESCRIPTION
- The new `cvd` version now creates the runtime directories under `/tmp`, hence the HO logic to manage runtime directories is no longer needed.