### PR TITLE
Split result_matchers.h into its own library

### DIFF
--- a/base/cvd/allocd/BUILD.bazel
+++ b/base/cvd/allocd/BUILD.bazel
@@ -23,6 +23,7 @@ cc_binary(
     ],
     includes = [""],
     deps = [
+        "//cuttlefish/common/libs/fs",
         "//cuttlefish/host/libs/config",
         "//libbase",
         "@gflags",

--- a/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
@@ -20,6 +20,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cuttlefish/common/libs/utils:result",
+        "@fmt",
     ],
 )
 
@@ -34,6 +35,7 @@ cc_test(
     ],
     includes = [""],
     deps = [
+        "//libbase",
         ":fs",
         "@googletest//:gtest",
         "@googletest//:gtest_main",

--- a/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
@@ -28,6 +28,7 @@ cc_library(
     strip_include_prefix = "//cuttlefish",
     visibility = ["//visibility:public"],
     deps = [
+        "//libbase",
         ":result",
         "@googletest//:gtest",
     ],
@@ -126,6 +127,8 @@ cc_test(
         "-Icuttlefish",
     ],
     deps = [
+        "//cuttlefish/common/libs/fs",
+        "//libbase",
         ":result",
         ":result_matchers",
         ":utils",

--- a/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
@@ -5,7 +5,6 @@ cc_library(
     ],
     hdrs = [
         "result.h",
-        "result_matchers.h",
     ],
     copts = [
         "-std=c++17",
@@ -15,6 +14,22 @@ cc_library(
     deps = [
         "//libbase",
         "@fmt",
+    ],
+)
+
+cc_library(
+    name = "result_matchers",
+    hdrs = [
+        "result_matchers.h",
+    ],
+    copts = [
+        "-std=c++17",
+    ],
+    strip_include_prefix = "//cuttlefish",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":result",
+        "@googletest//:gtest",
     ],
 )
 
@@ -88,6 +103,7 @@ cc_test(
     ],
     deps = [
         ":result",
+        ":result_matchers",
         "//libbase",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
@@ -111,6 +127,7 @@ cc_test(
     ],
     deps = [
         ":result",
+        ":result_matchers",
         ":utils",
         "@googletest//:gtest",
         "@googletest//:gtest_main",

--- a/base/cvd/cuttlefish/host/commands/cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/BUILD.bazel
@@ -425,6 +425,7 @@ cc_test(
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils",
         "//cuttlefish/common/libs/utils:result",
+        "//cuttlefish/common/libs/utils:result_matchers",
         "//libbase",
         ":cvd_persistent_data",
         ":launch_cvd_cc_proto",

--- a/base/cvd/cuttlefish/host/commands/cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/BUILD.bazel
@@ -338,6 +338,7 @@ cc_library(
         "-Werror=sign-compare",
         "-Wno-ctad-maybe-unsupported",
         "-std=c++17",
+        "-lcurl",
     ],
     strip_include_prefix = "//cuttlefish",
     deps = [
@@ -377,6 +378,7 @@ cc_binary(
     visibility = ["//visibility:public"],
     deps = [
         ":libcvd",
+        "//cuttlefish/common/libs/utils",
         "//libbase",
         "//libsparse",
         "@fmt",
@@ -426,6 +428,7 @@ cc_test(
         "//cuttlefish/common/libs/utils",
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/common/libs/utils:result_matchers",
+        "//cuttlefish/host/libs/config",
         "//libbase",
         ":cvd_persistent_data",
         ":launch_cvd_cc_proto",

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -23,7 +23,11 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cuttlefish/common/libs/utils",
+        "//cuttlefish/common/libs/utils:result",
+        "//libbase",
+        "@fmt",
         "@jsoncpp",
+        "@zlib",
     ],
 )
 

--- a/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
@@ -47,6 +47,7 @@ cc_test(
     includes = [""],
     deps = [
         ":web",
+        "//cuttlefish/common/libs/utils:result_matchers",
         "//libsparse",
         "@googletest//:gtest",
         "@googletest//:gtest_main",

--- a/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
@@ -27,10 +27,13 @@ cc_library(
     strip_include_prefix = "//cuttlefish",
     visibility = ["//visibility:public"],
     deps = [
+        "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils",
         "//cuttlefish/common/libs/utils:result",
+        "//libbase",
         "@fmt",
         "@jsoncpp",
+        "@boringssl//:crypto",
     ],
 )
 
@@ -47,6 +50,8 @@ cc_test(
     includes = [""],
     deps = [
         ":web",
+        "//cuttlefish/common/libs/utils",
+        "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/common/libs/utils:result_matchers",
         "//libsparse",
         "@googletest//:gtest",


### PR DESCRIPTION
This header is only used for testing