### PR TITLE
Add placeholder test script for kokoro

### DIFF
--- a/.kokoro/continuous.cfg
+++ b/.kokoro/continuous.cfg
@@ -1,0 +1,1 @@
+build_file: "android-cuttlefish/.kokoro/public_test.sh"

--- a/.kokoro/presubmit.cfg
+++ b/.kokoro/presubmit.cfg
@@ -1,0 +1,1 @@
+build_file: "android-cuttlefish/.kokoro/public_test.sh"

--- a/.kokoro/public_test.sh
+++ b/.kokoro/public_test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Fail on errors
+set -e
+
+echo "Cuttlefish debian package build and testing placeholder script for kokoro"


### PR DESCRIPTION
This is defined as an `echo` to validate the Kokoro presubmit and postsubmit make it through.

Bug: b/324127343