### PR TITLE
Let `CvdServerHandler` instances create their own `SubprocessWaiter`s

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/command_sequence.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/command_sequence.cpp
@@ -17,6 +17,8 @@
 
 #include <memory>
 
+#include <android-base/strings.h>
+
 #include "common/libs/fs/shared_buf.h"
 #include "host/commands/cvd/request_context.h"
 #include "host/commands/cvd/server_client.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/request_context.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/request_context.cpp
@@ -69,16 +69,15 @@ RequestContext::RequestContext(
   request_handlers_.emplace_back(
       NewCvdCmdlistHandler(command_sequence_executor_));
   request_handlers_.emplace_back(
-      NewCvdDisplayCommandHandler(instance_manager_, subprocess_waiter_));
-  request_handlers_.emplace_back(
-      NewCvdEnvCommandHandler(instance_manager_, subprocess_waiter_));
+      NewCvdDisplayCommandHandler(instance_manager_));
+  request_handlers_.emplace_back(NewCvdEnvCommandHandler(instance_manager_));
   request_handlers_.emplace_back(NewCvdFetchCommandHandler());
   request_handlers_.emplace_back(
       NewCvdFleetCommandHandler(instance_manager_, host_tool_target_manager_));
   request_handlers_.emplace_back(
-      NewCvdGenericCommandHandler(instance_manager_, subprocess_waiter_));
-  request_handlers_.emplace_back(NewCvdStopCommandHandler(
-      instance_manager_, subprocess_waiter_, host_tool_target_manager_));
+      NewCvdGenericCommandHandler(instance_manager_));
+  request_handlers_.emplace_back(
+      NewCvdStopCommandHandler(instance_manager_, host_tool_target_manager_));
   request_handlers_.emplace_back(
       NewCvdServerHandlerProxy(command_sequence_executor_));
   request_handlers_.emplace_back(NewCvdHelpHandler(this->request_handlers_));
@@ -86,14 +85,14 @@ RequestContext::RequestContext(
   request_handlers_.emplace_back(
       NewLoadConfigsCommand(command_sequence_executor_, instance_manager_));
   request_handlers_.emplace_back(NewCvdDevicePowerCommandHandler(
-      host_tool_target_manager_, instance_manager_, subprocess_waiter_));
+      host_tool_target_manager_, instance_manager_));
   request_handlers_.emplace_back(NewRemoveCvdCommandHandler(instance_manager_));
   request_handlers_.emplace_back(NewCvdResetCommandHandler(instance_manager_));
   request_handlers_.emplace_back(
       NewSerialLaunchCommand(command_sequence_executor_, lock_file_manager_));
   request_handlers_.emplace_back(NewSerialPreset(command_sequence_executor_));
   request_handlers_.emplace_back(NewCvdSnapshotCommandHandler(
-      instance_manager_, subprocess_waiter_, host_tool_target_manager_));
+      instance_manager_, host_tool_target_manager_));
   request_handlers_.emplace_back(
       NewCvdStartCommandHandler(instance_manager_, host_tool_target_manager_,
                                 command_sequence_executor_));

--- a/base/cvd/cuttlefish/host/commands/cvd/request_context.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/request_context.h
@@ -25,7 +25,6 @@
 #include "host/commands/cvd/server_client.h"
 #include "host/commands/cvd/server_command/host_tool_target_manager.h"
 #include "host/commands/cvd/server_command/server_handler.h"
-#include "host/commands/cvd/server_command/subprocess_waiter.h"
 
 namespace cuttlefish {
 
@@ -43,7 +42,6 @@ class RequestContext {
   std::vector<std::unique_ptr<CvdServerHandler>> request_handlers_;
   InstanceLockFileManager& instance_lockfile_manager_;
   InstanceManager& instance_manager_;
-  SubprocessWaiter subprocess_waiter_;
   InstanceLockFileManager lock_file_manager_;
   HostToolTargetManager& host_tool_target_manager_;
   CommandSequenceExecutor command_sequence_executor_;

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/display.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/display.cpp
@@ -32,6 +32,7 @@
 #include "host/commands/cvd/selector/instance_group_record.h"
 #include "host/commands/cvd/selector/selector_constants.h"
 #include "host/commands/cvd/server_command/server_handler.h"
+#include "host/commands/cvd/server_command/subprocess_waiter.h"
 #include "host/commands/cvd/server_command/utils.h"
 #include "host/commands/cvd/types.h"
 
@@ -51,14 +52,11 @@ Commands:
     list                Prints the currently connected displays.
     remove              Removes a display from a given device.
 )";
-}
 
 class CvdDisplayCommandHandler : public CvdServerHandler {
  public:
-  CvdDisplayCommandHandler(InstanceManager& instance_manager,
-                           SubprocessWaiter& subprocess_waiter)
+  CvdDisplayCommandHandler(InstanceManager& instance_manager)
       : instance_manager_{instance_manager},
-        subprocess_waiter_(subprocess_waiter),
         cvd_display_operations_{"display"} {}
 
   Result<bool> CanHandle(const RequestWithStdio& request) const {
@@ -188,15 +186,17 @@ class CvdDisplayCommandHandler : public CvdServerHandler {
   }
 
   InstanceManager& instance_manager_;
-  SubprocessWaiter& subprocess_waiter_;
+  SubprocessWaiter subprocess_waiter_;
   std::vector<std::string> cvd_display_operations_;
   static constexpr char kDisplayBin[] = "cvd_internal_display";
 };
 
+}  // namespace
+
 std::unique_ptr<CvdServerHandler> NewCvdDisplayCommandHandler(
-    InstanceManager& instance_manager, SubprocessWaiter& subprocess_waiter) {
+    InstanceManager& instance_manager) {
   return std::unique_ptr<CvdServerHandler>(
-      new CvdDisplayCommandHandler(instance_manager, subprocess_waiter));
+      new CvdDisplayCommandHandler(instance_manager));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/display.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/display.h
@@ -20,11 +20,10 @@
 
 #include "host/commands/cvd/instance_manager.h"
 #include "host/commands/cvd/server_command/server_handler.h"
