### PR TITLE
Support user project override

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd.cc
@@ -338,8 +338,9 @@ Result<std::unique_ptr<BuildApi>> GetBuildApi(const BuildApiFlags& flags) {
   const auto cache_base_path = PerUserDir() + "/cache";
   return CreateBuildApi(std::move(retrying_http_client), std::move(curl),
                         std::move(credential_source), std::move(flags.api_key),
-                        flags.wait_retry_period, std::move(flags.api_base_url),
-                        flags.enable_caching, std::move(cache_base_path));
+                        flags.wait_retry_period, std::move(flags.api_base_url), 
+                        std::move(flags.project_id), flags.enable_caching, 
+                        std::move(cache_base_path));
 }
 
 Result<LuciBuildApi> GetLuciBuildApi(const BuildApiFlags& flags) {

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd_parser.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd_parser.cc
@@ -87,6 +87,9 @@ std::vector<Flag> GetFlagsVector(FetchFlags& fetch_flags,
   flags.emplace_back(
       GflagsCompatFlag("credential_source", build_api_flags.credential_source)
           .Help("Build API credential source"));
+  flags.emplace_back(
+      GflagsCompatFlag("project_id", build_api_flags.project_id)
+          .Help("Project ID used to access the Build API"));
   flags.emplace_back(GflagsCompatFlagSeconds("wait_retry_period",
                                              build_api_flags.wait_retry_period)
                          .Help("Retry period for pending builds given in "

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd_parser.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd_parser.h
@@ -34,6 +34,7 @@ inline constexpr char kDefaultCredentialFilepath[] = "";
 inline constexpr char kDefaultServiceAccountFilepath[] = "";
 inline constexpr char kDefaultApiKey[] = "";
 inline constexpr char kDefaultCredentialSource[] = "";
+inline constexpr char kDefaultProjectID[] = "";
 inline constexpr std::chrono::seconds kDefaultWaitRetryPeriod =
     std::chrono::seconds(20);
 inline constexpr bool kDefaultExternalDnsResolver =
@@ -62,6 +63,7 @@ struct BuildApiFlags {
   std::string api_key = kDefaultApiKey;
   CredentialFlags credential_flags;
   std::string credential_source = kDefaultCredentialSource;
+  std::string project_id = kDefaultProjectID;
   std::chrono::seconds wait_retry_period = kDefaultWaitRetryPeriod;
   bool external_dns_resolver = kDefaultExternalDnsResolver;
   std::string api_base_url = kAndroidBuildServiceUrl;

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/fetch_config_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/fetch_config_parser.cpp
@@ -163,6 +163,10 @@ Result<std::vector<std::string>> ParseFetchCvdConfigs(
     auto value = fetch_config.credential_source();
     result.emplace_back(GenerateFlag("credential_source", std::move(value)));
   }
+  if (fetch_config.has_project_id()) {
+    auto value = fetch_config.project_id();
+    result.emplace_back(GenerateFlag("project_id", std::move(value)));
+  }
   if (fetch_config.has_wait_retry_period_seconds()) {
     auto value = fetch_config.wait_retry_period_seconds();
     result.emplace_back(GenerateFlag("wait_retry_period", std::move(value)));

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/load_config.proto
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/load_config.proto
@@ -39,6 +39,7 @@ message Fetch {
   optional bool external_dns_resolver = 4;
   optional bool keep_downloaded_archives = 5;
   optional string api_base_url = 6;
+  optional string project_id = 7;
 }
 
 message Instance {

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/load_configs_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/load_configs_parser.cpp
@@ -51,6 +51,7 @@ namespace {
 constexpr std::string_view kOverrideSeparator = ":";
 constexpr std::string_view kCredentialSourceOverride =
     "fetch.credential_source";
+constexpr std::string_view kProjectIDOverride = "fetch.project_id";
 
 bool IsLocalBuild(std::string path) {
   return android::base::StartsWith(path, "/");
@@ -160,6 +161,8 @@ std::vector<Flag> GetFlagsVector(LoadFlags& load_flags) {
   std::vector<Flag> flags;
   flags.emplace_back(
       GflagsCompatFlag("credential_source", load_flags.credential_source));
+  flags.emplace_back(
+      GflagsCompatFlag("project_id", load_flags.project_id));
   flags.emplace_back(
       GflagsCompatFlag("base_directory", load_flags.base_dir)
           .Help("Parent directory for artifacts and runtime files. Defaults to "
@@ -351,6 +354,17 @@ Result<LoadFlags> GetFlags(std::vector<std::string>& args,
     load_flags.overrides.emplace_back(
         Override{.config_path = std::string(kCredentialSourceOverride),
                  .new_value = load_flags.credential_source});
+  }
+  if (!load_flags.project_id.empty()){
+    for (const auto& flag : load_flags.overrides) {
+      CF_EXPECT(!android::base::StartsWith(flag.config_path,
+                                           kProjectIDOverride),
+                "Specifying both --override=fetch.project_id and the "
+                "--project_id flag is not allowed.");
+    }
+    load_flags.overrides.emplace_back(
+        Override{.config_path = std::string(kProjectIDOverride),
+                 .new_value = load_flags.project_id});
   }
   return load_flags;
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/load_configs_parser.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/load_configs_parser.h
@@ -52,6 +52,7 @@ struct LoadFlags {
   std::vector<Override> overrides;
   std::string config_path;
   std::string credential_source;
+  std::string project_id;
   std::string base_dir;
 };
 

--- a/base/cvd/cuttlefish/host/libs/web/android_build_api.h
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_api.h
@@ -76,7 +76,7 @@ class BuildApi {
            std::unique_ptr<HttpClient> inner_http_client,
            std::unique_ptr<CredentialSource> credential_source,
            std::string api_key, const std::chrono::seconds retry_period,
-           std::string api_base_url);
+           std::string api_base_url, std::string project_id);
 
   Result<Build> GetBuild(const BuildString& build_string,
                          const std::string& fallback_target);
@@ -139,6 +139,7 @@ class BuildApi {
   std::string api_key_;
   std::chrono::seconds retry_period_;
   std::string api_base_url_;
+  std::string project_id_;
 };
 
 std::string GetBuildZipName(const Build& build, const std::string& name);

--- a/base/cvd/cuttlefish/host/libs/web/caching_build_api.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/caching_build_api.cpp
@@ -79,11 +79,11 @@ CachingBuildApi::CachingBuildApi(
     std::unique_ptr<HttpClient> http_client,
     std::unique_ptr<HttpClient> inner_http_client,
     std::unique_ptr<CredentialSource> credential_source, std::string api_key,
-    const std::chrono::seconds retry_period, std::string api_base_url,
+    const std::chrono::seconds retry_period, std::string api_base_url, std::string project_id,
     const std::string cache_base_path)
     : BuildApi(std::move(http_client), std::move(inner_http_client),
                std::move(credential_source), std::move(api_key), retry_period,
-               std::move(api_base_url)),
+               std::move(api_base_url), std::move(project_id)),
       cache_base_path_(std::move(cache_base_path)) {};
 
 Result<bool> CachingBuildApi::CanCache(const std::string& target_directory) {
@@ -149,18 +149,18 @@ std::unique_ptr<BuildApi> CreateBuildApi(
     std::unique_ptr<HttpClient> http_client,
     std::unique_ptr<HttpClient> inner_http_client,
     std::unique_ptr<CredentialSource> credential_source, std::string api_key,
-    const std::chrono::seconds retry_period, std::string api_base_url,
+    const std::chrono::seconds retry_period, std::string api_base_url, std::string project_id,
     const bool enable_caching, const std::string cache_base_path) {
   if (enable_caching && EnsureCacheDirectory(cache_base_path)) {
     return std::make_unique<CachingBuildApi>(
         std::move(http_client), std::move(inner_http_client),
         std::move(credential_source), std::move(api_key), retry_period,
-        std::move(api_base_url), std::move(cache_base_path));
+        std::move(api_base_url), std::move(project_id), std::move(cache_base_path));
   }
   return std::make_unique<BuildApi>(
       std::move(http_client), std::move(inner_http_client),
       std::move(credential_source), std::move(api_key), retry_period,
-      std::move(api_base_url));
+      std::move(api_base_url), std::move(project_id));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/web/caching_build_api.h
+++ b/base/cvd/cuttlefish/host/libs/web/caching_build_api.h
@@ -35,7 +35,8 @@ class CachingBuildApi : public BuildApi {
                   std::unique_ptr<HttpClient> inner_http_client,
                   std::unique_ptr<CredentialSource> credential_source,
                   std::string api_key, const std::chrono::seconds retry_period,
-                  std::string api_base_url, const std::string cache_base_path);
+                  std::string api_base_url, std::string project_id,
+                  const std::string cache_base_path);
 
   Result<std::string> DownloadFile(const Build& build,
                                    const std::string& target_directory,
@@ -55,7 +56,7 @@ std::unique_ptr<BuildApi> CreateBuildApi(
     std::unique_ptr<HttpClient> http_client,
     std::unique_ptr<HttpClient> inner_http_client,
     std::unique_ptr<CredentialSource> credential_source, std::string api_key,
-    const std::chrono::seconds retry_period, std::string api_base_url,
+    const std::chrono::seconds retry_period, std::string api_base_url, std::string project_id,
     const bool enable_caching, const std::string cache_base_path);
 
 }  // namespace cuttlefish


### PR DESCRIPTION
It's a method that enables users to authenticate with their own OAuth credentials and use the token to send requests to the Build API without enabling the API in their GCP project.