### PR TITLE
Dockerfile for ARM64 uses debian packages built with local code

### DIFF
--- a/docker/arm-server/Dockerfile
+++ b/docker/arm-server/Dockerfile
@@ -20,17 +20,8 @@ RUN set -x
 # Install dependants of CF debian packages.
 RUN apt update
 RUN apt install -y --no-install-recommends \
-    build-essential:native \
     ca-certificates \
-    config-package-dev \
     curl \
-    debhelper-compat \
-    dpkg-dev \
-    gcc-10 \
-    git \
-    golang-1.13 \
-    libprotobuf-dev \
-    protobuf-compiler \
     sudo
 RUN update-ca-certificates
 

--- a/docker/arm-server/Dockerfile
+++ b/docker/arm-server/Dockerfile
@@ -1,30 +1,53 @@
-FROM ubuntu:22.04
+# Docker image for running CF instances in ARM64 server.
+# Docker image includes HO(Host Orchestrator) inside,
+# so it could execute CF instance with API in HO.
+FROM ubuntu:22.04 AS cuttlefish-arm64
 
+# Expose Operator Port (HTTP:1080, HTTPS:1443)
+EXPOSE 1080 1443
+# Expose HO(Host Orchestrator) Port (HTTP:2080, HTTPS:2443)
+EXPOSE 2080 2443
+# Expose WebRTC Port
 EXPOSE 15550-15560
-EXPOSE 1443
+# Expose ADB Port
+# Corresponding ADB port for CF instance is, 6520+instance_num-1.
 EXPOSE 6520-6620
+
 USER root
 
 RUN set -x
 
+# Install dependants of CF debian packages.
 RUN apt update
-RUN apt install -y --no-install-recommends git
-RUN apt install -y --no-install-recommends ca-certificates && update-ca-certificates
-RUN apt install -y --no-install-recommends dpkg-dev build-essential:native config-package-dev debhelper-compat golang-1.13 libprotobuf-dev protobuf-compiler curl sudo
-RUN apt install -y --no-install-recommends gcc-10
+RUN apt install -y --no-install-recommends \
+    build-essential:native \
+    ca-certificates \
+    config-package-dev \
+    curl \
+    debhelper-compat \
+    dpkg-dev \
+    gcc-10 \
+    git \
+    golang-1.13 \
+    libprotobuf-dev \
+    protobuf-compiler \
+    sudo
+RUN update-ca-certificates
 
+# ADD CF debian packages built by
+# docker/debs-builder-docker/build-debs-with-docker.sh.
+COPY ./out/cuttlefish-base_*.deb /root/
+COPY ./out/cuttlefish-user_*.deb /root/
+COPY ./out/cuttlefish-orchestration_*.deb /root/
+
+# Install CF debian packages.
 WORKDIR /root
-RUN git clone https://github.com/google/android-cuttlefish.git
-WORKDIR /root/android-cuttlefish/base
-RUN dpkg-buildpackage
-WORKDIR /root/android-cuttlefish/frontend
-RUN dpkg-buildpackage
+RUN apt install -y -f \
+    /root/cuttlefish-base_*.deb \
+    /root/cuttlefish-user_*.deb \
+    /root/cuttlefish-orchestration_*.deb
 
-WORKDIR /root/android-cuttlefish
-RUN apt install -y -f ./cuttlefish-base_*.deb ./cuttlefish-user_*.deb ./cuttlefish-orchestration_*.deb
 RUN echo "num_cvd_accounts=100" >> /etc/default/cuttlefish-host-resources
-
-WORKDIR /root
 
 RUN usermod -aG kvm root
 RUN usermod -aG cvdnetwork root

--- a/docker/arm-server/build.sh
+++ b/docker/arm-server/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This shell script exists for building ARM64 docker image.
+# Docker image includes HO(Host Orchestrator) inside,
+# so it could execute CF instance with API in HO.
+
+# Build debian packages(e.g. cuttlefish-base) with docker.
+pushd ..
+./debs-builder-docker/build-debs-with-docker.sh
+popd
+mkdir out
+mv ../out/cuttlefish-*.deb ./out
+
+# Build docker image
+docker build --no-cache -t cuttlefish-arm64 $PWD
+
+# Cleanup out directory
+rm -rf out

--- a/docker/arm-server/run.sh
+++ b/docker/arm-server/run.sh
@@ -1,0 +1,2 @@
+# Shell script to run docker image.
+docker run --privileged -d -P -it cuttlefish-arm64

--- a/docker/arm-server/run_services.sh
+++ b/docker/arm-server/run_services.sh
@@ -3,7 +3,12 @@
 service cuttlefish-host-resources start
 service cuttlefish-operator start
 service cuttlefish-host_orchestrator start
-/root/cvd_home/bin/cvd start --vhost-user-vsock=true --report_anonymous_usage_stats=y $@
+
+if [ -f /root/cvd_home/bin/cvd ]; then
+  /root/cvd_home/bin/cvd start \
+    --vhost-user-vsock=true \
+    --report_anonymous_usage_stats=y \
+    $@
+fi
 # To keep it running
 tail -f /dev/null
-

--- a/docker/debs-builder-docker/build-debs-with-docker.sh
+++ b/docker/debs-builder-docker/build-debs-with-docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# at /path/to/android-cuttlefish, run like this:
+# at /path/to/android-cuttlefish/docker, run like this:
 #  ./debs-builder-docker/build-debs-docker.sh
 #
 


### PR DESCRIPTION
Also I did some refactoring around dockerfile for ARM64.

BTW, this PR weren't verified in ARM64 environment, just only in x86_64 env w/ my local machine.
I'll proceed to verify when review is approved.