-#include "host/commands/cvd/server_command/subprocess_waiter.h"
 
 namespace cuttlefish {
 
 std::unique_ptr<CvdServerHandler> NewCvdDisplayCommandHandler(
-    InstanceManager& instance_manager, SubprocessWaiter& subprocess_waiter);
+    InstanceManager& instance_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/env.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/env.cpp
@@ -27,6 +27,7 @@
 #include "host/commands/cvd/flag.h"
 #include "host/commands/cvd/selector/instance_group_record.h"
 #include "host/commands/cvd/server_command/server_handler.h"
+#include "host/commands/cvd/server_command/subprocess_waiter.h"
 #include "host/commands/cvd/server_command/utils.h"
 #include "host/commands/cvd/types.h"
 
@@ -44,15 +45,10 @@ cvd env ls $SERVICE_NAME $METHOD_NAME - list information on input + output messa
 cvd env type $SERVICE_NAME $REQUEST_MESSAGE_TYPE - outputs the proto the specified request message type
 )";
 
-}  // namespace
-
 class CvdEnvCommandHandler : public CvdServerHandler {
  public:
-  CvdEnvCommandHandler(InstanceManager& instance_manager,
-                       SubprocessWaiter& subprocess_waiter)
-      : instance_manager_{instance_manager},
-        subprocess_waiter_(subprocess_waiter),
-        cvd_env_operations_{"env"} {}
+  CvdEnvCommandHandler(InstanceManager& instance_manager)
+      : instance_manager_{instance_manager}, cvd_env_operations_{"env"} {}
 
   Result<bool> CanHandle(const RequestWithStdio& request) const override {
     auto invocation = ParseInvocation(request.Message());
@@ -139,16 +135,17 @@ class CvdEnvCommandHandler : public CvdServerHandler {
   }
 
   InstanceManager& instance_manager_;
-  SubprocessWaiter& subprocess_waiter_;
+  SubprocessWaiter subprocess_waiter_;
   std::vector<std::string> cvd_env_operations_;
 
   static constexpr char kCvdEnvBin[] = "cvd_internal_env";
 };
 
-std::unique_ptr<CvdServerHandler> NewCvdEnvCommandHandler(
-    InstanceManager& instance_manager, SubprocessWaiter& subprocess_waiter) {
-  return std::unique_ptr<CvdServerHandler>(
-      new CvdEnvCommandHandler(instance_manager, subprocess_waiter));
-}
+}  // namespace
 
+std::unique_ptr<CvdServerHandler> NewCvdEnvCommandHandler(
+    InstanceManager& instance_manager) {
+  return std::unique_ptr<CvdServerHandler>(
+      new CvdEnvCommandHandler(instance_manager));
+}
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/env.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/env.h
@@ -20,11 +20,10 @@
 
 #include "host/commands/cvd/instance_manager.h"
 #include "host/commands/cvd/server_command/server_handler.h"
