### PR TITLE
Add bazel detection when installation.

### DIFF
--- a/tools/buildutils/build_packages.sh
+++ b/tools/buildutils/build_packages.sh
@@ -25,7 +25,7 @@ function build_package() {
 REPO_DIR="$(realpath "$(dirname "$0")/../..")"
 INSTALL_BAZEL="$(dirname $0)/installbazel.sh"
 
-sudo "${INSTALL_BAZEL}"
+command -v bazel &> /dev/null || sudo "${INSTALL_BAZEL}"
 install_debuild_dependencies
 
 build_package "${REPO_DIR}/base"


### PR DESCRIPTION
In my case, can't install bazel by installbazel.sh successfully, it keep return `curl: (7) Failed to connect to bazel.build port 443: Connection refused` error, so I tried to install bazel manually.
After successful installation of bazel, the `install_bazel_x86_64` function still tries to install it. This would be causing failure when local environment can't access bazel.build server.
