### PR TITLE
Add ADB port into ListCVDsResponse

### DIFF
--- a/frontend/src/host_orchestrator/orchestrator/createcvdaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/createcvdaction.go
@@ -165,7 +165,11 @@ func (a *CreateCVDAction) launchWithCanonicalConfig(op apiv1.Operation) (*apiv1.
 	if err != nil {
 		return nil, err
 	}
-	return &apiv1.CreateCVDResponse{CVDs: group.toAPIObject()}, nil
+	cvds, err := group.toAPIObject()
+	if err != nil {
+		return nil, err
+	}
+	return &apiv1.CreateCVDResponse{CVDs: cvds}, nil
 }
 
 func (a *CreateCVDAction) launchCVDResult(op apiv1.Operation) *OperationResult {
@@ -201,7 +205,11 @@ func (a *CreateCVDAction) launchCVDResult(op apiv1.Operation) *OperationResult {
 		}
 	}
 	group.Instances = relevant
-	res := &apiv1.CreateCVDResponse{CVDs: group.toAPIObject()}
+	cvds, err := group.toAPIObject()
+	if err != nil {
+		return &OperationResult{Error: operator.NewInternalError(ErrMsgLaunchCVDFailed, err)}
+	}
+	res := &apiv1.CreateCVDResponse{CVDs: cvds}
 	return &OperationResult{Value: res}
 }
 

--- a/frontend/src/host_orchestrator/orchestrator/listcvdsaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/listcvdsaction.go
@@ -43,5 +43,9 @@ func (a *ListCVDsAction) Run() (*apiv1.ListCVDsResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &apiv1.ListCVDsResponse{CVDs: group.toAPIObject()}, nil
+	cvds, err := group.toAPIObject()
+	if err != nil {
+		return nil, err
+	}
+	return &apiv1.ListCVDsResponse{CVDs: cvds}, nil
 }

--- a/frontend/src/host_orchestrator/orchestrator/listcvdsaction_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/listcvdsaction_test.go
@@ -98,6 +98,7 @@ func TestListCVDsSucceeds(t *testing.T) {
 			Status:         "Running",
 			Displays:       []string{"720 x 1280 ( 320 )"},
 			WebRTCDeviceID: "cvd-1",
+			ADBPort:        6520,
 		},
 	}}
 	if diff := cmp.Diff(want, res); diff != "" {

--- a/frontend/src/liboperator/api/v1/messages.go
+++ b/frontend/src/liboperator/api/v1/messages.go
@@ -187,6 +187,8 @@ type CVD struct {
 	Displays []string `json:"displays"`
 	// [Output Only]
 	WebRTCDeviceID string `json:"webrtc_device_id"`
+	// [Output Only]
+	ADBPort int `json:"adb_port"`
 }
 
 // Identifier within the whole fleet. Format: "{group}/{name}".


### PR DESCRIPTION
The purpose of this PR is to show adb port of CF instance in `GET /cvds`. For instance:
```
{"cvds":[{"group":"cvd","name":"1","build_source":{},"status":"Running","displays":["720 x 1280 ( 320 )"],"webrtc_device_id":"cvd-1","adb_port":"6520"}]}
```


FYI, this PR doesn't work in latest code, since `GET /cvds` in HO on top of docker instance is already broken after https://github.com/google/android-cuttlefish/pull/503. About that, I created a bug internally.