### PR TITLE
Don't use `SubprocessWaiter` in uninterruptible contexts

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/acloud/converter.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/acloud/converter.h
@@ -16,12 +16,10 @@
 
 #pragma once
 
-#include <mutex>
 #include <string>
 #include <vector>
 
 #include "host/commands/cvd/server_client.h"
-#include "host/commands/cvd/server_command/subprocess_waiter.h"
 
 namespace cuttlefish {
 
@@ -36,20 +34,8 @@ struct ConvertedAcloudCreateCommand {
 
 namespace acloud_impl {
 
-/*
- * Converts the acloud create commands.
- *
- * Given that the lock is already acquired, it may start a subprocess
- * using waiter. If it runs multiple subprocesses in turn using the same
- * waiter, it acquire the lock before Start() and release the lock before
- * Wait(). The interrupt_lock_released in the return value says whether
- * the lock is released or not.
- * The input parameters waiter, callback_unlock and callback_lock
- * provide locking system to support interrupt.
- *
- */
 Result<ConvertedAcloudCreateCommand> ConvertAcloudCreate(
-    const RequestWithStdio& request, SubprocessWaiter& waiter);
+    const RequestWithStdio& request);
 
 }  // namespace acloud_impl
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/command_sequence.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/command_sequence.h
@@ -31,7 +31,6 @@ class CommandSequenceExecutor {
   CommandSequenceExecutor(
       const std::vector<std::unique_ptr<CvdServerHandler>>& server_handlers);
 
-  Result<void> Interrupt();
   Result<std::vector<cvd::Response>> Execute(
       const std::vector<RequestWithStdio>&, SharedFD report);
   Result<cvd::Response> ExecuteOne(const RequestWithStdio&, SharedFD report);

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/acloud_mixsuperimage.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/acloud_mixsuperimage.cpp
@@ -26,7 +26,6 @@
 #include "host/commands/cvd/server_client.h"
 #include "host/commands/cvd/server_command/acloud_mixsuperimage.h"
 #include "host/commands/cvd/server_command/server_handler.h"
-#include "host/commands/cvd/server_command/subprocess_waiter.h"
 #include "host/commands/cvd/server_command/utils.h"
 #include "host/commands/cvd/types.h"
 #include "host/libs/config/config_utils.h"
@@ -237,13 +236,13 @@ class AcloudMixSuperImageCommand : public CvdServerHandler {
     CF_EXPECT(_RewriteMiscInfo(new_misc_info_path, misc_info_path,
                                lpmake_binary, get_image));
 
-    Command command(build_super_image_binary);
-    command.AddParameter(new_misc_info_path);
-    command.AddParameter(output_path);
-    auto subprocess = command.Start();
-    CF_EXPECT(subprocess.Started());
-    CF_EXPECT(waiter_.Setup(std::move(subprocess)));
-    CF_EXPECT(waiter_.Wait());
+    Subprocess subprocess = Command(build_super_image_binary)
+                                .AddParameter(new_misc_info_path)
+                                .AddParameter(output_path)
+                                .Start();
+
+    CF_EXPECT(subprocess.Wait() == 0);
+
     return {};
   }
 
@@ -294,8 +293,6 @@ class AcloudMixSuperImageCommand : public CvdServerHandler {
                                       });
         });
   }
-
-  SubprocessWaiter waiter_;
 };
 
 std::unique_ptr<CvdServerHandler> NewAcloudMixSuperImageCommand() {

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/display.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/display.cpp
@@ -32,7 +32,6 @@
 #include "host/commands/cvd/selector/instance_group_record.h"
 #include "host/commands/cvd/selector/selector_constants.h"
 #include "host/commands/cvd/server_command/server_handler.h"
-#include "host/commands/cvd/server_command/subprocess_waiter.h"
 #include "host/commands/cvd/server_command/utils.h"
 #include "host/commands/cvd/types.h"
 
@@ -77,9 +76,10 @@ class CvdDisplayCommandHandler : public CvdServerHandler {
     Command command =
         is_help ? CF_EXPECT(HelpCommand(request, subcmd_args, envs))
                 : CF_EXPECT(NonHelpCommand(request, subcmd_args, envs));
-    CF_EXPECT(subprocess_waiter_.Setup(command.Start()));
 
-    auto infop = CF_EXPECT(subprocess_waiter_.Wait());
+    siginfo_t infop;
+    command.Start().Wait(&infop, WEXITED);
+
     return ResponseFromSiginfo(infop);
   }
 
@@ -186,7 +186,6 @@ class CvdDisplayCommandHandler : public CvdServerHandler {
   }
 
   InstanceManager& instance_manager_;
-  SubprocessWaiter subprocess_waiter_;
   std::vector<std::string> cvd_display_operations_;
   static constexpr char kDisplayBin[] = "cvd_internal_display";
 };

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/env.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/env.cpp
@@ -27,7 +27,6 @@
 #include "host/commands/cvd/flag.h"
 #include "host/commands/cvd/selector/instance_group_record.h"
 #include "host/commands/cvd/server_command/server_handler.h"
-#include "host/commands/cvd/server_command/subprocess_waiter.h"
 #include "host/commands/cvd/server_command/utils.h"
 #include "host/commands/cvd/types.h"
 
@@ -76,9 +75,10 @@ class CvdEnvCommandHandler : public CvdServerHandler {
     Command command =
         is_help ? CF_EXPECT(HelpCommand(request, subcmd_args, envs))
                 : CF_EXPECT(NonHelpCommand(request, subcmd_args, envs));
-    CF_EXPECT(subprocess_waiter_.Setup(command.Start()));
 
-    auto infop = CF_EXPECT(subprocess_waiter_.Wait());
+    siginfo_t infop;
+    command.Start().Wait(&infop, WEXITED);
+
     return ResponseFromSiginfo(infop);
   }
 
