### PR TITLE
Support vendor BuildAPI classes

### DIFF
--- a/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
@@ -13,6 +13,7 @@ cc_library(
     hdrs = [
         "android_build_api.h",
         "android_build_string.h",
+        "build_api.h",
         "caching_build_api.h",
         "chrome_os_build_string.h",
         "credential_source.h",

--- a/base/cvd/cuttlefish/host/libs/web/android_build_api.h
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_api.h
@@ -29,6 +29,7 @@
 
 #include "common/libs/utils/result.h"
 #include "host/libs/web/android_build_string.h"
+#include "host/libs/web/build_api.h"
 #include "host/libs/web/credential_source.h"
 #include "host/libs/web/http_client/http_client.h"
 
@@ -37,58 +38,31 @@ namespace cuttlefish {
 inline constexpr char kAndroidBuildServiceUrl[] =
     "https://www.googleapis.com/android/internal/build/v3";
 
-struct DeviceBuild {
-  DeviceBuild(std::string id, std::string target,
-              std::optional<std::string> filepath);
-
-  std::string id;
-  std::string target;
-  std::string product;
-  std::optional<std::string> filepath;
-};
-
-std::ostream& operator<<(std::ostream&, const DeviceBuild&);
-
-struct DirectoryBuild {
-  // TODO(schuffelen): Support local builds other than "eng"
-  DirectoryBuild(std::vector<std::string> paths, std::string target,
-                 std::optional<std::string> filepath);
-
-  std::vector<std::string> paths;
-  std::string target;
-  std::string id;
-  std::string product;
-  std::optional<std::string> filepath;
-};
-
-std::ostream& operator<<(std::ostream&, const DirectoryBuild&);
-
-using Build = std::variant<DeviceBuild, DirectoryBuild>;
-
-std::ostream& operator<<(std::ostream&, const Build&);
-
-class BuildApi {
+class AndroidBuildApi : public BuildApi {
  public:
-  BuildApi() = delete;
-  BuildApi(BuildApi&&) = delete;
-  virtual ~BuildApi() = default;
-  BuildApi(std::unique_ptr<HttpClient> http_client,
-           std::unique_ptr<HttpClient> inner_http_client,
-           std::unique_ptr<CredentialSource> credential_source,
-           std::string api_key, const std::chrono::seconds retry_period,
-           std::string api_base_url, std::string project_id);
+  AndroidBuildApi() = delete;
+  AndroidBuildApi(AndroidBuildApi&&) = delete;
+  virtual ~AndroidBuildApi() = default;
+  AndroidBuildApi(std::unique_ptr<HttpClient> http_client,
+                  std::unique_ptr<HttpClient> inner_http_client,
+                  std::unique_ptr<CredentialSource> credential_source,
+                  std::string api_key, const std::chrono::seconds retry_period,
+                  std::string api_base_url, std::string project_id);
 
   Result<Build> GetBuild(const BuildString& build_string,
                          const std::string& fallback_target);
 
-  virtual Result<std::string> DownloadFile(const Build& build,
-                                           const std::string& target_directory,
-                                           const std::string& artifact_name);
+  Result<std::string> DownloadFile(const Build& build,
+                                   const std::string& target_directory,
+                                   const std::string& artifact_name);
 
-  virtual Result<std::string> DownloadFileWithBackup(
+  Result<std::string> DownloadFileWithBackup(
       const Build& build, const std::string& target_directory,
       const std::string& artifact_name,
       const std::string& backup_artifact_name);
+
+  Result<std::string> GetBuildZipName(const Build& build,
+                                      const std::string& name);
 
  private:
   Result<std::vector<std::string>> Headers();
@@ -141,8 +115,6 @@ class BuildApi {
   std::string api_base_url_;
   std::string project_id_;
 };
-
-std::string GetBuildZipName(const Build& build, const std::string& name);
 
 std::tuple<std::string, std::string> GetBuildIdAndTarget(const Build& build);
 

--- a/base/cvd/cuttlefish/host/libs/web/build_api.h
+++ b/base/cvd/cuttlefish/host/libs/web/build_api.h
@@ -1,0 +1,79 @@
+//
+// Copyright (C) 2019 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <optional>
+#include <ostream>
+#include <string>
+#include <tuple>
+#include <variant>
+#include <vector>
+
+#include "common/libs/utils/result.h"
+#include "host/libs/web/android_build_string.h"
+
+namespace cuttlefish {
+
+struct DeviceBuild {
+  DeviceBuild(std::string id, std::string target,
+              std::optional<std::string> filepath);
+
+  std::string id;
+  std::string target;
+  std::string product;
+  std::optional<std::string> filepath;
+};
+
+std::ostream& operator<<(std::ostream&, const DeviceBuild&);
+
+struct DirectoryBuild {
+  // TODO(schuffelen): Support local builds other than "eng"
+  DirectoryBuild(std::vector<std::string> paths, std::string target,
+                 std::optional<std::string> filepath);
+
+  std::vector<std::string> paths;
+  std::string target;
+  std::string id;
+  std::string product;
+  std::optional<std::string> filepath;
+};
+
+std::ostream& operator<<(std::ostream&, const DirectoryBuild&);
+
+using Build = std::variant<DeviceBuild, DirectoryBuild>;
+
+std::ostream& operator<<(std::ostream&, const Build&);
+
+class BuildApi {
+ public:
+  virtual ~BuildApi() = default;
+  virtual Result<Build> GetBuild(const BuildString& build_string,
+                                 const std::string& fallback_target) = 0;
+
+  virtual Result<std::string> DownloadFile(
+      const Build& build, const std::string& target_directory,
+      const std::string& artifact_name) = 0;
+
+  virtual Result<std::string> DownloadFileWithBackup(
+      const Build& build, const std::string& target_directory,
+      const std::string& artifact_name,
+      const std::string& backup_artifact_name) = 0;
+
+  virtual Result<std::string> GetBuildZipName(const Build& build,
+                                              const std::string& name) = 0;
+};
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/web/caching_build_api.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/caching_build_api.cpp
@@ -75,19 +75,20 @@ CachingPaths ConstructCachePaths(const std::string& cache_base,
 
 }  // namespace
 
-CachingBuildApi::CachingBuildApi(
-    std::unique_ptr<HttpClient> http_client,
-    std::unique_ptr<HttpClient> inner_http_client,
-    std::unique_ptr<CredentialSource> credential_source, std::string api_key,
-    const std::chrono::seconds retry_period, std::string api_base_url, std::string project_id,
-    const std::string cache_base_path)
-    : BuildApi(std::move(http_client), std::move(inner_http_client),
-               std::move(credential_source), std::move(api_key), retry_period,
-               std::move(api_base_url), std::move(project_id)),
-      cache_base_path_(std::move(cache_base_path)) {};
+CachingBuildApi::CachingBuildApi(std::unique_ptr<BuildApi> build_api,
+                                 std::string cache_base_path)
+    : build_api_(std::move(build_api)),
+      cache_base_path_(std::move(cache_base_path)) {
+  CHECK(build_api_ != nullptr) << "Underlying build api can't be null";
+};
 
 Result<bool> CachingBuildApi::CanCache(const std::string& target_directory) {
   return CF_EXPECT(CanHardLink(target_directory, cache_base_path_));
+}
+
+Result<Build> CachingBuildApi::GetBuild(const BuildString& build_string,
+                                        const std::string& fallback_target) {
+  return CF_EXPECT(build_api_->GetBuild(build_string, fallback_target));
 }
 
 Result<std::string> CachingBuildApi::DownloadFile(
@@ -99,13 +100,14 @@ Result<std::string> CachingBuildApi::DownloadFile(
         << target_directory << "\" and cache directory \"" << cache_base_path_
         << "\"";
     return CF_EXPECT(
-        BuildApi::DownloadFile(build, target_directory, artifact_name));
+        build_api_->DownloadFile(build, target_directory, artifact_name));
   }
   const auto paths = ConstructCachePaths(cache_base_path_, build,
                                          target_directory, artifact_name);
   CF_EXPECT(EnsureDirectoryExists(paths.build_cache));
   if (!FileExists(paths.cache_artifact)) {
-    CF_EXPECT(BuildApi::DownloadFile(build, paths.build_cache, artifact_name));
+    CF_EXPECT(
+        build_api_->DownloadFile(build, paths.build_cache, artifact_name));
   }
   return CF_EXPECT(CreateHardLink(paths.cache_artifact, paths.target_artifact,
                                   kOverwriteExistingFile));
@@ -119,7 +121,7 @@ Result<std::string> CachingBuildApi::DownloadFileWithBackup(
         << "Caching disabled, unable to hard link between fetch directory \""
         << target_directory << "\" and cache directory \"" << cache_base_path_
         << "\"";
-    return CF_EXPECT(BuildApi::DownloadFileWithBackup(
+    return CF_EXPECT(build_api_->DownloadFileWithBackup(
         build, target_directory, artifact_name, backup_artifact_name));
   }
   const auto paths =
@@ -135,7 +137,7 @@ Result<std::string> CachingBuildApi::DownloadFileWithBackup(
                                     paths.target_backup_artifact,
                                     kOverwriteExistingFile));
   }
-  const auto artifact_filepath = CF_EXPECT(BuildApi::DownloadFileWithBackup(
+  const auto artifact_filepath = CF_EXPECT(build_api_->DownloadFileWithBackup(
       build, paths.build_cache, artifact_name, backup_artifact_name));
   if (android::base::EndsWith(artifact_filepath, artifact_name)) {
     return CF_EXPECT(CreateHardLink(paths.cache_artifact, paths.target_artifact,
@@ -144,6 +146,10 @@ Result<std::string> CachingBuildApi::DownloadFileWithBackup(
   return CF_EXPECT(CreateHardLink(paths.cache_backup_artifact,
                                   paths.target_backup_artifact));
 }
+Result<std::string> CachingBuildApi::GetBuildZipName(const Build& build,
+                                                     const std::string& name) {
+  return CF_EXPECT(build_api_->GetBuildZipName(build, name));
+}
 
 std::unique_ptr<BuildApi> CreateBuildApi(
     std::unique_ptr<HttpClient> http_client,
@@ -151,16 +157,14 @@ std::unique_ptr<BuildApi> CreateBuildApi(
     std::unique_ptr<CredentialSource> credential_source, std::string api_key,
     const std::chrono::seconds retry_period, std::string api_base_url, std::string project_id,
     const bool enable_caching, const std::string cache_base_path) {
-  if (enable_caching && EnsureCacheDirectory(cache_base_path)) {
-    return std::make_unique<CachingBuildApi>(
-        std::move(http_client), std::move(inner_http_client),
-        std::move(credential_source), std::move(api_key), retry_period,
-        std::move(api_base_url), std::move(project_id), std::move(cache_base_path));
-  }
-  return std::make_unique<BuildApi>(
+  auto build_api = std::make_unique<AndroidBuildApi>(
       std::move(http_client), std::move(inner_http_client),
       std::move(credential_source), std::move(api_key), retry_period,
       std::move(api_base_url), std::move(project_id));
+  if (enable_caching && EnsureCacheDirectory(cache_base_path)) {
+    return std::make_unique<CachingBuildApi>(std::move(build_api),
+                                             std::move(cache_base_path));
+  }
+  return std::move(build_api);
 }
-
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/web/caching_build_api.h
+++ b/base/cvd/cuttlefish/host/libs/web/caching_build_api.h
@@ -31,13 +31,11 @@ class CachingBuildApi : public BuildApi {
   CachingBuildApi() = delete;
   CachingBuildApi(CachingBuildApi&&) = delete;
   ~CachingBuildApi() override = default;
-  CachingBuildApi(std::unique_ptr<HttpClient> http_client,
-                  std::unique_ptr<HttpClient> inner_http_client,
-                  std::unique_ptr<CredentialSource> credential_source,
-                  std::string api_key, const std::chrono::seconds retry_period,
-                  std::string api_base_url, std::string project_id,
-                  const std::string cache_base_path);
+  CachingBuildApi(std::unique_ptr<BuildApi> build_api,
+                  std::string cache_base_path);
 
+  Result<Build> GetBuild(const BuildString& build_string,
+                         const std::string& fallback_target);
   Result<std::string> DownloadFile(const Build& build,
                                    const std::string& target_directory,
                                    const std::string& artifact_name) override;
@@ -46,9 +44,13 @@ class CachingBuildApi : public BuildApi {
       const std::string& artifact_name,
       const std::string& backup_artifact_name) override;
 
+  Result<std::string> GetBuildZipName(const Build& build,
+                                      const std::string& name);
+
  private:
   Result<bool> CanCache(const std::string& target_directory);
 
+  std::unique_ptr<BuildApi> build_api_;
   std::string cache_base_path_;
 };
 


### PR DESCRIPTION
These changes enable us to implement unique/additional Android build image repositories.  Locally we have a new BuildApi subclass that will download from either our internal image repository or AOSP, depending on branch name/BUILD ID.