### PR TITLE
Don't drop command output in cvd load

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/command_sequence.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/command_sequence.cpp
@@ -48,6 +48,8 @@ std::string BashEscape(const std::string& input) {
 
 std::string FormattedCommand(const cvd::CommandRequest command) {
   std::stringstream effective_command;
+  effective_command << "*******************************************************"
+                       "*************************\n";
   effective_command << "Executing `";
   for (const auto& [name, val] : command.env()) {
     effective_command << BashEscape(name) << "=" << BashEscape(val) << " ";

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/host_tool_target.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/host_tool_target.cpp
@@ -57,11 +57,10 @@ Result<HostToolTarget> HostToolTarget::Create(
   for (const auto& [op, candidates] : OpToBinsMap()) {
     for (const auto& bin_name : candidates) {
       const auto bin_path = ConcatToString(bin_dir_path, "/", bin_name);
-      if (!FileExists(bin_path)) {
-        continue;
+      if (FileExists(bin_path)) {
+        op_to_impl_map[op] = OperationImplementation{.bin_name_ = bin_name};
+        break;
       }
-      op_to_impl_map[op] = OperationImplementation{.bin_name_ = bin_name};
-      break;
     }
   }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/load_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/load_configs.cpp
@@ -159,9 +159,7 @@ class LoadConfigsCommand : public CvdServerHandler {
     }
 
     /*Verbose is disabled by default*/
-    auto dev_null = SharedFD::Open("/dev/null", O_RDWR);
-    CF_EXPECT(dev_null->IsOpen(), dev_null->StrError());
-    std::vector<SharedFD> fds = {dev_null, dev_null, dev_null};
+    std::vector<SharedFD> fds = {request.In(), request.Out(), request.Err()};
     std::vector<RequestWithStdio> ret;
 
     for (auto& request_proto : req_protos) {


### PR DESCRIPTION
cvd load executes a sequence of commands in the cvd server. When one of these commands fail its output contains clues about the reason, but `cvd load` was redirecting that output to `/dev/null`.