### PR TITLE
Add menu for copying adb connect command that uses cvdr

### DIFF
--- a/frontend/src/operator/webui/src/app/app.module.ts
+++ b/frontend/src/operator/webui/src/app/app.module.ts
@@ -10,8 +10,10 @@ import {MatButtonModule} from '@angular/material/button';
 import {MatCardModule} from '@angular/material/card';
 import {MatCheckboxModule} from '@angular/material/checkbox';
 import {MatIconModule} from '@angular/material/icon';
+import {MatMenuModule} from '@angular/material/menu';
 import {MatSidenavModule} from '@angular/material/sidenav';
 import {MatSlideToggleModule} from '@angular/material/slide-toggle';
+import {MatSnackBarModule} from '@angular/material/snack-bar';
 import {MatToolbarModule} from '@angular/material/toolbar';
 import {ViewPaneComponent} from './view-pane/view-pane.component';
 import {SafeDeviceUrlPipe} from './safe-device-url.pipe';
@@ -32,8 +34,10 @@ import {RouterModule} from '@angular/router';
     MatCardModule,
     MatCheckboxModule,
     MatIconModule,
+    MatMenuModule,
     MatSidenavModule,
     MatSlideToggleModule,
+    MatSnackBarModule,
     MatToolbarModule,
     FormsModule,
     HttpClientModule,

--- a/frontend/src/operator/webui/src/app/device-pane/device-pane.component.html
+++ b/frontend/src/operator/webui/src/app/device-pane/device-pane.component.html
@@ -17,7 +17,11 @@
           (change)="displaysService.toggleVisibility(device.device_id)"
           >{{ device.device_id }}</mat-slide-toggle
         >
-        <button mat-icon-button class="menu" title="menu">
+        <button
+          mat-icon-button class="menu" title="menu"
+          [matMenuTriggerFor]="deviceMenu"
+          [matMenuTriggerData]="{device_id: device.device_id}"
+        >
           <mat-icon>more_vert</mat-icon>
         </button>
       </li>
@@ -29,3 +33,9 @@
     Show All
   </button>
 </div>
+
+<mat-menu #deviceMenu="matMenu">
+  <ng-template matMenuContent let-device_id="device_id">
+    <button mat-menu-item (click)="copyAdbCommand(device_id)">Copy ADB connect command</button>
+  </ng-template>
+</mat-menu>

--- a/frontend/src/operator/webui/src/app/device-pane/device-pane.component.ts
+++ b/frontend/src/operator/webui/src/app/device-pane/device-pane.component.ts
@@ -4,6 +4,7 @@ import {DisplaysService} from '../displays.service';
 import {filter, first, mergeMap} from 'rxjs/operators';
 import {GroupService} from '../group.service';
 import {ActivatedRoute, NavigationEnd, Router} from '@angular/router';
+import {MatSnackBar} from '@angular/material/snack-bar'
 
 @Component({
   selector: 'app-device-pane',
@@ -19,7 +20,8 @@ export class DevicePaneComponent {
     public displaysService: DisplaysService,
     private groupService: GroupService,
     private activatedRoute: ActivatedRoute,
-    private router: Router
+    private router: Router,
+    private snackBar: MatSnackBar
   ) {}
 
   ngOnInit(): void {
@@ -48,6 +50,16 @@ export class DevicePaneComponent {
           this.displaysService.toggleVisibility(device.device_id);
         }
       });
+    });
+  }
+
+  copyAdbCommand(deviceId: string) {
+    var currentUrl = window.location.href
+    var command = 'cvdr connect --connect_agent=websocket_agent ' +
+                  `--service_url=${currentUrl} --host=websocket ${deviceId}`
+    navigator.clipboard.writeText(command)
+    this.snackBar.open('ADB connect command copied to the Clipboard', 'OK', {
+      duration: 3000,
     });
   }
 }


### PR DESCRIPTION
Add sub-menu for device that copies adb connect command to the clipboard.

the command would be like

`cvdr connect --connect_agent=websocket_agent --service_url=https://127.0.0.1:1443/ --host=websocket cvd-1`