### PR TITLE
Get rid of VerifyPrecondition

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/common_utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/common_utils.h
@@ -102,4 +102,10 @@ std::string DefaultBaseDir();
 
 Result<std::string> GroupDirFromHome(std::string_view group_home_dir);
 
+// Returns the path to the directory containing the host binaries, shared
+// libraries and other files built with the Android build system. It searches,
+// in order, the ANDROID_HOST_OUT, ANDROID_SOONG_HOST_OUT and HOME environment
+// variables followed by the current directory.
+Result<std::string> AndroidHostPath(const cvd_common::Envs& env);
+
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/selector/creation_analyzer.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/selector/creation_analyzer.cpp
@@ -180,13 +180,13 @@ Result<GroupCreationInfo> CreationAnalyzer::ExtractGroupInfo() {
 
   auto home = CF_EXPECT(AnalyzeHome());
 
-  CF_EXPECT(Contains(envs_, kAndroidHostOut));
+  auto android_host_out = CF_EXPECT(AndroidHostPath(envs_));
   std::string android_product_out_path = Contains(envs_, kAndroidProductOut)
                                              ? envs_.at(kAndroidProductOut)
-                                             : envs_.at(kAndroidHostOut);
+                                             : android_host_out;
   return GroupCreationInfo{
       .home = home,
-      .host_artifacts_path = envs_.at(kAndroidHostOut),
+      .host_artifacts_path = android_host_out,
       .product_out_path = android_product_out_path,
       .group_name = group_info.group_name,
       .instances = std::move(instance_info),

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/clear.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/clear.cpp
@@ -68,14 +68,6 @@ Result<cvd::Response> CvdClearCommandHandler::Handle(
   cvd::Response response;
   response.mutable_command_response();
 
-  auto precondition_verified = VerifyPrecondition(request);
-  if (!precondition_verified.ok()) {
-    response.mutable_status()->set_code(cvd::Status::FAILED_PRECONDITION);
-    response.mutable_status()->set_message(
-        precondition_verified.error().Message());
-    return response;
-  }
-
   auto [subcmd, cmd_args] = ParseInvocation(request.Message());
 
   if (CF_EXPECT(IsHelpSubcmd(cmd_args))) {

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/create.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/create.cpp
@@ -332,7 +332,8 @@ Result<cvd::Response> CvdCreateCommandHandler::Handle(
 
   if (flags.start) {
     auto start_cmd = CreateStartCommand(request, group, subcmd_args, envs);
-    response = CF_EXPECT(command_executor_.ExecuteOne(start_cmd, request.Err()));
+    response =
+        CF_EXPECT(command_executor_.ExecuteOne(start_cmd, request.Err()));
   }
 
   *response.mutable_command_response()->mutable_instance_group_info() =

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/env.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/env.cpp
@@ -114,7 +114,7 @@ class CvdEnvCommandHandler : public CvdServerHandler {
     const auto& android_host_out = group.Proto().host_artifacts_path();
     auto cvd_env_bin_path =
         ConcatToString(android_host_out, "/bin/", kCvdEnvBin);
-    const auto& internal_device_name = fmt::format("cvd-%d", instance.id());
+    const auto& internal_device_name = fmt::format("cvd-{}", instance.id());
 
     cvd_common::Args cvd_env_args{internal_device_name};
     cvd_env_args.insert(cvd_env_args.end(), subcmd_args.begin(),

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/env.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/env.cpp
@@ -55,7 +55,6 @@ class CvdEnvCommandHandler : public CvdServerHandler {
 
   Result<cvd::Response> Handle(const RequestWithStdio& request) override {
     CF_EXPECT(CanHandle(request));
-    CF_EXPECT(VerifyPrecondition(request));
     cvd_common::Envs envs = request.Envs();
 
     auto [_, subcmd_args] = ParseInvocation(request.Message());
@@ -97,9 +96,10 @@ class CvdEnvCommandHandler : public CvdServerHandler {
   Result<Command> HelpCommand(const RequestWithStdio& request,
                               const cvd_common::Args& subcmd_args,
                               const cvd_common::Envs& envs) {
-    CF_EXPECT(Contains(envs, kAndroidHostOut));
+    cvd_common::Envs envs_copy = envs;
+    envs_copy[kAndroidHostOut] = CF_EXPECT(AndroidHostPath(envs));
     return CF_EXPECT(
-        ConstructCvdHelpCommand(kCvdEnvBin, envs, subcmd_args, request));
+        ConstructCvdHelpCommand(kCvdEnvBin, envs_copy, subcmd_args, request));
   }
 
   Result<Command> NonHelpCommand(const RequestWithStdio& request,

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/snapshot.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/snapshot.cpp
@@ -77,7 +77,6 @@ class CvdSnapshotCommandHandler : public CvdServerHandler {
 
   Result<cvd::Response> Handle(const RequestWithStdio& request) override {
     CF_EXPECT(CanHandle(request));
-    CF_EXPECT(VerifyPrecondition(request));
     cvd_common::Envs envs = request.Envs();
 
     auto [subcmd, subcmd_args] = ParseInvocation(request.Message());

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
@@ -354,7 +354,7 @@ Result<void> CvdStartCommandHandler::AcloudCompatActions(
       continue;
     }
     auto link_res = CreateSymLink(home_dir, acloud_compat_home,
-                      /* override_existing*/ true);
+                                  /* override_existing*/ true);
     if (!link_res.ok()) {
       LOG(ERROR) << "Failed to symlink group's HOME directory to acloud "
                     "compatible location";
@@ -546,16 +546,6 @@ Result<cvd::Response> CvdStartCommandHandler::Handle(
             "The 'start' command doesn't accept --config_file, did you mean "
             "'create'?");
 
-  auto precondition_verified = VerifyPrecondition(request);
-  if (!precondition_verified.ok()) {
-    cvd::Response response;
-    response.mutable_command_response();
-    response.mutable_status()->set_code(cvd::Status::FAILED_PRECONDITION);
-    response.mutable_status()->set_message(
-        precondition_verified.error().Message());
-    return response;
-  }
-
   cvd_common::Envs envs = request.Envs();
   if (Contains(envs, "HOME")) {
     if (envs.at("HOME").empty()) {
@@ -591,9 +581,8 @@ Result<cvd::Response> CvdStartCommandHandler::Handle(
   const bool is_help = CF_EXPECT(IsHelpSubcmd(subcmd_args));
 
   if (is_help) {
-    auto it = envs.find(kAndroidHostOut);
-    CF_EXPECT(it != envs.end());
-    const auto bin = CF_EXPECT(FindStartBin(it->second));
+    auto android_host_out = CF_EXPECT(AndroidHostPath(envs));
+    const auto bin = CF_EXPECT(FindStartBin(android_host_out));
 
     Command command =
         CF_EXPECT(ConstructCvdHelpCommand(bin, envs, subcmd_args, request));

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/status.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/status.cpp
@@ -21,7 +21,6 @@
 #include <android-base/parseint.h>
 #include <android-base/strings.h>
 
-#include "common/libs/fs/shared_buf.h"
 #include "common/libs/utils/contains.h"
 #include "common/libs/utils/result.h"
 #include "cuttlefish/host/commands/cvd/cvd_server.pb.h"
@@ -169,16 +168,6 @@ static Result<bool> HasPrint(cvd_common::Args cmd_args) {
 Result<cvd::Response> CvdStatusCommandHandler::Handle(
     const RequestWithStdio& request) {
   CF_EXPECT(CanHandle(request));
-
-  auto precondition_verified = VerifyPrecondition(request);
-  if (!precondition_verified.ok()) {
-    cvd::Response response;
-    response.mutable_command_response();
-    response.mutable_status()->set_code(cvd::Status::FAILED_PRECONDITION);
-    response.mutable_status()->set_message(
-        precondition_verified.error().Message());
-    return response;
-  }
 
   auto [subcmd, cmd_args] = ParseInvocation(request.Message());
   CF_EXPECT(Contains(supported_subcmds_, subcmd));

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/status_fetcher.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/status_fetcher.cpp
@@ -203,9 +203,6 @@ Result<StatusFetcherOutput> StatusFetcher::FetchStatus(
 
   // find group
   const auto selector_args = request.SelectorArgs();
-  CF_EXPECT(Contains(envs, kAndroidHostOut) &&
-            DirectoryExists(envs.at(kAndroidHostOut)));
-
   CvdFlag<bool> all_instances_flag("all_instances");
   auto all_instances_opt = CF_EXPECT(all_instances_flag.FilterFlag(cmd_args));
 

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/utils.h
@@ -41,8 +41,6 @@ CommandInvocation ParseInvocation(const cvd::Request& request);
 
 cuttlefish::cvd::Response ResponseFromSiginfo(siginfo_t infop);
 
-Result<void> VerifyPrecondition(const RequestWithStdio& request);
-
 struct ConstructCommandParam {
   const std::string& bin_path;
   const std::string& home;


### PR DESCRIPTION
It was only checking that ANDROID_HOST_OUT was always present in the environment, which is not always true. To make that check pass a default path was calculated when the request was created and added to the environment, only to be replaced with the value from an existing group most of the time.