### PR TITLE
Add more log output to `cvd fetch` stderr

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd.cc
@@ -335,8 +335,8 @@ Result<std::unique_ptr<BuildApi>> GetBuildApi(const BuildApiFlags& flags) {
   const auto cache_base_path = PerUserDir() + "/cache";
   return CreateBuildApi(std::move(retrying_http_client), std::move(curl),
                         std::move(credential_source), std::move(flags.api_key),
-                        flags.wait_retry_period, std::move(flags.api_base_url), 
-                        std::move(flags.project_id), flags.enable_caching, 
+                        flags.wait_retry_period, std::move(flags.api_base_url),
+                        std::move(flags.project_id), flags.enable_caching,
                         std::move(cache_base_path));
 }
 
@@ -774,7 +774,8 @@ Result<void> FetchCvdMain(int argc, char** argv, bool log_to_stderr) {
                                    host_target.host_tools_directory, targets));
   std::string log_file = GetFetchLogsFileName(flags.target_directory);
   auto old_logger = android::base::SetLogger(
-      log_to_stderr ? LogToStderrAndFiles({log_file}) : LogToFiles({log_file}));
+      log_to_stderr ? LogToStderrAndFiles({log_file}, "", MetadataLevel::FULL)
+                    : LogToFiles({log_file}));
   android::base::SetMinimumLogSeverity(flags.verbosity);
 
   auto fetch_res = Fetch(flags, host_target, targets);

--- a/base/cvd/cuttlefish/host/libs/web/http_client/http_client.cc
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/http_client.cc
@@ -175,6 +175,7 @@ class CurlClient : public HttpClient {
     auto [shared_fd, temp_path] = CF_EXPECT(SharedFD::Mkostemp(path));
     SharedFDOstream stream(shared_fd);
     auto callback = [&stream](char* data, size_t size) -> bool {
+      LOG(INFO) << "Downloaded chunk of " << size << " bytes";
       if (data == nullptr) {
         return !stream.fail();
       }


### PR DESCRIPTION
... to debug an issue around build downloading getting stuck.

As written this change increases the stderr output from a regular `cvd fetch` from about 300 lines / 28KiB to 217K lines / 19 MB.

Bug: b/364058922
Test: /usr/bin/bazel run commands/cvd:cvd -- fetch --target_directory=/tmp/a --default_build=aosp-main/aosp_cf_x86_64_phone-trunk_staging-userdebug