### PR TITLE
Refactor cvd fetch logging

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/tee_logging.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/tee_logging.cpp
@@ -24,7 +24,6 @@
 #include <cinttypes>
 #include <cstring>
 #include <ctime>
-#include <memory>
 #include <ostream>
 #include <sstream>
 #include <string>

--- a/base/cvd/cuttlefish/common/libs/utils/tee_logging.h
+++ b/base/cvd/cuttlefish/common/libs/utils/tee_logging.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -36,11 +37,7 @@ std::string StderrOutputGenerator(const struct tm& now, int pid, uint64_t tid,
 android::base::LogSeverity ConsoleSeverity();
 android::base::LogSeverity LogFileSeverity();
 
-enum class MetadataLevel {
-  FULL,
-  ONLY_MESSAGE,
-  TAG_AND_MESSAGE
-};
+enum class MetadataLevel { FULL, ONLY_MESSAGE, TAG_AND_MESSAGE };
 
 struct SeverityTarget {
   android::base::LogSeverity severity;
@@ -49,27 +46,29 @@ struct SeverityTarget {
 };
 
 class TeeLogger {
-private:
+ private:
   std::vector<SeverityTarget> destinations_;
-public:
- TeeLogger(const std::vector<SeverityTarget>& destinations,
-           const std::string& log_prefix = "");
- ~TeeLogger() = default;
 
- void operator()(android::base::LogId log_id,
-                 android::base::LogSeverity severity, const char* tag,
-                 const char* file, unsigned int line, const char* message);
+ public:
+  TeeLogger(const std::vector<SeverityTarget>& destinations,
+            const std::string& log_prefix = "");
+  ~TeeLogger() = default;
 
-private:
- std::string prefix_;
+  void operator()(android::base::LogId log_id,
+                  android::base::LogSeverity severity, const char* tag,
+                  const char* file, unsigned int line, const char* message);
+
+ private:
+  std::string prefix_;
 };
 
 TeeLogger LogToFiles(const std::vector<std::string>& files,
                      const std::string& log_prefix = "");
-TeeLogger LogToStderrAndFiles(const std::vector<std::string>& files,
-                              const std::string& log_prefix = "",
-                              MetadataLevel stderr_level = MetadataLevel::ONLY_MESSAGE);
+TeeLogger LogToStderrAndFiles(
+    const std::vector<std::string>& files, const std::string& log_prefix = "",
+    MetadataLevel stderr_level = MetadataLevel::ONLY_MESSAGE,
+    std::optional<android::base::LogSeverity> stderr_serverity = std::nullopt);
 
 std::string StripColorCodes(const std::string& str);
 
-} // namespace cuttlefish
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd.h
@@ -24,6 +24,6 @@ inline constexpr char kHostToolsSubdirectory[] = "host_tools";
 
 std::string GetFetchLogsFileName(const std::string& target_directory);
 
-Result<void> FetchCvdMain(int argc, char** argv, bool log_to_stderr);
+Result<void> FetchCvdMain(int argc, char** argv);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/main.cc
@@ -31,10 +31,9 @@
 #include "common/libs/utils/files.h"
 #include "common/libs/utils/subprocess.h"
 #include "host/commands/cvd/client.h"
-#include "host/commands/cvd/cvd.h"
 #include "host/commands/cvd/common_utils.h"
-#include "host/commands/cvd/fetch/fetch_cvd.h"
-#include "host/commands/cvd/flag.h"
+#include "host/commands/cvd/cvd.h"
+#include "common/libs/utils/flag_parser.h"
 // TODO(315772518) Re-enable once metrics send is reenabled
 // #include "host/commands/cvd/metrics/cvd_metrics_api.h"
 #include "host/commands/cvd/run_server.h"
@@ -143,7 +142,7 @@ void IncreaseFileLimit() {
     return;
   }
   LOG(VERBOSE) << "Old limits -> soft limit= " << old_lim.rlim_cur << "\t"
-            << " hard limit= " << old_lim.rlim_max;
+               << " hard limit= " << old_lim.rlim_max;
   // Set new value
   old_lim.rlim_cur = old_lim.rlim_max;
   // Set limits
@@ -179,15 +178,15 @@ Result<void> CvdMain(int argc, char** argv, char** envp,
     TryInheritServerDatabase();
   }
 
-
   auto env = EnvpToMap(envp);
   // TODO(315772518) Re-enable once metrics send is skipped in a env
   // without network support
   // CvdMetrics::SendCvdMetrics(all_args);
 
   if (android::base::Basename(all_args[0]) == "fetch_cvd") {
-    CF_EXPECT(FetchCvdMain(argc, argv, /*log_to_stderr*/ true));
-    return {};
+    // Convert `fetch_cvd args...` into `cvd fetch args...`
+    all_args[0] = "fetch";
+    all_args.insert(all_args.begin(), "cvd");
   }
 
   IncreaseFileLimit();

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/fetch.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/fetch.cpp
@@ -66,8 +66,7 @@ Result<cvd::Response> CvdFetchCommandHandler::Handle(
     args_data.emplace_back(argument.data());
   }
 
-  CF_EXPECT(FetchCvdMain(args_data.size(), args_data.data(),
-                         /*log_to_stderr*/ !request.IsNullIo()));
+  CF_EXPECT(FetchCvdMain(args_data.size(), args_data.data()));
 
   cvd::Response response;
   response.mutable_command_response();

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/help.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/help.cpp
@@ -26,7 +26,6 @@
 
 #include <android-base/strings.h>
 
-#include "common/libs/fs/shared_fd.h"
 #include "common/libs/utils/result.h"
 #include "cuttlefish/host/commands/cvd/cvd_server.pb.h"
 #include "host/commands/cvd/request_context.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/load_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/load_configs.cpp
@@ -184,9 +184,11 @@ class LoadConfigsCommand : public CvdServerHandler {
 
   RequestWithStdio BuildFetchCmd(const RequestWithStdio& request,
                                  const CvdFlags& cvd_flags) {
-    return RequestWithStdio::NullIo()
+    return RequestWithStdio::InheritIo(request)
         .SetEnv(request.Env())
-        .AddArguments({"cvd", "fetch"})
+        // The fetch operation is too verbose by default, set it to WARNING
+        // unconditionally, the full logs are available in fetch.log anyways.
+        .AddArguments({"cvd", "fetch", "-verbosity", "WARNING"})
         .AddArguments(cvd_flags.fetch_cvd_flags);
   }
 

--- a/base/cvd/cuttlefish/host/libs/web/android_build_api.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_api.cpp
@@ -134,15 +134,15 @@ Result<Build> BuildApi::GetBuild(const DeviceBuildString& build_string,
   std::string status = CF_EXPECT(BuildStatus(proposed_build));
   CF_EXPECT(status != "",
             proposed_build << " is not a valid branch or build id.");
-  LOG(INFO) << "Status for build " << proposed_build << " is " << status;
+  LOG(DEBUG) << "Status for build " << proposed_build << " is " << status;
   while (retry_period_ != std::chrono::seconds::zero() &&
          !StatusIsTerminal(status)) {
-    LOG(INFO) << "Status is \"" << status << "\". Waiting for "
+    LOG(DEBUG) << "Status is \"" << status << "\". Waiting for "
               << retry_period_.count() << " seconds.";
     std::this_thread::sleep_for(retry_period_);
     status = CF_EXPECT(BuildStatus(proposed_build));
   }
-  LOG(INFO) << "Status for build " << proposed_build << " is " << status;
+  LOG(DEBUG) << "Status for build " << proposed_build << " is " << status;
   proposed_build.product = CF_EXPECT(ProductName(proposed_build));
   return proposed_build;
 }

--- a/base/cvd/cuttlefish/host/libs/web/credential_source.cc
+++ b/base/cvd/cuttlefish/host/libs/web/credential_source.cc
@@ -18,8 +18,6 @@
 #include <fcntl.h>
 
 #include <chrono>
-#include <fstream>
-#include <istream>
 #include <memory>
 #include <sstream>
 #include <string>

--- a/base/cvd/cuttlefish/host/libs/web/http_client/http_client.cc
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/http_client.cc
@@ -51,7 +51,7 @@ int LoggingCurlDebugFunction(CURL*, curl_infotype type, char* data, size_t size,
   switch (type) {
     case CURLINFO_TEXT:
       LOG(VERBOSE) << "CURLINFO_TEXT ";
-      LOG(INFO) << ScrubSecrets(TrimWhitespace(data, size));
+      LOG(DEBUG) << ScrubSecrets(TrimWhitespace(data, size));
       break;
     case CURLINFO_HEADER_IN:
       LOG(VERBOSE) << "CURLINFO_HEADER_IN ";
@@ -172,12 +172,12 @@ class CurlClient : public HttpClient {
   Result<HttpResponse<std::string>> DownloadToFile(
       const std::string& url, const std::string& path,
       const std::vector<std::string>& headers) override {
-    LOG(INFO) << "Attempting to save \"" << url << "\" to \"" << path << "\"";
+    LOG(DEBUG) << "Attempting to save \"" << url << "\" to \"" << path << "\"";
 
     auto [shared_fd, temp_path] = CF_EXPECT(SharedFD::Mkostemp(path));
     SharedFDOstream stream(shared_fd);
     auto callback = [&stream](char* data, size_t size) -> bool {
-      LOG(INFO) << "Downloaded chunk of " << size << " bytes";
+      LOG(DEBUG) << "Downloaded chunk of " << size << " bytes";
       if (data == nullptr) {
         return !stream.fail();
       }
@@ -212,7 +212,7 @@ class CurlClient : public HttpClient {
     if (!resolver_) {
       return ManagedCurlSlist(nullptr, curl_slist_free_all);
     }
-    LOG(INFO) << "Manually resolving \"" << url_str << "\"";
+    LOG(DEBUG) << "Manually resolving \"" << url_str << "\"";
     std::stringstream resolve_line;
     std::unique_ptr<CURLU, decltype(&curl_url_cleanup)> url(curl_url(),
                                                             curl_url_cleanup);

--- a/base/cvd/cuttlefish/host/libs/web/http_client/http_client.cc
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/http_client.cc
@@ -70,6 +70,8 @@ int LoggingCurlDebugFunction(CURL*, curl_infotype type, char* data, size_t size,
     case CURLINFO_SSL_DATA_OUT:
       break;
     case CURLINFO_END:
+      LOG(VERBOSE) << "CURLINFO_END ";
+      LOG(DEBUG) << ScrubSecrets(TrimWhitespace(data, size));
       break;
     default:
       LOG(ERROR) << "Unexpected cURL output type: " << type;


### PR DESCRIPTION
- Log result end of downloads at VERBOSE level
- Make fetch_cvd and `cvd fetch` the same
- Downgrade some INFO level logs to DEBUG in the build api and http client libraries
- fetch always logs at VERBOSE level to the files, while the console level is configurable via the -verbosity argument

Bug: b/370812572