### PR TITLE
Update secret scrubbing logic in HttpClient

### DIFF
--- a/base/cvd/cuttlefish/host/libs/web/http_client/http_client.cc
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/http_client.cc
@@ -48,7 +48,7 @@ int LoggingCurlDebugFunction(CURL*, curl_infotype type, char* data, size_t size,
   switch (type) {
     case CURLINFO_TEXT:
       LOG(VERBOSE) << "CURLINFO_TEXT ";
-      LOG(INFO) << TrimWhitespace(data, size);
+      LOG(INFO) << ScrubSecrets(TrimWhitespace(data, size));
       break;
     case CURLINFO_HEADER_IN:
       LOG(VERBOSE) << "CURLINFO_HEADER_IN ";

--- a/base/cvd/cuttlefish/host/libs/web/http_client/http_client_util.cc
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/http_client_util.cc
@@ -25,8 +25,8 @@ std::string ScrubSecrets(const std::string& data) {
   // eg [<head>]Authorization: Bearer token_text[<tail>] ->
   //    [<head>]Authorization: Bearer token_...[<tail>]
   result = std::regex_replace(
-      result, std::regex("(Authorization:[ ]+\\S+[ ]+)(\\S{6})\\S*"),
-      "$1$2...");
+      result, std::regex("(.*)([Aa]uthorization:[ ]+\\S+[ ]+)(\\S{6})\\S*"),
+      "$1$2$3...");
   // eg [<head>]client_secret=token_text[<tail>] ->
   //    [<head>]client_secret=token_...[<tail>]
   result = std::regex_replace(

--- a/base/cvd/cuttlefish/host/libs/web/http_client/unittest/http_client_util_test.cc
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/unittest/http_client_util_test.cc
@@ -35,6 +35,8 @@ TEST(HttpClientUtilTest, ScrubSecretsAuthorizationMatch) {
             "Authorization: Bearer 123456... \nnext_line");
   EXPECT_EQ(ScrubSecrets("Authorization: Bearer 1234567890  \nnext_line"),
             "Authorization: Bearer 123456...  \nnext_line");
+  EXPECT_EQ(ScrubSecrets("[text] [authorization: Bearer 1234567890]"),
+            "[text] [authorization: Bearer 123456...");
 }
 
 TEST(HttpClientUtilTest, ScrubSecretsAuthorizationNoMatch) {


### PR DESCRIPTION
The `cvd fetch` output is showing Bearer tokens again.  This updates the regex to catch that case, and applies it to the `CURLINFO_TEXT` type of outputs that the tokens were being output under.

Bug: 341173224
Test: cvd fetch --target_directory=/tmp/cvd/fetch_test --default_build=aosp-main
Test: # search for "Bearer" in the outputs and make sure every case shows a truncated token