### PR TITLE
Revert "Remove broken e2e test. (#494)"

### DIFF
--- a/e2etests/BUILD
+++ b/e2etests/BUILD
@@ -43,4 +43,10 @@ cvd_load_boot_test(
   env_file="environment_specs/aosp_main_x64_phone.json",
 )
 
+cvd_load_boot_test(
+  name="load_aosp_main_x64_phone_x2",
+  env_file="environment_specs/aosp_main_x64_phone_x2.json",
+  size="enormous",
+)
+
 # TODO(b/329100411) test loading older branches


### PR DESCRIPTION
The AOSP issue affecting this test has been fixed.

This reverts commit 1883b16006d5e2b737654b93a4f0e40bb03d38a5.