### PR TITLE
Actually remove extension header include

### DIFF
--- a/base/cvd/cuttlefish/host/libs/web/http_client/http_client.cc
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/http_client.cc
@@ -16,7 +16,6 @@
 #include "host/libs/web/http_client/http_client.h"
 
 #include <stdio.h>
-#include <ext/stdio_filebuf.h>
 
 #include <functional>
 #include <memory>


### PR DESCRIPTION
I forgot to remove the include when I removed the dependency on it.

Test: build