### PR TITLE
Improve message when cvd_internal_start not found

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
@@ -561,9 +561,11 @@ static void ShowLaunchCommand(const Command& command,
 Result<std::string> CvdStartCommandHandler::FindStartBin(
     const std::string& android_host_out) {
   auto start_bin = CF_EXPECT(host_tool_target_manager_.ExecBaseName({
-      .artifacts_path = android_host_out,
-      .op = "start",
-  }));
+                                 .artifacts_path = android_host_out,
+                                 .op = "start",
+                             }),
+                             "\nMaybe try `cvd fetch` or running `lunch "
+                             "<target>` to enable starting a CF device?");
   return start_bin;
 }
 


### PR DESCRIPTION
Trying to add more details and a suggestion of a potential fix to guide users.  The previous error message was still leaving me puzzled if I had not seen it in a while.

Test: # in non-lunch environment or when not in a fetched directory
Test: cvd start --help