### PR TITLE
Fix out-of-range access to vector.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/utils.cpp
@@ -40,7 +40,7 @@ CommandInvocation ParseInvocation(const cvd::Request& request) {
     invocation.arguments.push_back(arg);
   }
   invocation.arguments[0] = cpp_basename(invocation.arguments[0]);
-  if (invocation.arguments[0] == "cvd") {
+  if (invocation.arguments[0] == "cvd" && invocation.arguments.size() > 1) {
     invocation.command = invocation.arguments[1];
     invocation.arguments.erase(invocation.arguments.begin());
     invocation.arguments.erase(invocation.arguments.begin());


### PR DESCRIPTION
The command `cvd --group_name=cvd_1 --instance_name=1` was failing with a segmentation fault. Valgrind reported an invalid memory access.

```
==2063245== Invalid read of size 8
==2063245==    at 0x4B6ED26: std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_assign(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33)
==2063245==    by 0x4B6F20C: std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::operator=(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33)
==2063245==    by 0x6FE9FF: cuttlefish::ParseInvocation(cuttlefish::cvd::Request const&) (in /usr/local/google/home/schuffelen/.cache/bazel/_bazel_schuffelen/e5255ea4f0651a267b9880f9e2ad5869/execroot/_main/bazel-out/k8-fastbuild/bin/cuttlefish/cvd)
==2063245==    by 0x5EEA6B: cuttlefish::AcloudCommand::CanHandle(cuttlefish::RequestWithStdio const&) const (in /usr/local/google/home/schuffelen/.cache/bazel/_bazel_schuffelen/e5255ea4f0651a267b9880f9e2ad5869/execroot/_main/bazel-out/k8-fastbuild/bin/cuttlefish/cvd)
==2063245==    by 0x5532A7: cuttlefish::RequestHandler(cuttlefish::RequestWithStdio const&, std::vector<std::unique_ptr<cuttlefish::CvdServerHandler, std::default_delete<cuttlefish::CvdServerHandler> >, std::allocator<std::unique_ptr<cuttlefish::CvdServerHandler, std::default_delete<cuttlefish::CvdServerHandler> > > > const&) (in /usr/local/google/home/schuffelen/.cache/bazel/_bazel_schuffelen/e5255ea4f0651a267b9880f9e2ad5869/execroot/_main/bazel-out/k8-fastbuild/bin/cuttlefish/cvd)
==2063245==    by 0x5531CC: cuttlefish::RequestContext::Handler(cuttlefish::RequestWithStdio const&) (in /usr/local/google/home/schuffelen/.cache/bazel/_bazel_schuffelen/e5255ea4f0651a267b9880f9e2ad5869/execroot/_main/bazel-out/k8-fastbuild/bin/cuttlefish/cvd)
==2063245==    by 0x4932F7: cuttlefish::Cvd::HandleCommand(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) (in /usr/local/google/home/schuffelen/.cache/bazel/_bazel_schuffelen/e5255ea4f0651a267b9880f9e2ad5869/execroot/_main/bazel-out/k8-fastbuild/bin/cuttlefish/cvd)
==2063245==    by 0x493F0D: cuttlefish::Cvd::HandleCvdCommand(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&) (in /usr/local/google/home/schuffelen/.cache/bazel/_bazel_schuffelen/e5255ea4f0651a267b9880f9e2ad5869/execroot/_main/bazel-out/k8-fastbuild/bin/cuttlefish/cvd)
==2063245==    by 0x46C42C: cuttlefish::(anonymous namespace)::CvdMain(int, char**, char**, android::base::LogSeverity) (in /usr/local/google/home/schuffelen/.cache/bazel/_bazel_schuffelen/e5255ea4f0651a267b9880f9e2ad5869/execroot/_main/bazel-out/k8-fastbuild/bin/cuttlefish/cvd)
==2063245==    by 0x46DD84: main (in /usr/local/google/home/schuffelen/.cache/bazel/_bazel_schuffelen/e5255ea4f0651a267b9880f9e2ad5869/execroot/_main/bazel-out/k8-fastbuild/bin/cuttlefish/cvd)
==2063245==  Address 0x6188738 is 8 bytes after a block of size 32 alloc'd
==2063245==    at 0x4840F83: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==2063245==    by 0x485227: std::__new_allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::allocate(unsigned long, void const*) (in /usr/local/google/home/schuffelen/.cache/bazel/_bazel_schuffelen/e5255ea4f0651a267b9880f9e2ad5869/execroot/_main/bazel-out/k8-fastbuild/bin/cuttlefish/cvd)
==2063245==    by 0x48321E: std::_Vector_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::_M_allocate(unsigned long) (in /usr/local/google/home/schuffelen/.cache/bazel/_bazel_schuffelen/e5255ea4f0651a267b9880f9e2ad5869/execroot/_main/bazel-out/k8-fastbuild/bin/cuttlefish/cvd)
==2063245==    by 0x4BA980: void std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::_M_realloc_insert<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(__gnu_cxx::__normal_iterator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /usr/local/google/home/schuffelen/.cache/bazel/_bazel_schuffelen/e5255ea4f0651a267b9880f9e2ad5869/execroot/_main/bazel-out/k8-fastbuild/bin/cuttlefish/cvd)
==2063245==    by 0x4B6E86: std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::push_back(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /usr/local/google/home/schuffelen/.cache/bazel/_bazel_schuffelen/e5255ea4f0651a267b9880f9e2ad5869/execroot/_main/bazel-out/k8-fastbuild/bin/cuttlefish/cvd)
==2063245==    by 0x6FE929: cuttlefish::ParseInvocation(cuttlefish::cvd::Request const&) (in /usr/local/google/home/schuffelen/.cache/bazel/_bazel_schuffelen/e5255ea4f0651a267b9880f9e2ad5869/execroot/_main/bazel-out/k8-fastbuild/bin/cuttlefish/cvd)
==2063245==    by 0x5EEA6B: cuttlefish::AcloudCommand::CanHandle(cuttlefish::RequestWithStdio const&) const (in /usr/local/google/home/schuffelen/.cache/bazel/_bazel_schuffelen/e5255ea4f0651a267b9880f9e2ad5869/execroot/_main/bazel-out/k8-fastbuild/bin/cuttlefish/cvd)
==2063245==    by 0x5532A7: cuttlefish::RequestHandler(cuttlefish::RequestWithStdio const&, std::vector<std::unique_ptr<cuttlefish::CvdServerHandler, std::default_delete<cuttlefish::CvdServerHandler> >, std::allocator<std::unique_ptr<cuttlefish::CvdServerHandler, std::default_delete<cuttlefish::CvdServerHandler> > > > const&) (in /usr/local/google/home/schuffelen/.cache/bazel/_bazel_schuffelen/e5255ea4f0651a267b9880f9e2ad5869/execroot/_main/bazel-out/k8-fastbuild/bin/cuttlefish/cvd)
==2063245==    by 0x5531CC: cuttlefish::RequestContext::Handler(cuttlefish::RequestWithStdio const&) (in /usr/local/google/home/schuffelen/.cache/bazel/_bazel_schuffelen/e5255ea4f0651a267b9880f9e2ad5869/execroot/_main/bazel-out/k8-fastbuild/bin/cuttlefish/cvd)
==2063245==    by 0x4932F7: cuttlefish::Cvd::HandleCommand(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) (in /usr/local/google/home/schuffelen/.cache/bazel/_bazel_schuffelen/e5255ea4f0651a267b9880f9e2ad5869/execroot/_main/bazel-out/k8-fastbuild/bin/cuttlefish/cvd)
==2063245==    by 0x493F0D: cuttlefish::Cvd::HandleCvdCommand(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&) (in /usr/local/google/home/schuffelen/.cache/bazel/_bazel_schuffelen/e5255ea4f0651a267b9880f9e2ad5869/execroot/_main/bazel-out/k8-fastbuild/bin/cuttlefish/cvd)
==2063245==    by 0x46C42C: cuttlefish::(anonymous namespace)::CvdMain(int, char**, char**, android::base::LogSeverity) (in /usr/local/google/home/schuffelen/.cache/bazel/_bazel_schuffelen/e5255ea4f0651a267b9880f9e2ad5869/execroot/_main/bazel-out/k8-fastbuild/bin/cuttlefish/cvd)
```

Reproduced by
```
$ bazel build cuttlefish:cvd
$ bazel run cuttlefish:cvd -- --group_name=cvd_1 --instance_name=1
$ valgrind bazel-bin/cuttlefish/cvd --group_name=cvd_1 --instance_name=1
```

The command `cvd --group_name=cvd_1 --instance_name=1` looks like it should have more than 1 member in the argv `std::vector`, but I suspect some intermediate layer is stripping out "selector arguments" before it makes it to this call.

Bug: b/366040241
Test: bazel run cuttlefish:cvd -- --group_name=cvd_1 --instance_name=1