### PR TITLE
Deserialize the flag values validated in `graphics_config_test.cc`

### DIFF
--- a/base/cvd/cuttlefish/BUILD.bazel
+++ b/base/cvd/cuttlefish/BUILD.bazel
@@ -542,6 +542,7 @@ cc_test(
     deps = [
         ":cuttlefish_common",
         ":cvd_persistent_data",
+        ":launch_cvd_cc_proto",
         ":libcvd",
         "//libbase",
         "@googletest//:gtest",


### PR DESCRIPTION
The protobuf binary format is not guaranteed to be stable, only the deserialization is guaranteed to be stable.

In practice this caused a presubmit failure: http://shortn/_WOVqWc1jIc

Test: bazel run '...'