### PR TITLE
Reduce fetching redundancy and logging verbosity

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/archive.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/archive.cpp
@@ -104,23 +104,6 @@ bool Archive::ExtractFiles(const std::vector<std::string>& to_extract,
   return bsdtar_ret == 0;
 }
 
-std::string Archive::ExtractToMemory(const std::string& path) {
-  Command bsdtar_cmd("/usr/bin/bsdtar");
-  bsdtar_cmd.AddParameter("-xf");
-  bsdtar_cmd.AddParameter(file_);
-  bsdtar_cmd.AddParameter("-O");
-  bsdtar_cmd.AddParameter(path);
-  std::string stdout_str;
-  auto ret =
-      RunWithManagedStdio(std::move(bsdtar_cmd), nullptr, &stdout_str, nullptr);
-  if (ret != 0) {
-    LOG(ERROR) << "Could not extract \"" << path << "\" from \"" << file_
-               << "\" to memory.";
-    return "";
-  }
-  return stdout_str;
-}
-
 Result<std::vector<std::string>> ExtractImages(
     const std::string& archive_filepath, const std::string& target_directory,
     const std::vector<std::string>& images, const bool keep_archive) {

--- a/base/cvd/cuttlefish/common/libs/utils/archive.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/archive.cpp
@@ -74,12 +74,13 @@ std::vector<std::string> Archive::Contents() {
       : std::vector<std::string>();
 }
 
-bool Archive::ExtractAll(const std::string& target_directory) {
-  return ExtractFiles({}, target_directory);
+Result<void> Archive::ExtractAll(const std::string& target_directory) {
+  CF_EXPECT(ExtractFiles({}, target_directory));
+  return {};
 }
 
-bool Archive::ExtractFiles(const std::vector<std::string>& to_extract,
-                           const std::string& target_directory) {
+Result<void> Archive::ExtractFiles(const std::vector<std::string>& to_extract,
+                                   const std::string& target_directory) {
   Command bsdtar_cmd("/usr/bin/bsdtar");
   bsdtar_cmd.AddParameter("-x");
   bsdtar_cmd.AddParameter("-v");
@@ -97,11 +98,9 @@ bool Archive::ExtractFiles(const std::vector<std::string>& to_extract,
   int bsdtar_ret = RunWithManagedStdio(std::move(bsdtar_cmd), nullptr, nullptr,
                                        &bsdtar_output);
   LOG(DEBUG) << bsdtar_output;
-  if (bsdtar_ret != 0) {
-    LOG(ERROR) << "bsdtar extraction on \"" << file_ << "\" returned "
-               << bsdtar_ret;
-  }
-  return bsdtar_ret == 0;
+  CF_EXPECTF(bsdtar_ret == 0, "bsdtar extraction failed on '{}', '''{}'''",
+             file_, bsdtar_output);
+  return {};
 }
 
 Result<std::vector<std::string>> ExtractImages(

--- a/base/cvd/cuttlefish/common/libs/utils/archive.h
+++ b/base/cvd/cuttlefish/common/libs/utils/archive.h
@@ -22,21 +22,6 @@
 
 namespace cuttlefish {
 
-// Operations on archive files
-class Archive {
-  std::string file_;
-
- public:
-  Archive(const std::string& file);
-  ~Archive();
-
-  Result<std::vector<std::string>> ExtractAll(
-      const std::string& target_directory);
-  Result<std::vector<std::string>> ExtractFiles(
-      const std::vector<std::string>& files,
-      const std::string& target_directory);
-};
-
 Result<std::vector<std::string>> ExtractImages(
     const std::string& archive_filepath, const std::string& target_directory,
     const std::vector<std::string>& images, bool keep_archive);

--- a/base/cvd/cuttlefish/common/libs/utils/archive.h
+++ b/base/cvd/cuttlefish/common/libs/utils/archive.h
@@ -31,23 +31,22 @@ class Archive {
   ~Archive();
 
   std::vector<std::string> Contents();
-  bool ExtractAll(const std::string& target_directory = ".");
+  bool ExtractAll(const std::string& target_directory);
   bool ExtractFiles(const std::vector<std::string>& files,
-                    const std::string& target_directory = ".");
-  std::string ExtractToMemory(const std::string& path);
+                    const std::string& target_directory);
 };
 
 Result<std::vector<std::string>> ExtractImages(
     const std::string& archive_filepath, const std::string& target_directory,
-    const std::vector<std::string>& images, const bool keep_archive);
+    const std::vector<std::string>& images, bool keep_archive);
 
 Result<std::string> ExtractImage(const std::string& archive_filepath,
                                  const std::string& target_directory,
                                  const std::string& image,
-                                 const bool keep_archive = true);
+                                 bool keep_archive = true);
 
 Result<std::vector<std::string>> ExtractArchiveContents(
     const std::string& archive_filepath, const std::string& target_directory,
-    const bool keep_archive);
+    bool keep_archive);
 
 } // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/archive.h
+++ b/base/cvd/cuttlefish/common/libs/utils/archive.h
@@ -31,9 +31,9 @@ class Archive {
   ~Archive();
 
   std::vector<std::string> Contents();
-  bool ExtractAll(const std::string& target_directory);
-  bool ExtractFiles(const std::vector<std::string>& files,
-                    const std::string& target_directory);
+  Result<void> ExtractAll(const std::string& target_directory);
+  Result<void> ExtractFiles(const std::vector<std::string>& files,
+                            const std::string& target_directory);
 };
 
 Result<std::vector<std::string>> ExtractImages(

--- a/base/cvd/cuttlefish/common/libs/utils/archive.h
+++ b/base/cvd/cuttlefish/common/libs/utils/archive.h
@@ -30,10 +30,11 @@ class Archive {
   Archive(const std::string& file);
   ~Archive();
 
-  std::vector<std::string> Contents();
-  Result<void> ExtractAll(const std::string& target_directory);
-  Result<void> ExtractFiles(const std::vector<std::string>& files,
-                            const std::string& target_directory);
+  Result<std::vector<std::string>> ExtractAll(
+      const std::string& target_directory);
+  Result<std::vector<std::string>> ExtractFiles(
+      const std::vector<std::string>& files,
+      const std::string& target_directory);
 };
 
 Result<std::vector<std::string>> ExtractImages(

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_tracer.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_tracer.cpp
@@ -22,6 +22,8 @@
 #include <sstream>
 #include <vector>
 
+#include <fmt/format.h>
+
 namespace cuttlefish {
 namespace {
 
@@ -43,13 +45,33 @@ struct FetchTracer::TraceImpl {
 
 namespace {
 
+std::string FormatByteSize(uint64_t size) {
+  if (size < 10240) {
+    return fmt::format("{} B", size);
+  }
+  size /= 1024;
+  if (size < 10240) {
+    return fmt::format("{} KiB", size);
+  }
+  size /= 1024;
+  if (size < 10240) {
+    return fmt::format("{} MiB", size);
+  }
+  size /= 1024;
+  if (size < 10240) {
+    return fmt::format("{} GiB", size);
+  }
+  size /= 1024;
+  return fmt::format("{} TiB", size);
+}
+
 std::string ToStyledString(const FetchTracer::TraceImpl& trace,
                            std::string indent_prefix) {
   std::stringstream ss;
   for (const Phase& phase : trace.phases) {
     ss << indent_prefix << phase.name << ": " << phase.duration.count() << "s";
     if (phase.size_bytes) {
-      ss << ", " << *phase.size_bytes / 1024 << "MB";
+      ss << ", " << FormatByteSize(*phase.size_bytes);
     }
     ss << '\n';
   }

--- a/base/cvd/cuttlefish/host/libs/web/android_build_api.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_api.cpp
@@ -126,9 +126,9 @@ Result<Build> BuildApi::GetBuild(const DeviceBuildString& build_string,
                               build_string.target.value_or(fallback_target)));
   if (latest_build_id) {
     proposed_build.id = *latest_build_id;
-    LOG(INFO) << "Latest build id for branch" << build_string.branch_or_id
-              << " and target " << proposed_build.target << " is "
-              << proposed_build.id;
+    LOG(INFO) << "Latest build id for branch '" << build_string.branch_or_id
+              << "' and target '" << proposed_build.target << "' is '"
+              << proposed_build.id << "'";
   }
 
   std::string status = CF_EXPECT(BuildStatus(proposed_build));

--- a/base/cvd/cuttlefish/host/libs/web/credential_source.cc
+++ b/base/cvd/cuttlefish/host/libs/web/credential_source.cc
@@ -77,8 +77,7 @@ Result<std::unique_ptr<CredentialSource>> GetCredentialSourceLegacy(
           http_client, oauth_contents);
       if (attempt_load.ok()) {
         result.reset(new RefreshCredentialSource(std::move(*attempt_load)));
-        LOG(INFO) << "\"" << oauth_filepath
-                  << "\" was found, using that as credentials";
+        LOG(DEBUG) << "Loaded credentials from '" << oauth_filepath << "'";
       } else {
         LOG(ERROR) << "Failed to load oauth credentials from \""
                    << oauth_filepath

--- a/base/debian/changelog
+++ b/base/debian/changelog
@@ -3,6 +3,9 @@ cuttlefish-common (1.0.0) UNRELEASED; urgency=medium
   [ Jorge E. Moreira ]
   * Delete unused experimental commands
 
+  [ A. Cody Schuffelen]
+  * Reduce logging verbosity
+
  -- Jorge Moreira <jemoreira@google.com>  Thu, 05 Sep 2024 11:05:25 -0700
 
 cuttlefish-common (0.9.31) unstable; urgency=medium


### PR DESCRIPTION
`stderr` output now looks like
```
$ cvd fetch --target_directory=/tmp/a --default_build=aosp-main/aosp_cf_x86_64_phone-trunk_staging-userdebug
Latest build id for branch 'aosp-main' and target 'aosp_cf_x86_64_phone-trunk_staging-userdebug' is '12504151'
Starting fetch to "/tmp/a"
Preparing host package for (id="12504151", target="aosp_cf_x86_64_phone-trunk_staging-userdebug", filepath="")
Downloading image zip for (id="12504151", target="aosp_cf_x86_64_phone-trunk_staging-userdebug", filepath="")
Completed target fetch to '/tmp/a' (1 out of 1)
Completed all fetches
```

`fetch.log` is now 224KiB, down from 18MiB. Rather than logging every data chunk from `libcurl` on file downloads, it now logs at exponentially increasing intervals on bytes downloaded.

Removes a `bsdtar -tf` call used to retrieve file contents. The file contents are already printed during an earlier `bsdtar -xvf` call. This output is now parsed to access the contents. I don't have an explanation why, but in practice we have seen the `bsdtar -tf` call hang. It is an expensive operation anyway because `.tar*` files have no central archive and must be completely decompressed and scanned to produce the file contents, so skipping it saves some IO.