### PR TITLE
Rename `super` and `retry_period` config proto fields, keeping the json name

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/parser/fetch_config_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/fetch_config_parser.cpp
@@ -163,8 +163,8 @@ Result<std::vector<std::string>> ParseFetchCvdConfigs(
     auto value = fetch_config.credential_source();
     result.emplace_back(GenerateFlag("credential_source", std::move(value)));
   }
-  if (fetch_config.has_wait_retry_period()) {
-    auto value = fetch_config.wait_retry_period();
+  if (fetch_config.has_wait_retry_period_seconds()) {
+    auto value = fetch_config.wait_retry_period_seconds();
     result.emplace_back(GenerateFlag("wait_retry_period", std::move(value)));
   }
   if (fetch_config.has_external_dns_resolver()) {

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/fetch_config_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/fetch_config_parser.cpp
@@ -42,7 +42,7 @@ bool ShouldFetch(const Instance& instance) {
   const auto& disk = instance.disk();
 
   for (const auto& value :
-       {disk.default_build(), disk.super().system(), boot.kernel().build(),
+       {disk.default_build(), disk.super_partition().system(), boot.kernel().build(),
         boot.kernel().build(), boot.build(), boot.bootloader().build(),
         disk.otatools()}) {
     // expects non-prefixed build strings already converted to empty strings
@@ -73,7 +73,7 @@ Result<Instance> RemoveNonPrefixedBuildStrings(const Instance& instance) {
   disk.set_default_build(CF_EXPECT(GetFetchBuildString(disk.default_build())));
   disk.set_otatools(CF_EXPECT(GetFetchBuildString(disk.otatools())));
 
-  auto& system = *disk.mutable_super()->mutable_system();
+  auto& system = *disk.mutable_super_partition()->mutable_system();
   system = CF_EXPECT(GetFetchBuildString(system));
 
   auto& boot = *result.mutable_boot();
@@ -93,7 +93,7 @@ static std::string DefaultBuild(const Instance& instance) {
 }
 
 static std::string SystemBuild(const Instance& instance) {
-  return instance.disk().super().system();
+  return instance.disk().super_partition().system();
 }
 
 static std::string KernelBuild(const Instance& instance) {

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/load_config.proto
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/load_config.proto
@@ -88,7 +88,7 @@ message Display {
 
 message Disk {
   optional string default_build = 1;
-  optional Super super = 2;
+  optional Super super_partition = 2 [json_name="super"];
   optional bool download_img_zip = 3;
   optional bool download_target_files_zip = 4;
   optional uint32 blank_data_image_mb = 5;

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/load_config.proto
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/load_config.proto
@@ -35,7 +35,7 @@ message Common {
 message Fetch {
   optional string api_key = 1;
   optional string credential_source = 2;
-  optional uint32 wait_retry_period = 3;
+  optional uint32 wait_retry_period_seconds = 3 [json_name="wait_retry_period"];
   optional bool external_dns_resolver = 4;
   optional bool keep_downloaded_archives = 5;
   optional string api_base_url = 6;


### PR DESCRIPTION
The json name is part of our public interface, but the proto name conflicts with a language keyword in one of the supported proto languages.