### PR TITLE
Use lesser id first while allocating id for CVD

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/unique_resource_allocator.h
+++ b/base/cvd/cuttlefish/common/libs/utils/unique_resource_allocator.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <set>
 #include <type_traits>
 #include <unordered_set>
 #include <utility>
@@ -281,13 +282,13 @@ class UniqueResourceAllocator {
    *
    * The itr must belong to available_resources_.
    */
-  const T* RemoveFromPool(const typename std::unordered_set<T>::iterator itr) {
+  const T* RemoveFromPool(const typename std::set<T>::iterator itr) {
     T tmp = std::move(*itr);
     available_resources_.erase(itr);
     const auto [new_itr, _] = allocated_resources_.insert(std::move(tmp));
     return std::addressof(*new_itr);
   }
-  std::unordered_set<T> available_resources_;
+  std::set<T> available_resources_;
   std::unordered_set<T> allocated_resources_;
   std::mutex mutex_;
 };


### PR DESCRIPTION
While launching device using automatic device id allocator, device id is not predictable because it allocates id from unordered_set. Change it to use ordered set to allocate lesser id first.