### PR TITLE
Factor out a helper to make download steps clearer

### DIFF
--- a/base/cvd/cuttlefish/host/libs/web/android_build_api.h
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_api.h
@@ -111,6 +111,8 @@ class BuildApi {
   Result<std::unordered_set<std::string>> Artifacts(
       const Build& build, const std::vector<std::string>& artifact_filenames);
 
+  Result<std::string> GetArtifactDownloadUrl(const DeviceBuild& build,
+                                             const std::string& artifact);
   Result<void> ArtifactToFile(const DeviceBuild& build,
                               const std::string& artifact,
                               const std::string& path);


### PR DESCRIPTION
The initial step of needing to retrieve the download URL from AB and then using that to do the actual download has left me briefly confused multiple times.

Test: cvd fetch --target_directory=/tmp/cvd/fetch_test --default_build=aosp-main
Test: # verify all typical artifacts are still downloaded