### PR TITLE
Do not use rc.local to install gce guest environment dependencies.

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -1,5 +1,9 @@
 name: Artifacts
 on:
+  pull_request:
+    paths:
+      - '.github/workflows/artifacts.yaml'
+      - 'tools/buildimage/**'
   push:
     branches:
       - main


### PR DESCRIPTION
- Installs the dependencies in the image already reducint host start time.