### PR TITLE
Implement multi-vd vsock connectivity configuration

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/parser/cf_configs_instances.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/cf_configs_instances.cpp
@@ -31,6 +31,7 @@
 #include "host/commands/cvd/parser/instance/cf_security_configs.h"
 #include "host/commands/cvd/parser/instance/cf_streaming_configs.h"
 #include "host/commands/cvd/parser/instance/cf_vm_configs.h"
+#include "host/commands/cvd/parser/instance/cf_connectivity_configs.h"
 
 namespace cuttlefish {
 
@@ -55,6 +56,7 @@ Result<std::vector<std::string>> GenerateInstancesFlags(
   result = MergeResults(result, CF_EXPECT(GenerateSecurityFlags(instances)));
   result = MergeResults(result, CF_EXPECT(GenerateStreamingFlags(instances)));
   result = MergeResults(result, CF_EXPECT(GenerateVmFlags(instances)));
+  result = MergeResults(result, CF_EXPECT(GenerateConnectivityFlags(instances)));
 
   return result;
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
@@ -119,6 +119,11 @@ const auto& kRoot = *new ConfigNode{.type = objectValue, .children = {
         {"streaming", ConfigNode{.type = objectValue, .children = {
           {"device_id", ConfigNode{.type = stringValue}},
         }}},
+        {"connectivity", ConfigNode{.type = objectValue, .children = {
+          {"vsock", ConfigNode{.type = objectValue, .children = {
+            {"guest_group", ConfigNode{.type = stringValue}},
+          }}}
+        }}}
       }}},
     }}},
   {"fetch", ConfigNode{.type = objectValue, .children = {

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/instance/cf_connectivity_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/instance/cf_connectivity_configs.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fmt/format.h>
+#include <json/json.h>
+
+#include "common/libs/utils/result.h"
+
+namespace cuttlefish {
+
+std::string GenerateGroupFlag(const Json::Value& instances_json) {
+  std::vector<std::string> vsock_groups;
+
+  for (const auto& instance_json : instances_json) {
+    vsock_groups.emplace_back(
+        instance_json["connectivity"]["vsock"]["guest_group"].asString());
+  }
+
+  std::string args = fmt::format("{}", fmt::join(vsock_groups, ","));
+  return "--vsock_guest_group=" + args;
+}
+
+Result<std::vector<std::string>> GenerateConnectivityFlags(
+    const Json::Value& instances) {
+  std::vector<std::string> result;
+  result.emplace_back(GenerateGroupFlag(instances));
+  return result;
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/instance/cf_connectivity_configs.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/instance/cf_connectivity_configs.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <json/json.h>
+#include <string>
+#include <vector>
+
+namespace cuttlefish {
+Result<std::vector<std::string>> GenerateConnectivityFlags(const Json::Value& root);
+};  // namespace cuttlefish

--- a/base/cvd/meson.build
+++ b/base/cvd/meson.build
@@ -74,6 +74,7 @@ cvd_sources = [
   'cuttlefish/host/commands/cvd/parser/cf_metrics_configs.cpp',
   'cuttlefish/host/commands/cvd/parser/fetch_config_parser.cpp',
   'cuttlefish/host/commands/cvd/parser/instance/cf_boot_configs.cpp',
+  'cuttlefish/host/commands/cvd/parser/instance/cf_connectivity_configs.cpp',
   'cuttlefish/host/commands/cvd/parser/instance/cf_disk_configs.cpp',
   'cuttlefish/host/commands/cvd/parser/instance/cf_graphics_configs.cpp',
   'cuttlefish/host/commands/cvd/parser/instance/cf_security_configs.cpp',


### PR DESCRIPTION
This PR enables `cvd` to configure a `vsock_guest_group` launch parameter as part of a new `connectivity` section, which controls vsock communications isolation. The `vhost-device-vsock` service documents this feature with examples at: https://github.com/rust-vmm/vhost-device/blob/main/vhost-device-vsock/README.md , for reference the `groups` parameter used there is identical in format and function to the new `vsock_guest_group` argument that was added in this PR (and below CL)

Note that this PR is intended to be used with several other Cuttlefish changes, all of which are visible and documented at: [aosp/2995598](https://android-review.git.corp.google.com/c/device/google/cuttlefish/+/2995598)  There is an example config there as well for reference, and instructions on how this feature was tested.