### PR TITLE
Update help text on most commands

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/acloud_mixsuperimage.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/acloud_mixsuperimage.cpp
@@ -170,7 +170,14 @@ class AcloudMixSuperImageCommand : public CvdServerHandler {
     return false;
   }
 
+  // not intended to be used by the user
   cvd_common::Args CmdList() const override { return {}; }
+  // not intended to show up in help
+  Result<std::string> SummaryHelp() const override { return ""; }
+  bool ShouldInterceptHelp() const { return false; }
+  Result<std::string> DetailedHelp(std::vector<std::string>&) const override {
+    return "";
+  }
 
   Result<cvd::Response> Handle(const RequestWithStdio& request) override {
     CF_EXPECT(CanHandle(request));

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/acloud_translator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/acloud_translator.cpp
@@ -54,7 +54,14 @@ class AcloudTranslatorCommand : public CvdServerHandler {
     return false;
   }
 
+  // not intended to be used by the user
   cvd_common::Args CmdList() const override { return {}; }
+  // not intended to show up in help
+  Result<std::string> SummaryHelp() const override { return ""; }
+  bool ShouldInterceptHelp() const { return false; }
+  Result<std::string> DetailedHelp(std::vector<std::string>&) const override {
+    return "";
+  }
 
   Result<cvd::Response> Handle(const RequestWithStdio& request) override {
     CF_EXPECT(CanHandle(request));

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/cmd_list.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/cmd_list.cpp
@@ -57,6 +57,12 @@ class CvdCmdlistHandler : public CvdServerHandler {
 
   // not intended to be used by the user
   cvd_common::Args CmdList() const override { return {}; }
+  // not intended to show up in help
+  Result<std::string> SummaryHelp() const override { return ""; }
+  bool ShouldInterceptHelp() const { return false; }
+  Result<std::string> DetailedHelp(std::vector<std::string>&) const override {
+    return "";
+  }
 
  private:
   CommandSequenceExecutor& executor_;

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/generic.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/generic.cpp
@@ -42,6 +42,12 @@
 #include "host/commands/cvd/types.h"
 
 namespace cuttlefish {
+namespace {
+
+constexpr char kSummaryHelpText[] =
+    "Run cvd <command> --help for command description";
+
+}  // namespace
 
 class CvdGenericCommandHandler : public CvdServerHandler {
  public:
@@ -53,6 +59,9 @@ class CvdGenericCommandHandler : public CvdServerHandler {
   Result<bool> CanHandle(const RequestWithStdio& request) const override;
   Result<cvd::Response> Handle(const RequestWithStdio& request) override;
   cvd_common::Args CmdList() const override;
+  Result<std::string> SummaryHelp() const override;
+  bool ShouldInterceptHelp() const override;
+  Result<std::string> DetailedHelp(std::vector<std::string>&) const override;
 
  private:
   struct CommandInvocationInfo {
@@ -233,6 +242,23 @@ std::vector<std::string> CvdGenericCommandHandler::CmdList() const {
     subcmd_list.emplace_back(cmd);
   }
   return subcmd_list;
+}
+
+Result<std::string> CvdGenericCommandHandler::SummaryHelp() const {
+  return kSummaryHelpText;
+}
+
+bool CvdGenericCommandHandler::ShouldInterceptHelp() const { return false; }
+
+Result<std::string> CvdGenericCommandHandler::DetailedHelp(
+    std::vector<std::string>& arguments) const {
+  static constexpr char kDetailedHelpText[] =
+      "Run cvd {} --help for full help text";
+  std::string replacement = "<command>";
+  if (!arguments.empty()) {
+    replacement = arguments.front();
+  }
+  return fmt::format(kDetailedHelpText, replacement);
 }
 
 Result<CvdGenericCommandHandler::BinPathInfo>

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/handler_proxy.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/handler_proxy.cpp
@@ -109,6 +109,12 @@ class CvdServerHandlerProxy : public CvdServerHandler {
 
   // not intended to be used by the user
   cvd_common::Args CmdList() const override { return {}; }
+  // not intended to show up in help
+  Result<std::string> SummaryHelp() const override { return ""; }
+  bool ShouldInterceptHelp() const { return false; }
+  Result<std::string> DetailedHelp(std::vector<std::string>&) const override {
+    return "";
+  }
 
  private:
   CommandSequenceExecutor& executor_;

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/help.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/help.cpp
@@ -69,6 +69,8 @@ Example usage:
   cvd help <command> - displays more detailed help for the specific command
 )";
 
+constexpr char kIgnorableHandlerCommand[] = "experimental";
+
 }  // namespace
 
 class CvdHelpHandler : public CvdServerHandler {
@@ -124,7 +126,7 @@ class CvdHelpHandler : public CvdServerHandler {
       std::string command_list = android::base::Join(handler->CmdList(), ", ");
       // exclude commands without any command list values as not intended for
       // use by users or sub-subcommands
-      if (!command_list.empty()) {
+      if (!command_list.empty() && command_list != kIgnorableHandlerCommand) {
         help_message << "\t" << command_list << " - ";
         help_message << CF_EXPECT(handler->SummaryHelp()) << std::endl
                      << std::endl;

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/noop.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/noop.cpp
@@ -56,6 +56,12 @@ class CvdNoopHandler : public CvdServerHandler {
   }
 
   Result<std::string> SummaryHelp() const override { return kSummaryHelpText; }
+
+  bool ShouldInterceptHelp() const override { return true; }
+
+  Result<std::string> DetailedHelp(std::vector<std::string>&) const override {
+    return "DEPRECATED: This command is a no-op";
+  }
 };
 
 }  // namespace

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/power.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/power.cpp
@@ -16,12 +16,14 @@
 
 #include "host/commands/cvd/server_command/power.h"
 
-#include <android-base/strings.h>
-
 #include <functional>
 #include <optional>
 #include <sstream>
 #include <string>
+#include <vector>
+
+#include <android-base/strings.h>
+#include <fmt/format.h>
 
 #include "common/libs/fs/shared_buf.h"
 #include "common/libs/utils/contains.h"
@@ -36,6 +38,13 @@
 #include "host/commands/cvd/types.h"
 
 namespace cuttlefish {
+namespace {
+
+constexpr char kSummaryHelpText[] =
+    "Trigger power button event on the device, reset device to first boot "
+    "state, restart device";
+
+}  // namespace
 
 class CvdDevicePowerCommandHandler : public CvdServerHandler {
  public:
@@ -91,6 +100,21 @@ class CvdDevicePowerCommandHandler : public CvdServerHandler {
       valid_ops.push_back(op);
     }
     return valid_ops;
+  }
+
+  Result<std::string> SummaryHelp() const override { return kSummaryHelpText; }
+
+  bool ShouldInterceptHelp() const override { return false; }
+
+  Result<std::string> DetailedHelp(
+      std::vector<std::string>& arguments) const override {
+    static constexpr char kDetailedHelpText[] =
+        "Run cvd {} --help for full help text";
+    std::string replacement = "<command>";
+    if (!arguments.empty()) {
+      replacement = arguments.front();
+    }
+    return fmt::format(kDetailedHelpText, replacement);
   }
 
  private:

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/serial_launch.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/serial_launch.cpp
@@ -134,6 +134,12 @@ class SerialLaunchCommand : public CvdServerHandler {
   }
 
   cvd_common::Args CmdList() const override { return {"experimental"}; }
+  // not intended to show up in help
+  Result<std::string> SummaryHelp() const override { return ""; }
+  bool ShouldInterceptHelp() const { return false; }
+  Result<std::string> DetailedHelp(std::vector<std::string>&) const override {
+    return "";
+  }
 
   Result<DemoCommandSequence> CreateCommandSequence(
       const RequestWithStdio& request) {

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/serial_preset.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/serial_preset.cpp
@@ -75,6 +75,12 @@ class SerialPreset : public CvdServerHandler {
   }
 
   cvd_common::Args CmdList() const override { return {"experimental"}; }
+  // not intended to show up in help
+  Result<std::string> SummaryHelp() const override { return ""; }
+  bool ShouldInterceptHelp() const { return false; }
+  Result<std::string> DetailedHelp(std::vector<std::string>&) const override {
+    return "";
+  }
 
  private:
   CommandSequenceExecutor& executor_;

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/server_handler.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/server_handler.h
@@ -33,14 +33,10 @@ class CvdServerHandler {
   virtual Result<cvd::Response> Handle(const RequestWithStdio&) = 0;
   // returns the list of subcommand it can handle
   virtual cvd_common::Args CmdList() const = 0;
-  // TODO make pure virtual once every implementation has overrides
-  virtual Result<std::string> SummaryHelp() const {
-    return "Consider contributing a CL with help text if you read this :)";
-  }
-  virtual bool ShouldInterceptHelp() const { return false; }
-  virtual Result<std::string> DetailedHelp(std::vector<std::string>&) const {
-    return "Consider contributing a CL with help text if you read this :)";
-  }
+  // used for command help text
+  virtual Result<std::string> SummaryHelp() const = 0;
+  virtual bool ShouldInterceptHelp() const = 0;
+  virtual Result<std::string> DetailedHelp(std::vector<std::string>&) const = 0;
 };
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
@@ -56,6 +56,12 @@
 namespace cuttlefish {
 namespace {
 
+constexpr char kSummaryHelpText[] =
+    "Start a Cuttlefish virtual device or environment";
+
+constexpr char kDetailedHelpText[] =
+    "Run cvd start --help for the full help text.";
+
 std::optional<std::string> GetConfigPath(cvd_common::Args& args) {
   std::size_t initial_size = args.size();
   std::string config_file;
@@ -218,6 +224,9 @@ class CvdStartCommandHandler : public CvdServerHandler {
   Result<bool> CanHandle(const RequestWithStdio& request) const override;
   Result<cvd::Response> Handle(const RequestWithStdio& request) override;
   std::vector<std::string> CmdList() const override;
+  Result<std::string> SummaryHelp() const override;
+  bool ShouldInterceptHelp() const override;
+  Result<std::string> DetailedHelp(std::vector<std::string>&) const override;
 
  private:
   Result<cvd::Response> LaunchDevice(Command command,
@@ -869,6 +878,19 @@ std::vector<std::string> CvdStartCommandHandler::CmdList() const {
     subcmd_list.emplace_back(cmd);
   }
   return subcmd_list;
+}
+
+Result<std::string> CvdStartCommandHandler::SummaryHelp() const {
+  return kSummaryHelpText;
+}
+
+// TODO(b/315027339): Swap to true.  Will likely need to add `cvd::Request` as a
+// parameter of DetailedHelp to match current implementation
+bool CvdStartCommandHandler::ShouldInterceptHelp() const { return false; }
+
+Result<std::string> CvdStartCommandHandler::DetailedHelp(
+    std::vector<std::string>&) const {
+  return kDetailedHelpText;
 }
 
 const std::array<std::string, 2> CvdStartCommandHandler::supported_commands_{

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/try_acloud.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/try_acloud.cpp
@@ -37,6 +37,19 @@ namespace {
 
 constexpr char kCvdrBinName[] = "cvdr";
 
+constexpr char kSummaryHelpText[] =
+    "Test whether an `acloud CLI` command could be satisfied using either "
+    "`cvd` or `cvdr`";
+
+constexpr char kDetailedHelpText[] =
+    R"(cvd try-acloud - verifies whether an original `acloud CLI` command
+    could be satisfied using either:
+   
+    - `cvd` for local instance management, determined by flag
+    `--local-instance`.
+   
+    - Or `cvdr` for remote instance management.)";
+
 bool CheckIfCvdrExist() {
   auto cmd = Command("which").AddParameter(kCvdrBinName);
   int ret = RunWithManagedStdio(std::move(cmd), nullptr, nullptr, nullptr,
@@ -58,18 +71,14 @@ class TryAcloudCommand : public CvdServerHandler {
 
   cvd_common::Args CmdList() const override { return {"try-acloud"}; }
 
-  /**
-   * The `try-acloud` command verifies whether an original `acloud CLI` command
-   * could be satisfied using either:
-   *
-   * - `cvd` for local instance management, determined by flag
-   * `--local-instance`.
-   *
-   * - Or `cvdr` for remote instance management (#if ENABLE_CVDR_TRANSLATION).
-   *
-   * If the test fails, the command will be handed to the `python acloud CLI`.
-   *
-   */
+  Result<std::string> SummaryHelp() const override { return kSummaryHelpText; }
+
+  bool ShouldInterceptHelp() const override { return true; }
+
+  Result<std::string> DetailedHelp(std::vector<std::string>&) const override {
+    return kDetailedHelpText;
+  }
+
   Result<cvd::Response> Handle(const RequestWithStdio& request) override {
 #if ENABLE_CVDR_TRANSLATION
     auto res = VerifyWithCvdRemote(request);

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/utils.cpp
@@ -182,7 +182,7 @@ Result<Command> ConstructCvdGenericNonHelpCommand(
  *
  */
 constexpr static std::array help_bool_opts{
-    "help", "helpfull", "helpshort", "helppackage", "helpxml", "version"};
+    "help", "helpfull", "helpshort", "helppackage", "helpxml", "version", "h"};
 constexpr static std::array help_str_opts{
     "helpon",
     "helpmatch",

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/version.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/version.cpp
@@ -63,6 +63,12 @@ class CvdVersionHandler : public CvdServerHandler {
   cvd_common::Args CmdList() const override { return {"version"}; }
 
   Result<std::string> SummaryHelp() const override { return kSummaryHelpText; }
+
+  bool ShouldInterceptHelp() const override { return true; }
+
+  Result<std::string> DetailedHelp(std::vector<std::string>&) const override {
+    return kSummaryHelpText;
+  }
 };
 
 }  // namespace


### PR DESCRIPTION
Remove all of the contribute request messages in favor of messages that actually have help text (or point the user towards how to get the help text).  Also, remove `--help` flag processing on the commands where we now intercept help flags to use `DetailedHelp`.

Somewhat based on existing comments, help text, and go/cvd-sub-commands.