### PR TITLE
Reduce noise in `cvd load` output

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/environment.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/environment.cpp
@@ -19,6 +19,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <string>
 
@@ -29,13 +30,17 @@
 
 namespace cuttlefish {
 
-std::string StringFromEnv(const std::string& varname,
-                          const std::string& defval) {
+std::optional<std::string> StringFromEnv(const std::string& varname) {
   const char* const valstr = getenv(varname.c_str());
   if (!valstr) {
-    return defval;
+    return std::nullopt;
   }
   return valstr;
+}
+
+std::string StringFromEnv(const std::string& varname,
+                          const std::string& defval) {
+  return StringFromEnv(varname).value_or(defval);
 }
 
 /**

--- a/base/cvd/cuttlefish/common/libs/utils/environment.h
+++ b/base/cvd/cuttlefish/common/libs/utils/environment.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <optional>
 #include <string>
 
 namespace cuttlefish {
@@ -26,6 +27,8 @@ enum class Arch {
   X86,
   X86_64,
 };
+
+std::optional<std::string> StringFromEnv(const std::string& varname);
 
 std::string StringFromEnv(const std::string& varname,
                           const std::string& defval);

--- a/base/cvd/cuttlefish/host/commands/cvd/command_sequence.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/command_sequence.cpp
@@ -19,7 +19,7 @@
 
 #include <android-base/strings.h>
 
-#include "common/libs/fs/shared_buf.h"
+#include "common/libs/utils/environment.h"
 #include "host/commands/cvd/request_context.h"
 #include "host/commands/cvd/command_request.h"
 #include "host/commands/cvd/types.h"
@@ -54,7 +54,10 @@ std::string FormattedCommand(const CommandRequest& command) {
                        "*************************\n";
   effective_command << "Executing `";
   for (const auto& [name, val] : command.Env()) {
-    effective_command << BashEscape(name) << "=" << BashEscape(val) << " ";
+    // Print only those variables that differ from the current environment
+    if (StringFromEnv(name) != val) {
+      effective_command << BashEscape(name) << "=" << BashEscape(val) << " ";
+    }
   }
   auto args = command.Args();
   auto selector_args = command.SelectorArgs();


### PR DESCRIPTION
by printing only modified environment variables in the commands