### PR TITLE
Do not untar cvd host package at creation.

### DIFF
--- a/frontend/src/host_orchestrator/orchestrator/createcvdaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/createcvdaction.go
@@ -293,9 +293,6 @@ func (a *CreateCVDAction) launchFromAndroidCI(
 func (a *CreateCVDAction) launchFromUserBuild(
 	buildSource *apiv1.UserBuildSource, instancesCount uint32, op apiv1.Operation) ([]uint32, error) {
 	artifactsDir := a.userArtifactsDirResolver.GetDirPath(buildSource.ArtifactsDir)
-	if err := untarCVDHostPackage(artifactsDir); err != nil {
-		return nil, err
-	}
 	// assemble_cvd needs writer permission over vbmeta images
 	// https://cs.android.com/android/platform/superproject/main/+/main:device/google/cuttlefish/host/commands/assemble_cvd/disk_flags.cc;l=639;drc=b0ec6e4df1126fd4045ce32bbfcedb79f25bd5bc
 	for _, name := range []string{"vbmeta.img", "vbmeta_system.img"} {

--- a/frontend/src/host_orchestrator/orchestrator/createcvdaction_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/createcvdaction_test.go
@@ -314,10 +314,8 @@ func (r *fakeUADirRes) GetDirPath(string) string { return r.Dir }
 func TestCreateCVDFromUserBuildVerifyStartCVDCmdArgs(t *testing.T) {
 	dir := orchtesting.TempDir(t)
 	defer orchtesting.RemoveDir(t, dir)
-	tarContent, _ := ioutil.ReadFile(getTestTarFilename())
 	ioutil.WriteFile(dir+"/vbmeta.img", []byte{}, 0755)
 	ioutil.WriteFile(dir+"/vbmeta_system.img", []byte{}, 0755)
-	ioutil.WriteFile(dir+"/"+CVDHostPackageName, tarContent, 0755)
 	expected := fmt.Sprintf("sudo -u fakecvduser "+
 		"ANDROID_HOST_OUT=%[1]s %[2]s --group_name=cvd start --daemon --report_anonymous_usage_stats=y"+
 		" --base_instance_num=1 --system_image_dir=%[1]s", dir, cvd.CVDBin)

--- a/frontend/src/host_orchestrator/orchestrator/instancemanager.go
+++ b/frontend/src/host_orchestrator/orchestrator/instancemanager.go
@@ -205,15 +205,6 @@ func defaultMainBuild() *apiv1.AndroidCIBuild {
 	return &apiv1.AndroidCIBuild{Branch: mainBuildDefaultBranch, Target: mainBuildDefaultTarget}
 }
 
-const CVDHostPackageName = "cvd-host_package.tar.gz"
-
-func untarCVDHostPackage(dir string) error {
-	if err := Untar(dir, dir+"/"+CVDHostPackageName); err != nil {
-		return fmt.Errorf("Failed to untar %s with error: %w", CVDHostPackageName, err)
-	}
-	return nil
-}
-
 type fetchCVDCommandArtifactsFetcher struct {
 	execContext ExecContext
 	credentials string


### PR DESCRIPTION
- This is an API breaking change, use the new `/:extract` endpoint before creation.