### PR TITLE
Copy the first instance's config

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
@@ -647,7 +647,7 @@ Result<void> CvdStartCommandHandler::CreateSymlinks(
   // cvd_internal_start to persist the user's choice for
   // -report_anonymous_usage_stats.
   CF_EXPECT(
-      Copy(group.HomeDir() + "/cuttlefish/assembly/cuttlefish_config.json",
+      Copy(group.InstanceDir(group.Instances()[0]) + "/cuttlefish_config.json",
            CF_EXPECT(SystemWideUserHome()) + "/.cuttlefish_config.json"),
       "Failed to copy config file to home directory");
 


### PR DESCRIPTION
instead of the one on assembly, which is empty in some cases.