### PR TITLE
Remove UserBuildSource in favor of environment configs.

### DIFF
--- a/frontend/src/host_orchestrator/api/v1/messages.go
+++ b/frontend/src/host_orchestrator/api/v1/messages.go
@@ -83,18 +83,10 @@ type AndroidCIBuildSource struct {
 	SystemImageBuild *AndroidCIBuild `json:"system_image_build,omitempty"`
 }
 
-// Represents a user build.
-type UserBuildSource struct {
-	// [REQUIRED] Name of the directory where the user artifacts are stored.
-	ArtifactsDir string `json:"artifacts_dir"`
-}
-
 // Represents the artifacts source to build the CVD.
 type BuildSource struct {
 	// A build from ci.android.com
 	AndroidCIBuildSource *AndroidCIBuildSource `json:"android_ci_build_source,omitempty"`
-	// A user build.
-	UserBuildSource *UserBuildSource `json:"user_build_source,omitempty"`
 }
 
 type ListOperationsResponse struct {

--- a/frontend/src/host_orchestrator/orchestrator/createcvdaction_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/createcvdaction_test.go
@@ -49,7 +49,6 @@ func TestCreateCVDInvalidRequestsEmptyFields(t *testing.T) {
 		{func(r *apiv1.CreateCVDRequest) { r.CVD.BuildSource.AndroidCIBuildSource = nil }},
 		{func(r *apiv1.CreateCVDRequest) {
 			r.CVD.BuildSource.AndroidCIBuildSource = nil
-			r.CVD.BuildSource.UserBuildSource = &apiv1.UserBuildSource{ArtifactsDir: ""}
 		}},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
- Use the following env config template when working when user uploaded artifacts.

```
  {
    "common": {
      "host_package": "@user_artifacts/DIR"
    },
    "instances": [
      {
        "vm": {
          "memory_mb": 8192,
          "setupwizard_mode": "OPTIONAL",
          "cpus": 8
        },
        "disk": {
          "default_build": "@user_artifacts/DIR"
        },
        "streaming": {
          "device_id": "cvd-1"
        }
      }
    ]
  }

```