### PR TITLE
Remove stdio file descriptors from RequestWithStdio

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/acloud/converter.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/acloud/converter.cpp
@@ -669,27 +669,20 @@ Result<ConvertedAcloudCreateCommand> ConvertAcloudCreate(
     start_env[kCuttlefishInstanceEnvVarName] =
         std::to_string(*parsed_flags.local_instance.id);
   }
+  // TODO(schuffelen): Find a way to hide command output
   // we don't know which HOME is assigned by cvd start.
   // cvd server does not rely on the working directory for cvd start
   *start_command.mutable_working_directory() =
       request_command.working_directory();
-  std::vector<SharedFD> fds;
-  if (parsed_flags.verbose) {
-    fds = request.FileDescriptors();
-  } else {
-    auto dev_null = SharedFD::Open("/dev/null", O_RDWR);
-    CF_EXPECT(dev_null->IsOpen(), dev_null->StrError());
-    fds = {dev_null, dev_null, dev_null};
-  }
 
   ConvertedAcloudCreateCommand ret{
-      .start_request = RequestWithStdio(start_request, fds),
+      .start_request = RequestWithStdio(start_request),
       .fetch_command_str = fetch_command_str,
       .fetch_cvd_args_file = fetch_cvd_args_file,
       .verbose = parsed_flags.verbose,
   };
   for (auto& request_proto : request_protos) {
-    ret.prep_requests.emplace_back(request_proto, fds);
+    ret.prep_requests.emplace_back(request_proto);
   }
   return ret;
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/command_sequence.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/command_sequence.cpp
@@ -19,7 +19,6 @@
 
 #include <android-base/strings.h>
 
-#include "common/libs/fs/shared_buf.h"
 #include "host/commands/cvd/request_context.h"
 #include "host/commands/cvd/server_client.h"
 #include "host/commands/cvd/types.h"
