### PR TITLE
cvd fleet prints full info for non-running instances

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/selector/cvd_persistent_data.proto
+++ b/base/cvd/cuttlefish/host/commands/cvd/selector/cvd_persistent_data.proto
@@ -35,6 +35,8 @@ message Instance {
   uint32 id = 1;
   string name = 2;
   InstanceState state = 3;
+  uint32 adb_port = 4;
+  string webrtc_device_id = 5;
 }
 
 message InstanceGroup {

--- a/base/cvd/cuttlefish/host/commands/cvd/selector/instance_group_record.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/selector/instance_group_record.cpp
@@ -139,6 +139,14 @@ std::vector<cvd::Instance> LocalInstanceGroup::FindByInstanceName(
   });
 }
 
+std::string LocalInstanceGroup::AssemblyDir() const {
+  return HomeDir() + "/cuttlefish/assembly";
+}
+
+std::string LocalInstanceGroup::InstanceDir(const cvd::Instance& instance) const {
+  return fmt::format("{}/cuttlefish/instances/cvd-{}", HomeDir(), instance.id());
+}
+
 Result<LocalInstanceGroup> LocalInstanceGroup::Deserialize(
     const Json::Value& group_json) {
   CF_EXPECT(group_json.isMember(kJsonGroupName));

--- a/base/cvd/cuttlefish/host/commands/cvd/selector/instance_group_record.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/selector/instance_group_record.h
@@ -57,6 +57,9 @@ class LocalInstanceGroup {
   void SetAllStates(cvd::InstanceState state);
   void SetAllStatesAndResetIds(cvd::InstanceState state);
 
+  std::string AssemblyDir() const;
+  std::string InstanceDir(const cvd::Instance&) const;
+
   std::vector<cvd::Instance> FindById(const unsigned id) const;
   /**
    * Find by per-instance name.


### PR DESCRIPTION
By not relying only on the output of cvd_internal_status, but instead keeping the relevant information in the database.
Some info is still parsed from the status command output the first time it's run (right after a successful boot) and then stored in the database: webrtc_device_id and adb_port.
Additionally, cvd fleet prints the adb port on its own, which is more useful than the serial for remote use cases.