### PR TITLE
Add explicit sign conversions to many integer comparisons

### DIFF
--- a/base/cvd/cuttlefish/BUILD.bazel
+++ b/base/cvd/cuttlefish/BUILD.bazel
@@ -438,6 +438,7 @@ cc_library(
         "host/commands/metrics/metrics_defs.h",
     ],
     copts = [
+        "-Werror=sign-compare",
         "-Wno-ctad-maybe-unsupported",
         "-std=c++17",
     ],

--- a/base/cvd/cuttlefish/common/libs/utils/unique_resource_allocator.h
+++ b/base/cvd/cuttlefish/common/libs/utils/unique_resource_allocator.h
@@ -163,7 +163,7 @@ class UniqueResourceAllocator {
 
   template <typename V = T>
   std::enable_if_t<std::is_integral<V>::value, std::optional<ReservationSet>>
-  UniqueConsecutiveItems(const int n) {
+  UniqueConsecutiveItems(const std::size_t n) {
     static_assert(std::is_same<T, V>::value);
     std::lock_guard<std::mutex> lock(mutex_);
     if (n <= 0 || available_resources_.size() < n) {

--- a/base/cvd/cuttlefish/host/commands/cvd/command_sequence.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/command_sequence.cpp
@@ -88,7 +88,8 @@ Result<std::vector<cvd::Response>> CommandSequenceExecutor::Execute(
     if (inner_proto.has_command_request()) {
       auto& command = inner_proto.command_request();
       std::string str = FormattedCommand(command);
-      CF_EXPECT(WriteAll(report, str) == str.size(), report->StrError());
+      CF_EXPECT(WriteAll(report, str) == (ssize_t)str.size(),
+                report->StrError());
     }
 
     auto handler = CF_EXPECT(RequestHandler(request, server_handlers_));
@@ -107,7 +108,7 @@ Result<std::vector<cvd::Response>> CommandSequenceExecutor::Execute(
 Result<cvd::Response> CommandSequenceExecutor::ExecuteOne(
     const RequestWithStdio& request, SharedFD report) {
   auto response_in_vector = CF_EXPECT(Execute({request}, report));
-  CF_EXPECT_EQ(response_in_vector.size(), 1);
+  CF_EXPECT_EQ(response_in_vector.size(), 1ul);
   return response_in_vector.front();
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd.cc
@@ -109,7 +109,7 @@ bool ShouldAppendSubdirectory(const FetchFlags& flags) {
 }
 
 template <typename T>
-T AccessOrDefault(const std::vector<T>& vector, const int i,
+T AccessOrDefault(const std::vector<T>& vector, const std::size_t i,
                   const T& default_value) {
   if (i < vector.size()) {
     return vector[i];
@@ -249,7 +249,7 @@ void DeAndroidSparse(const std::vector<std::string>& image_files) {
 std::vector<Target> GetFetchTargets(const FetchFlags& flags,
                                     const bool append_subdirectory) {
   std::vector<Target> result(flags.number_of_builds);
-  for (int i = 0; i < result.size(); ++i) {
+  for (std::size_t i = 0; i < result.size(); ++i) {
     result[i] = Target{
         .build_strings = GetBuildStrings(flags.vector_flags, i),
         .download_flags = GetDownloadFlags(flags.vector_flags, i),

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd_parser.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd_parser.cc
@@ -162,7 +162,7 @@ std::vector<Flag> GetFlagsVector(FetchFlags& fetch_flags,
 Result<int> GetNumberOfBuilds(
     const VectorFlags& flags,
     const std::vector<std::string>& subdirectory_flag) {
-  std::optional<int> number_of_builds;
+  std::optional<std::size_t> number_of_builds;
   for (const auto& flag_size :
        {flags.default_build.size(), flags.system_build.size(),
         flags.kernel_build.size(), flags.boot_build.size(),

--- a/base/cvd/cuttlefish/host/commands/cvd/flag.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/flag.h
@@ -85,7 +85,7 @@ class CvdFlag {
   // returns CF_ERR if parsing error,
   // returns std::nullopt if parsing was okay but the flag wasn't given
   Result<std::optional<T>> FilterFlag(cvd_common::Args& args) const {
-    const int args_initial_size = args.size();
+    const std::size_t args_initial_size = args.size();
     if (args_initial_size == 0) {
       return std::nullopt;
     }

--- a/base/cvd/cuttlefish/host/commands/cvd/instance_lock.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instance_lock.cpp
@@ -158,7 +158,7 @@ static Result<TypeAndId> ParseMatchedLine(
     const std::smatch& device_string_match) {
   std::string device_string = *device_string_match.begin();
   auto tokens = android::base::Tokenize(device_string, "-");
-  CF_EXPECT_GE(tokens.size(), 3);
+  CF_EXPECT_GE(tokens.size(), 3ul);
   const auto cvd = tokens.front();
   int id = 0;
   CF_EXPECT(android::base::ParseInt(tokens.back(), &id));

--- a/base/cvd/cuttlefish/host/commands/cvd/instance_manager.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instance_manager.cpp
@@ -259,7 +259,7 @@ Result<InstanceManager::LocalInstanceGroup> InstanceManager::FindGroup(
 Result<InstanceManager::LocalInstanceGroup> InstanceManager::FindGroup(
     const Queries& queries) const {
   auto output = CF_EXPECT(instance_db_.FindGroups(queries));
-  CF_EXPECT_EQ(output.size(), 1);
+  CF_EXPECT_EQ(output.size(), 1ul);
   return *(output.begin());
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/cf_configs_common.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/cf_configs_common.cpp
@@ -98,7 +98,7 @@ Result<std::string> Base64EncodeGflag(
   auto values =
       CF_EXPECTF(GetArrayValues<std::string>(instances, selectors),
                  "Unable to produce values for gflag \"{}\"", gflag_name);
-  for (int i = 0; i < values.size(); i++) {
+  for (std::size_t i = 0; i < values.size(); i++) {
     std::string out;
     CF_EXPECT(EncodeBase64(values[i].c_str(), values[i].size(), &out));
     values[i] = out;
@@ -125,7 +125,7 @@ std::vector<std::string> MergeResults(std::vector<std::string> first_list,
 void MergeTwoJsonObjs(Json::Value& dst, const Json::Value& src) {
   for (const auto& key : src.getMemberNames()) {
     if (src[key].type() == Json::arrayValue) {
-      for (int i = 0; i < src[key].size(); i++) {
+      for (int i = 0; i < (int)src[key].size(); i++) {
         MergeTwoJsonObjs(dst[key][i], src[key][i]);
       }
     } else if (src[key].type() == Json::objectValue) {

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/fetch_config_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/fetch_config_parser.cpp
@@ -125,7 +125,7 @@ Result<std::vector<std::string>> GenerateFetchFlags(
   CF_EXPECT_EQ(instances.size(), target_subdirectories.size(),
                "Mismatched sizes between number of subdirectories and number "
                "of instances");
-  for (int i = 0; i < instances.size(); i++) {
+  for (int i = 0; i < (int)instances.size(); i++) {
     const auto prefix_filtered =
         CF_EXPECT(RemoveNonPrefixedBuildStrings(instances[i]));
     if (ShouldFetch(prefix_filtered)) {

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/launch_cvd_templates.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/launch_cvd_templates.cpp
@@ -299,7 +299,7 @@ Json::Value ExtractInstaneTemplate(const Json::Value& instance) {
 }
 
 void ExtractLaunchTemplates(Json::Value& root) {
-  int num_instances = root.size();
+  std::size_t num_instances = root.size();
   for (unsigned int i = 0; i < num_instances; i++) {
     // Validate @import flag values are supported or not
     if (root[i].isMember("@import")) {

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/load_configs_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/load_configs_parser.cpp
@@ -237,7 +237,7 @@ Result<LoadDirectories> GenerateLoadDirectories(
   int num_remote = 0;
   for (int i = 0; i < num_instances; i++) {
     const std::string instance_build_path = system_image_path_configs[i];
-    CF_EXPECT_EQ(system_image_path_configs.size(), num_instances,
+    CF_EXPECT_EQ((int)system_image_path_configs.size(), num_instances,
                  "Number of instances is inconsistent");
 
     auto target_subdirectory = std::to_string(i);

--- a/base/cvd/cuttlefish/host/commands/cvd/selector/data_viewer.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/selector/data_viewer.cpp
@@ -42,8 +42,8 @@ Result<void> DataViewer::StoreData(SharedFD fd, cvd::PersistentData data) {
   std::string str;
   CF_EXPECT(data.SerializeToString(&str), "Failed to serialize data");
   auto write_size = WriteAll(fd, str);
-  CF_EXPECTF(write_size == str.size(), "Failed to write to backing file: {}",
-             fd->StrError());
+  CF_EXPECTF(write_size == (ssize_t)str.size(),
+             "Failed to write to backing file: {}", fd->StrError());
   return {};
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/selector/instance_database.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/selector/instance_database.h
@@ -95,7 +95,7 @@ class InstanceDatabase {
   template <typename T>
   Result<T> ExactlyOne(Result<std::vector<T>>&& container_result) const {
     auto container = CF_EXPECT(std::move(container_result));
-    CF_EXPECT_EQ(container.size(), 1, "Expected unique result");
+    CF_EXPECT_EQ(container.size(), (std::size_t)1, "Expected unique result");
     return {*container.begin()};
   }
   struct FindParam {

--- a/base/cvd/cuttlefish/host/commands/cvd/selector/instance_group_record.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/selector/instance_group_record.cpp
@@ -62,9 +62,9 @@ Result<LocalInstanceGroup> LocalInstanceGroup::Create(
     ids.insert(instance_proto.id());
     names.insert(instance_proto.name());
   }
-  CF_EXPECT(ids.size() == group_proto.instances_size(),
+  CF_EXPECT(ids.size() == (size_t)group_proto.instances_size(),
             "Instances must have unique ids");
-  CF_EXPECT(names.size() == group_proto.instances_size(),
+  CF_EXPECT(names.size() == (size_t)group_proto.instances_size(),
             "Instances must have unique names");
   return LocalInstanceGroup(group_proto, instances);
 }
@@ -131,7 +131,7 @@ Result<LocalInstanceGroup> LocalInstanceGroup::Deserialize(
   CF_EXPECT(group_json.isMember(kJsonInstances));
   const Json::Value& instances_json_array = group_json[kJsonInstances];
   CF_EXPECT(instances_json_array.isArray());
-  for (int i = 0; i < instances_json_array.size(); i++) {
+  for (int i = 0; i < (int)instances_json_array.size(); i++) {
     const Json::Value& instance_json = instances_json_array[i];
     CF_EXPECT(instance_json.isMember(LocalInstance::kJsonInstanceName));
     const std::string instance_name =

--- a/base/cvd/cuttlefish/host/commands/cvd/selector/instance_selector.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/selector/instance_selector.cpp
@@ -60,7 +60,7 @@ Result<InstanceSelector> InstanceSelector::GetSelector(
   }
   if (common_parser.PerInstanceNames()) {
     const auto per_instance_names = common_parser.PerInstanceNames().value();
-    CF_EXPECT_LE(per_instance_names.size(), 1,
+    CF_EXPECT_LE(per_instance_names.size(), 1ul,
                  "Instance Selector only picks up to 1 instance and thus "
                  "only take up to 1 instance_name");
     if (!per_instance_names.empty()) {
@@ -112,7 +112,7 @@ Result<LocalInstance> InstanceSelector::FindDefaultInstance(
     const InstanceDatabase& instance_database) {
   auto group = CF_EXPECT(GetDefaultGroup(instance_database));
   const auto instances = group.Instances();
-  CF_EXPECT_EQ(instances.size(), 1,
+  CF_EXPECT_EQ(instances.size(), 1ul,
                "Default instance is the single instance in the default group.");
   return *instances.cbegin();
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/selector/selector_option_parser_utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/selector/selector_option_parser_utils.h
@@ -33,7 +33,7 @@ Result<void> FilterSelectorFlag(std::vector<std::string>& args,
                                 const std::string& flag_name,
                                 std::optional<T>& value_opt) {
   value_opt = std::nullopt;
-  const int args_initial_size = args.size();
+  const std::size_t args_initial_size = args.size();
   if (args_initial_size == 0) {
     return {};
   }

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/acloud_command.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/acloud_command.cpp
@@ -160,7 +160,7 @@ Result<void> AcloudCommand::PrintBriefSummary(
   ss << std::endl
      << "acloud list or cvd fleet for more information." << std::endl;
   auto n_write = WriteAll(*stream_fd, ss.str());
-  CF_EXPECT_EQ(n_write, ss.str().size());
+  CF_EXPECT_EQ(n_write, (ssize_t)ss.str().size());
   return {};
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/fleet.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/fleet.cpp
@@ -108,7 +108,7 @@ Result<cvd::Response> CvdFleetCommandHandler::Handle(
   output_json["groups"] = groups_json;
   auto serialized_json = output_json.toStyledString();
   CF_EXPECT_EQ(WriteAll(request.Out(), serialized_json),
-               serialized_json.size());
+               (ssize_t)serialized_json.size());
   return ok_response;
 }
 
@@ -124,7 +124,7 @@ bool CvdFleetCommandHandler::IsHelp(const cvd_common::Args& args) const {
 Result<cvd::Status> CvdFleetCommandHandler::CvdFleetHelp(
     const SharedFD& out) const {
   const std::string help_message(kHelpMessage);
-  CF_EXPECT_EQ(WriteAll(out, help_message), help_message.size());
+  CF_EXPECT_EQ(WriteAll(out, help_message), (ssize_t)help_message.size());
   cvd::Status status;
   status.set_code(cvd::Status::OK);
   return status;

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/generic.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/generic.cpp
@@ -338,19 +338,19 @@ CvdGenericCommandHandler::ExtractInfo(const RequestWithStdio& request) {
     auto group_summaries = CF_EXPECT(instance_manager_.GroupSummaryMenu());
     auto& group_summary_menu = group_summaries.menu;
     CF_EXPECT_EQ(WriteAll(request.Out(), group_summary_menu + "\n"),
-                 group_summary_menu.size() + 1);
+                 (ssize_t)group_summary_menu.size() + 1);
     terminal_ = std::make_unique<InterruptibleTerminal>(request.In());
 
     const bool is_tty = request.Err()->IsOpen() && request.Err()->IsATTY();
     while (true) {
       std::string question = fmt::format(
           "For which instance group would you like to run {}? ", subcmd);
-      CF_EXPECT_EQ(WriteAll(request.Out(), question), question.size());
+      CF_EXPECT_EQ(WriteAll(request.Out(), question), (ssize_t)question.size());
 
       std::string input_line = CF_EXPECT(terminal_->ReadLine());
       int selection = -1;
       if (android::base::ParseInt(input_line, &selection)) {
-        const auto n_groups = group_summaries.idx_to_group_name.size();
+        const int n_groups = group_summaries.idx_to_group_name.size();
         if (n_groups <= selection || selection < 0) {
           std::string out_of_range = fmt::format(
               "\n  Selection {}{}{} is beyond the range {}[0, {}]{}\n\n",
@@ -359,7 +359,7 @@ CvdGenericCommandHandler::ExtractInfo(const RequestWithStdio& request) {
               TerminalColor(is_tty, TerminalColors::kCyan), n_groups - 1,
               TerminalColor(is_tty, TerminalColors::kReset));
           CF_EXPECT_EQ(WriteAll(request.Err(), out_of_range),
-                       out_of_range.size());
+                       (ssize_t)out_of_range.size());
           continue;
         }
         chosen_group_name = group_summaries.idx_to_group_name[selection];
@@ -379,7 +379,7 @@ CvdGenericCommandHandler::ExtractInfo(const RequestWithStdio& request) {
           TerminalColor(is_tty, TerminalColors::kBoldRed), chosen_group_name,
           TerminalColor(is_tty, TerminalColors::kReset));
       CF_EXPECT_EQ(WriteAll(request.Err(), cannot_find_group_name),
-                   cannot_find_group_name.size());
+                   (ssize_t)cannot_find_group_name.size());
     }
   }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/handler_proxy.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/handler_proxy.cpp
@@ -49,8 +49,8 @@ class CvdServerHandlerProxy : public CvdServerHandler {
     const auto& selector_opts =
         request.Message().command_request().selector_opts();
     auto all_args = cvd_common::ConvertToArgs(selector_opts.args());
-    CF_EXPECT_GE(all_args.size(), 1);
-    if (all_args.size() == 1) {
+    CF_EXPECT_GE(all_args.size(), 1ul);
+    if (all_args.size() == 1ul) {
       all_args = cvd_common::Args{"cvd", "help"};
     }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/lint.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/lint.cpp
@@ -72,7 +72,7 @@ class LintCommandHandler : public CvdServerHandler {
     message_stream << "Lint of flags and config \"" << config_path
                    << "\" succeeded\n";
     const auto message = message_stream.str();
-    CF_EXPECT_EQ(WriteAll(request.Out(), message), message.size(),
+    CF_EXPECT_EQ(WriteAll(request.Out(), message), (ssize_t)message.size(),
                  "Error writing message");
     cvd::Response response;
     response.mutable_command_response();

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/noop.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/noop.cpp
@@ -43,7 +43,7 @@ class CvdNoopHandler : public CvdServerHandler {
     auto msg = fmt::format("DEPRECATED: The {} command is a no-op",
                            invocation.command);
     auto write_len = WriteAll(request.Out(), msg);
-    CF_EXPECTF(write_len == msg.size(),
+    CF_EXPECTF(write_len == (ssize_t)msg.size(),
                "Failed to write deprecation message: {}",
                request.Out()->StrError());
     cvd::Response response;

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/serial_launch.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/serial_launch.cpp
@@ -211,7 +211,7 @@ class SerialLaunchCommand : public CvdServerHandler {
     auto args = ParseInvocation(request.Message()).arguments;
     for (const auto& arg : args) {
       std::string message = "argument: \"" + arg + "\"\n";
-      CF_EXPECT(WriteAll(request.Err(), message) == message.size());
+      CF_EXPECT(WriteAll(request.Err(), message) == (ssize_t)message.size());
     }
 
     CF_EXPECT(ConsumeFlags(flags, args));
@@ -258,7 +258,7 @@ class SerialLaunchCommand : public CvdServerHandler {
 
     bool is_first = true;
 
-    int index = 0;
+    size_t index = 0;
     for (const auto& device : devices) {
       auto& mkdir_cmd = *req_protos.emplace_back().mutable_command_request();
       *mkdir_cmd.mutable_env() = client_env;
@@ -370,7 +370,7 @@ class SerialLaunchCommand : public CvdServerHandler {
     std::vector<std::string> tokens =
         android::base::Tokenize(path_exclude_root, "/");
     std::string current_dir = "/";
-    for (int i = 0; i < tokens.size(); i++) {
+    for (std::size_t i = 0; i < tokens.size(); i++) {
       current_dir.append(tokens[i]);
       if (!DirectoryExists(current_dir)) {
         output.emplace_back(

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/serial_preset.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/serial_preset.cpp
@@ -61,7 +61,7 @@ class SerialPreset : public CvdServerHandler {
     for (const auto& device : devices->second) {
       cmd.add_args("--device=" + device);
     }
-    for (int i = 1; i < invocation.arguments.size(); i++) {
+    for (std::size_t i = 1; i < invocation.arguments.size(); i++) {
       cmd.add_args(invocation.arguments[i]);
     }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/snapshot.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/snapshot.cpp
@@ -123,8 +123,9 @@ class CvdSnapshotCommandHandler : public CvdServerHandler {
   Result<cvd::Response> HandleHelp(const SharedFD& client_stderr) {
     std::string help_message(kSnapshot);
     help_message.append("\n");
-    CF_EXPECT(WriteAll(client_stderr, help_message) == help_message.size(),
-              "Failed to write the help message");
+    CF_EXPECT(
+        WriteAll(client_stderr, help_message) == (ssize_t)help_message.size(),
+        "Failed to write the help message");
     cvd::Response response;
     response.mutable_command_response();
     response.mutable_status()->set_code(cvd::Status::OK);

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
@@ -111,7 +111,7 @@ void StopHandlingInterruptSignals() {
 }
 
 std::optional<std::string> GetConfigPath(cvd_common::Args& args) {
-  int initial_size = args.size();
+  std::size_t initial_size = args.size();
   std::string config_file;
   std::vector<Flag> config_flags = {
       GflagsCompatFlag("config_file", config_file)};
@@ -515,7 +515,7 @@ static std::ostream& operator<<(std::ostream& out, const cvd_common::Args& v) {
   if (v.empty()) {
     return out;
   }
-  for (int i = 0; i < v.size() - 1; i++) {
+  for (std::size_t i = 0; i < v.size() - 1; i++) {
     out << v.at(i) << " ";
   }
   out << v.back();
@@ -744,7 +744,7 @@ Result<cvd::Response> CvdStartCommandHandler::Handle(
   auto group_json = CF_EXPECT(status_fetcher_.FetchGroupStatus(group, request));
   auto serialized_json = group_json.toStyledString();
   CF_EXPECT_EQ(WriteAll(request.Out(), serialized_json),
-               serialized_json.size());
+               (ssize_t)serialized_json.size());
 
   return FillOutNewInstanceInfo(std::move(response), group_creation_info);
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/status.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/status.cpp
@@ -200,10 +200,10 @@ Result<cvd::Response> CvdStatusCommandHandler::Handle(
 
   std::string serialized_group_json = instances_json.toStyledString();
   CF_EXPECT_EQ(WriteAll(request.Err(), entire_stderr_msg),
-               entire_stderr_msg.size());
+               (ssize_t)entire_stderr_msg.size());
   if (has_print) {
     CF_EXPECT_EQ(WriteAll(request.Out(), serialized_group_json),
-                 serialized_group_json.size());
+                 (ssize_t)serialized_group_json.size());
   }
   return response;
 }
@@ -218,7 +218,7 @@ Result<cvd::Response> CvdStatusCommandHandler::HandleHelp(
   response.mutable_command_response();  // Sets oneof member
   response.mutable_status()->set_code(cvd::Status::OK);
   CF_EXPECT_EQ(WriteAll(request.Out(), kHelpMessage),
-               strnlen(kHelpMessage, sizeof(kHelpMessage) - 1));
+               (ssize_t)strnlen(kHelpMessage, sizeof(kHelpMessage) - 1));
   return response;
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/status_fetcher.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/status_fetcher.cpp
@@ -123,7 +123,7 @@ Result<StatusFetcherOutput> StatusFetcher::FetchOneInstanceStatus(
   CF_EXPECT_GE(ReadAll(redirect_stderr_fd, &status_stderr), 0);
 
   auto instance_status_json = CF_EXPECT(ParseJson(serialized_json));
-  CF_EXPECT_EQ(instance_status_json.size(), 1);
+  CF_EXPECT_EQ(instance_status_json.size(), 1ul);
   instance_status_json = instance_status_json[0];
   static constexpr auto kWebrtcProp = "webrtc_device_id";
   static constexpr auto kNameProp = "instance_name";

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/utils.cpp
@@ -248,7 +248,8 @@ Result<cvd::Response> NoGroupResponse(const RequestWithStdio& request) {
       TerminalColor(is_tty, TerminalColors::kReset),
       TerminalColor(is_tty, TerminalColors::kCyan), uid,
       TerminalColor(is_tty, TerminalColors::kReset));
-  CF_EXPECT_EQ(WriteAll(request.Out(), notice + "\n"), notice.size() + 1);
+  CF_EXPECT_EQ(WriteAll(request.Out(), notice + "\n"),
+               (ssize_t)notice.size() + 1);
 
   response.mutable_status()->set_message(notice);
   return response;
@@ -270,7 +271,8 @@ Result<cvd::Response> NoTTYResponse(const RequestWithStdio& request) {
       TerminalColor(is_tty, TerminalColors::kReset),
       TerminalColor(is_tty, TerminalColors::kCyan), uid,
       TerminalColor(is_tty, TerminalColors::kReset));
-  CF_EXPECT_EQ(WriteAll(request.Out(), notice + "\n"), notice.size() + 1);
+  CF_EXPECT_EQ(WriteAll(request.Out(), notice + "\n"),
+               (ssize_t)notice.size() + 1);
   response.mutable_status()->set_message(notice);
   return response;
 }
@@ -278,7 +280,7 @@ Result<cvd::Response> NoTTYResponse(const RequestWithStdio& request) {
 Result<cvd::Response> WriteToFd(SharedFD fd, const std::string& output) {
   cvd::Response response;
   auto written_size = WriteAll(fd, output);
-  CF_EXPECT_EQ(output.size(), written_size, fd->StrError());
+  CF_EXPECT_EQ((ssize_t)output.size(), written_size, fd->StrError());
   response.mutable_command_response();  // Sets oneof member
   response.mutable_status()->set_code(cvd::Status::OK);
   return response;

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/version.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/version.cpp
@@ -53,7 +53,7 @@ class CvdVersionHandler : public CvdServerHandler {
     version.set_crc32(FileCrc(kServerExecPath));
     auto version_str = fmt::format("{}", version);
     auto write_len = WriteAll(request.Out(), version_str);
-    CF_EXPECTF(write_len == version_str.size(),
+    CF_EXPECTF(write_len == (ssize_t)version_str.size(),
                "Failed to write version output: {}", request.Out()->StrError());
     cvd::Response response;
     response.mutable_status()->set_code(cvd::Status::OK);


### PR DESCRIPTION
This fixes some of the "signed compared to unsigned" errors that scroll by when building with bazel.