### PR TITLE
Support user artifact path for CVD creation with canonical config

### DIFF
--- a/frontend/src/host_orchestrator/orchestrator/createcvdaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/createcvdaction.go
@@ -15,6 +15,7 @@
 package orchestrator
 
 import (
+	"bytes"
 	"encoding/json"
 	"io/ioutil"
 	"log"
@@ -123,6 +124,9 @@ func (a *CreateCVDAction) launchWithCanonicalConfig(op apiv1.Operation) (*apiv1.
 	if err != nil {
 		return nil, err
 	}
+	data = bytes.ReplaceAll(data,
+		[]byte(apiv1.EnvConfigUserArtifactsVar + "/"),
+		[]byte(a.userArtifactsDirResolver.GetDirPath("")))
 	configFile, err := createTempFile("cvdload*.json", data, 0640)
 	if err != nil {
 		return nil, err

--- a/frontend/src/liboperator/api/v1/messages.go
+++ b/frontend/src/liboperator/api/v1/messages.go
@@ -110,6 +110,9 @@ type AndroidCIBundle struct {
 	Type ArtifactsBundleType `json:"type"`
 }
 
+// Prefix for specifying user artifact path while creating CVD with CreateCVDRequest.EnvConfig.
+const EnvConfigUserArtifactsVar = "@user_artifacts"
+
 // Use `X-Cutf-Host-Orchestrator-BuildAPI-Creds` http header to pass the Build API credentials.
 type CreateCVDRequest struct {
 	// Environment canonical configuration.


### PR DESCRIPTION
Add support for the notation `@user_artifact` to specify user artifact path at canonical config.

Example config for using user artifact while launching CVD with canonical config.

```
{
  "env_config": {
    "common": {
      "host_package": "@user_artifact/$user_artifact_id"
    },
    "instances": [
      {
        "vm": {
          "memory_mb": 8192,
          "setupwizard_mode": "OPTIONAL",
          "cpus": 8
        },
        "disk": {
          "default_build": "@user_artifact/$user_artifact_id"
        }
      }
    ]
  }
}
```