### PR TITLE
Remove duplicate text in `cvd fetch` failures

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd.cc
@@ -765,11 +765,8 @@ Result<void> FetchCvdMain(int argc, char** argv) {
       LogToStderrAndFiles({flags.target_directory + "/fetch.log"}));
   android::base::SetMinimumLogSeverity(flags.verbosity);
 
-  auto result = Fetch(flags, host_target, targets);
-  if (!result.ok()) {
-    LOG(ERROR) << result.error().FormatForEnv();
-  }
-  return result;
+  CF_EXPECT(Fetch(flags, host_target, targets));
+  return {};
 }
 
 }  // namespace cuttlefish


### PR DESCRIPTION
After:
```
8. main.cc:208 | CvdMain | 
7. cvd.cpp:85 | HandleCvdCommand | 
6. handler_proxy.cpp:105 | Handle | 
5. command_sequence.cpp:110 | ExecuteOne | 
4. command_sequence.cpp:97 | Execute | 
3. fetch.cpp:76 | Handle | 
2. fetch_cvd.cc:767 | FetchCvdMain | 
1. fetch_cvd.cc:729 | Fetch | 
 | cuttlefish/host/commands/cvd/fetch/fetch_cvd.cc:430
 | cuttlefish::Result<std::variant<cuttlefish::DeviceBuild, cuttlefish::DirectoryBuild> > cuttlefish::{anonymous}::GetHostBuild(cuttlefish::BuildApi&, HostToolsTarget&, const std::optional<std::variant<cuttlefish::DeviceBuild, cuttlefish::DirectoryBuild> >&)
 v CF_EXPECT(host_package_build.has_value() || fallback_host_build.has_value())
Either the host_package_build or default_build requires a value. (previous default_build default was aosp-master/aosp_cf_x86_64_phone-userdebug)

    If the error above is unclear, please copy the text into an issue at:
        

```

Before:
```
1. fetch_cvd.cc:729 | Fetch | 
 | cuttlefish/host/commands/cvd/fetch/fetch_cvd.cc:430
 | cuttlefish::Result<std::variant<cuttlefish::DeviceBuild, cuttlefish::DirectoryBuild> > cuttlefish::{anonymous}::GetHostBuild(cuttlefish::BuildApi&, HostToolsTarget&, const std::optional<std::variant<cuttlefish::DeviceBuild, cuttlefish::DirectoryBuild> >&)
 v CF_EXPECT(host_package_build.has_value() || fallback_host_build.has_value())
Either the host_package_build or default_build requires a value. (previous default_build default was aosp-master/aosp_cf_x86_64_phone-userdebug)
2. main.cc:189 | CvdMain | 
1. fetch_cvd.cc:729 | Fetch | 
 | cuttlefish/host/commands/cvd/fetch/fetch_cvd.cc:430
 | cuttlefish::Result<std::variant<cuttlefish::DeviceBuild, cuttlefish::DirectoryBuild> > cuttlefish::{anonymous}::GetHostBuild(cuttlefish::BuildApi&, HostToolsTarget&, const std::optional<std::variant<cuttlefish::DeviceBuild, cuttlefish::DirectoryBuild> >&)
 v CF_EXPECT(host_package_build.has_value() || fallback_host_build.has_value())
Either the host_package_build or default_build requires a value. (previous default_build default was aosp-master/aosp_cf_x86_64_phone-userdebug)

    If the error above is unclear, please copy the text into an issue at:
        

4. main.cc:208 | CvdMain | 
3. cvd.cpp:85 | HandleCvdCommand | 
2. handler_proxy.cpp:105 | Handle | 
1. command_sequence.cpp:110 | ExecuteOne | 
 | cuttlefish/host/commands/cvd/command_sequence.cpp:100
 | cuttlefish::Result<std::vector<cuttlefish::cvd::Response> > cuttlefish::CommandSequenceExecutor::Execute(const std::vector<cuttlefish::RequestWithStdio>&, cuttlefish::SharedFD)
 v CF_EXPECT(response.status().code() == cvd::Status::OK)
Reason: "Exited with code 255"

    If the error above is unclear, please copy the text into an issue at:
        
```