### PR TITLE
Documentation for guiding docker image release

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,18 @@ cuttlefish-orchestration latest 0123456789ab   2 minutes ago    690MB
 
 ### Download prebuilt image
 
-Sorry for inconvenience, currently it's not supported yet.
+Downloading latest image is available
+[here](https://github.com/google/android-cuttlefish/releases/tag/latest).
+
+After downloading image, please load the image and verify with
+`docker image list`.
+
+```bash
+docker load --input ${PATH_TO_PREBUILT_DOCKER_IMAGE}
+```
+
+Registering the tag of loaded image as `latest` is available with below script.
+
+```bash
+docker tag cuttlefish-orchestration:${PREBUILT_DOCKER_IMAGE_TAG} cuttlefish-orchestration:latest
+```


### PR DESCRIPTION
I uploaded the guidance for downloading & loading docker image released in this Github repository.

About latest tag, I think we can skip to run command described in README.md file, when we're ready to release it into public docker repository such as gcr.io or docker hub.