### PR TITLE
Set lengthier timeout for CVD creation under Docker

### DIFF
--- a/docker/arm-server/Dockerfile
+++ b/docker/arm-server/Dockerfile
@@ -40,7 +40,7 @@ RUN apt install -y -f \
 
 RUN echo "num_cvd_accounts=100" >> /etc/default/cuttlefish-host-resources
 
-RUN sed -i s/.*orchestrator_cvd_creation_timeout.*/orchestrator_cvd_creation_timeout=30/g /etc/default/cuttlefish-host_orchestrator
+RUN sed -i s/.*orchestrator_cvd_creation_timeout_secs.*/orchestrator_cvd_creation_timeout_secs=1800/g /etc/default/cuttlefish-host_orchestrator
 
 RUN usermod -aG kvm root
 RUN usermod -aG cvdnetwork root

--- a/docker/arm-server/Dockerfile
+++ b/docker/arm-server/Dockerfile
@@ -40,6 +40,8 @@ RUN apt install -y -f \
 
 RUN echo "num_cvd_accounts=100" >> /etc/default/cuttlefish-host-resources
 
+RUN sed -i s/.*orchestrator_cvd_creation_timeout.*/orchestrator_cvd_creation_timeout=30/g /etc/default/cuttlefish-host_orchestrator
+
 RUN usermod -aG kvm root
 RUN usermod -aG cvdnetwork root
 

--- a/docker/arm-server/Dockerfile
+++ b/docker/arm-server/Dockerfile
@@ -40,7 +40,7 @@ RUN apt install -y -f \
 
 RUN echo "num_cvd_accounts=100" >> /etc/default/cuttlefish-host-resources
 
-RUN sed -i s/.*orchestrator_cvd_creation_timeout_secs.*/orchestrator_cvd_creation_timeout_secs=1800/g /etc/default/cuttlefish-host_orchestrator
+RUN echo "orchestrator_cvd_creation_timeout_secs=1800" >> /etc/default/cuttlefish-host_orchestrator
 
 RUN usermod -aG kvm root
 RUN usermod -aG cvdnetwork root

--- a/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.default
+++ b/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.default
@@ -26,7 +26,7 @@ orchestrator_cvd_artifacts_dir=/var/lib/cuttlefish-common
 #
 # Timeout for CVD creation
 # Defaults to 7 mins
-orchestrator_cvd_creation_timeout=7
+orchestrator_cvd_creation_timeout_secs=420
 #
 # Where web UI in the application is from
 # If it isn't empty, the application uses web UI from the url,

--- a/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.default
+++ b/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.default
@@ -24,11 +24,9 @@ orchestrator_https_port=2443
 # Defaults to "/tmp/<uid>/cvd_artifacts"
 orchestrator_cvd_artifacts_dir=/var/lib/cuttlefish-common
 #
-# Timeout of CVD creation under docker environment
-# Docker containers can be run with other containers and creation time
-# could vary under environments.
-# Defaults to 30 mins
-orchestrator_cvd_creation_docker_timeout=30
+# Timeout for CVD creation
+# Defaults to 7 mins
+orchestrator_cvd_creation_timeout=7
 #
 # Where web UI in the application is from
 # If it isn't empty, the application uses web UI from the url,

--- a/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.default
+++ b/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.default
@@ -24,6 +24,12 @@ orchestrator_https_port=2443
 # Defaults to "/tmp/<uid>/cvd_artifacts"
 orchestrator_cvd_artifacts_dir=/var/lib/cuttlefish-common
 #
+# Timeout of CVD creation under docker environment
+# Docker containers can be run with other containers and creation time
+# could vary under environments.
+# Defaults to 30 mins
+orchestrator_cvd_creation_docker_timeout=30
+#
 # Where web UI in the application is from
 # If it isn't empty, the application uses web UI from the url,
 # else, it uses web pages which is generated during the build

--- a/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.default
+++ b/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.default
@@ -26,7 +26,7 @@ orchestrator_cvd_artifacts_dir=/var/lib/cuttlefish-common
 #
 # Timeout for CVD creation
 # Defaults to 7 mins
-orchestrator_cvd_creation_timeout_secs=420
+# orchestrator_cvd_creation_timeout_secs=420
 #
 # Where web UI in the application is from
 # If it isn't empty, the application uses web UI from the url,

