### PR TITLE
Fix double closure of sockets while proxying ADB

### DIFF
--- a/frontend/src/liboperator/operator/operator.go
+++ b/frontend/src/liboperator/operator/operator.go
@@ -537,7 +537,6 @@ func adbProxy(w http.ResponseWriter, r *http.Request, pool *DevicePool) {
 		pos:    0,
 		buf:    nil,
 	}
-	defer wsWrapper.Close()
 
 	// Redirect WebSocket to ADB tcp socket
 	go func() {


### PR DESCRIPTION
While proxying ADB, wsWrapper.Close() is executed twice, at deferred function and inside go routine. Call wsWrapper.Close() only at go routine that writes data to the wsWrapper.

Also move tcpConn.Close() after io.Copy(...) to avoid confusion.