### PR TITLE
Return clear message when no groups exist

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/bugreport.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/bugreport.cpp
@@ -88,6 +88,9 @@ Result<cvd::Response> CvdBugreportCommandHandler::Handle(
   std::string android_host_out;
   std::string home = CF_EXPECT(SystemWideUserHome());
   if (!CF_EXPECT(IsHelpSubcmd(cmd_args))) {
+    if (!CF_EXPECT(instance_manager_.HasInstanceGroups())) {
+      return NoGroupResponse(request);
+    }
     auto instance_group = CF_EXPECT(SelectGroup(instance_manager_, request));
     android_host_out = instance_group.HostArtifactsPath();
     home = instance_group.HomeDir();

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/display.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/display.cpp
@@ -23,7 +23,6 @@
 #include <string>
 #include <vector>
 
-#include "common/libs/fs/shared_buf.h"
 #include "common/libs/utils/contains.h"
 #include "common/libs/utils/subprocess.h"
 #include "common/libs/utils/users.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/remove.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/remove.cpp
@@ -20,7 +20,6 @@
 #include <string>
 #include <vector>
 
-#include "common/libs/fs/shared_buf.h"
 #include "common/libs/utils/contains.h"
 #include "common/libs/utils/result.h"
 #include "host/commands/cvd/group_selector.h"
@@ -78,6 +77,9 @@ class RemoveCvdCommandHandler : public CvdServerHandler {
       return Success();
     }
 
+    if (!CF_EXPECT(instance_manager_.HasInstanceGroups())) {
+      return NoGroupResponse(request);
+    }
     auto group = CF_EXPECT(SelectGroup(instance_manager_, request));
 
     auto stop_res = StopGroup(group, request);

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
@@ -599,6 +599,10 @@ Result<cvd::Response> CvdStartCommandHandler::Handle(
     return ResponseFromSiginfo(infop);
   }
 
+  if (!CF_EXPECT(instance_manager_.HasInstanceGroups())) {
+    return NoGroupResponse(request);
+  }
+
   CF_EXPECT(ConsumeDaemonModeFlag(subcmd_args));
   subcmd_args.push_back("--daemon=true");
 

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/status.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/status.cpp
@@ -174,7 +174,7 @@ Result<cvd::Response> CvdStatusCommandHandler::Handle(
   const bool has_print = CF_EXPECT(HasPrint(cmd_args));
 
   if (!CF_EXPECT(instance_manager_.HasInstanceGroups())) {
-    return CF_EXPECT(NoGroupResponse(request));
+    return NoGroupResponse(request);
   }
   RequestWithStdio new_request = CF_EXPECT(ProcessInstanceNameFlag(request));
 

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/stop.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/stop.cpp
@@ -121,7 +121,7 @@ Result<cvd::Response> CvdStopCommandHandler::Handle(
   }
 
   if (!CF_EXPECT(instance_manager_.HasInstanceGroups())) {
-    return CF_EXPECT(NoGroupResponse(request));
+    return NoGroupResponse(request);
   }
   cvd_common::Envs envs = request.Envs();
   const auto selector_args = request.SelectorArgs();

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/utils.cpp
@@ -219,17 +219,15 @@ std::string_view TerminalColors::Cyan() const {
   return is_tty_ ? kTerminalCyan : "";
 }
 
-Result<cvd::Response> NoGroupResponse(const RequestWithStdio& request) {
+cvd::Response NoGroupResponse(const RequestWithStdio& request) {
   cvd::Response response;
   response.mutable_command_response();
   response.mutable_status()->set_code(cvd::Status::OK);
-  const uid_t uid = getuid();
   TerminalColors colors(isatty(1));
   std::string notice = fmt::format(
-      "Command `{}{}{}` is not applicable:\n  {}{}{} (uid: '{}{}{}')",
-      colors.Red(), fmt::join(request.Message().command_request().args(), " "),
-      colors.Reset(), colors.BoldRed(), "no device", colors.Reset(),
-      colors.Cyan(), uid, colors.Reset());
+      "Command `{}{}{}` is not applicable: {}{}{}", colors.Red(),
+      fmt::join(request.Message().command_request().args(), " "),
+      colors.Reset(), colors.BoldRed(), "no device", colors.Reset());
   request.Out() << notice << "\n";
 
   response.mutable_status()->set_message(notice);

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/utils.h
@@ -75,7 +75,7 @@ Result<bool> IsHelpSubcmd(const std::vector<std::string>& args);
 
 // Call this when there is no instance group is running
 // The function does not verify that.
-Result<cvd::Response> NoGroupResponse(const RequestWithStdio& request);
+cvd::Response NoGroupResponse(const RequestWithStdio& request);
 
 // Call this when there is more than one group, which the selector flags are
 // not sufficients to choose one from. The function does not verify that.


### PR DESCRIPTION
A clear message existed for stop and status, it's extended for:
- bugreport
- remove
- display
- start