### PR TITLE
Ensure /tmp/cvd has 0777 file mode

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/common_utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/common_utils.cpp
@@ -163,6 +163,10 @@ android::base::LogSeverity GetMinimumVerbosity() {
   return android::base::GetMinimumLogSeverity();
 }
 
+std::string CvdDir() {
+  return "/tmp/cvd";
+}
+
 std::string PerUserDir() {
   return fmt::format("/tmp/cvd/{}", getuid());
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/common_utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/common_utils.h
@@ -94,6 +94,8 @@ Result<android::base::LogSeverity> SetMinimumVerbosity(const std::string&);
 
 android::base::LogSeverity GetMinimumVerbosity();
 
+std::string CvdDir();
+
 std::string PerUserDir();
 
 std::string InstanceDatabasePath();

--- a/base/cvd/cuttlefish/host/commands/cvd/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/main.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include <cstdio>
@@ -98,10 +99,25 @@ Result<void> KillOldServer() {
   return {};
 }
 
+Result<void> EnsureCvdDirectoriesExist() {
+  // This is accessed by all users.
+  CF_EXPECT(EnsureDirectoryExists(CvdDir(), 0777));
+  // The process' umask likely prevented the right permissions to be applied
+  // to the cvd directory. Changing the umask before this call would only set
+  // the permissions for a newly created directory, while this approach ensures
+  // the permissions are correct even if the directory already exists.
+  CF_EXPECTF(chmod(CvdDir().c_str(), 0777) == 0,
+             "Failed to set permission on {}: {}", CvdDir(), strerror(errno));
+
+  // This is where the instance database resides.
+  CF_EXPECT(EnsureDirectoryExists(PerUserDir(), 0750));
+
+  return {};
+}
+
 Result<void> CvdMain(int argc, char** argv, char** envp,
                      const android::base::LogSeverity verbosity) {
-  // This is where the instance database resides, so make sure it exists.
-  CF_EXPECT(EnsureDirectoryExists(PerUserDir(), 0770));
+  CF_EXPECT(EnsureCvdDirectoriesExist());
 
   CF_EXPECT(KillOldServer());
 


### PR DESCRIPTION
This directory is shared among all users, but created by the first one to execute cvd and affected by the process umask. An explicit call to chmod(2) ensures the correct permissions are set.