### PR TITLE
Let defaultCVDBinAndroidBuildID for ARM64 use aosp-main-throttled

### DIFF
--- a/frontend/src/host_orchestrator/constants_arm64.go
+++ b/frontend/src/host_orchestrator/constants_arm64.go
@@ -18,6 +18,7 @@
 package main
 
 const (
-	defaultCVDBinAndroidBuildID     = "11219993"
+	// Build ID relies on aosp-main-throttled
+	defaultCVDBinAndroidBuildID     = "11220041"
 	defaultCVDBinAndroidBuildTarget = "aosp_cf_arm64_only_phone-trunk_staging-userdebug"
 )

--- a/frontend/src/host_orchestrator/constants_x86_64.go
+++ b/frontend/src/host_orchestrator/constants_x86_64.go
@@ -18,6 +18,7 @@
 package main
 
 const (
+	// Build ID relies on aosp-main
 	defaultCVDBinAndroidBuildID     = "11219993"
 	defaultCVDBinAndroidBuildTarget = "aosp_cf_x86_64_phone-trunk_staging-userdebug"
 )


### PR DESCRIPTION
In current code, it points to aosp-main, which doesn't have any CF arm64 targets. Let's move the build ID from aosp-main into aosp-main-throttled. And I found the most similar build ID with 11219993, to minimize the difference.