### PR TITLE
Don't require ANDROID_HOST_OUT on cvd start

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/request_context.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/request_context.cpp
@@ -69,8 +69,9 @@ RequestContext::RequestContext(
   request_handlers_.emplace_back(NewAcloudTranslatorCommand(instance_manager_));
   request_handlers_.emplace_back(
       NewCvdCmdlistHandler(command_sequence_executor_));
-  request_handlers_.emplace_back(NewCvdCreateCommandHandler(
-      instance_manager_, command_sequence_executor_));
+  request_handlers_.emplace_back(
+      NewCvdCreateCommandHandler(instance_manager_, host_tool_target_manager_,
+                                 command_sequence_executor_));
   request_handlers_.emplace_back(
       NewCvdDisplayCommandHandler(instance_manager_));
   request_handlers_.emplace_back(NewCvdEnvCommandHandler(instance_manager_));

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/create.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/create.h
@@ -26,6 +26,7 @@ namespace cuttlefish {
 
 std::unique_ptr<CvdServerHandler> NewCvdCreateCommandHandler(
     InstanceManager& instance_manager,
+    HostToolTargetManager& host_tool_target_manager,
     CommandSequenceExecutor& executor);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
@@ -477,11 +477,9 @@ static void ShowLaunchCommand(const Command& command,
 Result<std::string> CvdStartCommandHandler::FindStartBin(
     const std::string& android_host_out) {
   auto start_bin = CF_EXPECT(host_tool_target_manager_.ExecBaseName({
-                                 .artifacts_path = android_host_out,
-                                 .op = "start",
-                             }),
-                             "\nMaybe try `cvd fetch` or running `lunch "
-                             "<target>` to enable starting a CF device?");
+      .artifacts_path = android_host_out,
+      .op = "start",
+  }));
   return start_bin;
 }
 


### PR DESCRIPTION
cvd start uses the host artifacts path from the group to be started, which is stored in the instance database. It's not necessary then to required ANDROID_HOST_OUT to be defined and point to a valid location.