### PR TITLE
Remove build-arm64-cuttlefish-deb-job from presubmit.

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -102,5 +102,3 @@ jobs:
       with:
         name: testlogs
         path: e2etests/bazel-testlogs
-  build-arm64-cuttlefish-deb-job:
-    uses: ./.github/workflows/reusable-build.yaml


### PR DESCRIPTION
- This job is already run in postsubmit at: https://github.com/google/android-cuttlefish/blob/10d7f50621aff30f6a591ac251bb913f82b0e65a/.github/workflows/host-image-ci.yml#L46