### PR TITLE
Add --retry to curl in nodejs installation

### DIFF
--- a/frontend/setup-nodejs-env.sh
+++ b/frontend/setup-nodejs-env.sh
@@ -26,8 +26,8 @@ install_nodejs() {
   uninstall_nodejs
   mkdir -p $NODE_ROOT
   pushd $NODE_ROOT >/dev/null
-  curl https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-$NODE_DISTRO.tar.xz -O
-  curl https://nodejs.org/dist/$NODE_VERSION/SHASUMS256.txt -O
+  curl https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-$NODE_DISTRO.tar.xz -O --retry 3 --retry_delay 3
+  curl https://nodejs.org/dist/$NODE_VERSION/SHASUMS256.txt -O --retry 3 --retry_delay 3
   if ! echo "$NODE_SHA256SUM node-$NODE_VERSION-$NODE_DISTRO.tar.xz" | sha256sum -c ; then
     echo "** ERROR: KEY MISMATCH **"; popd >/dev/null; exit 1;
   fi

--- a/frontend/setup-nodejs-env.sh
+++ b/frontend/setup-nodejs-env.sh
@@ -26,8 +26,8 @@ install_nodejs() {
   uninstall_nodejs
   mkdir -p $NODE_ROOT
   pushd $NODE_ROOT >/dev/null
-  curl https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-$NODE_DISTRO.tar.xz -O --retry 3 --retry_delay 3
-  curl https://nodejs.org/dist/$NODE_VERSION/SHASUMS256.txt -O --retry 3 --retry_delay 3
+  curl https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-$NODE_DISTRO.tar.xz -O --retry 3
+  curl https://nodejs.org/dist/$NODE_VERSION/SHASUMS256.txt -O --retry 3
   if ! echo "$NODE_SHA256SUM node-$NODE_VERSION-$NODE_DISTRO.tar.xz" | sha256sum -c ; then
     echo "** ERROR: KEY MISMATCH **"; popd >/dev/null; exit 1;
   fi


### PR DESCRIPTION
This curl occasionally fails, adding --retry manually has resolved the issue for us

> curl: (92) HTTP/2 stream 1 was not closed cleanly: INTERNAL_ERROR (err 2)
> node-v16.17.0-linux-x64.tar.xz: FAILED
> sha256sum: WARNING: 1 computed checksum did NOT match