@@ -135,7 +135,6 @@ class CvdEnvCommandHandler : public CvdServerHandler {
   }
 
   InstanceManager& instance_manager_;
-  SubprocessWaiter subprocess_waiter_;
   std::vector<std::string> cvd_env_operations_;
 
   static constexpr char kCvdEnvBin[] = "cvd_internal_env";

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/generic.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/generic.h
@@ -20,7 +20,6 @@
 
 #include "host/commands/cvd/instance_manager.h"
 #include "host/commands/cvd/server_command/server_handler.h"
-#include "host/commands/cvd/server_command/subprocess_waiter.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/power.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/power.cpp
@@ -79,12 +79,12 @@ class CvdDevicePowerCommandHandler : public CvdServerHandler {
 
     // may modify subcmd_args by consuming in parsing
     Command command =
-        is_help
-            ? CF_EXPECT(HelpCommand(request, op, subcmd_args, envs))
-            : CF_EXPECT(NonHelpCommand(request, op, subcmd_args, envs));
-    CF_EXPECT(subprocess_waiter_.Setup(command.Start()));
+        is_help ? CF_EXPECT(HelpCommand(request, op, subcmd_args, envs))
+                : CF_EXPECT(NonHelpCommand(request, op, subcmd_args, envs));
 
-    auto infop = CF_EXPECT(subprocess_waiter_.Wait());
+    siginfo_t infop;
+    command.Start().Wait(&infop, WEXITED);
+
     return ResponseFromSiginfo(infop);
   }
 
@@ -242,7 +242,6 @@ class CvdDevicePowerCommandHandler : public CvdServerHandler {
 
   HostToolTargetManager& host_tool_target_manager_;
   InstanceManager& instance_manager_;
-  SubprocessWaiter subprocess_waiter_;
   using BinGetter = std::function<Result<std::string>(const std::string&)>;
   std::unordered_map<std::string, BinGetter> cvd_power_operations_;
 };

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/power.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/power.h
@@ -21,7 +21,6 @@
 #include "host/commands/cvd/instance_manager.h"
 #include "host/commands/cvd/server_command/host_tool_target_manager.h"
 #include "host/commands/cvd/server_command/server_handler.h"
-#include "host/commands/cvd/server_command/subprocess_waiter.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/snapshot.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/snapshot.cpp
@@ -92,9 +92,10 @@ class CvdSnapshotCommandHandler : public CvdServerHandler {
     // may modify subcmd_args by consuming in parsing
     Command command =
         CF_EXPECT(GenerateCommand(request, subcmd, subcmd_args, envs));
-    CF_EXPECT(subprocess_waiter_.Setup(command.Start()));
 
-    auto infop = CF_EXPECT(subprocess_waiter_.Wait());
+    siginfo_t infop;
+    command.Start().Wait(&infop, WEXITED);
+
     return ResponseFromSiginfo(infop);
   }
 
@@ -171,7 +172,6 @@ class CvdSnapshotCommandHandler : public CvdServerHandler {
   }
 
   InstanceManager& instance_manager_;
-  SubprocessWaiter subprocess_waiter_;
   HostToolTargetManager& host_tool_target_manager_;
   std::vector<std::string> cvd_snapshot_operations_;
 };

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/snapshot.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/snapshot.h
@@ -21,7 +21,6 @@
 #include "host/commands/cvd/instance_manager.h"
 #include "host/commands/cvd/server_command/host_tool_target_manager.h"
 #include "host/commands/cvd/server_command/server_handler.h"
-#include "host/commands/cvd/server_command/subprocess_waiter.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/status_fetcher.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/status_fetcher.h
@@ -18,7 +18,6 @@
 
 #include <sys/types.h>
 
-#include <mutex>
 #include <string>
 
 #include "common/libs/utils/result.h"
@@ -27,7 +26,6 @@
 #include "host/commands/cvd/selector/instance_group_record.h"
 #include "host/commands/cvd/server_client.h"
 #include "host/commands/cvd/server_command/host_tool_target_manager.h"
-#include "host/commands/cvd/server_command/subprocess_waiter.h"
 
 namespace cuttlefish {
 
@@ -43,7 +41,6 @@ class StatusFetcher {
                 HostToolTargetManager& host_tool_target_manager)
       : instance_manager_(instance_manager),
         host_tool_target_manager_(host_tool_target_manager) {}
-  Result<void> Interrupt();
   Result<StatusFetcherOutput> FetchStatus(const RequestWithStdio&);
 
   Result<Json::Value> FetchGroupStatus(const RequestWithStdio& original_request,
@@ -55,13 +52,8 @@ class StatusFetcher {
       const RequestWithStdio&, const InstanceManager::LocalInstanceGroup& group,
       cvd::Instance&);
 
-  std::mutex interruptible_;
-  bool interrupted_ = false;
-
   InstanceManager& instance_manager_;
   HostToolTargetManager& host_tool_target_manager_;
-  // needs to be exclusively owned by StatusFetcher
-  SubprocessWaiter subprocess_waiter_;
 };
 
 }  // namespace cuttlefish


### PR DESCRIPTION
Since PR #517 removed interrupt handling, a lot of classes have been unnecessarily using `SubprocessWaiter`, which provides additional functionality around being interrupted.