### PR TITLE
Download files to a temporary filename first

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/files.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/files.cpp
@@ -28,6 +28,7 @@
 #include <ftw.h>
 #include <libgen.h>
 #include <sched.h>
+#include <stdlib.h>
 #include <sys/ioctl.h>
 #include <sys/select.h>
 #include <sys/socket.h>
@@ -35,6 +36,7 @@
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <unistd.h>
+#include <ext/stdio_filebuf.h>
 
 #include <algorithm>
 #include <array>
@@ -54,6 +56,7 @@
 #include <ratio>
 #include <regex>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <android-base/file.h>
@@ -854,6 +857,18 @@ Result<std::string> EmulateAbsolutePath(const InputPathForm& path_info) {
                "Failed to effectively conduct readpath -f {}", processed_path);
   }
   return real_path;
+}
+
+Result<std::pair<std::filebuf, std::string>> MakeTempFileBuf(
+    const std::string& path) {
+  // mkstemp replaces the Xs with random selections to make a unique filename
+  auto temp_path = path + "XXXXXX";
+  const int fd = mkostemp(temp_path.data(), O_CLOEXEC);
+  CF_EXPECTF(fd != -1, "Error creating temporary file: {}", strerror(errno));
+  __gnu_cxx::stdio_filebuf<char> file_buffer(
+      fd, std::ios::out | std::ios::binary | std::ios::trunc);
+  return std::make_pair<std::filebuf, std::string>(std::move(file_buffer),
+                                                   std::move(temp_path));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/files.h
+++ b/base/cvd/cuttlefish/common/libs/utils/files.h
@@ -19,8 +19,10 @@
 #include <sys/types.h>
 
 #include <chrono>
+#include <fstream>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "common/libs/utils/result.h"
@@ -121,5 +123,8 @@ struct InputPathForm {
  *  but SystemWideUserHome() call fails.
  */
 Result<std::string> EmulateAbsolutePath(const InputPathForm& path_info);
+
+Result<std::pair<std::filebuf, std::string>> MakeTempFileBuf(
+    const std::string& path);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/web/http_client/http_client.cc
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/http_client.cc
@@ -16,10 +16,12 @@
 #include "host/libs/web/http_client/http_client.h"
 
 #include <stdio.h>
+#include <ext/stdio_filebuf.h>
 
-#include <fstream>
 #include <functional>
+#include <memory>
 #include <mutex>
+#include <ostream>
 #include <regex>
 #include <sstream>
 #include <string>
@@ -31,6 +33,7 @@
 #include <curl/curl.h>
 #include <json/json.h>
 
+#include "common/libs/utils/files.h"
 #include "common/libs/utils/json.h"
 #include "common/libs/utils/subprocess.h"
 #include "host/libs/web/http_client/http_client_util.h"
@@ -168,16 +171,18 @@ class CurlClient : public HttpClient {
       const std::string& url, const std::string& path,
       const std::vector<std::string>& headers) {
     LOG(INFO) << "Attempting to save \"" << url << "\" to \"" << path << "\"";
-    std::fstream stream;
-    auto callback = [&stream, path](char* data, size_t size) -> bool {
+
+    auto [fbuf, temp_path] = CF_EXPECT(MakeTempFileBuf(path));
+    std::ostream stream(&fbuf);
+    auto callback = [&stream](char* data, size_t size) -> bool {
       if (data == nullptr) {
-        stream.open(path, std::ios::out | std::ios::binary | std::ios::trunc);
         return !stream.fail();
       }
       stream.write(data, size);
       return !stream.fail();
     };
     auto http_response = CF_EXPECT(DownloadToCallback(callback, url, headers));
+    CF_EXPECT(RenameFile(temp_path, path));
     return HttpResponse<std::string>{path, http_response.http_code};
   }
 


### PR DESCRIPTION
Intended to avoid issues with multiple fetches interacting with the local cache at the same time.  Uses `mkstemp` to get a guaranteed unique filename+fd to download to.

Test: cvd fetch --target_directory=/tmp/cvd/fetch_test --default_build=aosp-main