### PR TITLE
Fix issues with cvd load

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags_defaults.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags_defaults.h
@@ -206,7 +206,7 @@
 // Streaming default parameters
 #define CF_DEFAULTS_START_WEBRTC false
 #define CF_DEFAULTS_START_WEBRTC_SIG_SERVER true
-#define CF_DEFAULTS_WEBRTC_DEVICE_ID "cvd-{num}"
+#define CF_DEFAULTS_WEBRTC_DEVICE_ID ""
 #define CF_DEFAULTS_VERIFY_SIG_SERVER_CERTIFICATE false
 #define CF_DEFAULTS_WEBRTC_ASSETS_DIR \
   DefaultHostArtifactsPath("usr/share/webrtc/assets")

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/load_configs_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/load_configs_parser.cpp
@@ -20,8 +20,8 @@
 
 #include <cstdio>
 #include <set>
-#include <string_view>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <android-base/file.h>
@@ -267,8 +267,7 @@ Result<LoadDirectories> GenerateLoadDirectories(
         result.target_directory + "/" + kHostToolsSubdirectory;
   }
 
-  result.system_image_directory_flag =
-      "--system_image_dir=" +
+  result.system_image_directory_flag_value =
       android::base::Join(system_image_directories, ',');
   return result;
 }
@@ -298,17 +297,18 @@ std::vector<std::string> FillEmptyInstanceNames(
 
 Result<CvdFlags> ParseCvdConfigs(const EnvironmentSpecification& launch,
                                  const LoadDirectories& load_directories) {
-  CvdFlags flags{.launch_cvd_flags = CF_EXPECT(ParseLaunchCvdConfigs(launch)),
-                  .selector_flags = ParseSelectorConfigs(launch),
-                  .fetch_cvd_flags = CF_EXPECT(ParseFetchCvdConfigs(
-                      launch, load_directories.target_directory,
-                      load_directories.target_subdirectories)),
-                  .load_directories = load_directories,
+  CvdFlags flags{
+      .launch_cvd_flags = CF_EXPECT(ParseLaunchCvdConfigs(launch)),
+      .selector_flags = ParseSelectorConfigs(launch),
+      .fetch_cvd_flags = CF_EXPECT(
+          ParseFetchCvdConfigs(launch, load_directories.target_directory,
+                               load_directories.target_subdirectories)),
+      .load_directories = load_directories,
   };
   if (launch.common().has_group_name()) {
     flags.group_name = launch.common().group_name();
   }
-  for (const auto& instance: launch.instances()) {
+  for (const auto& instance : launch.instances()) {
     flags.instance_names.push_back(instance.name());
   }
   flags.instance_names =

--- a/base/cvd/cuttlefish/host/commands/cvd/parser/load_configs_parser.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/parser/load_configs_parser.h
@@ -29,7 +29,7 @@ struct LoadDirectories {
   std::vector<std::string> target_subdirectories;
   std::string launch_home_directory;
   std::string host_package_directory;
-  std::string system_image_directory_flag;
+  std::string system_image_directory_flag_value;
 };
 
 struct CvdFlags {

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
@@ -39,7 +39,6 @@
 #include "common/libs/utils/users.h"
 #include "cuttlefish/host/commands/cvd/cvd_server.pb.h"
 #include "cuttlefish/host/commands/cvd/selector/cvd_persistent_data.pb.h"
-#include "host/commands/cvd/command_sequence.h"
 #include "host/commands/cvd/common_utils.h"
 #include "host/commands/cvd/group_selector.h"
 #include "host/commands/cvd/interrupt_listener.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
@@ -142,12 +142,19 @@ std::vector<std::string> GenerateUniqueWebRTCDeviceIds(
 Result<void> UpdateWebrtcDeviceIds(cvd_common::Args& args,
                                    selector::LocalInstanceGroup& group) {
   std::vector<std::string> webrtc_ids = CF_EXPECT(ExtractWebRTCDeviceIds(args));
+  std::vector<std::string> generated_webrtc_ids =
+      GenerateUniqueWebRTCDeviceIds(group);
   if (webrtc_ids.empty()) {
-    webrtc_ids = GenerateUniqueWebRTCDeviceIds(group);
+    webrtc_ids = generated_webrtc_ids;
   }
   CF_EXPECT_EQ(
       webrtc_ids.size(), group.Instances().size(),
       "The number of webrtc device ids doesn't match the number of instances");
+  for (size_t i = 0; i < webrtc_ids.size(); ++i) {
+    if (webrtc_ids[i].empty()) {
+      webrtc_ids[i] = generated_webrtc_ids[i];
+    }
+  }
   args.push_back("--webrtc_device_id=" + android::base::Join(webrtc_ids, ","));
 
   for (size_t i = 0; i < webrtc_ids.size(); ++i) {


### PR DESCRIPTION
Fix starting after a stop of a group created from an environment config

Fix the generated webrtc_device_id from when not provided in the environment config