-#include "host/commands/cvd/server_command/subprocess_waiter.h"
 
 namespace cuttlefish {
 
 std::unique_ptr<CvdServerHandler> NewCvdEnvCommandHandler(
-    InstanceManager& instance_manager, SubprocessWaiter& subprocess_waiter);
+    InstanceManager& instance_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/generic.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/generic.cpp
@@ -47,12 +47,9 @@ namespace {
 constexpr char kSummaryHelpText[] =
     "Run cvd <command> --help for command description";
 
-}  // namespace
-
 class CvdGenericCommandHandler : public CvdServerHandler {
  public:
-  CvdGenericCommandHandler(InstanceManager& instance_manager,
-                           SubprocessWaiter& subprocess_waiter);
+  CvdGenericCommandHandler(InstanceManager& instance_manager);
 
   Result<bool> CanHandle(const RequestWithStdio& request) const override;
   Result<cvd::Response> Handle(const RequestWithStdio& request) override;
@@ -101,7 +98,7 @@ class CvdGenericCommandHandler : public CvdServerHandler {
                                      const cvd_common::Envs& envs) const;
 
   InstanceManager& instance_manager_;
-  SubprocessWaiter& subprocess_waiter_;
+  SubprocessWaiter subprocess_waiter_;
   using BinGeneratorType = std::function<Result<std::string>(
       const std::string& host_artifacts_path)>;
   std::map<std::string, std::string> command_to_binary_map_;
@@ -116,9 +113,8 @@ class CvdGenericCommandHandler : public CvdServerHandler {
 };
 
 CvdGenericCommandHandler::CvdGenericCommandHandler(
-    InstanceManager& instance_manager, SubprocessWaiter& subprocess_waiter)
+    InstanceManager& instance_manager)
     : instance_manager_(instance_manager),
-      subprocess_waiter_(subprocess_waiter),
       command_to_binary_map_{{"host_bugreport", kHostBugreportBin},
                              {"cvd_host_bugreport", kHostBugreportBin},
                              {"clear", kClearBin},
@@ -402,10 +398,12 @@ Result<std::string> CvdGenericCommandHandler::GetBin(
   return GetBin(subcmd);
 }
 
+}  // namespace
+
 std::unique_ptr<CvdServerHandler> NewCvdGenericCommandHandler(
-    InstanceManager& instance_manager, SubprocessWaiter& subprocess_waiter) {
+    InstanceManager& instance_manager) {
   return std::unique_ptr<CvdServerHandler>(
-      new CvdGenericCommandHandler(instance_manager, subprocess_waiter));
+      new CvdGenericCommandHandler(instance_manager));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/generic.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/generic.h
@@ -25,6 +25,6 @@
 namespace cuttlefish {
 
 std::unique_ptr<CvdServerHandler> NewCvdGenericCommandHandler(
-    InstanceManager& instance_manager, SubprocessWaiter& subprocess_waiter);
+    InstanceManager& instance_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/power.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/power.cpp
@@ -43,16 +43,12 @@ constexpr char kSummaryHelpText[] =
     "Trigger power button event on the device, reset device to first boot "
     "state, restart device";
 
-}  // namespace
-
 class CvdDevicePowerCommandHandler : public CvdServerHandler {
  public:
   CvdDevicePowerCommandHandler(HostToolTargetManager& host_tool_target_manager,
-                               InstanceManager& instance_manager,
-                               SubprocessWaiter& subprocess_waiter)
+                               InstanceManager& instance_manager)
       : host_tool_target_manager_(host_tool_target_manager),
-        instance_manager_{instance_manager},
-        subprocess_waiter_(subprocess_waiter) {
+        instance_manager_{instance_manager} {
     cvd_power_operations_["restart"] =
         [this](const std::string& android_host_out) -> Result<std::string> {
       return CF_EXPECT(RestartDeviceBin(android_host_out));
@@ -246,16 +242,18 @@ class CvdDevicePowerCommandHandler : public CvdServerHandler {
 
   HostToolTargetManager& host_tool_target_manager_;
   InstanceManager& instance_manager_;
-  SubprocessWaiter& subprocess_waiter_;
+  SubprocessWaiter subprocess_waiter_;
   using BinGetter = std::function<Result<std::string>(const std::string&)>;
   std::unordered_map<std::string, BinGetter> cvd_power_operations_;
 };
 
+}  // namespace
+
 std::unique_ptr<CvdServerHandler> NewCvdDevicePowerCommandHandler(
     HostToolTargetManager& host_tool_target_manager,
-    InstanceManager& instance_manager, SubprocessWaiter& subprocess_waiter) {
+    InstanceManager& instance_manager) {
   return std::unique_ptr<CvdServerHandler>(new CvdDevicePowerCommandHandler(
-      host_tool_target_manager, instance_manager, subprocess_waiter));
+      host_tool_target_manager, instance_manager));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/power.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/power.h
@@ -28,6 +28,6 @@ namespace cuttlefish {
 // restart, powerwash, powerbtn
 std::unique_ptr<CvdServerHandler> NewCvdDevicePowerCommandHandler(
     HostToolTargetManager& host_tool_target_manager,
-    InstanceManager& instance_manager, SubprocessWaiter& subprocess_waiter);
+    InstanceManager& instance_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/snapshot.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/snapshot.cpp
@@ -62,15 +62,11 @@ QEMU:
 
 )";
 
-}  // namespace
-
 class CvdSnapshotCommandHandler : public CvdServerHandler {
  public:
   CvdSnapshotCommandHandler(InstanceManager& instance_manager,
-                            SubprocessWaiter& subprocess_waiter,
                             HostToolTargetManager& host_tool_target_manager)
       : instance_manager_{instance_manager},
-        subprocess_waiter_(subprocess_waiter),
         host_tool_target_manager_(host_tool_target_manager),
         cvd_snapshot_operations_{"suspend", "resume", "snapshot_take"} {}
 
@@ -175,16 +171,18 @@ class CvdSnapshotCommandHandler : public CvdServerHandler {
   }
 
   InstanceManager& instance_manager_;
-  SubprocessWaiter& subprocess_waiter_;
+  SubprocessWaiter subprocess_waiter_;
   HostToolTargetManager& host_tool_target_manager_;
   std::vector<std::string> cvd_snapshot_operations_;
 };
 
+}  // namespace
+
 std::unique_ptr<CvdServerHandler> NewCvdSnapshotCommandHandler(
-    InstanceManager& instance_manager, SubprocessWaiter& subprocess_waiter,
+    InstanceManager& instance_manager,
     HostToolTargetManager& host_tool_target_manager) {
   return std::unique_ptr<CvdServerHandler>(new CvdSnapshotCommandHandler(
-      instance_manager, subprocess_waiter, host_tool_target_manager));
+      instance_manager, host_tool_target_manager));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/snapshot.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/snapshot.h
@@ -26,7 +26,7 @@
 namespace cuttlefish {
 
 std::unique_ptr<CvdServerHandler> NewCvdSnapshotCommandHandler(
-    InstanceManager& instance_manager, SubprocessWaiter& subprocess_waiter,
+    InstanceManager& instance_manager,
     HostToolTargetManager& host_tool_target_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/stop.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/stop.cpp
@@ -53,7 +53,6 @@ constexpr char kSummaryHelpText[] =
 class CvdStopCommandHandler : public CvdServerHandler {
  public:
   CvdStopCommandHandler(InstanceManager& instance_manager,
-                        SubprocessWaiter& subprocess_waiter,
                         HostToolTargetManager& host_tool_target_manager);
 
   Result<bool> CanHandle(const RequestWithStdio& request) const override;
@@ -80,17 +79,16 @@ class CvdStopCommandHandler : public CvdServerHandler {
                                      const cvd_common::Envs& envs) const;
 
   InstanceManager& instance_manager_;
-  SubprocessWaiter& subprocess_waiter_;
+  SubprocessWaiter subprocess_waiter_;
   HostToolTargetManager& host_tool_target_manager_;
   using BinGeneratorType = std::function<Result<std::string>(
       const std::string& host_artifacts_path)>;
 };
 
 CvdStopCommandHandler::CvdStopCommandHandler(
-    InstanceManager& instance_manager, SubprocessWaiter& subprocess_waiter,
+    InstanceManager& instance_manager,
     HostToolTargetManager& host_tool_target_manager)
     : instance_manager_(instance_manager),
-      subprocess_waiter_(subprocess_waiter),
       host_tool_target_manager_(host_tool_target_manager) {}
 
 Result<bool> CvdStopCommandHandler::CanHandle(
@@ -294,10 +292,10 @@ Result<std::string> CvdStopCommandHandler::GetBin(
 }
 
 std::unique_ptr<CvdServerHandler> NewCvdStopCommandHandler(
-    InstanceManager& instance_manager, SubprocessWaiter& subprocess_waiter,
+    InstanceManager& instance_manager,
     HostToolTargetManager& host_tool_target_manager) {
-  return std::unique_ptr<CvdServerHandler>(new CvdStopCommandHandler(
-      instance_manager, subprocess_waiter, host_tool_target_manager));
+  return std::unique_ptr<CvdServerHandler>(
+      new CvdStopCommandHandler(instance_manager, host_tool_target_manager));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/stop.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/stop.h
@@ -20,12 +20,11 @@
 
 #include "host/commands/cvd/instance_manager.h"
 #include "host/commands/cvd/server_command/server_handler.h"
-#include "host/commands/cvd/server_command/subprocess_waiter.h"
 
 namespace cuttlefish {
 
 std::unique_ptr<CvdServerHandler> NewCvdStopCommandHandler(
-    InstanceManager& instance_manager, SubprocessWaiter& subprocess_waiter,
+    InstanceManager& instance_manager,
     HostToolTargetManager& host_tool_target_manager);
 
 }  // namespace cuttlefish


### PR DESCRIPTION
These don't need to be shared between instances, and each instance can only handle one process at a time anyway.