### PR TITLE
Nested CF_EXPECT statements generate messy errors

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/load_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/load_configs.cpp
@@ -66,7 +66,8 @@ class LoadConfigsCommand : public CvdServerHandler {
   }
 
   Result<cvd::Response> Handle(const RequestWithStdio& request) override {
-    CF_EXPECT(CF_EXPECT(CanHandle(request)));
+    bool can_handle_request = CF_EXPECT(CanHandle(request));
+    CF_EXPECT_EQ(can_handle_request, true);
 
     auto commands = CF_EXPECT(CreateCommandSequence(request));
     CF_EXPECT(executor_.Execute(commands, request.Err()));

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/serial_launch.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/serial_launch.cpp
@@ -119,7 +119,8 @@ class SerialLaunchCommand : public CvdServerHandler {
            invocation.arguments[0] == "serial_launch";
   }
   Result<cvd::Response> Handle(const RequestWithStdio& request) override {
-    CF_EXPECT(CF_EXPECT(CanHandle(request)));
+    bool can_handle_request = CF_EXPECT(CanHandle(request));
+    CF_EXPECT_EQ(can_handle_request, true);
 
     auto commands = CF_EXPECT(CreateCommandSequence(request));
     CF_EXPECT(executor_.Execute(commands.requests, request.Err()));

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/serial_preset.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/serial_preset.cpp
@@ -43,7 +43,8 @@ class SerialPreset : public CvdServerHandler {
   }
 
   Result<cvd::Response> Handle(const RequestWithStdio& request) override {
-    CF_EXPECT(CF_EXPECT(CanHandle(request)));
+    bool can_handle_request = CF_EXPECT(CanHandle(request));
+    CF_EXPECT_EQ(can_handle_request, true);
 
     auto invocation = ParseInvocation(request.Message());
     CF_EXPECT(invocation.arguments.size() >= 1);

--- a/base/cvd/cuttlefish/host/libs/web/android_build_api.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_api.cpp
@@ -366,6 +366,9 @@ Result<void> BuildApi::ArtifactToFile(const DeviceBuild& build,
                                       const std::string& path) {
   const auto url = CF_EXPECT(GetArtifactDownloadUrl(build, artifact));
   CF_EXPECT(CF_EXPECT(http_client->DownloadToFile(url, path)).HttpSuccess());
+  bool is_successful_download =
+      CF_EXPECT(http_client->DownloadToFile(url, path)).HttpSuccess();
+  CF_EXPECT_EQ(is_successful_download, true);
   return {};
 }
 


### PR DESCRIPTION
Introducing an intermediate variable to split up the calls

Github search to find these cases:
https://github.com/search?q=repo%3Agoogle%2Fandroid-cuttlefish+path%3Abase%2Fcvd%2F+%2FCF_EXPECT%5C%28%5Cs*CF_EXPECT%5C%28%2F&type=code

Test: meson compile