### PR TITLE
Fix host_bugreport when ANDROID_HOST_OUT is not set.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/generic.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/generic.cpp
@@ -380,6 +380,7 @@ CvdGenericCommandHandler::ExtractInfo(const RequestWithStdio& request) {
                                   .args = cmd_args,
                                   .envs = envs};
   result.envs["HOME"] = home;
+  result.envs[kAndroidHostOut] = android_host_out;
   extracted_info.invocation_info = result;
   extracted_info.group = instance_group;
   return extracted_info;


### PR DESCRIPTION
- Command `host_bugreport` uses the ANDROID_HOST_OUT env variable to locate the `adb`, when the variable is not set, `cvd` uses the HOME value instead.