### PR TITLE
Default host orchestrator port to 2080.

### DIFF
--- a/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.default
+++ b/frontend/debian/cuttlefish-orchestration.cuttlefish-host_orchestrator.default
@@ -5,8 +5,8 @@
 orchestrator_listen_address=0.0.0.0
 #
 # The port on which the orchestrator server should listen on for plain HTTP.
-# Defaults to 2081.
-# orchestrator_http_port=
+# Defaults to 2080.
+orchestrator_http_port=2081
 #
 # Android Build URL. Defaults to "https://androidbuildinternal.googleapis.com"
 # orchestrator_android_build_url=

--- a/frontend/src/host_orchestrator/main.go
+++ b/frontend/src/host_orchestrator/main.go
@@ -100,7 +100,7 @@ func newOperatorProxy(port int) *httputil.ReverseProxy {
 }
 
 func main() {
-	httpPort := flag.Int("http_port", 2081, "Port to listen on for HTTP requests.")
+	httpPort := flag.Int("http_port", 2080, "Port to listen on for HTTP requests.")
 	cvdUser := flag.String("cvd_user", "", "User to execute cvd as.")
 	operatorPort := flag.Int("operator_http_port", 1080, "Port where the operator is listening.")
 	abURL := flag.String("android_build_url", defaultAndroidBuildURL, "URL to an Android Build API.")


### PR DESCRIPTION
- When using nginx, use 2081 instead.