### PR TITLE
Update package building instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ metapackage that depends on `cuttlefish-base` and `cuttlefish-user`
 The packages can be built with the following command:
 
 ```bash
+sudo apt install devscripts equivs
 for dir in base frontend; do
     pushd $dir
     # Install build dependencies


### PR DESCRIPTION
Install devscripts and equivs before attempting to install dependencies or build the packages.