### PR TITLE
Add tail -f /dev/null to keep it running

### DIFF
--- a/docker/arm-server/run_services.sh
+++ b/docker/arm-server/run_services.sh
@@ -4,3 +4,6 @@ service cuttlefish-host-resources start
 service cuttlefish-operator start
 service cuttlefish-host_orchestrator start
 /root/cvd_home/bin/cvd start --vhost-user-vsock=true --report_anonymous_usage_stats=y $@
+# To keep it running
+tail -f /dev/null
+


### PR DESCRIPTION
Because daemon is turned on by default, docker instance ends when cvd finishes. But we want it to keep running