### PR TITLE
Fix warnings and version tag

### DIFF
--- a/base/cvd/.bazelrc
+++ b/base/cvd/.bazelrc
@@ -1,1 +1,3 @@
 build --copt=-fdiagnostics-color=always
+# hide warning from protobuf code
+build --output_filter='^//(allocd|cuttlefish):'

--- a/base/cvd/BUILD.bazel
+++ b/base/cvd/BUILD.bazel
@@ -1,10 +1,3 @@
 package(
     default_visibility = ["//visibility:public"],
 )
-
-genrule(
-    name = "build_version_header",
-    srcs = ["build_version.h.in"],
-    outs = ["build/version.h"],
-    cmd = "sed -e \"s|@VCS_TAG@|`git describe`|\" $< > $@",
-)

--- a/base/cvd/allocd/utils.cpp
+++ b/base/cvd/allocd/utils.cpp
@@ -126,6 +126,7 @@ std::string ReqTyToStr(RequestType req_ty) {
     case RequestType::ID:
       return "id";
   }
+  abort();
 }
 
 RequestType StrToReqTy(const std::string& req) {
@@ -157,6 +158,7 @@ std::string StatusToStr(RequestStatus st) {
     case RequestStatus::Failure:
       return "failure";
   }
+  abort();
 }
 
 std::string IfaceTyToStr(IfaceType iface) {
@@ -176,6 +178,7 @@ std::string IfaceTyToStr(IfaceType iface) {
     case IfaceType::ebr:
       return "ebr";
   }
+  abort();
 }
 
 IfaceType StrToIfaceTy(const std::string& iface) {

--- a/base/cvd/cuttlefish/BUILD.bazel
+++ b/base/cvd/cuttlefish/BUILD.bazel
@@ -88,6 +88,7 @@ cc_library(
     ],
     copts = [
         "-std=c++17",
+        "-Werror=sign-compare",
     ],
     linkopts = ["-lcurl"],
     strip_include_prefix = "//cuttlefish",
@@ -537,6 +538,7 @@ cc_test(
     ],
     copts = [
         "-Wno-ctad-maybe-unsupported",
+        "-Werror=sign-compare",
         "-Ithird_party/android_cuttlefish/base/cvd/cuttlefish",
         "-std=c++17",
     ],

--- a/base/cvd/cuttlefish/BUILD.bazel
+++ b/base/cvd/cuttlefish/BUILD.bazel
@@ -167,7 +167,6 @@ cc_proto_library(
 cc_library(
     name = "libcvd",
     srcs = [
-        "//:build_version_header",
         "host/commands/assemble_cvd/flags_defaults.h",
         "host/commands/cvd/acloud/config.cpp",
         "host/commands/cvd/acloud/config.h",
@@ -353,6 +352,7 @@ cc_library(
         "host/commands/cvd/selector/data_viewer.cpp",
     ],
     hdrs = [
+        "build/version.h",
         "host/commands/assemble_cvd/flags_defaults.h",
         "host/commands/cvd/acloud/config.h",
         "host/commands/cvd/acloud/converter.h",
@@ -463,7 +463,6 @@ cc_library(
         ":launch_cvd_cc_proto",
         ":load_config_cc_proto",
         ":user_config_cc_proto",
-        "//:build_version_header",
         "//libbase",
         "//libsparse",
         "@fmt",
@@ -471,6 +470,7 @@ cc_library(
         "@jsoncpp",
         "@tinyxml2",
     ],
+    linkstamp = "build/version.cpp",
 )
 
 cc_binary(

--- a/base/cvd/cuttlefish/build/version.cpp
+++ b/base/cvd/cuttlefish/build/version.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string>
+
+namespace android {
+namespace build {
+
+std::string GetBuildNumber() {
+  return std::to_string(BUILD_TIMESTAMP);
+}
+
+} // namespace build
+} // namespace android
+

--- a/base/cvd/cuttlefish/build/version.h
+++ b/base/cvd/cuttlefish/build/version.h
@@ -22,9 +22,7 @@
 namespace android {
 namespace build {
 
-constexpr char* GetBuildNumber() {
-  return "@VCS_TAG@";
-}
+std::string GetBuildNumber();
 
 } // namespace build
 } // namespace android

--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd.cpp
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd.cpp
@@ -425,7 +425,7 @@ SharedFD SharedFD::MemfdCreate(const std::string& name, unsigned int flags) {
 
 SharedFD SharedFD::MemfdCreateWithData(const std::string& name, const std::string& data, unsigned int flags) {
   auto memfd = MemfdCreate(name, flags);
-  if (WriteAll(memfd, data) != data.size()) {
+  if (WriteAll(memfd, data) != (ssize_t)data.size()) {
     return ErrorFD(errno);
   }
   if (memfd->LSeek(0, SEEK_SET) != 0) {
@@ -758,7 +758,7 @@ SharedFD SharedFD::VsockClient(unsigned int cid, unsigned int port, int type,
 
     const std::string expected_res = fmt::format("OK {}\n", port);
     std::string actual_res(expected_res.length(), ' ');
-    if (ReadExact(client, &actual_res) != expected_res.length()) {
+    if (ReadExact(client, &actual_res) != (ssize_t)expected_res.length()) {
       client->Close();
       LOG(ERROR) << "cannot connect to " << cid << ":" << port;
       return client;

--- a/base/cvd/cuttlefish/common/libs/utils/files.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/files.cpp
@@ -205,7 +205,7 @@ Result<void> ChangeGroup(const std::string& path,
                          const std::string& group_name) {
   auto groupId = GroupIdFromName(group_name);
 
-  if (groupId == -1) {
+  if (groupId == (gid_t)-1) {
     return CF_ERR("Failed to get group id: ") << group_name;
   }
 

--- a/base/cvd/cuttlefish/common/libs/utils/flag_parser.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/flag_parser.cpp
@@ -197,7 +197,7 @@ Result<Flag::FlagProcessResult> Flag::Process(
 }
 
 Result<void> Flag::Parse(std::vector<std::string>& arguments) const {
-  for (int i = 0; i < arguments.size();) {
+  for (size_t i = 0; i < arguments.size();) {
     std::string arg = arguments[i];
     std::optional<std::string> next_arg;
     if (i < arguments.size() - 1) {

--- a/base/cvd/cuttlefish/common/libs/utils/proc_file_utils.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/proc_file_utils.cpp
@@ -68,7 +68,7 @@ static Result<ProcStatusUids> OwnerUids(const pid_t pid) {
       continue;
     }
     // the line, then 4 uids
-    CF_EXPECT_EQ(matches.size(), 5,
+    CF_EXPECT_EQ(matches.size(), 5ul,
                  fmt::format("Error in the Uid line: \"{}\"", line));
     uids.reserve(4);
     for (int i = 1; i < 5; i++) {
@@ -126,7 +126,7 @@ static std::vector<std::string> TokenizeByNullChar(const std::string& input) {
   }
   std::vector<std::string> tokens;
   std::string token;
-  for (int i = 0; i < input.size(); i++) {
+  for (size_t i = 0; i < input.size(); i++) {
     if (input.at(i) != '\0') {
       token.append(1, input.at(i));
     } else {

--- a/base/cvd/cuttlefish/common/libs/utils/unique_resource_allocator.h
+++ b/base/cvd/cuttlefish/common/libs/utils/unique_resource_allocator.h
@@ -148,13 +148,13 @@ class UniqueResourceAllocator {
   }
 
   // gives n unique integers from the pool, and then remove them from the pool
-  std::optional<ReservationSet> UniqueItems(const int n) {
+  std::optional<ReservationSet> UniqueItems(const size_t n) {
     std::lock_guard<std::mutex> lock(mutex_);
     if (n <= 0 || available_resources_.size() < n) {
       return std::nullopt;
     }
     ReservationSet result;
-    for (int i = 0; i < n; i++) {
+    for (size_t i = 0; i < n; i++) {
       auto itr = available_resources_.begin();
       result.insert(Reservation{*this, *(RemoveFromPool(itr))});
     }

--- a/base/cvd/cuttlefish/common/libs/utils/unique_resource_allocator_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/unique_resource_allocator_test.cpp
@@ -33,7 +33,7 @@ TEST_P(OneEachTest, GetAnyAvailableOne) {
   using Reservation = UniqueResourceAllocator<unsigned>::Reservation;
 
   std::vector<Reservation> allocated;
-  for (int i = 0; i < resources.size(); i++) {
+  for (size_t i = 0; i < resources.size(); i++) {
     auto id_opt = allocator->UniqueItem();
     ASSERT_TRUE(id_opt);
     ASSERT_TRUE(Contains(expected_ids, id_opt->Get()));

--- a/base/cvd/cuttlefish/common/libs/utils/unix_sockets_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/unix_sockets_test.cpp
@@ -30,7 +30,7 @@ namespace cuttlefish {
 
 SharedFD CreateMemFDWithData(const std::string& data) {
   auto memfd = SharedFD::MemfdCreate("");
-  CHECK(WriteAll(memfd, data) == data.size()) << memfd->StrError();
+  CHECK(WriteAll(memfd, data) == (ssize_t)data.size()) << memfd->StrError();
   CHECK(memfd->LSeek(0, SEEK_SET) == 0);
   return memfd;
 }

--- a/base/cvd/cuttlefish/host/libs/config/host_tools_version.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/host_tools_version.cpp
@@ -63,7 +63,7 @@ static std::map<std::string, uint32_t> DirectoryCrc(const std::string& path) {
         std::async(FileCrc, DefaultHostArtifactsPath(file)));
   }
   std::map<std::string, uint32_t> crcs;
-  for (int i = 0; i < files.size(); i++) {
+  for (size_t i = 0; i < files.size(); i++) {
     crcs[files[i]] = calculations[i].get();
   }
   return crcs;

--- a/base/cvd/cuttlefish/host/libs/config/instance_nums.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/instance_nums.cpp
@@ -224,7 +224,7 @@ Result<std::vector<std::int32_t>> InstanceNumsCalculator::CalculateFromFlags() {
 
   if (instance_nums_opt) {
     if (num_instances_) {
-      CF_EXPECT(instance_nums_.size() == *num_instances_);
+      CF_EXPECT(instance_nums_.size() == (size_t)*num_instances_);
     }
     CF_EXPECT(instance_nums_.size() > 0, "no instance nums");
     return instance_nums_;

--- a/base/cvd/cuttlefish/host/libs/web/credential_source.cc
+++ b/base/cvd/cuttlefish/host/libs/web/credential_source.cc
@@ -228,7 +228,7 @@ Result<RefreshCredentialSource> RefreshCredentialSource::FromOauth2ClientFile(
     auto& cache = json["cache"];
     CF_EXPECT_EQ(cache.type(), Json::ValueType::arrayValue);
 
-    CF_EXPECT_EQ(cache.size(), 1);
+    CF_EXPECT_EQ(cache.size(), 1ul);
     auto& cache_first = cache[0];
     CF_EXPECT_EQ(cache_first.type(), Json::ValueType::objectValue);
 
@@ -324,7 +324,7 @@ ServiceAccountOauthCredentialSource::FromJson(HttpClient& http_client,
   std::unique_ptr<BIO, int (*)(BIO*)> bo(CF_EXPECT(BIO_new(BIO_s_mem())),
                                          BIO_free);
   CF_EXPECT(BIO_write(bo.get(), key_str.c_str(), key_str.size()) ==
-            key_str.size());
+            (ssize_t)key_str.size());
 
   auto pkey = CF_EXPECT(PEM_read_bio_PrivateKey(bo.get(), nullptr, 0, 0),
                         CollectSslErrors());


### PR DESCRIPTION
There are no warnings with `bazel build '...'` in `base/cvd` after this PR.

Will make comparable changes to AOSP later.

Within `base/cvd`, warnings are hidden outside of `allocd` and `cuttlefish`.

The `@VCS_TAG` logic wasn't working in bazel, because bazel hides the git repository and it was producing an empty string.