### PR TITLE
Replace `SharedFD`s in `RequestWithStdio` with `std::[io]stream&`s.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/command_sequence.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/command_sequence.cpp
@@ -83,15 +83,13 @@ CommandSequenceExecutor::CommandSequenceExecutor(
     : server_handlers_(server_handlers) {}
 
 Result<std::vector<cvd::Response>> CommandSequenceExecutor::Execute(
-    const std::vector<RequestWithStdio>& requests, SharedFD report) {
+    const std::vector<RequestWithStdio>& requests, std::ostream& report) {
   std::vector<cvd::Response> responses;
   for (const auto& request : requests) {
     auto& inner_proto = request.Message();
     if (inner_proto.has_command_request()) {
       auto& command = inner_proto.command_request();
-      std::string str = FormattedCommand(command);
-      CF_EXPECT(WriteAll(report, str) == (ssize_t)str.size(),
-                report->StrError());
+      report << FormattedCommand(command);
     }
 
     auto handler = CF_EXPECT(RequestHandler(request, server_handlers_));
@@ -108,7 +106,7 @@ Result<std::vector<cvd::Response>> CommandSequenceExecutor::Execute(
 }
 
 Result<cvd::Response> CommandSequenceExecutor::ExecuteOne(
-    const RequestWithStdio& request, SharedFD report) {
+    const RequestWithStdio& request, std::ostream& report) {
   auto response_in_vector = CF_EXPECT(Execute({request}, report));
   CF_EXPECT_EQ(response_in_vector.size(), 1ul);
   return response_in_vector.front();

--- a/base/cvd/cuttlefish/host/commands/cvd/command_sequence.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/command_sequence.h
@@ -16,10 +16,9 @@
 #pragma once
 
 #include <memory>
-#include <mutex>
+#include <ostream>
 #include <vector>
 
-#include "common/libs/fs/shared_fd.h"
 #include "cuttlefish/host/commands/cvd/cvd_server.pb.h"
 #include "host/commands/cvd/server_client.h"
 #include "host/commands/cvd/server_command/server_handler.h"
@@ -32,8 +31,9 @@ class CommandSequenceExecutor {
       const std::vector<std::unique_ptr<CvdServerHandler>>& server_handlers);
 
   Result<std::vector<cvd::Response>> Execute(
-      const std::vector<RequestWithStdio>&, SharedFD report);
-  Result<cvd::Response> ExecuteOne(const RequestWithStdio&, SharedFD report);
+      const std::vector<RequestWithStdio>&, std::ostream& report);
+  Result<cvd::Response> ExecuteOne(const RequestWithStdio&,
+                                   std::ostream& report);
 
   std::vector<std::string> CmdList() const;
   Result<CvdServerHandler*> GetHandler(const RequestWithStdio& request);

--- a/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
@@ -69,8 +69,8 @@ Result<cvd::Response> Cvd::HandleCommand(
 
   RequestContext context(instance_lockfile_manager_, instance_manager_,
                          host_tool_target_manager_);
-  RequestWithStdio request_with_stdio(
-      request, {SharedFD::Dup(0), SharedFD::Dup(1), SharedFD::Dup(2)});
+  RequestWithStdio request_with_stdio =
+      RequestWithStdio::StdIo(std::move(request));
   auto handler = CF_EXPECT(context.Handler(request_with_stdio));
   return handler->Handle(request_with_stdio);
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/instance_manager.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instance_manager.h
@@ -33,6 +33,7 @@
 #include "host/commands/cvd/selector/instance_database.h"
 #include "host/commands/cvd/selector/instance_database_types.h"
 #include "host/commands/cvd/selector/instance_selector.h"
+#include "host/commands/cvd/server_client.h"
 #include "host/commands/cvd/server_command/host_tool_target_manager.h"
 
 namespace cuttlefish {
@@ -71,7 +72,7 @@ class InstanceManager {
                               const cvd::Instance& instance);
   Result<bool> RemoveInstanceGroupByHome(const std::string&);
 
-  cvd::Status CvdClear(const SharedFD& out, const SharedFD& err);
+  cvd::Status CvdClear(const RequestWithStdio&);
   static Result<std::string> GetCuttlefishConfigPath(const std::string& home);
 
   Result<std::optional<InstanceLockFile>> TryAcquireLock(int instance_num);
@@ -86,9 +87,10 @@ class InstanceManager {
   Result<void> SetAcloudTranslatorOptout(bool optout);
   Result<bool> GetAcloudTranslatorOptout() const;
 
-  Result<void> IssueStopCommand(const SharedFD& out, const SharedFD& err,
+  Result<void> IssueStopCommand(const RequestWithStdio& request,
                                 const std::string& config_file_path,
                                 selector::LocalInstanceGroup& group);
+
  private:
   Result<std::string> StopBin(const std::string& host_android_out);
 

--- a/base/cvd/cuttlefish/host/commands/cvd/interruptible_terminal.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/interruptible_terminal.h
@@ -29,7 +29,7 @@ namespace cuttlefish {
 
 class InterruptibleTerminal {
  public:
-  InterruptibleTerminal(SharedFD stdin_fd);
+  InterruptibleTerminal();
   /*
    * Returns a line from the stdin_fd, which is the client stdin
    *
@@ -44,7 +44,6 @@ class InterruptibleTerminal {
   Result<std::string> ReadLine();
 
  private:
-  SharedFD stdin_fd_;
   SharedFD interrupt_event_fd_;
   bool interrupted_ = false;
   // one owner per InterruptibleTerminal

--- a/base/cvd/cuttlefish/host/commands/cvd/server_client.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_client.h
@@ -33,15 +33,16 @@ namespace cuttlefish {
 
 class RequestWithStdio {
  public:
-  RequestWithStdio(cvd::Request, std::vector<SharedFD>);
+  static RequestWithStdio StdIo(cvd::Request);
+  static RequestWithStdio NullIo(cvd::Request);
+  static RequestWithStdio InheritIo(cvd::Request, const RequestWithStdio&);
 
-  SharedFD Client() const;
   const cvd::Request& Message() const;
-  const std::vector<SharedFD>& FileDescriptors() const;
-  SharedFD In() const;
-  SharedFD Out() const;
-  SharedFD Err() const;
-  std::optional<SharedFD> Extra() const;
+  std::istream& In() const;
+  std::ostream& Out() const;
+  std::ostream& Err() const;
+
+  bool IsNullIo() const;
 
   // Convenient accessors to commonly used properties in the underlying message
   cvd_common::Args Args() const {
@@ -56,8 +57,12 @@ class RequestWithStdio {
   }
 
  private:
+  RequestWithStdio(cvd::Request, std::istream&, std::ostream&, std::ostream&);
+
   cvd::Request message_;
-  std::vector<SharedFD> fds_;
+  std::istream& in_;
+  std::ostream& out_;
+  std::ostream& err_;
 };
 
 Result<UnixMessageSocket> GetClient(const SharedFD& client);

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/acloud_mixsuperimage.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/acloud_mixsuperimage.cpp
@@ -18,7 +18,6 @@
 
 #include <android-base/file.h>
 
-#include "common/libs/fs/shared_buf.h"
 #include "common/libs/utils/files.h"
 #include "common/libs/utils/flag_parser.h"
 #include "common/libs/utils/result.h"
@@ -197,7 +196,7 @@ class AcloudMixSuperImageCommand : public CvdServerHandler {
     CF_EXPECT(ConsumeFlags(mixsuperimage_flags, invocation.arguments),
               "Failed to process mix-super-image flag.");
     if (help) {
-      WriteAll(request.Out(), kMixSuperImageHelpMessage);
+      request.Out() << kMixSuperImageHelpMessage;
       return response;
     }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/acloud_translator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/acloud_translator.cpp
@@ -85,7 +85,7 @@ class AcloudTranslatorCommand : public CvdServerHandler {
     CF_EXPECT(ConsumeFlags(translator_flags, invocation.arguments),
               "Failed to process translator flag.");
     if (help) {
-      WriteAll(request.Out(), kTranslatorHelpMessage);
+      request.Out() << kTranslatorHelpMessage;
       return response;
     }
     CF_EXPECT(flag_optout != flag_optin,

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/cmd_list.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/cmd_list.cpp
@@ -19,9 +19,8 @@
 #include <vector>
 
 #include <android-base/strings.h>
+#include <json/value.h>
 
-#include "common/libs/fs/shared_buf.h"
-#include "common/libs/utils/json.h"
 #include "host/commands/cvd/server_command/server_handler.h"
 #include "host/commands/cvd/server_command/utils.h"
 #include "host/commands/cvd/types.h"
@@ -51,7 +50,7 @@ class CvdCmdlistHandler : public CvdServerHandler {
     const auto subcmds_str = android::base::Join(subcmds_vec, ",");
     Json::Value subcmd_info;
     subcmd_info["subcmd"] = subcmds_str;
-    WriteAll(request.Out(), subcmd_info.toStyledString());
+    request.Out() << subcmd_info.toStyledString();
     return response;
   }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/create.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/create.cpp
@@ -131,7 +131,7 @@ RequestWithStdio CreateLoadCommand(const RequestWithStdio& request,
     command.add_args(arg);
   }
   command.add_args(config_file);
-  return RequestWithStdio(request_proto, request.FileDescriptors());
+  return RequestWithStdio::InheritIo(request_proto, request);
 }
 
 RequestWithStdio CreateStartCommand(const RequestWithStdio& request,
@@ -153,7 +153,7 @@ RequestWithStdio CreateStartCommand(const RequestWithStdio& request,
   for (const auto& arg : args) {
     command.add_args(arg);
   }
-  return RequestWithStdio(request_proto, request.FileDescriptors());
+  return RequestWithStdio::InheritIo(request_proto, request);
 }
 
 Result<cvd_common::Envs> GetEnvs(const RequestWithStdio& request) {

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/display.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/display.cpp
@@ -114,9 +114,7 @@ class CvdDisplayCommandHandler : public CvdServerHandler {
         .envs = envs,
         .working_dir = request.Message().command_request().working_directory(),
         .command_name = kDisplayBin,
-        .in = request.In(),
-        .out = request.Out(),
-        .err = request.Err()};
+        .null_stdio = request.IsNullIo()};
     Command command = CF_EXPECT(ConstructCommand(construct_cmd_param));
     return command;
   }
@@ -151,13 +149,12 @@ class CvdDisplayCommandHandler : public CvdServerHandler {
     envs[kAndroidSoongHostOut] = android_host_out;
 
     std::stringstream command_to_issue;
-    command_to_issue << "HOME=" << home << " " << kAndroidHostOut << "="
-                     << android_host_out << " " << kAndroidSoongHostOut << "="
-                     << android_host_out << " " << cvd_display_bin_path << " ";
+    request.Err() << "HOME=" << home << " " << kAndroidHostOut << "="
+                  << android_host_out << " " << kAndroidSoongHostOut << "="
+                  << android_host_out << " " << cvd_display_bin_path << " ";
     for (const auto& arg : cvd_env_args) {
-      command_to_issue << arg << " ";
+      request.Err() << arg << " ";
     }
-    WriteAll(request.Err(), command_to_issue.str());
 
     ConstructCommandParam construct_cmd_param{
         .bin_path = cvd_display_bin_path,
@@ -166,9 +163,7 @@ class CvdDisplayCommandHandler : public CvdServerHandler {
         .envs = envs,
         .working_dir = request.Message().command_request().working_directory(),
         .command_name = kDisplayBin,
-        .in = request.In(),
-        .out = request.Out(),
-        .err = request.Err()};
+        .null_stdio = request.IsNullIo()};
     Command command = CF_EXPECT(ConstructCommand(construct_cmd_param));
     return command;
   }

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/generic.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/generic.cpp
@@ -142,8 +142,7 @@ Result<cvd::Response> CvdGenericCommandHandler::Handle(
       CF_EXPECT(ExtractInfo(request));
 
   if (invocation_info.bin == kClearBin) {
-    *response.mutable_status() =
-        instance_manager_.CvdClear(request.Out(), request.Err());
+    *response.mutable_status() = instance_manager_.CvdClear(request);
     return response;
   }
 
@@ -162,9 +161,7 @@ Result<cvd::Response> CvdGenericCommandHandler::Handle(
       .envs = invocation_info.envs,
       .working_dir = request.Message().command_request().working_directory(),
       .command_name = invocation_info.bin,
-      .in = request.In(),
-      .out = request.Out(),
-      .err = request.Err()};
+      .null_stdio = request.IsNullIo()};
   Command command = CF_EXPECT(ConstructCommand(construct_cmd_param));
 
   siginfo_t infop;

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/lint.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/lint.cpp
@@ -17,11 +17,9 @@
 #include "host/commands/cvd/server_command/lint.h"
 
 #include <memory>
-#include <sstream>
 #include <string>
 #include <vector>
 
-#include "common/libs/fs/shared_buf.h"
 #include "common/libs/utils/result.h"
 #include "host/commands/cvd/parser/load_configs_parser.h"
 #include "host/commands/cvd/server_client.h"
@@ -61,12 +59,9 @@ class LintCommandHandler : public CvdServerHandler {
         request.Message().command_request().working_directory();
     const auto config_path = CF_EXPECT(ValidateConfig(args, working_directory));
 
-    std::stringstream message_stream;
-    message_stream << "Lint of flags and config \"" << config_path
-                   << "\" succeeded\n";
-    const auto message = message_stream.str();
-    CF_EXPECT_EQ(WriteAll(request.Out(), message), (ssize_t)message.size(),
-                 "Error writing message");
+    request.Out() << "Lint of flags and config \"" << config_path
+                  << "\" succeeded\n";
+
     cvd::Response response;
     response.mutable_command_response();
     response.mutable_status()->set_code(cvd::Status::OK);

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/load_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/load_configs.cpp
@@ -188,8 +188,7 @@ class LoadConfigsCommand : public CvdServerHandler {
     for (const auto& flag : cvd_flags.fetch_cvd_flags) {
       fetch_cmd.add_args(flag);
     }
-    return RequestWithStdio(fetch_req,
-                            {request.In(), request.Out(), request.Err()});
+    return RequestWithStdio::InheritIo(std::move(fetch_req), request);
   }
 
   RequestWithStdio BuildMkdirCmd(const RequestWithStdio& request,
@@ -201,8 +200,7 @@ class LoadConfigsCommand : public CvdServerHandler {
     mkdir_cmd.add_args("mkdir");
     mkdir_cmd.add_args("-p");
     mkdir_cmd.add_args(cvd_flags.load_directories.launch_home_directory);
-    return RequestWithStdio(mkdir_req,
-                            {request.In(), request.Out(), request.Err()});
+    return RequestWithStdio::InheritIo(std::move(mkdir_req), request);
   }
 
   RequestWithStdio BuildLaunchCmd(const RequestWithStdio& request,
@@ -249,8 +247,7 @@ class LoadConfigsCommand : public CvdServerHandler {
     launch_cmd.mutable_selector_opts()->add_args("--group_name");
     launch_cmd.mutable_selector_opts()->add_args(group.GroupName());
 
-    return RequestWithStdio(launch_req,
-                            {request.In(), request.Out(), request.Err()});
+    return RequestWithStdio::InheritIo(std::move(launch_req), request);
   }
 
  private:

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/noop.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/noop.cpp
@@ -40,12 +40,8 @@ class CvdNoopHandler : public CvdServerHandler {
 
   Result<cvd::Response> Handle(const RequestWithStdio& request) override {
     auto invocation = ParseInvocation(request.Message());
-    auto msg = fmt::format("DEPRECATED: The {} command is a no-op",
-                           invocation.command);
-    auto write_len = WriteAll(request.Out(), msg);
-    CF_EXPECTF(write_len == (ssize_t)msg.size(),
-               "Failed to write deprecation message: {}",
-               request.Out()->StrError());
+    fmt::print(request.Out(), "DEPRECATED: The {} command is a no-op",
+               invocation.command);
     cvd::Response response;
     response.mutable_status()->set_code(cvd::Status::OK);
     return response;

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/power.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/power.cpp
@@ -158,9 +158,7 @@ class CvdDevicePowerCommandHandler : public CvdServerHandler {
         .envs = envs,
         .working_dir = request.Message().command_request().working_directory(),
         .command_name = bin_base,
-        .in = request.In(),
-        .out = request.Out(),
-        .err = request.Err()};
+        .null_stdio = request.IsNullIo()};
     Command command = CF_EXPECT(ConstructCommand(construct_cmd_param));
     return command;
   }
@@ -202,7 +200,7 @@ class CvdDevicePowerCommandHandler : public CvdServerHandler {
     for (const auto& arg : cvd_env_args) {
       command_to_issue << arg << " ";
     }
-    WriteAll(request.Err(), command_to_issue.str());
+    request.Err() << command_to_issue.str();
 
     ConstructCommandParam construct_cmd_param{
         .bin_path = cvd_power_bin_path,
@@ -211,9 +209,7 @@ class CvdDevicePowerCommandHandler : public CvdServerHandler {
         .envs = envs,
         .working_dir = request.Message().command_request().working_directory(),
         .command_name = bin_base,
-        .in = request.In(),
-        .out = request.Out(),
-        .err = request.Err()};
+        .null_stdio = request.IsNullIo()};
     Command command = CF_EXPECT(ConstructCommand(construct_cmd_param));
     return command;
   }

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/remove.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/remove.cpp
@@ -71,8 +71,10 @@ class RemoveCvdCommandHandler : public CvdServerHandler {
   Result<cvd::Response> Handle(const RequestWithStdio& request) override {
     CF_EXPECT(CanHandle(request));
     auto [op, subcmd_args] = ParseInvocation(request.Message());
+
     if (CF_EXPECT(IsHelpSubcmd(subcmd_args))) {
-      CF_EXPECT(HelpCommand(request));
+      std::vector<std::string> unused;
+      request.Out() << CF_EXPECT(DetailedHelp(unused));
       return Success();
     }
 
@@ -98,15 +100,14 @@ class RemoveCvdCommandHandler : public CvdServerHandler {
     }
     auto config_path =
         CF_EXPECT(selector::GetCuttlefishConfigPath(group.HomeDir()));
-    CF_EXPECT(instance_manager_.IssueStopCommand(request.Out(), request.Err(),
-                                                 config_path, group));
+    CF_EXPECT(instance_manager_.IssueStopCommand(request, config_path, group));
     return {};
   }
 
   Result<void> HelpCommand(const RequestWithStdio& request) const {
     std::vector<std::string> unused;
     std::string msg = CF_EXPECT(DetailedHelp(unused));
-    CF_EXPECT_EQ(WriteAll(request.Out(), msg), (ssize_t)msg.size());
+    request.Out() << msg;
     return {};
   }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/reset.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/reset.cpp
@@ -137,7 +137,7 @@ class CvdResetCommandHandler : public CvdServerHandler {
       return {};
     }
 
-    instance_manager_.CvdClear(request.Out(), request.Err());
+    instance_manager_.CvdClear(request);
     // The instance database is obsolete now, clear it.
     auto instance_db_deleted = RemoveFile(InstanceDatabasePath());
     if (!instance_db_deleted) {

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/serial_preset.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/serial_preset.cpp
@@ -64,8 +64,8 @@ class SerialPreset : public CvdServerHandler {
       cmd.add_args(invocation.arguments[i]);
     }
 
-    RequestWithStdio inner_request(std::move(inner_req_proto),
-                                   request.FileDescriptors());
+    RequestWithStdio inner_request =
+        RequestWithStdio::InheritIo(std::move(inner_req_proto), request);
 
     CF_EXPECT(executor_.Execute({std::move(inner_request)}, request.Err()));
 

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/snapshot.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/snapshot.cpp
@@ -136,14 +136,12 @@ class CvdSnapshotCommandHandler : public CvdServerHandler {
     envs[kAndroidHostOut] = android_host_out;
     envs[kAndroidSoongHostOut] = android_host_out;
 
-    std::stringstream command_to_issue;
-    command_to_issue << "HOME=" << home << " " << kAndroidHostOut << "="
-                     << android_host_out << " " << kAndroidSoongHostOut << "="
-                     << android_host_out << " " << cvd_snapshot_bin_path << " ";
+    request.Err() << "HOME=" << home << " " << kAndroidHostOut << "="
+                  << android_host_out << " " << kAndroidSoongHostOut << "="
+                  << android_host_out << " " << cvd_snapshot_bin_path << " ";
     for (const auto& arg : cvd_snapshot_args) {
-      command_to_issue << arg << " ";
+      request.Err() << arg << " ";
     }
-    WriteAll(request.Err(), command_to_issue.str());
 
     ConstructCommandParam construct_cmd_param{
         .bin_path = cvd_snapshot_bin_path,
@@ -152,9 +150,7 @@ class CvdSnapshotCommandHandler : public CvdServerHandler {
         .envs = envs,
         .working_dir = request.Message().command_request().working_directory(),
         .command_name = android::base::Basename(cvd_snapshot_bin_path),
-        .in = request.In(),
-        .out = request.Out(),
-        .err = request.Err()};
+        .null_stdio = request.IsNullIo()};
     Command command = CF_EXPECT(ConstructCommand(construct_cmd_param));
     return command;
   }

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/status.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/status.cpp
@@ -157,7 +157,7 @@ static Result<RequestWithStdio> ProcessInstanceNameFlag(
       .selector_args = request.SelectorArgs(),
       .working_dir = request.Message().command_request().working_directory(),
   });
-  return RequestWithStdio(new_message, request.FileDescriptors());
+  return RequestWithStdio::InheritIo(std::move(new_message), (request));
 }
 
 static Result<bool> HasPrint(cvd_common::Args cmd_args) {
@@ -196,11 +196,9 @@ Result<cvd::Response> CvdStatusCommandHandler::Handle(
   }
 
   std::string serialized_group_json = instances_json.toStyledString();
-  CF_EXPECT_EQ(WriteAll(request.Err(), entire_stderr_msg),
-               (ssize_t)entire_stderr_msg.size());
+  request.Err() << serialized_group_json;
   if (has_print) {
-    CF_EXPECT_EQ(WriteAll(request.Out(), serialized_group_json),
-                 (ssize_t)serialized_group_json.size());
+    request.Out() << serialized_group_json;
   }
   return response;
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/stop.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/stop.cpp
@@ -103,9 +103,7 @@ Result<cvd::Response> CvdStopCommandHandler::HandleHelpCmd(
       .envs = envs,
       .working_dir = request.Message().command_request().working_directory(),
       .command_name = bin,
-      .in = request.In(),
-      .out = request.Out(),
-      .err = request.Err()};
+      .null_stdio = request.IsNullIo()};
   Command command = CF_EXPECT(ConstructCommand(construct_cmd_param));
 
   siginfo_t infop;
@@ -154,9 +152,7 @@ Result<cvd::Response> CvdStopCommandHandler::Handle(
       .envs = envs,
       .working_dir = request.Message().command_request().working_directory(),
       .command_name = bin,
-      .in = request.In(),
-      .out = request.Out(),
-      .err = request.Err()};
+      .null_stdio = request.IsNullIo()};
   Command command = CF_EXPECT(ConstructCommand(construct_cmd_param));
 
   siginfo_t infop;

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/utils.h
@@ -50,9 +50,7 @@ struct ConstructCommandParam {
   const cvd_common::Envs& envs;
   const std::string& working_dir;
   const std::string& command_name;
-  SharedFD in;
-  SharedFD out;
-  SharedFD err;
+  bool null_stdio;
 };
 Result<Command> ConstructCommand(const ConstructCommandParam& cmd_param);
 

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/version.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/version.cpp
@@ -46,15 +46,15 @@ class CvdVersionHandler : public CvdServerHandler {
 
   Result<cvd::Response> Handle(const RequestWithStdio& request) override {
     CF_EXPECT(CanHandle(request));
+
     cvd::Version version;
     version.set_major(cvd::kVersionMajor);
     version.set_minor(cvd::kVersionMinor);
     version.set_build(android::build::GetBuildNumber());
     version.set_crc32(FileCrc(kServerExecPath));
-    auto version_str = fmt::format("{}", version);
-    auto write_len = WriteAll(request.Out(), version_str);
-    CF_EXPECTF(write_len == (ssize_t)version_str.size(),
-               "Failed to write version output: {}", request.Out()->StrError());
+
+    fmt::print(request.Out(), "{}", version);
+
     cvd::Response response;
     response.mutable_status()->set_code(cvd::Status::OK);
     return response;


### PR DESCRIPTION
These are more convenient to write to than `SharedFD`s. Since `cvd` has stopped using a background server, the only remaining cases were that the regular stdin, stdout, stderr streams were used, or no stream was being used at all.