### PR TITLE
Fix race in some `CredentialSource` implementations

### DIFF
--- a/base/cvd/cuttlefish/host/libs/web/credential_source.cc
+++ b/base/cvd/cuttlefish/host/libs/web/credential_source.cc
@@ -26,11 +26,11 @@
 #include <android-base/file.h>
 #include <android-base/logging.h>
 #include <android-base/strings.h>
-#include "json/json.h"
-#include "openssl/bio.h"
-#include "openssl/err.h"
-#include "openssl/evp.h"
-#include "openssl/pem.h"
+#include <json/json.h>
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
 
 #include "common/libs/utils/base64.h"
 #include "common/libs/utils/files.h"

--- a/base/cvd/cuttlefish/host/libs/web/credential_source.h
+++ b/base/cvd/cuttlefish/host/libs/web/credential_source.h
@@ -45,9 +45,9 @@ class GceMetadataCredentialSource : public CredentialSource {
   static std::unique_ptr<CredentialSource> Make(HttpClient&);
 
  private:
-  HttpClient& http_client;
-  std::string latest_credential;
-  std::chrono::steady_clock::time_point expiration;
+  HttpClient& http_client_;
+  std::string latest_credential_;
+  std::chrono::steady_clock::time_point expiration_;
 
   Result<void> RefreshCredential();
 };
@@ -61,7 +61,7 @@ class FixedCredentialSource : public CredentialSource {
   static std::unique_ptr<CredentialSource> Make(const std::string& credential);
 
  private:
-  std::string credential;
+  std::string credential_;
 };
 
 class RefreshCredentialSource : public CredentialSource {

--- a/base/cvd/cuttlefish/host/libs/web/credential_source.h
+++ b/base/cvd/cuttlefish/host/libs/web/credential_source.h
@@ -16,11 +16,9 @@
 #pragma once
 
 #include <chrono>
-#include <istream>
 #include <memory>
 #include <string>
 
-#include "json/json.h"
 #include "openssl/evp.h"
 
 #include "common/libs/utils/result.h"
@@ -32,18 +30,12 @@ inline constexpr char kBuildScope[] =
     "https://www.googleapis.com/auth/androidbuild.internal";
 
 class CredentialSource {
-public:
+ public:
   virtual ~CredentialSource() = default;
   virtual Result<std::string> Credential() = 0;
 };
 
 class GceMetadataCredentialSource : public CredentialSource {
-  HttpClient& http_client;
-  std::string latest_credential;
-  std::chrono::steady_clock::time_point expiration;
-
-  Result<void> RefreshCredential();
-
  public:
   GceMetadataCredentialSource(HttpClient&);
   GceMetadataCredentialSource(GceMetadataCredentialSource&&) = default;
@@ -51,16 +43,25 @@ class GceMetadataCredentialSource : public CredentialSource {
   Result<std::string> Credential() override;
 
   static std::unique_ptr<CredentialSource> Make(HttpClient&);
+
+ private:
+  HttpClient& http_client;
+  std::string latest_credential;
+  std::chrono::steady_clock::time_point expiration;
+
+  Result<void> RefreshCredential();
 };
 
 class FixedCredentialSource : public CredentialSource {
-  std::string credential;
-public:
+ public:
   FixedCredentialSource(const std::string& credential);
 
   Result<std::string> Credential() override;
 
   static std::unique_ptr<CredentialSource> Make(const std::string& credential);
+
+ private:
+  std::string credential;
 };
 
 class RefreshCredentialSource : public CredentialSource {


### PR DESCRIPTION
There is concurrent access to the `BuildApi` class which uses `CredentialSource`. Accessing `Credential()` in some implementations of `CredentialSource` mutates internal state.

I don't believe this will affect the flakes we're currently seeing in production, as that code path uses `FixedCredentialSource` which does not mutate internal state.

PR also includes some refactoring of the `credential_source.*` files in earlier commits.