### PR TITLE
Use --spawn_strategy=local

### DIFF
--- a/base/debian/rules
+++ b/base/debian/rules
@@ -21,6 +21,6 @@ override_dh_installinit:
 	dh_installinit
 
 override_dh_auto_build:
-	cd cvd && bazel build cuttlefish:cvd
+	cd cvd && bazel build cuttlefish:cvd --spawn_strategy=local
 	dh_auto_build
 


### PR DESCRIPTION
- Using default `sandboxed` fails when building `cvd` from within a Docker container.
```
src/main/tools/linux-sandbox-pid1.cc:296: "mount(/home/vsoc-01/host/android-cuttlefish/base/cvd, /home/vsoc-01/.cache/bazel/_bazel_root/203f6c8d8088079d67a8fa6691f64c87/sandbox/linux-sandbox/11/_hermetic_tmp/bazel-source-roots/1, nullptr, MS_BIND | MS_REC, nullptr)": Permission denied
```