### PR TITLE
Create backward compatibility symlinks in case of failures

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
@@ -745,6 +745,13 @@ Result<cvd::Response> CvdStartCommandHandler::PostStartExecutionActions(
     }
   }
   auto final_response = ResponseFromSiginfo(infop);
+
+  // For backward compatibility, we add extra symlink in system wide home
+  // when HOME is NOT overridden and selector flags are NOT given.
+  if (group_creation_info.is_default_group) {
+    CF_EXPECT(CreateSymlinks(group_creation_info));
+  }
+
   if (!final_response.has_status() ||
       final_response.status().code() != cvd::Status::OK) {
     return final_response;
@@ -755,12 +762,6 @@ Result<cvd::Response> CvdStartCommandHandler::PostStartExecutionActions(
   // As the destructor will release the file lock, the instance lock
   // files must be marked as used
   MarkLockfilesInUse(group_creation_info);
-
-  // For backward compatibility, we add extra symlink in system wide home
-  // when HOME is NOT overridden and selector flags are NOT given.
-  if (group_creation_info.is_default_group) {
-    CF_EXPECT(CreateSymlinks(group_creation_info));
-  }
 
   // group_creation_info is nullopt only if is_help is false
   return FillOutNewInstanceInfo(std::move(final_response), group_creation_info);


### PR DESCRIPTION
Currently cuttlefish runtime symlinks are created only in case of succesfull boot. Acloud cannot pull them when cvd isn't booted, so we cannot see launcher/kernel logs on infra.

Fixing it by executing symlinks creating before cmd result check.

Test: locally emulate vmm issue verified symlinks are created
Test: launcher log is pulled in case of vmm failure
Bug: 325936323
Change-Id: I66d6aea50f011adde19fe175b460832ea281317c