### PR TITLE
Logs request path on proxy errors.

### DIFF
--- a/frontend/src/host_orchestrator/main.go
+++ b/frontend/src/host_orchestrator/main.go
@@ -96,7 +96,13 @@ func newOperatorProxy(port int) *httputil.ReverseProxy {
 	if err != nil {
 		log.Fatalf("Invalid operator port (%d): %v", port, err)
 	}
-	return httputil.NewSingleHostReverseProxy(operatorURL)
+	proxy := httputil.NewSingleHostReverseProxy(operatorURL)
+	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+		log.Printf("request %q failed: proxy error: %v", r.Method+" "+r.URL.Path, err)
+		w.Header().Add("x-cutf-proxy", "ho-operator")
+		w.WriteHeader(http.StatusBadGateway)
+	}
+	return proxy
 }
 
 func main() {

--- a/frontend/src/liboperator/operator/operator.go
+++ b/frontend/src/liboperator/operator/operator.go
@@ -481,6 +481,11 @@ func openwrt(w http.ResponseWriter, r *http.Request, pool *DevicePool) {
 
 	url, _ := url.Parse("http://" + openwrtAddr)
 	proxy := httputil.NewSingleHostReverseProxy(url)
+	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+		log.Printf("request %q failed: proxy error: %v", r.Method+" "+r.URL.Path, err)
+		w.Header().Add("x-cutf-proxy", "op-openwrt")
+		w.WriteHeader(http.StatusBadGateway)
+	}
 	r.URL.Path = "/devices/" + openwrtDevId + "/openwrt" + path
 	proxy.ServeHTTP(w, r)
 }

--- a/frontend/src/operator/main.go
+++ b/frontend/src/operator/main.go
@@ -116,6 +116,11 @@ func main() {
 	if *webUiUrlStr != "" {
 		webUiUrl, _ := url.Parse(*webUiUrlStr)
 		proxy := httputil.NewSingleHostReverseProxy(webUiUrl)
+		proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+			log.Printf("request %q failed: proxy error: %v", r.Method+" "+r.URL.Path, err)
+			w.Header().Add("x-cutf-proxy", "op-webui")
+			w.WriteHeader(http.StatusBadGateway)
+		}
 		r.PathPrefix("/").Handler(proxy)
 	} else {
 		fs := http.FileServer(http.Dir(DefaultStaticFilesDir))


### PR DESCRIPTION
- Adds `x-cutf-proxy` header to failed proxy responses to localize the relevant proxy from final response.