### PR TITLE
Fix forward use of `X-Cutf-Cloud-Orchestrator-Inject-BuildAPI-Creds`.

### DIFF
--- a/frontend/src/libhoclient/BUILD.bazel
+++ b/frontend/src/libhoclient/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "@com_github_google_android_cuttlefish_frontend_src_liboperator//api/v1:api",
         "@com_github_google_cloud_android_orchestration//pkg/webrtcclient",
         "@com_github_gorilla_websocket//:websocket",
-        "@com_github_hashicorp_go_multierror//:go-multierror",
         "@com_github_pion_webrtc_v3//:webrtc",
     ],
 )
@@ -32,6 +31,5 @@ go_test(
     deps = [
         "@com_github_google_android_cuttlefish_frontend_src_host_orchestrator//api/v1:api",
         "@com_github_google_go_cmp//cmp",
-        "@com_github_hashicorp_go_multierror//:go-multierror",
     ],
 )


### PR DESCRIPTION
- Use of the header got broken in https://github.com/google/android-cuttlefish/commit/aa520271e19342cdda6abcd6e5e78da7c91635c4