### PR TITLE
installbazel.sh Install symlink to /usr/bin/bazel in arm64

### DIFF
--- a/base/debian/rules
+++ b/base/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 # Start build by executing:
-# $ debuild --no-tgz-check -us -uc
+# $ debuild --prepend-path /usr/local/bin --no-tgz-check -us -uc
 
 # Uncomment this line out to make installation process more chatty.
 # Keep it on until we know there's no outstanding problems with installation.

--- a/build_debs.sh
+++ b/build_debs.sh
@@ -41,7 +41,7 @@ for dsc in *.dsc; do
   dir="$(basename "${dsc}" .dsc)"
   dir="${dir/_/-}"
   pushd "${dir}/"
-  debuild -uc -us
+  debuild --prepend-path /usr/local/bin -uc -us
   popd
 done
 

--- a/frontend/debian/rules
+++ b/frontend/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 # Start build by executing:
-# $ debuild --no-tgz-check -us -uc
+# $ debuild --prepend-path /usr/local/bin --no-tgz-check -us -uc
 
 # Uncomment this line out to make installation process more chatty.
 # Keep it on until we know there's no outstanding problems with installation.

--- a/tools/buildutils/build_packages.sh
+++ b/tools/buildutils/build_packages.sh
@@ -18,7 +18,7 @@ function build_package() {
   echo "Installing package dependencies"
   sudo mk-build-deps -i -t 'apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y'
   echo "Building packages"
-  debuild -i -uc -us -b
+  debuild --prepend-path /usr/local/bin -i -uc -us -b
   popd
 }
 


### PR DESCRIPTION
We are seeing build errors on our ARM64 Ubuntu 24.04 servers, if they have either the default bazel installed, or no bazel installed.    This commit resolves the issue.  I believe adding `--prepend-path /usr/local/bin` to the `debuild` commands would also work.