### PR TITLE
Set `client_max_body_size` into nginx config to upload artifacts

### DIFF
--- a/frontend/host/packages/cuttlefish-orchestration/etc/nginx/conf.d/cuttlefish-orchestration.conf
+++ b/frontend/host/packages/cuttlefish-orchestration/etc/nginx/conf.d/cuttlefish-orchestration.conf
@@ -37,5 +37,8 @@ server {
     # Host Orchestrator
     location / {
         proxy_pass http://127.0.0.1:2081;
+
+        # This is required for uploading huge artifacts.
+        client_max_body_size 20G;
     }
 }


### PR DESCRIPTION
After wrapping `Host Orchestrator` with `nginx`, it cannot upload large artifacts with status 413. This change is the fix for it.