### PR TITLE
Delete unused code and minor fixes

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
@@ -65,8 +65,7 @@ Result<cvd::Response> Cvd::HandleCommand(
     const std::vector<std::string>& selector_args) {
   cvd::Request request = MakeRequest({.cmd_args = cvd_process_args,
                                       .env = env,
-                                      .selector_args = selector_args},
-                                     cvd::WAIT_BEHAVIOR_COMPLETE);
+                                      .selector_args = selector_args});
 
   RequestContext context(instance_lockfile_manager_, instance_manager_,
                          host_tool_target_manager_);

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/generic.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/generic.cpp
@@ -171,18 +171,7 @@ Result<cvd::Response> CvdGenericCommandHandler::Handle(
       .err = request.Err()};
   Command command = CF_EXPECT(ConstructCommand(construct_cmd_param));
 
-  SubprocessOptions options;
-  if (request.Message().command_request().wait_behavior() ==
-      cvd::WAIT_BEHAVIOR_START) {
-    options.ExitWithParent(false);
-  }
-  CF_EXPECT(subprocess_waiter_.Setup(command.Start(std::move(options))));
-
-  if (request.Message().command_request().wait_behavior() ==
-      cvd::WAIT_BEHAVIOR_START) {
-    response.mutable_status()->set_code(cvd::Status::OK);
-    return response;
-  }
+  CF_EXPECT(subprocess_waiter_.Setup(command.Start()));
 
   auto infop = CF_EXPECT(subprocess_waiter_.Wait());
 

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/handler_proxy.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/handler_proxy.cpp
@@ -84,8 +84,7 @@ class CvdServerHandlerProxy : public CvdServerHandler {
          .env = envs,
          .selector_args = selector_args,
          .working_dir =
-             request.Message().command_request().working_directory()},
-        request.Message().command_request().wait_behavior());
+             request.Message().command_request().working_directory()});
 
     RequestWithStdio forwarded_request(
         std::move(exec_request), request.FileDescriptors());

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/handler_proxy.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/handler_proxy.cpp
@@ -110,7 +110,7 @@ class CvdServerHandlerProxy : public CvdServerHandler {
   cvd_common::Args CmdList() const override { return {}; }
   // not intended to show up in help
   Result<std::string> SummaryHelp() const override { return ""; }
-  bool ShouldInterceptHelp() const { return false; }
+  bool ShouldInterceptHelp() const override { return false; }
   Result<std::string> DetailedHelp(std::vector<std::string>&) const override {
     return "";
   }

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
@@ -818,9 +818,6 @@ Result<cvd::Response> CvdStartCommandHandler::LaunchDevice(
     const cvd_common::Envs& envs, const RequestWithStdio& request) {
   ShowLaunchCommand(launch_command, envs);
 
-  CF_EXPECT(request.Message().command_request().wait_behavior() !=
-            cvd::WAIT_BEHAVIOR_START);
-
   CF_EXPECT(subprocess_waiter_.Setup(launch_command.Start()));
 
   auto acloud_compat_action_result = AcloudCompatActions(group, envs, request);

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/status.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/status.cpp
@@ -183,10 +183,6 @@ Result<cvd::Response> CvdStatusCommandHandler::Handle(
     return response;
   }
 
-  CF_EXPECT_NE(request.Message().command_request().wait_behavior(),
-               cvd::WAIT_BEHAVIOR_START,
-               "cvd status shouldn't be cvd::WAIT_BEHAVIOR_START");
-
   auto [subcmd, cmd_args] = ParseInvocation(request.Message());
   CF_EXPECT(Contains(supported_subcmds_, subcmd));
   const bool has_print = CF_EXPECT(HasPrint(cmd_args));


### PR DESCRIPTION
Eliminates most references of WaitBehavior since it's not needed without a cvd server. It's kept for the cvd client used to take over a running server if one is running at the time `cvd` executes, but removed from everywhere else.