### PR TITLE
Fix permission error on executing chmod for vbmeta images

### DIFF
--- a/frontend/src/host_orchestrator/orchestrator/createcvdaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/createcvdaction.go
@@ -285,7 +285,7 @@ func (a *CreateCVDAction) launchFromAndroidCI(
 func (a *CreateCVDAction) launchFromUserBuild(
 	buildSource *apiv1.UserBuildSource, instancesCount uint32, op apiv1.Operation) ([]uint32, error) {
 	artifactsDir := a.userArtifactsDirResolver.GetDirPath(buildSource.ArtifactsDir)
-	if err := setWritePermissionOnVbmetaImgs(artifactsDir); err != nil {
+	if err := setWritePermissionOnVbmetaImgs(artifactsDir, a.cvdUser); err != nil {
 		return nil, err
 	}
 	startParams := startCVDParams{
@@ -432,7 +432,7 @@ func tempFilename(pattern string) (string, error) {
 // cvd user (user running the cvd commands).
 // `assemble_cvd` needs writer permission over vbmeta images to enforce minimum size:
 // https://cs.android.com/android/platform/superproject/main/+/main:device/google/cuttlefish/host/commands/assemble_cvd/disk_flags.cc;l=628-650;drc=1a50803842a9e4f815f2f206f9fcdb924e1ec14d
-func setWritePermissionOnVbmetaImgs(dir string) error {
+func setWritePermissionOnVbmetaImgs(dir string, owner *user.User) error {
 	vbmetaImgs := []string{
 		"vbmeta.img",
 		"vbmeta_system.img",
@@ -442,7 +442,7 @@ func setWritePermissionOnVbmetaImgs(dir string) error {
 	for _, name := range vbmetaImgs {
 		filename := filepath.Join(dir, name)
 		if exist, _ := fileExist(filename); exist {
-			if err := os.Chmod(filename, 0664); err != nil {
+			if err := createUAFile(filename, owner); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
After previous fix(https://github.com/google/android-cuttlefish/pull/680) is merged, got a similar error on the following step.

```
CVDR_USER_CONFIG_PATH=scripts/docker/cvdr.toml \
./cvdr \
--local_images_zip_src=${HOME}/Downloads/aosp_cf_x86_64_phone-img-12243713.zip \
--local_cvd_host_pkg_src=${HOME}/Downloads/cvd-host_package.tar.gz \
--auto_connect=false \
create
Creating Host........................................ OK
Uploading "cvd-host_package.tar.gz".................. OK
Uploading "aosp_cf_x86_64_phone-img-12243713.zip".... OK
failed to create cvd: api call error 0: failed to launch cvd

DETAILS: failed to launch cvd: chmod /var/lib/cuttlefish-common/user_artifacts/tmp.EsQRqi2xem/vbmeta.img: operation not permitted
```

I followed previous approach applied into `untar` and `unzip` mechanisms in user artifacts. I saw `createUAFile` already does `chmod` things, so I replaced `os.chmod` into `createUAFile`.

