### PR TITLE
Use --instance_nums to pass instance number list

### DIFF
--- a/frontend/src/host_orchestrator/orchestrator/instancemanager.go
+++ b/frontend/src/host_orchestrator/orchestrator/instancemanager.go
@@ -347,7 +347,7 @@ func (h *startCVDHandler) Start(p startCVDParams) error {
 		// Use legacy `--base_instance_num` when multi-vd is not requested.
 		args = append(args, fmt.Sprintf("--base_instance_num=%d", p.InstanceNumbers[0]))
 	} else {
-		args = append(args, fmt.Sprintf("--num_instances=%s", strings.Join(SliceItoa(p.InstanceNumbers), ",")))
+		args = append(args, fmt.Sprintf("--instance_nums=%s", strings.Join(SliceItoa(p.InstanceNumbers), ",")))
 	}
 	args = append(args, fmt.Sprintf("--system_image_dir=%s", p.MainArtifactsDir))
 	if len(p.InstanceNumbers) > 1 {


### PR DESCRIPTION
To create an instance number list from orchestrator to cvd need to use the argument named instance_nums to pass intended numbers.