### PR TITLE
Add .clang-format file to base/cvd

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2020 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# See https://clang.llvm.org/docs/ClangFormatStyleOptions.html for the
+# various options that can be configured and for the definitions of each
+# of the below options.
+
+BasedOnStyle: Google
+IncludeBlocks: Preserve

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ cuttlefish-*_*.*.*.tar.xz
 
 !/.github/
 !/.kokoro/
+!/.clang-format
 
 /*/debian/cuttlefish-*/
 /*/debian/*.substvars


### PR DESCRIPTION
This does not yet add any GitHub action validation that the formatting is actually followed.