### PR TITLE
Removing ext/stdio_filebuf.h include

### DIFF
--- a/base/cvd/cuttlefish/BUILD.bazel
+++ b/base/cvd/cuttlefish/BUILD.bazel
@@ -4,6 +4,7 @@ cc_library(
         "common/libs/fs/epoll.cpp",
         "common/libs/fs/shared_buf.cc",
         "common/libs/fs/shared_fd.cpp",
+        "common/libs/fs/shared_fd_stream.cpp",
         "common/libs/utils/archive.cpp",
         "common/libs/utils/base64.cpp",
         "common/libs/utils/environment.cpp",

--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd.h
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd.h
@@ -38,6 +38,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -155,6 +156,8 @@ class SharedFD {
   static SharedFD MemfdCreate(const std::string& name, unsigned int flags = 0);
   static SharedFD MemfdCreateWithData(const std::string& name, const std::string& data, unsigned int flags = 0);
   static SharedFD Mkstemp(std::string* path);
+  static Result<std::pair<SharedFD, std::string>> Mkostemp(
+      const std::string_view path, const int flags = O_CLOEXEC);
   static int Poll(PollSharedFd* fds, size_t num_fds, int timeout);
   static int Poll(std::vector<PollSharedFd>& fds, int timeout);
   static bool SocketPair(int domain, int type, int protocol, SharedFD* fd0,

--- a/base/cvd/cuttlefish/common/libs/utils/files.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/files.cpp
@@ -36,7 +36,6 @@
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <unistd.h>
-#include <ext/stdio_filebuf.h>
 
 #include <algorithm>
 #include <array>
@@ -857,18 +856,6 @@ Result<std::string> EmulateAbsolutePath(const InputPathForm& path_info) {
                "Failed to effectively conduct readpath -f {}", processed_path);
   }
   return real_path;
-}
-
-Result<std::pair<std::filebuf, std::string>> MakeTempFileBuf(
-    const std::string& path) {
-  // mkstemp replaces the Xs with random selections to make a unique filename
-  auto temp_path = path + "XXXXXX";
-  const int fd = mkostemp(temp_path.data(), O_CLOEXEC);
-  CF_EXPECTF(fd != -1, "Error creating temporary file: {}", strerror(errno));
-  __gnu_cxx::stdio_filebuf<char> file_buffer(
-      fd, std::ios::out | std::ios::binary | std::ios::trunc);
-  return std::make_pair<std::filebuf, std::string>(std::move(file_buffer),
-                                                   std::move(temp_path));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/files.h
+++ b/base/cvd/cuttlefish/common/libs/utils/files.h
@@ -124,7 +124,4 @@ struct InputPathForm {
  */
 Result<std::string> EmulateAbsolutePath(const InputPathForm& path_info);
 
-Result<std::pair<std::filebuf, std::string>> MakeTempFileBuf(
-    const std::string& path);
-
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/web/http_client/http_client.cc
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/http_client.cc
@@ -33,6 +33,8 @@
 #include <curl/curl.h>
 #include <json/json.h>
 
+#include "common/libs/fs/shared_fd.h"
+#include "common/libs/fs/shared_fd_stream.h"
 #include "common/libs/utils/files.h"
 #include "common/libs/utils/json.h"
 #include "common/libs/utils/subprocess.h"
@@ -172,8 +174,8 @@ class CurlClient : public HttpClient {
       const std::vector<std::string>& headers) {
     LOG(INFO) << "Attempting to save \"" << url << "\" to \"" << path << "\"";
 
-    auto [fbuf, temp_path] = CF_EXPECT(MakeTempFileBuf(path));
-    std::ostream stream(&fbuf);
+    auto [shared_fd, temp_path] = CF_EXPECT(SharedFD::Mkostemp(path));
+    SharedFDOstream stream(shared_fd);
     auto callback = [&stream](char* data, size_t size) -> bool {
       if (data == nullptr) {
         return !stream.fail();


### PR DESCRIPTION
Fails to build in google3.  

Since this is now a `SharedFD`-based operation, I moved the logic there instead of `files.h/cpp`

Bug: 348040850
Test: cvd fetch --target_directory=/tmp/cvd/fetch-test --default_build=aosp-main