### PR TITLE
Change mode when creating a directory

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/files.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/files.cpp
@@ -129,8 +129,11 @@ Result<void> EnsureDirectoryExists(const std::string& directory_path,
                                                      << strerror(errno));
   }
 
+  CF_EXPECTF(chmod(directory_path.c_str(), mode) == 0,
+            "Failed to set permission on {}: {}", directory_path, strerror(errno));
+
   if (group_name != "") {
-    ChangeGroup(directory_path, group_name);
+    CF_EXPECT(ChangeGroup(directory_path, group_name));
   }
 
   return {};

--- a/base/cvd/cuttlefish/host/commands/cvd/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/main.cc
@@ -102,13 +102,6 @@ Result<void> KillOldServer() {
 Result<void> EnsureCvdDirectoriesExist() {
   // This is accessed by all users.
   CF_EXPECT(EnsureDirectoryExists(CvdDir(), 0777));
-  // The process' umask likely prevented the right permissions to be applied
-  // to the cvd directory. Changing the umask before this call would only set
-  // the permissions for a newly created directory, while this approach ensures
-  // the permissions are correct even if the directory already exists.
-  CF_EXPECTF(chmod(CvdDir().c_str(), 0777) == 0,
-             "Failed to set permission on {}: {}", CvdDir(), strerror(errno));
-
   // This is where the instance database resides.
   CF_EXPECT(EnsureDirectoryExists(PerUserDir(), 0750));
 


### PR DESCRIPTION
Recently I faced at the permission related issue when doing `POST /cvds` after `GET /cvds`.

And found the root cause `_cutf-operator` trying to change mode of `/tmp/cvd` directory, which is owned by `_cvd-executor`.

I can resolve this issue with this PR, but I still have doubts on:
- Why can't `mkdir` function set the mode?
- Why doesn't the group of `_cvd-executor` set as `cvdnetwork`?
- Why are the users different between `GET /cvds` and `POST /cvds`?