### PR TITLE
Validate cvd configs with a proto definition

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/parser/cf_configs_common.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/cf_configs_common.h
@@ -35,6 +35,7 @@ inline constexpr char kArrayValidationSentinel[] = "kArrayValidationSentinel";
 
 struct ConfigNode {
   Json::ValueType type;
+  std::string proto_name;
   std::map<std::string, ConfigNode> children;
 };
 

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/cf_configs_common.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/cf_configs_common.h
@@ -24,20 +24,12 @@
 #include <vector>
 
 #include <json/json.h>
+#include <google/protobuf/message.h>
 
 #include "common/libs/utils/json.h"
 #include "common/libs/utils/result.h"
 
 namespace cuttlefish {
-
-// sentinel lookup value for validating arrays to retrieve type of the elements
-inline constexpr char kArrayValidationSentinel[] = "kArrayValidationSentinel";
-
-struct ConfigNode {
-  Json::ValueType type;
-  std::string proto_name;
-  std::map<std::string, ConfigNode> children;
-};
 
 template <typename T>
 Result<void> ValidateConfig(const Json::Value& instance,
@@ -96,6 +88,6 @@ std::vector<std::string> MergeResults(std::vector<std::string> first_list,
 
 void MergeTwoJsonObjs(Json::Value& dst, const Json::Value& src);
 
-Result<void> Validate(const Json::Value& value, const ConfigNode& node);
+Result<void> Validate(const Json::Value& value, google::protobuf::Message& node);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
@@ -50,9 +50,7 @@ const auto& kRoot = *new ConfigNode{.type = objectValue, .children = {
         {"security", ConfigNode{.proto_name = "cuttlefish.cvd.config.Security"}},
         {"disk", ConfigNode{.proto_name = "cuttlefish.cvd.config.Disk"}},
         {"graphics", ConfigNode{.proto_name = "cuttlefish.cvd.config.Graphics"}},
-        {"streaming", ConfigNode{.type = objectValue, .children = {
-          {"device_id", ConfigNode{.type = stringValue}},
-        }}},
+        {"streaming", ConfigNode{.proto_name = "cuttlefish.cvd.config.Streaming"}},
         {"connectivity", ConfigNode{.proto_name = "cuttlefish.cvd.config.Connectivity"}}
       }}},
     }}},

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
@@ -48,16 +48,7 @@ const auto& kRoot = *new ConfigNode{.type = objectValue, .children = {
         {"vm", ConfigNode{.proto_name = "cuttlefish.cvd.config.Vm"}},
         {"boot", ConfigNode{.proto_name = "cuttlefish.cvd.config.Boot"}},
         {"security", ConfigNode{.proto_name = "cuttlefish.cvd.config.Security"}},
-        {"disk", ConfigNode{.type = objectValue, .children = {
-          {"default_build", ConfigNode{.type = stringValue}},
-          {"super", ConfigNode{.type = objectValue, .children = {
-            {"system", ConfigNode{.type = stringValue}},
-          }}},
-          {"download_img_zip", ConfigNode{.type = booleanValue}},
-          {"download_target_zip_files", ConfigNode{.type = booleanValue}},
-          {"blank_data_image_mb", ConfigNode{.type = uintValue}},
-          {"otatools", ConfigNode{.type = stringValue}},
-        }}},
+        {"disk", ConfigNode{.proto_name = "cuttlefish.cvd.config.Disk"}},
         {"graphics", ConfigNode{.proto_name = "cuttlefish.cvd.config.Graphics"}},
         {"streaming", ConfigNode{.type = objectValue, .children = {
           {"device_id", ConfigNode{.type = stringValue}},

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
@@ -51,9 +51,7 @@ const auto& kRoot = *new ConfigNode{.type = objectValue, .children = {
           {"use_sdcard", ConfigNode{.type = booleanValue}},
           {"setupwizard_mode", ConfigNode{.type = stringValue}},
           {"uuid", ConfigNode{.type = stringValue}},
-          {"crosvm", ConfigNode{.type = objectValue, .children = {
-            {"enable_sandbox", ConfigNode{.type = booleanValue}},
-          }}},
+          {"crosvm", ConfigNode{.proto_name = "cuttlefish.cvd.config.Crosvm"}},
           {"custom_actions", ConfigNode{.type = arrayValue, .children = {
             {kArrayValidationSentinel, ConfigNode{.type = objectValue, .children = {
               {"shell_command", ConfigNode{.type = stringValue}},

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
@@ -45,49 +45,8 @@ const auto& kRoot = *new ConfigNode{.type = objectValue, .children = {
     {kArrayValidationSentinel, ConfigNode{.type = objectValue, .children = {
         {"@import", ConfigNode{.type = stringValue}},
         {"name", ConfigNode{.type = stringValue}},
-        {"vm", ConfigNode{.type = objectValue, .children = {
-          {"cpus", ConfigNode{.type = uintValue}},
-          {"memory_mb", ConfigNode{.type = uintValue}},
-          {"use_sdcard", ConfigNode{.type = booleanValue}},
-          {"setupwizard_mode", ConfigNode{.type = stringValue}},
-          {"uuid", ConfigNode{.type = stringValue}},
-          {"crosvm", ConfigNode{.proto_name = "cuttlefish.cvd.config.Crosvm"}},
-          {"custom_actions", ConfigNode{.type = arrayValue, .children = {
-            {kArrayValidationSentinel, ConfigNode{.type = objectValue, .children = {
-              {"shell_command", ConfigNode{.type = stringValue}},
-              {"button", ConfigNode{.type = objectValue, .children = {
-                {"command", ConfigNode{.type = stringValue}},
-                {"title", ConfigNode{.type = stringValue}},
-                {"icon_name", ConfigNode{.type = stringValue}},
-              }}},
-              {"server", ConfigNode{.type = stringValue}},
-              {"buttons", ConfigNode{.type = arrayValue, .children = {
-                {kArrayValidationSentinel, ConfigNode{.type = objectValue, .children = {
-                  {"command", ConfigNode{.type = stringValue}},
-                  {"title", ConfigNode{.type = stringValue}},
-                  {"icon_name", ConfigNode{.type = stringValue}},
-                }}},
-              }}},
-              {"device_states", ConfigNode{.type = arrayValue, .children = {
-                {kArrayValidationSentinel, ConfigNode{.type = objectValue, .children = {
-                  {"lid_switch_open", ConfigNode{.type = booleanValue}},
-                  {"hinge_angle_value", ConfigNode{.type = intValue}},
-                }}},
-              }}},
-            }}},
-          }}},
-        }}},
-        {"boot", ConfigNode{.type = objectValue, .children = {
-          {"kernel", ConfigNode{.type = objectValue, .children = {
-            {"build", ConfigNode{.type = stringValue}},
-          }}},
-          {"enable_bootanimation", ConfigNode{.type = booleanValue}},
-          {"extra_bootconfig_args", ConfigNode{.type = stringValue}},
-          {"build", ConfigNode{.type = stringValue}},
-          {"bootloader", ConfigNode{.type = objectValue, .children = {
-            {"build", ConfigNode{.type = stringValue}},
-          }}},
-        }}},
+        {"vm", ConfigNode{.proto_name = "cuttlefish.cvd.config.Vm"}},
+        {"boot", ConfigNode{.proto_name = "cuttlefish.cvd.config.Boot"}},
         {"security", ConfigNode{.proto_name = "cuttlefish.cvd.config.Security"}},
         {"disk", ConfigNode{.type = objectValue, .children = {
           {"default_build", ConfigNode{.type = stringValue}},

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
@@ -88,11 +88,7 @@ const auto& kRoot = *new ConfigNode{.type = objectValue, .children = {
             {"build", ConfigNode{.type = stringValue}},
           }}},
         }}},
-        {"security", ConfigNode{.type = objectValue, .children = {
-          {"serial_number", ConfigNode{.type = stringValue}},
-          {"use_random_serial", ConfigNode{.type = stringValue}},
-          {"guest_enforce_security", ConfigNode{.type = booleanValue}},
-        }}},
+        {"security", ConfigNode{.proto_name = "cuttlefish.cvd.config.Security"}},
         {"disk", ConfigNode{.type = objectValue, .children = {
           {"default_build", ConfigNode{.type = stringValue}},
           {"super", ConfigNode{.type = objectValue, .children = {

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
@@ -103,11 +103,7 @@ const auto& kRoot = *new ConfigNode{.type = objectValue, .children = {
         {"streaming", ConfigNode{.type = objectValue, .children = {
           {"device_id", ConfigNode{.type = stringValue}},
         }}},
-        {"connectivity", ConfigNode{.type = objectValue, .children = {
-          {"vsock", ConfigNode{.type = objectValue, .children = {
-            {"guest_group", ConfigNode{.type = stringValue}},
-          }}}
-        }}}
+        {"connectivity", ConfigNode{.proto_name = "cuttlefish.cvd.config.Connectivity"}}
       }}},
     }}},
   {"fetch", ConfigNode{.type = objectValue, .children = {

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
@@ -99,17 +99,7 @@ const auto& kRoot = *new ConfigNode{.type = objectValue, .children = {
           {"blank_data_image_mb", ConfigNode{.type = uintValue}},
           {"otatools", ConfigNode{.type = stringValue}},
         }}},
-        {"graphics", ConfigNode{.type = objectValue, .children = {
-          {"displays", ConfigNode{.type = arrayValue, .children = {
-            {kArrayValidationSentinel, ConfigNode{.type = objectValue, .children {
-              {"width", ConfigNode{.type = uintValue}},
-              {"height", ConfigNode{.type = uintValue}},
-              {"dpi", ConfigNode{.type = uintValue}},
-              {"refresh_rate_hertz", ConfigNode{.type = uintValue}},
-            }}},
-          }}},
-          {"record_screen", ConfigNode{.type = booleanValue}},
-        }}},
+        {"graphics", ConfigNode{.proto_name = "cuttlefish.cvd.config.Graphics"}},
         {"streaming", ConfigNode{.type = objectValue, .children = {
           {"device_id", ConfigNode{.type = stringValue}},
         }}},

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
@@ -56,14 +56,7 @@ const auto& kRoot = *new ConfigNode{.type = objectValue, .children = {
         {"connectivity", ConfigNode{.proto_name = "cuttlefish.cvd.config.Connectivity"}}
       }}},
     }}},
-  {"fetch", ConfigNode{.type = objectValue, .children = {
-      {"api_key", ConfigNode{.type = stringValue}},
-      {"credential_source", ConfigNode{.type = stringValue}},
-      {"wait_retry_period", ConfigNode{.type = uintValue}},
-      {"external_dns_resolver", ConfigNode{.type = booleanValue}},
-      {"keep_downloaded_archives", ConfigNode{.type = booleanValue}},
-      {"api_base_url", ConfigNode{.type = stringValue}},
-    }}},
+  {"fetch", ConfigNode{.proto_name = "cuttlefish.cvd.config.Fetch"}},
   {"metrics", ConfigNode{.type = objectValue, .children = {
       {"enable", ConfigNode{.type = booleanValue}},
     }}},

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
@@ -56,10 +56,7 @@ const auto& kRoot = *new ConfigNode{.type = objectValue, .children = {
     }}},
   {"fetch", ConfigNode{.proto_name = "cuttlefish.cvd.config.Fetch"}},
   {"metrics", ConfigNode{.proto_name = "cuttlefish.cvd.config.Metrics"}},
-  {"common", ConfigNode{.type = objectValue, .children = {
-    {"group_name", ConfigNode{.type = stringValue}},
-    {"host_package", ConfigNode{.type = stringValue}},
-  }}},
+  {"common", ConfigNode{.proto_name = "cuttlefish.cvd.config.Common"}},
 },
 };
 

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
@@ -38,27 +38,8 @@ using Json::ValueType::objectValue;
 using Json::ValueType::stringValue;
 using Json::ValueType::uintValue;
 
-const auto& kRoot = *new ConfigNode{.type = objectValue, .children = {
-  {"netsim_bt", ConfigNode{.type = booleanValue}},
-  {"netsim_uwb", ConfigNode{.type = booleanValue}},
-  {"instances", ConfigNode{.type = arrayValue, .children = {
-    {kArrayValidationSentinel, ConfigNode{.type = objectValue, .children = {
-        {"@import", ConfigNode{.type = stringValue}},
-        {"name", ConfigNode{.type = stringValue}},
-        {"vm", ConfigNode{.proto_name = "cuttlefish.cvd.config.Vm"}},
-        {"boot", ConfigNode{.proto_name = "cuttlefish.cvd.config.Boot"}},
-        {"security", ConfigNode{.proto_name = "cuttlefish.cvd.config.Security"}},
-        {"disk", ConfigNode{.proto_name = "cuttlefish.cvd.config.Disk"}},
-        {"graphics", ConfigNode{.proto_name = "cuttlefish.cvd.config.Graphics"}},
-        {"streaming", ConfigNode{.proto_name = "cuttlefish.cvd.config.Streaming"}},
-        {"connectivity", ConfigNode{.proto_name = "cuttlefish.cvd.config.Connectivity"}}
-      }}},
-    }}},
-  {"fetch", ConfigNode{.proto_name = "cuttlefish.cvd.config.Fetch"}},
-  {"metrics", ConfigNode{.proto_name = "cuttlefish.cvd.config.Metrics"}},
-  {"common", ConfigNode{.proto_name = "cuttlefish.cvd.config.Common"}},
-},
-};
+const auto& kRoot =
+    *new ConfigNode{.proto_name = "cuttlefish.cvd.config.Launch"};
 
 }  // namespace
 

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
@@ -57,9 +57,7 @@ const auto& kRoot = *new ConfigNode{.type = objectValue, .children = {
       }}},
     }}},
   {"fetch", ConfigNode{.proto_name = "cuttlefish.cvd.config.Fetch"}},
-  {"metrics", ConfigNode{.type = objectValue, .children = {
-      {"enable", ConfigNode{.type = booleanValue}},
-    }}},
+  {"metrics", ConfigNode{.proto_name = "cuttlefish.cvd.config.Metrics"}},
   {"common", ConfigNode{.type = objectValue, .children = {
     {"group_name", ConfigNode{.type = stringValue}},
     {"host_package", ConfigNode{.type = stringValue}},

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/cf_flags_validator.cpp
@@ -27,6 +27,7 @@
 #include "common/libs/utils/flags_validator.h"
 #include "common/libs/utils/result.h"
 #include "host/commands/cvd/parser/cf_configs_common.h"
+#include "load_config.pb.h"
 
 namespace cuttlefish {
 namespace {
@@ -38,9 +39,6 @@ using Json::ValueType::objectValue;
 using Json::ValueType::stringValue;
 using Json::ValueType::uintValue;
 
-const auto& kRoot =
-    *new ConfigNode{.proto_name = "cuttlefish.cvd.config.Launch"};
-
 }  // namespace
 
 Result<void> ValidateCfConfigs(const Json::Value& root) {
@@ -48,7 +46,8 @@ Result<void> ValidateCfConfigs(const Json::Value& root) {
       *new std::unordered_set<std::string>{"phone", "tablet", "tv", "wearable",
                                            "auto",  "slim",   "go", "foldable"};
 
-  CF_EXPECT(Validate(root, kRoot), "Validation failure in [root object] ->");
+  cvd::config::Launch launch_config;
+  CF_EXPECT(Validate(root, launch_config), "Validation failure in [root object] ->");
   for (const auto& instance : root["instances"]) {
     // TODO(chadreynolds): update `ExtractLaunchTemplates` to return a Result
     // and check import values there, then remove this check

--- a/base/cvd/load_config.proto
+++ b/base/cvd/load_config.proto
@@ -21,3 +21,9 @@ package cuttlefish.cvd.config;
 message Crosvm {
   optional bool enable_sandbox = 1;
 }
+
+message Security {
+  optional string serial_number = 1;
+  optional string use_random_serial = 2;
+  optional bool guest_enforce_security = 3;
+}

--- a/base/cvd/load_config.proto
+++ b/base/cvd/load_config.proto
@@ -18,6 +18,15 @@ syntax = "proto3";
 
 package cuttlefish.cvd.config;
 
+message Fetch {
+  optional string api_key = 1;
+  optional string credential_source = 2;
+  optional uint32 wait_retry_period = 3;
+  optional bool external_dns_resolver = 4;
+  optional bool keep_downloaded_archives = 5;
+  optional string api_base_url = 6;
+}
+
 message Boot {
   optional Build kernel = 1;
   optional bool enable_bootanimation = 2;

--- a/base/cvd/load_config.proto
+++ b/base/cvd/load_config.proto
@@ -18,16 +18,24 @@ syntax = "proto3";
 
 package cuttlefish.cvd.config;
 
+message Boot {
+  optional Build kernel = 1;
+  optional bool enable_bootanimation = 2;
+  optional string extra_bootconfig_args = 3;
+  optional string build = 4;
+  optional Build bootloader = 5;
+}
+
+message Build {
+  optional string build = 1;
+}
+
 message Connectivity {
   optional Vsock vsock = 1;
 }
 
 message Vsock {
   optional string guest_group = 1;
-}
-
-message Crosvm {
-  optional bool enable_sandbox = 1;
 }
 
 message Graphics {
@@ -47,3 +55,37 @@ message Security {
   optional string use_random_serial = 2;
   optional bool guest_enforce_security = 3;
 }
+
+message Vm {
+  optional uint32 cpus = 1;
+  optional uint32 memory_mb = 2;
+  optional bool use_sdcard = 3;
+  optional string setupwizard_mode = 4;
+  optional string uuid = 5;
+  optional Crosvm crosvm = 6;
+  repeated CustomAction custom_actions = 7;
+}
+
+message Crosvm {
+  optional bool enable_sandbox = 1;
+}
+
+message CustomAction {
+  optional string shell_command = 1;
+  optional Button button = 2;
+  optional string server = 3;
+  repeated Button buttons = 4;
+  repeated DeviceState device_states = 5;
+}
+
+message Button {
+  optional string command = 1;
+  optional string title = 2;
+  optional string icon_name = 3;
+}
+
+message DeviceState {
+  optional bool lid_switch_open = 1;
+  optional int32 hinge_angle_value = 2;
+}
+

--- a/base/cvd/load_config.proto
+++ b/base/cvd/load_config.proto
@@ -18,6 +18,11 @@ syntax = "proto3";
 
 package cuttlefish.cvd.config;
 
+message Common {
+  optional string group_name = 1;
+  optional string host_package = 2;
+}
+
 message Fetch {
   optional string api_key = 1;
   optional string credential_source = 2;

--- a/base/cvd/load_config.proto
+++ b/base/cvd/load_config.proto
@@ -78,6 +78,10 @@ message Security {
   optional bool guest_enforce_security = 3;
 }
 
+message Streaming {
+  optional string device_id = 1;
+}
+
 message Vm {
   optional uint32 cpus = 1;
   optional uint32 memory_mb = 2;

--- a/base/cvd/load_config.proto
+++ b/base/cvd/load_config.proto
@@ -50,6 +50,19 @@ message Display {
   optional uint32 refresh_rate_hertz = 4;
 }
 
+message Disk {
+  optional string default_build = 1;
+  optional Super super = 2;
+  optional bool download_img_zip = 3;
+  optional bool download_target_zip_files = 4;
+  optional uint32 blank_data_image_mb = 5;
+  optional string otatools = 6;
+}
+
+message Super {
+  optional string system = 1;
+}
+
 message Security {
   optional string serial_number = 1;
   optional string use_random_serial = 2;

--- a/base/cvd/load_config.proto
+++ b/base/cvd/load_config.proto
@@ -22,6 +22,18 @@ message Crosvm {
   optional bool enable_sandbox = 1;
 }
 
+message Graphics {
+  repeated Display displays = 1;
+  optional bool record_screen = 2;
+}
+
+message Display {
+  optional uint32 width = 1;
+  optional uint32 height = 2;
+  optional uint32 dpi = 3;
+  optional uint32 refresh_rate_hertz = 4;
+}
+
 message Security {
   optional string serial_number = 1;
   optional string use_random_serial = 2;

--- a/base/cvd/load_config.proto
+++ b/base/cvd/load_config.proto
@@ -111,3 +111,6 @@ message DeviceState {
   optional int32 hinge_angle_value = 2;
 }
 
+message Metrics {
+  optional bool enable = 1;
+}

--- a/base/cvd/load_config.proto
+++ b/base/cvd/load_config.proto
@@ -18,6 +18,14 @@ syntax = "proto3";
 
 package cuttlefish.cvd.config;
 
+message Connectivity {
+  optional Vsock vsock = 1;
+}
+
+message Vsock {
+  optional string guest_group = 1;
+}
+
 message Crosvm {
   optional bool enable_sandbox = 1;
 }

--- a/base/cvd/load_config.proto
+++ b/base/cvd/load_config.proto
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package cuttlefish.cvd.config;
+
+message Crosvm {
+  optional bool enable_sandbox = 1;
+}

--- a/base/cvd/load_config.proto
+++ b/base/cvd/load_config.proto
@@ -18,6 +18,15 @@ syntax = "proto3";
 
 package cuttlefish.cvd.config;
 
+message Launch {
+  repeated Instance instances = 1;
+  optional Fetch fetch = 2;
+  optional Metrics metrics = 3;
+  optional Common common = 4;
+  optional bool netsim_bt = 5;
+  optional bool netsim_uwb = 6;
+}
+
 message Common {
   optional string group_name = 1;
   optional string host_package = 2;
@@ -30,6 +39,19 @@ message Fetch {
   optional bool external_dns_resolver = 4;
   optional bool keep_downloaded_archives = 5;
   optional string api_base_url = 6;
+}
+
+message Instance {
+  optional string name = 1;
+  optional Vm vm = 2;
+  optional Boot boot = 3;
+  optional Security security = 4;
+  optional Disk disk = 5;
+  optional Graphics graphics = 6;
+  optional Streaming streaming = 7;
+  optional Connectivity connectivity = 8;
+  // TODO: b/337089452 - handle outside of proto logic
+  optional string import_template = 9 [json_name="@import"];
 }
 
 message Boot {

--- a/base/cvd/meson.build
+++ b/base/cvd/meson.build
@@ -152,7 +152,7 @@ protoc = find_program('protoc', required : true)
 deps = dependency('protobuf', required : true)
 protoc_generator = generator(protoc,
   output    : ['@BASENAME@.pb.cc', '@BASENAME@.pb.h'],
-  arguments : ['--proto_path=@CURRENT_SOURCE_DIR@', '--cpp_out=@BUILD_DIR@', '@INPUT@'])
+  arguments : ['--proto_path=@CURRENT_SOURCE_DIR@', '--cpp_out=@BUILD_DIR@', '@INPUT@', '--experimental_allow_proto3_optional'])
 
 server = protoc_generator.process('cvd_server.proto')
 server_dependency = declare_dependency(sources: server)
@@ -172,6 +172,9 @@ client_analytics_proto_dependency = declare_dependency(sources: client_analytics
 internal_user_log_proto = protoc_generator.process('internal_user_log.proto')
 internal_user_log_proto_dependency = declare_dependency(sources: internal_user_log_proto)
 
+cvd_load_config_proto = protoc_generator.process('load_config.proto')
+cvd_load_config_proto_dependency = declare_dependency(sources: cvd_load_config_proto)
+
 git_version_h = vcs_tag(
   command : ['git', 'describe'],
   fallback : 'unknown',
@@ -182,6 +185,7 @@ git_version_h_dependency = declare_dependency(sources: git_version_h)
 
 dependencies = [
   client_analytics_proto_dependency,
+  cvd_load_config_proto_dependency,
   dependency('fmt'),
   dependency('gflags'),
   dependency('jsoncpp'),


### PR DESCRIPTION
`cf_flags_validator.cpp` included functionality to validate field types inside a json structure based on a rigid schema. This commit introduces the capability to pull the schema from a protocol buffer definition.

Proto3 includes a canonical json translation:

https://protobuf.dev/programming-guides/proto3/#json

This is validated by replacing a single nested json structure with proto validation. It produces errors when the field types are wrong.

Bug: b/337089452