@@ -83,15 +82,13 @@ CommandSequenceExecutor::CommandSequenceExecutor(
     : server_handlers_(server_handlers) {}
 
 Result<std::vector<cvd::Response>> CommandSequenceExecutor::Execute(
-    const std::vector<RequestWithStdio>& requests, SharedFD report) {
+    const std::vector<RequestWithStdio>& requests) {
   std::vector<cvd::Response> responses;
   for (const auto& request : requests) {
     auto& inner_proto = request.Message();
     if (inner_proto.has_command_request()) {
       auto& command = inner_proto.command_request();
-      std::string str = FormattedCommand(command);
-      CF_EXPECT(WriteAll(report, str) == (ssize_t)str.size(),
-                report->StrError());
+      std::cerr << FormattedCommand(command);
     }
 
     auto handler = CF_EXPECT(RequestHandler(request, server_handlers_));
@@ -108,8 +105,8 @@ Result<std::vector<cvd::Response>> CommandSequenceExecutor::Execute(
 }
 
 Result<cvd::Response> CommandSequenceExecutor::ExecuteOne(
-    const RequestWithStdio& request, SharedFD report) {
-  auto response_in_vector = CF_EXPECT(Execute({request}, report));
+    const RequestWithStdio& request) {
+  auto response_in_vector = CF_EXPECT(Execute({request}));
   CF_EXPECT_EQ(response_in_vector.size(), 1ul);
   return response_in_vector.front();
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/command_sequence.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/command_sequence.h
@@ -16,10 +16,8 @@
 #pragma once
 
 #include <memory>
-#include <mutex>
 #include <vector>
 
-#include "common/libs/fs/shared_fd.h"
 #include "cuttlefish/host/commands/cvd/cvd_server.pb.h"
 #include "host/commands/cvd/server_client.h"
 #include "host/commands/cvd/server_command/server_handler.h"
@@ -32,8 +30,8 @@ class CommandSequenceExecutor {
       const std::vector<std::unique_ptr<CvdServerHandler>>& server_handlers);
 
   Result<std::vector<cvd::Response>> Execute(
-      const std::vector<RequestWithStdio>&, SharedFD report);
-  Result<cvd::Response> ExecuteOne(const RequestWithStdio&, SharedFD report);
+      const std::vector<RequestWithStdio>&);
+  Result<cvd::Response> ExecuteOne(const RequestWithStdio&);
 
   std::vector<std::string> CmdList() const;
   Result<CvdServerHandler*> GetHandler(const RequestWithStdio& request);

--- a/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
@@ -69,8 +69,7 @@ Result<cvd::Response> Cvd::HandleCommand(
 
   RequestContext context(instance_lockfile_manager_, instance_manager_,
                          host_tool_target_manager_);
-  RequestWithStdio request_with_stdio(
-      request, {SharedFD::Dup(0), SharedFD::Dup(1), SharedFD::Dup(2)});
+  RequestWithStdio request_with_stdio(request);
   auto handler = CF_EXPECT(context.Handler(request_with_stdio));
   return handler->Handle(request_with_stdio);
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/instance_manager.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instance_manager.cpp
@@ -179,14 +179,10 @@ Result<void> InstanceManager::UpdateInstance(const LocalInstanceGroup& group,
 }
 
 Result<void> InstanceManager::IssueStopCommand(
-    const SharedFD& out, const SharedFD& err,
-    const std::string& config_file_path,
-    selector::LocalInstanceGroup& group) {
+    const std::string& config_file_path, selector::LocalInstanceGroup& group) {
   const auto stop_bin = CF_EXPECT(StopBin(group.HostArtifactsPath()));
   Command command(group.HostArtifactsPath() + "/bin/" + stop_bin);
   command.AddParameter("--clear_instance_dirs");
-  command.RedirectStdIO(Subprocess::StdIOChannel::kStdOut, out);
-  command.RedirectStdIO(Subprocess::StdIOChannel::kStdErr, err);
   command.AddEnvironmentVariable(kCuttlefishConfigEnvVarName, config_file_path);
   auto wait_result = RunCommand(std::move(command));
   /**
@@ -195,26 +191,20 @@ Result<void> InstanceManager::IssueStopCommand(
    * error. Then, we will try to re-run it without the flag.
    */
   if (!wait_result.ok()) {
-    std::stringstream error_msg;
-    error_msg << stop_bin << " was executed internally, and failed. It might "
+    std::cerr << stop_bin << " was executed internally, and failed. It might "
               << "be failing to parse the new --clear_instance_dirs. Will try "
               << "without the flag.\n";
-    WriteAll(err, error_msg.str());
     Command no_clear_instance_dir_command(group.HostArtifactsPath() + "/bin/" +
                                           stop_bin);
-    no_clear_instance_dir_command.RedirectStdIO(
-        Subprocess::StdIOChannel::kStdOut, out);
-    no_clear_instance_dir_command.RedirectStdIO(
-        Subprocess::StdIOChannel::kStdErr, err);
     no_clear_instance_dir_command.AddEnvironmentVariable(
         kCuttlefishConfigEnvVarName, config_file_path);
     wait_result = RunCommand(std::move(no_clear_instance_dir_command));
   }
 
   if (!wait_result.ok()) {
-    WriteAll(err,
-             "Warning: error stopping instances for dir \"" + group.HomeDir() +
-                 "\".\nThis can happen if instances are already stopped.\n");
+    std::cerr << "Warning: error stopping instances for dir \"" +
+                     group.HomeDir() +
+                     "\".\nThis can happen if instances are already stopped.\n";
   }
   group.SetAllStates(cvd::INSTANCE_STATE_STOPPED);
   instance_db_.UpdateInstanceGroup(group);
@@ -224,19 +214,18 @@ Result<void> InstanceManager::IssueStopCommand(
       (*lock)->Status(InUseState::kNotInUse);
       continue;
     }
-    WriteAll(err, "InstanceLockFileManager failed to acquire lock");
+    std::cerr << "InstanceLockFileManager failed to acquire lock";
   }
   return {};
 }
 
-cvd::Status InstanceManager::CvdClear(const SharedFD& out,
-                                      const SharedFD& err) {
+cvd::Status InstanceManager::CvdClear() {
   cvd::Status status;
   const std::string config_json_name = cpp_basename(GetGlobalConfigFileLink());
   auto instance_groups_res = instance_db_.Clear();
   if (!instance_groups_res.ok()) {
-    WriteAll(err, fmt::format("Failed to clear instance database: {}",
-                              instance_groups_res.error().Message()));
+    fmt::print(std::cerr, "Failed to clear instance database: {}",
+               instance_groups_res.error().Message());
     status.set_code(cvd::Status::INTERNAL);
     return status;
   }
@@ -246,7 +235,7 @@ cvd::Status InstanceManager::CvdClear(const SharedFD& out,
     if (group.HasActiveInstances()) {
       auto config_path = selector::GetCuttlefishConfigPath(group.HomeDir());
       if (config_path.ok()) {
-        auto stop_result = IssueStopCommand(out, err, *config_path, group);
+        auto stop_result = IssueStopCommand(*config_path, group);
         if (!stop_result.ok()) {
           LOG(ERROR) << stop_result.error().FormatForEnv();
         }
@@ -258,7 +247,7 @@ cvd::Status InstanceManager::CvdClear(const SharedFD& out,
   }
   // TODO(kwstephenkim): we need a better mechanism to make sure that
   // we clear all run_cvd processes.
-  WriteAll(err, "Stopped all known instances\n");
+  std::cerr << "Stopped all known instances\n";
   status.set_code(cvd::Status::OK);
   return status;
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/instance_manager.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instance_manager.h
@@ -23,7 +23,6 @@
 #include <utility>
 #include <vector>
 
-#include "common/libs/fs/shared_fd.h"
 #include "common/libs/utils/result.h"
 #include "cuttlefish/host/commands/cvd/cvd_server.pb.h"
 #include "cuttlefish/host/commands/cvd/selector/cvd_persistent_data.pb.h"
@@ -71,7 +70,7 @@ class InstanceManager {
                               const cvd::Instance& instance);
   Result<bool> RemoveInstanceGroupByHome(const std::string&);
 
-  cvd::Status CvdClear(const SharedFD& out, const SharedFD& err);
+  cvd::Status CvdClear();
   static Result<std::string> GetCuttlefishConfigPath(const std::string& home);
 
   Result<std::optional<InstanceLockFile>> TryAcquireLock(int instance_num);
@@ -86,9 +85,9 @@ class InstanceManager {
   Result<void> SetAcloudTranslatorOptout(bool optout);
   Result<bool> GetAcloudTranslatorOptout() const;
 
-  Result<void> IssueStopCommand(const SharedFD& out, const SharedFD& err,
-                                const std::string& config_file_path,
+  Result<void> IssueStopCommand(const std::string& config_file_path,
                                 selector::LocalInstanceGroup& group);
+
  private:
   Result<std::string> StopBin(const std::string& host_android_out);
 

--- a/base/cvd/cuttlefish/host/commands/cvd/interruptible_terminal.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/interruptible_terminal.h
@@ -29,7 +29,7 @@ namespace cuttlefish {
 
 class InterruptibleTerminal {
  public:
-  InterruptibleTerminal(SharedFD stdin_fd);
+  InterruptibleTerminal();
   /*
    * Returns a line from the stdin_fd, which is the client stdin
    *
@@ -44,7 +44,6 @@ class InterruptibleTerminal {
   Result<std::string> ReadLine();
 
  private:
-  SharedFD stdin_fd_;
   SharedFD interrupt_event_fd_;
   bool interrupted_ = false;
   // one owner per InterruptibleTerminal

--- a/base/cvd/cuttlefish/host/commands/cvd/server_client.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_client.cpp
@@ -64,7 +64,7 @@ Result<std::optional<RequestWithStdio>> GetRequest(const SharedFD& client) {
     LOG(DEBUG) << "Has credentials, uid=" << creds->uid;
   }
 
-  return RequestWithStdio(std::move(request), std::move(fds));
+  return RequestWithStdio(std::move(request));
 }
 
 Result<void> SendResponse(const SharedFD& client,
@@ -81,30 +81,8 @@ Result<void> SendResponse(const SharedFD& client,
   return {};
 }
 
-RequestWithStdio::RequestWithStdio(cvd::Request message,
-                                   std::vector<SharedFD> fds)
-    : message_(message), fds_(std::move(fds)) {}
+RequestWithStdio::RequestWithStdio(cvd::Request message) : message_(message) {}
 
 const cvd::Request& RequestWithStdio::Message() const { return message_; }
-
-const std::vector<SharedFD>& RequestWithStdio::FileDescriptors() const {
-  return fds_;
-}
-
-SharedFD RequestWithStdio::In() const {
-  return fds_.size() > 0 ? fds_[0] : SharedFD();
-}
-
-SharedFD RequestWithStdio::Out() const {
-  return fds_.size() > 1 ? fds_[1] : SharedFD();
-}
-
-SharedFD RequestWithStdio::Err() const {
-  return fds_.size() > 2 ? fds_[2] : SharedFD();
-}
-
-std::optional<SharedFD> RequestWithStdio::Extra() const {
-  return fds_.size() > 3 ? fds_[3] : std::optional<SharedFD>{};
-}
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/server_client.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_client.h
@@ -19,9 +19,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 
-#include <memory>
 #include <optional>
-#include <vector>
 
 #include "cuttlefish/host/commands/cvd/cvd_server.pb.h"
 
@@ -31,21 +29,15 @@
 
 namespace cuttlefish {
 
+// TODO(schuffelen): Rename or replace now that stdio is not included.
 class RequestWithStdio {
  public:
-  RequestWithStdio(cvd::Request, std::vector<SharedFD>);
+  RequestWithStdio(cvd::Request);
 
-  SharedFD Client() const;
   const cvd::Request& Message() const;
-  const std::vector<SharedFD>& FileDescriptors() const;
-  SharedFD In() const;
-  SharedFD Out() const;
-  SharedFD Err() const;
-  std::optional<SharedFD> Extra() const;
 
  private:
   cvd::Request message_;
-  std::vector<SharedFD> fds_;
 };
 
 Result<UnixMessageSocket> GetClient(const SharedFD& client);

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/acloud_mixsuperimage.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/acloud_mixsuperimage.cpp
@@ -173,7 +173,7 @@ class AcloudMixSuperImageCommand : public CvdServerHandler {
   cvd_common::Args CmdList() const override { return {}; }
   // not intended to show up in help
   Result<std::string> SummaryHelp() const override { return ""; }
-  bool ShouldInterceptHelp() const { return false; }
+  bool ShouldInterceptHelp() const override { return false; }
   Result<std::string> DetailedHelp(std::vector<std::string>&) const override {
     return "";
   }
@@ -197,7 +197,7 @@ class AcloudMixSuperImageCommand : public CvdServerHandler {
     CF_EXPECT(ConsumeFlags(mixsuperimage_flags, invocation.arguments),
               "Failed to process mix-super-image flag.");
     if (help) {
-      WriteAll(request.Out(), kMixSuperImageHelpMessage);
+      std::cout << kMixSuperImageHelpMessage;
       return response;
     }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/acloud_translator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/acloud_translator.cpp
@@ -85,7 +85,7 @@ class AcloudTranslatorCommand : public CvdServerHandler {
     CF_EXPECT(ConsumeFlags(translator_flags, invocation.arguments),
               "Failed to process translator flag.");
     if (help) {
-      WriteAll(request.Out(), kTranslatorHelpMessage);
+      std::cout << kTranslatorHelpMessage;
       return response;
     }
     CF_EXPECT(flag_optout != flag_optin,

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/cmd_list.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/cmd_list.cpp
@@ -19,9 +19,8 @@
 #include <vector>
 
 #include <android-base/strings.h>
+#include <json/value.h>
 
-#include "common/libs/fs/shared_buf.h"
-#include "common/libs/utils/json.h"
 #include "host/commands/cvd/server_command/server_handler.h"
 #include "host/commands/cvd/server_command/utils.h"
 #include "host/commands/cvd/types.h"
@@ -51,7 +50,7 @@ class CvdCmdlistHandler : public CvdServerHandler {
     const auto subcmds_str = android::base::Join(subcmds_vec, ",");
     Json::Value subcmd_info;
     subcmd_info["subcmd"] = subcmds_str;
-    WriteAll(request.Out(), subcmd_info.toStyledString());
+    std::cout << subcmd_info.toStyledString();
     return response;
   }
 
@@ -59,7 +58,7 @@ class CvdCmdlistHandler : public CvdServerHandler {
   cvd_common::Args CmdList() const override { return {}; }
   // not intended to show up in help
   Result<std::string> SummaryHelp() const override { return ""; }
-  bool ShouldInterceptHelp() const { return false; }
+  bool ShouldInterceptHelp() const override { return false; }
   Result<std::string> DetailedHelp(std::vector<std::string>&) const override {
     return "";
   }

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/display.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/display.cpp
@@ -114,10 +114,7 @@ class CvdDisplayCommandHandler : public CvdServerHandler {
         .args = subcmd_args,
         .envs = envs,
         .working_dir = request.Message().command_request().working_directory(),
-        .command_name = kDisplayBin,
-        .in = request.In(),
-        .out = request.Out(),
-        .err = request.Err()};
+        .command_name = kDisplayBin};
     Command command = CF_EXPECT(ConstructCommand(construct_cmd_param));
     return command;
   }
@@ -153,14 +150,12 @@ class CvdDisplayCommandHandler : public CvdServerHandler {
     envs[kAndroidHostOut] = android_host_out;
     envs[kAndroidSoongHostOut] = android_host_out;
 
-    std::stringstream command_to_issue;
-    command_to_issue << "HOME=" << home << " " << kAndroidHostOut << "="
-                     << android_host_out << " " << kAndroidSoongHostOut << "="
-                     << android_host_out << " " << cvd_display_bin_path << " ";
+    std::cerr << "HOME=" << home << " " << kAndroidHostOut << "="
+              << android_host_out << " " << kAndroidSoongHostOut << "="
+              << android_host_out << " " << cvd_display_bin_path << " ";
     for (const auto& arg : cvd_env_args) {
-      command_to_issue << arg << " ";
+      std::cerr << arg << " ";
     }
-    WriteAll(request.Err(), command_to_issue.str());
 
     ConstructCommandParam construct_cmd_param{
         .bin_path = cvd_display_bin_path,
@@ -168,10 +163,7 @@ class CvdDisplayCommandHandler : public CvdServerHandler {
         .args = cvd_env_args,
         .envs = envs,
         .working_dir = request.Message().command_request().working_directory(),
-        .command_name = kDisplayBin,
-        .in = request.In(),
-        .out = request.Out(),
-        .err = request.Err()};
+        .command_name = kDisplayBin};
     Command command = CF_EXPECT(ConstructCommand(construct_cmd_param));
     return command;
   }

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/fleet.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/fleet.cpp
@@ -20,8 +20,6 @@
 
 #include <android-base/file.h>
 
-#include "common/libs/fs/shared_buf.h"
-#include "common/libs/fs/shared_fd.h"
 #include "common/libs/utils/result.h"
 #include "host/commands/cvd/server_client.h"
 #include "host/commands/cvd/server_command/server_handler.h"
@@ -64,7 +62,7 @@ class CvdFleetCommandHandler : public CvdServerHandler {
   StatusFetcher status_fetcher_;
 
   static constexpr char kFleetSubcmd[] = "fleet";
-  Result<cvd::Status> CvdFleetHelp(const SharedFD& out) const;
+  cvd::Status CvdFleetHelp() const;
   bool IsHelp(const cvd_common::Args& cmd_args) const;
 };
 
@@ -86,7 +84,7 @@ Result<cvd::Response> CvdFleetCommandHandler::Handle(
   auto [sub_cmd, args] = ParseInvocation(request.Message());
 
   if (IsHelp(args)) {
-    CF_EXPECT(CvdFleetHelp(request.Out()));
+    std::cout << kHelpMessage;
     return ok_response;
   }
 
@@ -98,9 +96,7 @@ Result<cvd::Response> CvdFleetCommandHandler::Handle(
   }
   Json::Value output_json(Json::objectValue);
   output_json["groups"] = groups_json;
-  auto serialized_json = output_json.toStyledString();
-  CF_EXPECT_EQ(WriteAll(request.Out(), serialized_json),
-               (ssize_t)serialized_json.size());
+  std::cout << output_json.toStyledString();
   return ok_response;
 }
 
@@ -111,15 +107,6 @@ bool CvdFleetCommandHandler::IsHelp(const cvd_common::Args& args) const {
     }
   }
   return false;
-}
-
-Result<cvd::Status> CvdFleetCommandHandler::CvdFleetHelp(
-    const SharedFD& out) const {
-  const std::string help_message(kHelpMessage);
-  CF_EXPECT_EQ(WriteAll(out, help_message), (ssize_t)help_message.size());
-  cvd::Status status;
-  status.set_code(cvd::Status::OK);
-  return status;
 }
 
 std::unique_ptr<CvdServerHandler> NewCvdFleetCommandHandler(

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/handler_proxy.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/handler_proxy.cpp
@@ -86,8 +86,7 @@ class CvdServerHandlerProxy : public CvdServerHandler {
          .working_dir =
              request.Message().command_request().working_directory()});
 
-    RequestWithStdio forwarded_request(
-        std::move(exec_request), request.FileDescriptors());
+    RequestWithStdio forwarded_request(std::move(exec_request));
     SharedFD dev_null = SharedFD::Open("/dev/null", O_RDWR);
     CF_EXPECT(dev_null->IsOpen(), "Failed to open /dev/null");
 
@@ -99,9 +98,10 @@ class CvdServerHandlerProxy : public CvdServerHandler {
         handler->ShouldInterceptHelp()) {
       std::string output =
           CF_EXPECT(handler->DetailedHelp(invocation_args)) + "\n";
-      response = CF_EXPECT(WriteToFd(forwarded_request.Out(), output));
+      std::cout << output;
     } else {
-      response = CF_EXPECT(executor_.ExecuteOne(forwarded_request, dev_null));
+      // TODO(schuffelen): Find a way to hide output here
+      response = CF_EXPECT(executor_.ExecuteOne(forwarded_request));
     }
     return response;
   }

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/help.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/help.cpp
@@ -94,7 +94,11 @@ class CvdHelpHandler : public CvdServerHandler {
     } else {
       output = CF_EXPECT(SubCommandHelp(args));
     }
-    auto response = CF_EXPECT(WriteToFd(request.Out(), output));
+    std::cout << output;
+
+    cvd::Response response;
+    response.mutable_command_response();  // Sets oneof member
+    response.mutable_status()->set_code(cvd::Status::OK);
     return response;
   }
 
@@ -116,7 +120,8 @@ class CvdHelpHandler : public CvdServerHandler {
     lookup_cmd.add_args(arg);
     auto dev_null = SharedFD::Open("/dev/null", O_RDWR);
     CF_EXPECT(dev_null->IsOpen(), dev_null->StrError());
-    return RequestWithStdio(lookup, {dev_null, dev_null, dev_null});
+    // TODO(schuffelen): Find alternative to hide output.
+    return RequestWithStdio(lookup);
   }
 
   Result<std::string> TopLevelHelp() {

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/lint.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/lint.cpp
@@ -16,8 +16,8 @@
 
 #include "host/commands/cvd/server_command/lint.h"
 
+#include <iostream>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <vector>
 
@@ -61,12 +61,9 @@ class LintCommandHandler : public CvdServerHandler {
         request.Message().command_request().working_directory();
     const auto config_path = CF_EXPECT(ValidateConfig(args, working_directory));
 
-    std::stringstream message_stream;
-    message_stream << "Lint of flags and config \"" << config_path
-                   << "\" succeeded\n";
-    const auto message = message_stream.str();
-    CF_EXPECT_EQ(WriteAll(request.Out(), message), (ssize_t)message.size(),
-                 "Error writing message");
+    std::cout << "Lint of flags and config \"" << config_path
+              << "\" succeeded\n";
+
     cvd::Response response;
     response.mutable_command_response();
     response.mutable_status()->set_code(cvd::Status::OK);

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/load_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/load_configs.cpp
@@ -146,7 +146,7 @@ class LoadConfigsCommand : public CvdServerHandler {
                          selector::LocalInstanceGroup& group,
                          CvdFlags cvd_flags) {
     auto mkdir_cmd = BuildMkdirCmd(request, cvd_flags);
-    auto mkdir_res = executor_.ExecuteOne(mkdir_cmd, request.Err());
+    auto mkdir_res = executor_.ExecuteOne(mkdir_cmd);
     if (!mkdir_res.ok()) {
       group.SetAllStates(cvd::INSTANCE_STATE_PREPARE_FAILED);
       instance_manager_.UpdateInstanceGroup(group);
@@ -155,7 +155,7 @@ class LoadConfigsCommand : public CvdServerHandler {
 
     if (!cvd_flags.fetch_cvd_flags.empty()) {
       auto fetch_cmd = BuildFetchCmd(request, cvd_flags);
-      auto fetch_res = executor_.ExecuteOne(fetch_cmd, request.Err());
+      auto fetch_res = executor_.ExecuteOne(fetch_cmd);
       if (!fetch_res.ok()) {
         group.SetAllStates(cvd::INSTANCE_STATE_PREPARE_FAILED);
         instance_manager_.UpdateInstanceGroup(group);
@@ -164,7 +164,7 @@ class LoadConfigsCommand : public CvdServerHandler {
     }
 
     auto launch_cmd = BuildLaunchCmd(request, cvd_flags, group);
-    CF_EXPECT(executor_.ExecuteOne(launch_cmd, request.Err()));
+    CF_EXPECT(executor_.ExecuteOne(launch_cmd));
     return {};
   }
 
@@ -188,8 +188,7 @@ class LoadConfigsCommand : public CvdServerHandler {
     for (const auto& flag : cvd_flags.fetch_cvd_flags) {
       fetch_cmd.add_args(flag);
     }
-    return RequestWithStdio(fetch_req,
-                            {request.In(), request.Out(), request.Err()});
+    return RequestWithStdio(fetch_req);
   }
 
   RequestWithStdio BuildMkdirCmd(const RequestWithStdio& request,
@@ -201,8 +200,7 @@ class LoadConfigsCommand : public CvdServerHandler {
     mkdir_cmd.add_args("mkdir");
     mkdir_cmd.add_args("-p");
     mkdir_cmd.add_args(cvd_flags.load_directories.launch_home_directory);
-    return RequestWithStdio(mkdir_req,
-                            {request.In(), request.Out(), request.Err()});
+    return RequestWithStdio(mkdir_req);
   }
 
   RequestWithStdio BuildLaunchCmd(const RequestWithStdio& request,
@@ -247,8 +245,7 @@ class LoadConfigsCommand : public CvdServerHandler {
     launch_cmd.mutable_selector_opts()->add_args("--group_name");
     launch_cmd.mutable_selector_opts()->add_args(group.GroupName());
 
-    return RequestWithStdio(launch_req,
-                            {request.In(), request.Out(), request.Err()});
+    return RequestWithStdio(launch_req);
   }
 
  private:

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/noop.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/noop.cpp
@@ -16,6 +16,7 @@
 
 #include "host/commands/cvd/server_command/noop.h"
 
+#include <iostream>
 #include <memory>
 
 #include "common/libs/fs/shared_buf.h"
@@ -40,12 +41,8 @@ class CvdNoopHandler : public CvdServerHandler {
 
   Result<cvd::Response> Handle(const RequestWithStdio& request) override {
     auto invocation = ParseInvocation(request.Message());
-    auto msg = fmt::format("DEPRECATED: The {} command is a no-op",
-                           invocation.command);
-    auto write_len = WriteAll(request.Out(), msg);
-    CF_EXPECTF(write_len == (ssize_t)msg.size(),
-               "Failed to write deprecation message: {}",
-               request.Out()->StrError());
+    fmt::print(std::cout, "DEPRECATED: The {} command is a no-op",
+               invocation.command);
     cvd::Response response;
     response.mutable_status()->set_code(cvd::Status::OK);
     return response;

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/power.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/power.cpp
@@ -157,10 +157,7 @@ class CvdDevicePowerCommandHandler : public CvdServerHandler {
         .args = subcmd_args,
         .envs = envs,
         .working_dir = request.Message().command_request().working_directory(),
-        .command_name = bin_base,
-        .in = request.In(),
-        .out = request.Out(),
-        .err = request.Err()};
+        .command_name = bin_base};
     Command command = CF_EXPECT(ConstructCommand(construct_cmd_param));
     return command;
   }
@@ -197,14 +194,12 @@ class CvdDevicePowerCommandHandler : public CvdServerHandler {
     envs[kAndroidHostOut] = android_host_out;
     envs[kAndroidSoongHostOut] = android_host_out;
 
-    std::stringstream command_to_issue;
-    command_to_issue << "HOME=" << home << " " << kAndroidHostOut << "="
-                     << android_host_out << " " << kAndroidSoongHostOut << "="
-                     << android_host_out << " " << cvd_power_bin_path << " ";
+    std::cerr << "HOME=" << home << " " << kAndroidHostOut << "="
+              << android_host_out << " " << kAndroidSoongHostOut << "="
+              << android_host_out << " " << cvd_power_bin_path << " ";
     for (const auto& arg : cvd_env_args) {
-      command_to_issue << arg << " ";
+      std::cerr << arg << " ";
     }
-    WriteAll(request.Err(), command_to_issue.str());
 
     ConstructCommandParam construct_cmd_param{
         .bin_path = cvd_power_bin_path,
@@ -212,10 +207,7 @@ class CvdDevicePowerCommandHandler : public CvdServerHandler {
         .args = cvd_env_args,
         .envs = envs,
         .working_dir = request.Message().command_request().working_directory(),
-        .command_name = bin_base,
-        .in = request.In(),
-        .out = request.Out(),
-        .err = request.Err()};
+        .command_name = bin_base};
     Command command = CF_EXPECT(ConstructCommand(construct_cmd_param));
     return command;
   }

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/remove.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/remove.cpp
@@ -93,8 +93,7 @@ class RemoveCvdCommandHandler : public CvdServerHandler {
     }
     auto config_path =
         CF_EXPECT(selector::GetCuttlefishConfigPath(group.HomeDir()));
-    CF_EXPECT(instance_manager_.IssueStopCommand(request.Out(), request.Err(),
-                                                 config_path, group));
+    CF_EXPECT(instance_manager_.IssueStopCommand(config_path, group));
     return {};
   }
 
@@ -113,8 +112,7 @@ class RemoveCvdCommandHandler : public CvdServerHandler {
 
   Result<void> HelpCommand(const RequestWithStdio& request) const {
     std::vector<std::string> unused;
-    std::string msg = CF_EXPECT(DetailedHelp(unused));
-    CF_EXPECT_EQ(WriteAll(request.Out(), msg), (ssize_t)msg.size());
+    std::cout << CF_EXPECT(DetailedHelp(unused));
     return {};
   }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/reset.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/reset.cpp
@@ -139,7 +139,7 @@ class CvdResetCommandHandler : public CvdServerHandler {
       return {};
     }
 
-    instance_manager_.CvdClear(request.Out(), request.Err());
+    instance_manager_.CvdClear();
     // The instance database is obsolete now, clear it.
     auto instance_db_deleted = RemoveFile(InstanceDatabasePath());
     if (!instance_db_deleted) {

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/serial_launch.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/serial_launch.cpp
@@ -122,7 +122,7 @@ class SerialLaunchCommand : public CvdServerHandler {
     CF_EXPECT_EQ(can_handle_request, true);
 
     auto commands = CF_EXPECT(CreateCommandSequence(request));
-    CF_EXPECT(executor_.Execute(commands.requests, request.Err()));
+    CF_EXPECT(executor_.Execute(commands.requests));
 
     for (auto& lock : commands.instance_locks) {
       CF_EXPECT(lock.Status(InUseState::kInUse));
@@ -215,8 +215,7 @@ class SerialLaunchCommand : public CvdServerHandler {
 
     auto args = ParseInvocation(request.Message()).arguments;
     for (const auto& arg : args) {
-      std::string message = "argument: \"" + arg + "\"\n";
-      CF_EXPECT(WriteAll(request.Err(), message) == (ssize_t)message.size());
+      std::cerr << "argument: \"" + arg + "\"\n";
     }
 
     CF_EXPECT(ConsumeFlags(flags, args));
@@ -225,7 +224,7 @@ class SerialLaunchCommand : public CvdServerHandler {
       static constexpr char kHelp[] =
           "Usage: cvd experimental serial_launch [--verbose] --credentials=XYZ "
           "--device=build/target --device=build/target";
-      CF_EXPECT(WriteAll(request.Out(), kHelp, sizeof(kHelp)) == sizeof(kHelp));
+      std::cout << kHelp;
       return {};
     }
 
@@ -341,21 +340,13 @@ class SerialLaunchCommand : public CvdServerHandler {
       launch_cmd.add_args("--rootcanal_instance_num=" + first_instance_num);
     }
 
-    std::vector<SharedFD> fds;
-    if (verbose) {
-      fds = request.FileDescriptors();
-    } else {
-      auto dev_null = SharedFD::Open("/dev/null", O_RDWR);
-      CF_EXPECT(dev_null->IsOpen(), dev_null->StrError());
-      fds = {dev_null, dev_null, dev_null};
-    }
-
+    // TODO(schuffelen): Find a way to hide command output
     DemoCommandSequence ret;
     for (auto& device : devices) {
       ret.instance_locks.emplace_back(std::move(device.ins_lock));
     }
     for (auto& request_proto : req_protos) {
-      ret.requests.emplace_back(request_proto, fds);
+      ret.requests.emplace_back(request_proto);
     }
 
     return ret;

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/serial_preset.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/serial_preset.cpp
@@ -64,10 +64,9 @@ class SerialPreset : public CvdServerHandler {
       cmd.add_args(invocation.arguments[i]);
     }
 
-    RequestWithStdio inner_request(std::move(inner_req_proto),
-                                   request.FileDescriptors());
+    RequestWithStdio inner_request(std::move(inner_req_proto));
 
-    CF_EXPECT(executor_.Execute({std::move(inner_request)}, request.Err()));
+    CF_EXPECT(executor_.Execute({std::move(inner_request)}));
 
     cvd::Response response;
     response.mutable_command_response();

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/snapshot.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/snapshot.cpp
@@ -139,14 +139,12 @@ class CvdSnapshotCommandHandler : public CvdServerHandler {
     envs[kAndroidHostOut] = android_host_out;
     envs[kAndroidSoongHostOut] = android_host_out;
 
-    std::stringstream command_to_issue;
-    command_to_issue << "HOME=" << home << " " << kAndroidHostOut << "="
-                     << android_host_out << " " << kAndroidSoongHostOut << "="
-                     << android_host_out << " " << cvd_snapshot_bin_path << " ";
+    std::cerr << "HOME=" << home << " " << kAndroidHostOut << "="
+              << android_host_out << " " << kAndroidSoongHostOut << "="
+              << android_host_out << " " << cvd_snapshot_bin_path << " ";
     for (const auto& arg : cvd_snapshot_args) {
-      command_to_issue << arg << " ";
+      std::cerr << arg << " ";
     }
-    WriteAll(request.Err(), command_to_issue.str());
 
     ConstructCommandParam construct_cmd_param{
         .bin_path = cvd_snapshot_bin_path,
@@ -154,10 +152,7 @@ class CvdSnapshotCommandHandler : public CvdServerHandler {
         .args = cvd_snapshot_args,
         .envs = envs,
         .working_dir = request.Message().command_request().working_directory(),
-        .command_name = android::base::Basename(cvd_snapshot_bin_path),
-        .in = request.In(),
-        .out = request.Out(),
-        .err = request.Err()};
+        .command_name = android::base::Basename(cvd_snapshot_bin_path)};
     Command command = CF_EXPECT(ConstructCommand(construct_cmd_param));
     return command;
   }

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/status.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/status.cpp
@@ -160,7 +160,7 @@ static Result<RequestWithStdio> ProcessInstanceNameFlag(
       .selector_args = cvd_common::ConvertToArgs(selector_opts.args()),
       .working_dir = request.Message().command_request().working_directory(),
   });
-  return RequestWithStdio(new_message, request.FileDescriptors());
+  return RequestWithStdio(new_message);
 }
 
 static Result<bool> HasPrint(cvd_common::Args cmd_args) {
@@ -198,12 +198,9 @@ Result<cvd::Response> CvdStatusCommandHandler::Handle(
     return response;
   }
 
-  std::string serialized_group_json = instances_json.toStyledString();
-  CF_EXPECT_EQ(WriteAll(request.Err(), entire_stderr_msg),
-               (ssize_t)entire_stderr_msg.size());
+  std::cerr << entire_stderr_msg;
   if (has_print) {
-    CF_EXPECT_EQ(WriteAll(request.Out(), serialized_group_json),
-                 (ssize_t)serialized_group_json.size());
+    std::cout << instances_json.toStyledString();
   }
   return response;
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/utils.h
@@ -49,7 +49,6 @@ struct ConstructCommandParam {
   const cvd_common::Envs& envs;
   const std::string& working_dir;
   const std::string& command_name;
-  SharedFD in;
   SharedFD out;
   SharedFD err;
 };
@@ -92,7 +91,5 @@ enum class TerminalColors : int {
 };
 
 std::string TerminalColor(const bool is_tty, TerminalColors color);
-
-Result<cvd::Response> WriteToFd(SharedFD fd, const std::string& output);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/version.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/version.cpp
@@ -16,10 +16,11 @@
 
 #include "host/commands/cvd/server_command/version.h"
 
+#include <iostream>
+
 #include "build/version.h"
 #include "cuttlefish/host/commands/cvd/cvd_server.pb.h"
 
-#include "common/libs/fs/shared_buf.h"
 #include "common/libs/utils/proto.h"
 #include "common/libs/utils/result.h"
 #include "host/commands/cvd/common_utils.h"
@@ -51,10 +52,9 @@ class CvdVersionHandler : public CvdServerHandler {
     version.set_minor(cvd::kVersionMinor);
     version.set_build(android::build::GetBuildNumber());
     version.set_crc32(FileCrc(kServerExecPath));
-    auto version_str = fmt::format("{}", version);
-    auto write_len = WriteAll(request.Out(), version_str);
-    CF_EXPECTF(write_len == (ssize_t)version_str.size(),
-               "Failed to write version output: {}", request.Out()->StrError());
+
+    fmt::print(std::cout, "{}", version);
+
     cvd::Response response;
     response.mutable_status()->set_code(cvd::Status::OK);
     return response;


### PR DESCRIPTION
In practice, these file descriptors were usually the same as the regular stdio file descriptors, but were sometimes `/dev/null`. This commit regresses on the `/dev/null` cases and collapses everything into the "inherit stdio" case, sometimes introducing extra output.