--- a/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.init
+++ b/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.init
@@ -95,8 +95,8 @@ start_orchestrator() {
   if [[ -n "${orchestrator_cvd_artifacts_dir}" ]]; then
     args+=("--cvd_artifacts_dir=${orchestrator_cvd_artifacts_dir}")
   fi
-  if [[ -n "${orchestrator_cvd_creation_docker_timeout}" ]]; then
-    args+=("--cvd_creation_docker_timeout=${orchestrator_cvd_creation_docker_timeout}")
+  if [[ -n "${orchestrator_cvd_creation_timeout}" ]]; then
+    args+=("--cvd_creation_timeout=${orchestrator_cvd_creation_timeout}")
   fi
   if [[ -n "${operator_http_port}" ]]; then
     args+=("--operator_http_port=${operator_http_port}")

--- a/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.init
+++ b/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.init
@@ -95,8 +95,8 @@ start_orchestrator() {
   if [[ -n "${orchestrator_cvd_artifacts_dir}" ]]; then
     args+=("--cvd_artifacts_dir=${orchestrator_cvd_artifacts_dir}")
   fi
-  if [[ -n "${orchestrator_cvd_creation_timeout}" ]]; then
-    args+=("--cvd_creation_timeout=${orchestrator_cvd_creation_timeout}")
+  if [[ -n "${orchestrator_cvd_creation_timeout_secs}" ]]; then
+    args+=("--cvd_creation_timeout_secs=${orchestrator_cvd_creation_timeout_secs}")
   fi
   if [[ -n "${operator_http_port}" ]]; then
     args+=("--operator_http_port=${operator_http_port}")

--- a/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.init
+++ b/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.init
@@ -95,6 +95,9 @@ start_orchestrator() {
   if [[ -n "${orchestrator_cvd_artifacts_dir}" ]]; then
     args+=("--cvd_artifacts_dir=${orchestrator_cvd_artifacts_dir}")
   fi
+  if [[ -n "${orchestrator_cvd_creation_docker_timeout}" ]]; then
+    args+=("--cvd_creation_docker_timeout=${orchestrator_cvd_creation_docker_timeout}")
+  fi
   if [[ -n "${operator_http_port}" ]]; then
     args+=("--operator_http_port=${operator_http_port}")
   fi

--- a/frontend/src/host_orchestrator/main.go
+++ b/frontend/src/host_orchestrator/main.go
@@ -105,7 +105,7 @@ func main() {
 	httpsPort := flag.Int("https_port", -1, "Port to listen on for HTTPS requests.")
 	tlsCertDir := flag.String("tls_cert_dir", defaultTLSCertDir, "Directory with the TLS certificate.")
 	cvdUser := flag.String("cvd_user", "", "User to execute cvd as.")
-	cvdCreationTimeout := flag.Int("cvd_creation_timeout", 7, "CVD creation timeout")
+	cvdCreationTimeoutSecs := flag.Int("cvd_creation_timeout_secs", 420, "CVD creation timeout in seconds")
 	operatorPort := flag.Int("operator_http_port", 1080, "Port where the operator is listening.")
 	abURL := flag.String("android_build_url", defaultAndroidBuildURL, "URL to an Android Build API.")
 	imRootDir := flag.String("cvd_artifacts_dir", defaultCVDArtifactsDir(), "Directory where cvd will download android build artifacts to.")
@@ -136,7 +136,7 @@ func main() {
 		Config: orchestrator.Config{
 			Paths:                  imPaths,
 			AndroidBuildServiceURL: *abURL,
-			CVDCreationTimeout:     *cvdCreationTimeout,
+			CVDCreationTimeout:     time.Duration(*cvdCreationTimeoutSecs) * time.Second,
 			CVDUser:                *cvdUser,
 		},
 		OperationManager:      om,

--- a/frontend/src/host_orchestrator/main.go
+++ b/frontend/src/host_orchestrator/main.go
@@ -105,7 +105,7 @@ func main() {
 	httpsPort := flag.Int("https_port", -1, "Port to listen on for HTTPS requests.")
 	tlsCertDir := flag.String("tls_cert_dir", defaultTLSCertDir, "Directory with the TLS certificate.")
 	cvdUser := flag.String("cvd_user", "", "User to execute cvd as.")
-	cvdCreationDockerTimeout := flag.Int("cvd_creation_docker_timeout", 30, "CVD creation timeout under docker")
+	cvdCreationTimeout := flag.Int("cvd_creation_timeout", 7, "CVD creation timeout")
 	operatorPort := flag.Int("operator_http_port", 1080, "Port where the operator is listening.")
 	abURL := flag.String("android_build_url", defaultAndroidBuildURL, "URL to an Android Build API.")
 	imRootDir := flag.String("cvd_artifacts_dir", defaultCVDArtifactsDir(), "Directory where cvd will download android build artifacts to.")
@@ -134,10 +134,10 @@ func main() {
 	debugVarsManager := debug.NewVariablesManager(debugStaticVars)
 	imController := orchestrator.Controller{
 		Config: orchestrator.Config{
-			Paths:                    imPaths,
-			AndroidBuildServiceURL:   *abURL,
-			CVDCreationDockerTimeout: *cvdCreationDockerTimeout,
-			CVDUser:                  *cvdUser,
+			Paths:                  imPaths,
+			AndroidBuildServiceURL: *abURL,
+			CVDCreationTimeout:     *cvdCreationTimeout,
+			CVDUser:                *cvdUser,
 		},
 		OperationManager:      om,
 		WaitOperationDuration: 2 * time.Minute,

--- a/frontend/src/host_orchestrator/main.go
+++ b/frontend/src/host_orchestrator/main.go
@@ -105,6 +105,7 @@ func main() {
 	httpsPort := flag.Int("https_port", -1, "Port to listen on for HTTPS requests.")
 	tlsCertDir := flag.String("tls_cert_dir", defaultTLSCertDir, "Directory with the TLS certificate.")
 	cvdUser := flag.String("cvd_user", "", "User to execute cvd as.")
+	cvdCreationDockerTimeout := flag.Int("cvd_creation_docker_timeout", 30, "CVD creation timeout under docker")
 	operatorPort := flag.Int("operator_http_port", 1080, "Port where the operator is listening.")
 	abURL := flag.String("android_build_url", defaultAndroidBuildURL, "URL to an Android Build API.")
 	imRootDir := flag.String("cvd_artifacts_dir", defaultCVDArtifactsDir(), "Directory where cvd will download android build artifacts to.")
@@ -133,9 +134,10 @@ func main() {
 	debugVarsManager := debug.NewVariablesManager(debugStaticVars)
 	imController := orchestrator.Controller{
 		Config: orchestrator.Config{
-			Paths:                  imPaths,
-			AndroidBuildServiceURL: *abURL,
-			CVDUser:                *cvdUser,
+			Paths:                    imPaths,
+			AndroidBuildServiceURL:   *abURL,
+			CVDCreationDockerTimeout: *cvdCreationDockerTimeout,
+			CVDUser:                  *cvdUser,
 		},
 		OperationManager:      om,
 		WaitOperationDuration: 2 * time.Minute,

--- a/frontend/src/host_orchestrator/orchestrator/controller.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller.go
@@ -38,9 +38,10 @@ import (
 const HeaderBuildAPICreds = "X-Cutf-Host-Orchestrator-BuildAPI-Creds"
 
 type Config struct {
-	Paths                  IMPaths
-	AndroidBuildServiceURL string
-	CVDUser                string
+	Paths                    IMPaths
+	AndroidBuildServiceURL   string
+	CVDCreationDockerTimeout int
+	CVDUser                  string
 }
 
 type Controller struct {
@@ -185,7 +186,7 @@ func (h *createCVDHandler) Handle(r *http.Request) (interface{}, error) {
 	if isRunningInDocker() {
 		// Use a lengthier timeout when running within a docker because it could race resource with
 		// other containers and take much longer time than normal status.
-		cvdStartTimeout = 30 * time.Minute
+		cvdStartTimeout = time.Duration(h.Config.CVDCreationDockerTimeout) * time.Minute
 	} else if req.EnvConfig != nil {
 		// Use a lengthier timeout when using canonical configs as this operation downloads artifacts as well.
 		cvdStartTimeout = 7 * time.Minute

--- a/frontend/src/host_orchestrator/orchestrator/controller.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller.go
@@ -40,7 +40,7 @@ const HeaderBuildAPICreds = "X-Cutf-Host-Orchestrator-BuildAPI-Creds"
 type Config struct {
 	Paths                  IMPaths
 	AndroidBuildServiceURL string
-	CVDCreationTimeout     int
+	CVDCreationTimeout     time.Duration
 	CVDUser                string
 }
 
@@ -177,7 +177,6 @@ func (h *createCVDHandler) Handle(r *http.Request) (interface{}, error) {
 		http.DefaultClient, h.Config.AndroidBuildServiceURL, buildAPIOpts)
 	artifactsFetcher := newBuildAPIArtifactsFetcher(buildAPI)
 	cvdBundleFetcher := newFetchCVDCommandArtifactsFetcher(exec.CommandContext, creds)
-	cvdStartTimeout := time.Duration(h.Config.CVDCreationTimeout) * time.Minute
 	opts := CreateCVDActionOpts{
 		Request:                  req,
 		HostValidator:            &HostValidator{ExecContext: exec.CommandContext},
@@ -188,7 +187,7 @@ func (h *createCVDHandler) Handle(r *http.Request) (interface{}, error) {
 		ArtifactsFetcher:         artifactsFetcher,
 		CVDBundleFetcher:         cvdBundleFetcher,
 		UUIDGen:                  func() string { return uuid.New().String() },
-		CVDStartTimeout:          cvdStartTimeout,
+		CVDStartTimeout:          h.Config.CVDCreationTimeout,
 		CVDUser:                  h.Config.CVDUser,
 		UserArtifactsDirResolver: h.UADirResolver,
 		BuildAPICredentials:      creds,


### PR DESCRIPTION
Running CVD under docker can take much longer time to complete creation. To prevent CVD instance being killed by host orchestrator while booting instance, set lengthier timeout for CVD creation.