### PR TITLE
Fix shortcomings in cvd fleet

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/status_fetcher.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/status_fetcher.cpp
@@ -83,17 +83,17 @@ void OverrideInstanceJson(const selector::LocalInstanceGroup& group,
                         Json::Value& instance_json) {
   instance_json["instance_name"] = instance.name();
   instance_json["status"] = HumanFriendlyStateName(instance.state());
-  instance_json["adb_port"] = instance.adb_port();
   instance_json["assembly_dir"] = group.AssemblyDir();
   instance_json["instance_dir"] = group.InstanceDir(instance);
   instance_json["instance_name"] = instance.name();
-  instance_json["webrtc_device_id"] = instance.webrtc_device_id();
   if (instance.id() > 0) {
-    // Only running instances have id > 0, non running instances are not
-    // accessible via web UI.
+    // Only running instances have id > 0, this values only make sense for
+    // running instances.
     instance_json["web_access"] =
         fmt::format("https://localhost:1443/devices/{}/files/client.html",
                     instance.webrtc_device_id());
+    instance_json["webrtc_device_id"] = instance.webrtc_device_id();
+    instance_json["adb_port"] = instance.adb_port();
   }
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/status_fetcher.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/status_fetcher.cpp
@@ -150,6 +150,7 @@ Result<StatusFetcherOutput> StatusFetcher::FetchOneInstanceStatus(
     Json::Value instance_json;
     instance_json["instance_name"] = instance.name();
     instance_json["status"] = HumanFriendlyStateName(instance.state());
+    OverrideInstanceJson(group, instance, instance_json);
     cvd::Response response;
     response.mutable_command_response();  // set oneof field
     response.mutable_status()->set_code(cvd::Status::OK);


### PR DESCRIPTION
Prints more information for cancelled instances.

Don't print adb port and webrtc id when the instance isn't running.