### PR TITLE
Clearly separate command parsing from business logic for the status command

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/common_utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/common_utils.cpp
@@ -173,4 +173,9 @@ Result<std::string> GroupDirFromHome(std::string_view dir) {
   return std::string(dir);
 }
 
+std::string AssemblyDirFromHome(const std::string& group_home_dir) {
+  return group_home_dir + "/cuttlefish/assembly";
+}
+
+
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/common_utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/common_utils.h
@@ -89,6 +89,8 @@ std::string DefaultBaseDir();
 
 Result<std::string> GroupDirFromHome(std::string_view group_home_dir);
 
+std::string AssemblyDirFromHome(const std::string& group_home_dir);
+
 // Returns the path to the directory containing the host binaries, shared
 // libraries and other files built with the Android build system. It searches,
 // in order, the ANDROID_HOST_OUT, ANDROID_SOONG_HOST_OUT and HOME environment

--- a/base/cvd/cuttlefish/host/commands/cvd/instance_manager.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instance_manager.cpp
@@ -107,6 +107,13 @@ InstanceManager::SelectInstance(
   return CF_EXPECT(instance_selector.FindInstanceWithGroup(instance_db_));
 }
 
+Result<std::pair<InstanceManager::LocalInstance,
+                 InstanceManager::LocalInstanceGroup>>
+InstanceManager::FindInstanceById(unsigned id) const {
+  return CF_EXPECT(instance_db_.FindInstanceWithGroup(
+      Query(selector::kInstanceIdField, id)));
+}
+
 Result<bool> InstanceManager::HasInstanceGroups() {
   return !CF_EXPECT(instance_db_.IsEmpty());
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/instance_manager.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instance_manager.h
@@ -82,6 +82,9 @@ class InstanceManager {
   Result<LocalInstanceGroup> FindGroup(const Query& query) const;
   Result<LocalInstanceGroup> FindGroup(const Queries& queries) const;
 
+  Result<std::pair<LocalInstance, LocalInstanceGroup>> FindInstanceById(
+      unsigned id) const;
+
   Result<void> SetAcloudTranslatorOptout(bool optout);
   Result<bool> GetAcloudTranslatorOptout() const;
 

--- a/base/cvd/cuttlefish/host/commands/cvd/selector/instance_group_record.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/selector/instance_group_record.cpp
@@ -22,6 +22,7 @@
 #include <android-base/parseint.h>
 
 #include "common/libs/utils/result.h"
+#include "host/commands/cvd/common_utils.h"
 #include "host/commands/cvd/selector/instance_database_types.h"
 
 namespace cuttlefish {
@@ -139,7 +140,7 @@ std::vector<LocalInstance> LocalInstanceGroup::FindByInstanceName(
 }
 
 std::string LocalInstanceGroup::AssemblyDir() const {
-  return HomeDir() + "/cuttlefish/assembly";
+  return AssemblyDirFromHome(HomeDir());
 }
 
 Result<LocalInstanceGroup> LocalInstanceGroup::Deserialize(

--- a/base/cvd/cuttlefish/host/commands/cvd/selector/instance_group_record.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/selector/instance_group_record.cpp
@@ -200,5 +200,19 @@ Result<LocalInstanceGroup> LocalInstanceGroup::Deserialize(
   return Create(group_proto);
 }
 
+Result<Json::Value> LocalInstanceGroup::FetchStatus(
+    std::chrono::seconds timeout) {
+  Json::Value instances_json(Json::arrayValue);
+  for (auto& instance : Instances()) {
+    auto instance_status_json = CF_EXPECT(instance.FetchStatus(timeout));
+    instances_json.append(instance_status_json);
+  }
+  Json::Value group_json;
+  group_json["group_name"] = GroupName();
+  group_json["start_time"] = selector::Format(StartTime());
+  group_json["instances"] = instances_json;
+  return group_json;
+}
+
 }  // namespace selector
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/selector/instance_group_record.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/selector/instance_group_record.h
@@ -71,6 +71,10 @@ class LocalInstanceGroup {
    */
   std::vector<LocalInstance> FindByInstanceName(
       const std::string& instance_name) const;
+  // Fetches status from all instances in the group. Waits for run_cvd to
+  // respond for at most timeout seconds for each instance.
+  Result<Json::Value> FetchStatus(
+      std::chrono::seconds timeout = std::chrono::seconds(5));
 
  private:
   LocalInstanceGroup(const cvd::InstanceGroup& group_proto);

--- a/base/cvd/cuttlefish/host/commands/cvd/selector/instance_record.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/selector/instance_record.cpp
@@ -19,6 +19,8 @@
 #include <android-base/logging.h>
 #include <fmt/format.h>
 
+#include "host/commands/cvd/common_utils.h"
+
 namespace cuttlefish {
 namespace selector {
 
@@ -50,6 +52,10 @@ int LocalInstance::adb_port() const {
   // run_cvd picks this port from the instance id and doesn't provide a flag
   // to change in cvd_internal_flag
   return BASE_ADB_PORT + id() - BASE_INSTANCE_ID;
+}
+
+std::string LocalInstance::assembly_dir() const {
+  return AssemblyDirFromHome(home_directory());
 }
 
 bool LocalInstance::IsActive() const {

--- a/base/cvd/cuttlefish/host/commands/cvd/selector/instance_record.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/selector/instance_record.cpp
@@ -20,6 +20,7 @@
 #include <fmt/format.h>
 
 #include "host/commands/cvd/common_utils.h"
+#include "host/commands/cvd/server_command/status_fetcher.h"
 
 namespace cuttlefish {
 namespace selector {
@@ -77,6 +78,10 @@ bool LocalInstance::IsActive() const {
       LOG(FATAL) << "Invalid instance state: " << state();
   }
   return false;
+}
+
+Result<Json::Value> LocalInstance::FetchStatus(std::chrono::seconds timeout) {
+  return CF_EXPECT(FetchInstanceStatus(*this, timeout));
 }
 
 }  // namespace selector

--- a/base/cvd/cuttlefish/host/commands/cvd/selector/instance_record.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/selector/instance_record.h
@@ -16,8 +16,12 @@
 
 #pragma once
 
+#include <chrono>
 #include <string>
 
+#include <json/json.h>
+
+#include "common/libs/utils/result.h"
 #include "cuttlefish/host/commands/cvd/selector/cvd_persistent_data.pb.h"
 
 namespace cuttlefish {
@@ -51,6 +55,11 @@ class LocalInstance {
   std::string assembly_dir() const;
 
   bool IsActive() const;
+  // Contacts run_cvd to query the instance status. Returns a JSON object with
+  // a description of the instance properties. Waits for run_cvd to respond for
+  // at most timeout seconds.
+  Result<Json::Value> FetchStatus(
+      std::chrono::seconds timeout = std::chrono::seconds(5));
 
  private:
   LocalInstance(std::shared_ptr<cvd::InstanceGroup> group_proto,

--- a/base/cvd/cuttlefish/host/commands/cvd/selector/instance_record.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/selector/instance_record.h
@@ -42,6 +42,13 @@ class LocalInstance {
   }
   std::string instance_dir() const;
   int adb_port() const;
+  const std::string& home_directory() const {
+    return group_proto_->home_directory();
+  }
+  const std::string& host_artifacts_path() const {
+    return group_proto_->host_artifacts_path();
+  }
+  std::string assembly_dir() const;
 
   bool IsActive() const;
 

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/fleet.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/fleet.cpp
@@ -41,8 +41,7 @@ usage: cvd fleet [--help]
 class CvdFleetCommandHandler : public CvdServerHandler {
  public:
   CvdFleetCommandHandler(InstanceManager& instance_manager)
-      : instance_manager_(instance_manager),
-        status_fetcher_(instance_manager_) {}
+      : instance_manager_(instance_manager) {}
 
   Result<bool> CanHandle(const CommandRequest& request) const override;
   Result<cvd::Response> Handle(const CommandRequest& request) override;
@@ -58,7 +57,6 @@ class CvdFleetCommandHandler : public CvdServerHandler {
 
  private:
   InstanceManager& instance_manager_;
-  StatusFetcher status_fetcher_;
 
   static constexpr char kFleetSubcmd[] = "fleet";
   bool IsHelp(const cvd_common::Args& cmd_args) const;
@@ -89,8 +87,7 @@ Result<cvd::Response> CvdFleetCommandHandler::Handle(
   auto all_groups = CF_EXPECT(instance_manager_.FindGroups({}));
   Json::Value groups_json(Json::arrayValue);
   for (auto& group : all_groups) {
-    groups_json.append(
-        CF_EXPECT(status_fetcher_.FetchGroupStatus(request, group)));
+    groups_json.append(CF_EXPECT(FetchStatus(group)));
   }
   Json::Value output_json(Json::objectValue);
   output_json["groups"] = groups_json;

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/fleet.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/fleet.cpp
@@ -23,7 +23,6 @@
 #include "common/libs/utils/result.h"
 #include "host/commands/cvd/command_request.h"
 #include "host/commands/cvd/server_command/server_handler.h"
-#include "host/commands/cvd/server_command/status_fetcher.h"
 #include "host/commands/cvd/server_command/utils.h"
 #include "host/commands/cvd/types.h"
 
@@ -87,7 +86,7 @@ Result<cvd::Response> CvdFleetCommandHandler::Handle(
   auto all_groups = CF_EXPECT(instance_manager_.FindGroups({}));
   Json::Value groups_json(Json::arrayValue);
   for (auto& group : all_groups) {
-    groups_json.append(CF_EXPECT(FetchStatus(group)));
+    groups_json.append(CF_EXPECT(group.FetchStatus()));
   }
   Json::Value output_json(Json::objectValue);
   output_json["groups"] = groups_json;

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
@@ -225,8 +225,7 @@ Result<std::unique_ptr<OperatorControlConn>> PreregisterGroup(
 class CvdStartCommandHandler : public CvdServerHandler {
  public:
   CvdStartCommandHandler(InstanceManager& instance_manager)
-      : instance_manager_(instance_manager),
-        status_fetcher_(instance_manager_) {}
+      : instance_manager_(instance_manager) {}
 
   Result<bool> CanHandle(const CommandRequest& request) const override;
   Result<cvd::Response> Handle(const CommandRequest& request) override;
@@ -271,7 +270,6 @@ class CvdStartCommandHandler : public CvdServerHandler {
                                    const CommandRequest& request);
   InstanceManager& instance_manager_;
   SubprocessWaiter subprocess_waiter_;
-  StatusFetcher status_fetcher_;
   static const std::array<std::string, 2> supported_commands_;
 };
 
@@ -593,7 +591,7 @@ Result<cvd::Response> CvdStartCommandHandler::Handle(
   CF_EXPECT(instance_manager_.UpdateInstanceGroup(group));
   listener_handle.reset();
 
-  auto group_json = CF_EXPECT(status_fetcher_.FetchGroupStatus(request, group));
+  auto group_json = CF_EXPECT(FetchStatus(group));
   std::cout << group_json.toStyledString();
 
   return FillOutNewInstanceInfo(std::move(response), group);

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/start.cpp
@@ -591,7 +591,7 @@ Result<cvd::Response> CvdStartCommandHandler::Handle(
   CF_EXPECT(instance_manager_.UpdateInstanceGroup(group));
   listener_handle.reset();
 
-  auto group_json = CF_EXPECT(FetchStatus(group));
+  auto group_json = CF_EXPECT(group.FetchStatus());
   std::cout << group_json.toStyledString();
 
   return FillOutNewInstanceInfo(std::move(response), group);

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/status.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/status.cpp
@@ -27,7 +27,6 @@
 #include "cuttlefish/host/commands/cvd/cvd_server.pb.h"
 #include "host/commands/cvd/instance_manager.h"
 #include "host/commands/cvd/server_command/server_handler.h"
-#include "host/commands/cvd/server_command/status_fetcher.h"
 #include "host/commands/cvd/server_command/utils.h"
 #include "host/commands/cvd/types.h"
 #include "host/libs/config/config_constants.h"
@@ -168,8 +167,8 @@ Result<cvd::Response> CvdStatusCommandHandler::Handle(
     // No attempt at selecting an instance, get group status instead
     selector::LocalInstanceGroup group = CF_EXPECT(
         instance_manager_.SelectGroup(request.Selectors(), request.Env()));
-    status_array = CF_EXPECT(FetchStatus(
-        group, std::chrono::seconds(flags.wait_for_launcher_seconds)));
+    status_array = CF_EXPECT(group.FetchStatus(
+        std::chrono::seconds(flags.wait_for_launcher_seconds)));
     instance_manager_.UpdateInstanceGroup(group);
   } else {
     std::pair<selector::LocalInstance, selector::LocalInstanceGroup> pair =
@@ -180,8 +179,8 @@ Result<cvd::Response> CvdStatusCommandHandler::Handle(
                   CF_EXPECT(IdFromInstanceNameFlag(flags.instance_name))));
     selector::LocalInstance instance = pair.first;
     selector::LocalInstanceGroup group = pair.second;
-    status_array.append(CF_EXPECT(FetchStatus(
-        instance, std::chrono::seconds(flags.wait_for_launcher_seconds))));
+    status_array.append(CF_EXPECT(instance.FetchStatus(
+        std::chrono::seconds(flags.wait_for_launcher_seconds))));
     instance_manager_.UpdateInstanceGroup(group);
   }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/status_fetcher.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/status_fetcher.cpp
@@ -98,22 +98,8 @@ Result<std::string> GetBin(const std::string& host_artifacts_path) {
 
 }  // namespace
 
-Result<Json::Value> FetchStatus(selector::LocalInstanceGroup& group,
-                                std::chrono::seconds timeout) {
-  Json::Value instances_json(Json::arrayValue);
-  for (auto& instance : group.Instances()) {
-    auto instance_status_json = CF_EXPECT(FetchStatus(instance, timeout));
-    instances_json.append(instance_status_json);
-  }
-  Json::Value group_json;
-  group_json["group_name"] = group.GroupName();
-  group_json["start_time"] = selector::Format(group.StartTime());
-  group_json["instances"] = instances_json;
-  return group_json;
-}
-
-Result<Json::Value> FetchStatus(selector::LocalInstance& instance,
-                                std::chrono::seconds timeout) {
+Result<Json::Value> FetchInstanceStatus(selector::LocalInstance& instance,
+                                        std::chrono::seconds timeout) {
   // Only running instances are capable of responding to status requests. An
   // unreachable instance is also considered running, it just didnt't reply last
   // time.

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/status_fetcher.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/status_fetcher.cpp
@@ -17,7 +17,6 @@
 #include "host/commands/cvd/server_command/status_fetcher.h"
 
 #include <cctype>
-#include <map>
 #include <string>
 #include <vector>
 
@@ -28,9 +27,7 @@
 
 #include "common/libs/utils/files.h"
 #include "common/libs/utils/json.h"
-#include "cuttlefish/host/commands/cvd/cvd_server.pb.h"
 #include "cuttlefish/host/commands/cvd/selector/cvd_persistent_data.pb.h"
-#include "host/commands/cvd/flag.h"
 #include "host/commands/cvd/selector/instance_group_record.h"
 #include "host/commands/cvd/server_command/host_tool_target.h"
 #include "host/commands/cvd/server_command/utils.h"
@@ -77,12 +74,11 @@ std::string HumanFriendlyStateName(cvd::InstanceState state) {
 // Adds more information to the json object returned by cvd_internal_status,
 // including some that cvd_internal_status normally returns but doesn't when the
 // instance is not running.
-void OverrideInstanceJson(const selector::LocalInstanceGroup& group,
-                          const selector::LocalInstance& instance,
+void OverrideInstanceJson(const selector::LocalInstance& instance,
                           Json::Value& instance_json) {
   instance_json["instance_name"] = instance.name();
   instance_json["status"] = HumanFriendlyStateName(instance.state());
-  instance_json["assembly_dir"] = group.AssemblyDir();
+  instance_json["assembly_dir"] = instance.assembly_dir();
   instance_json["instance_dir"] = instance.instance_dir();
   instance_json["instance_name"] = instance.name();
   if (instance.IsActive()) {
@@ -96,12 +92,28 @@ void OverrideInstanceJson(const selector::LocalInstanceGroup& group,
   }
 }
 
+Result<std::string> GetBin(const std::string& host_artifacts_path) {
+  return CF_EXPECT(HostToolTarget(host_artifacts_path).GetStatusBinName());
+}
+
 }  // namespace
 
-Result<StatusFetcherOutput> StatusFetcher::FetchOneInstanceStatus(
-    const CommandRequest& request,
-    const InstanceManager::LocalInstanceGroup& group,
-    selector::LocalInstance& instance) {
+Result<Json::Value> FetchStatus(selector::LocalInstanceGroup& group,
+                                std::chrono::seconds timeout) {
+  Json::Value instances_json(Json::arrayValue);
+  for (auto& instance : group.Instances()) {
+    auto instance_status_json = CF_EXPECT(FetchStatus(instance, timeout));
+    instances_json.append(instance_status_json);
+  }
+  Json::Value group_json;
+  group_json["group_name"] = group.GroupName();
+  group_json["start_time"] = selector::Format(group.StartTime());
+  group_json["instances"] = instances_json;
+  return group_json;
+}
+
+Result<Json::Value> FetchStatus(selector::LocalInstance& instance,
+                                std::chrono::seconds timeout) {
   // Only running instances are capable of responding to status requests. An
   // unreachable instance is also considered running, it just didnt't reply last
   // time.
@@ -110,40 +122,28 @@ Result<StatusFetcherOutput> StatusFetcher::FetchOneInstanceStatus(
     Json::Value instance_json;
     instance_json["instance_name"] = instance.name();
     instance_json["status"] = HumanFriendlyStateName(instance.state());
-    OverrideInstanceJson(group, instance, instance_json);
-    cvd::Response response;
-    response.mutable_command_response();  // set oneof field
-    response.mutable_status()->set_code(cvd::Status::OK);
-    return StatusFetcherOutput{
-        .stderr_buf = "",
-        .json_from_stdout = instance_json,
-        .response = response,
-    };
+    OverrideInstanceJson(instance, instance_json);
+    return instance_json;
   }
-
-  auto [subcmd, cmd_args] = ParseInvocation(request);
-
-  // remove --all_instances if there is
-  bool all_instances = false;
-  CF_EXPECT(ConsumeFlags({GflagsCompatFlag("all_instances", all_instances)},
-                         cmd_args));
 
   const auto working_dir = CurrentDirectory();
 
-  auto android_host_out = group.Proto().host_artifacts_path();
-  auto home = group.Proto().home_directory();
+  auto android_host_out = instance.host_artifacts_path();
+  auto home = instance.home_directory();
   auto bin = CF_EXPECT(GetBin(android_host_out));
   auto bin_path = fmt::format("{}/bin/{}", android_host_out, bin);
 
-  cvd_common::Envs envs = request.Env();
+  cvd_common::Envs envs;
   envs["HOME"] = home;
   // old cvd_internal_status expects CUTTLEFISH_INSTANCE=<k>
   envs[kCuttlefishInstanceEnvVarName] = std::to_string(instance.id());
+  std::vector<std::string> args{"--print", "--wait_for_launcher",
+                                std::to_string(timeout.count())};
 
   ConstructCommandParam construct_cmd_param{
       .bin_path = bin_path,
       .home = home,
-      .args = cmd_args,
+      .args = args,
       .envs = envs,
       .working_dir = working_dir,
       .command_name = bin,
@@ -151,126 +151,36 @@ Result<StatusFetcherOutput> StatusFetcher::FetchOneInstanceStatus(
   Command command = CF_EXPECT(ConstructCommand(construct_cmd_param));
 
   std::string serialized_json;
-  std::string status_stderr;
 
   int res = RunWithManagedStdio(std::move(command), nullptr, &serialized_json,
-                                &status_stderr);
+                                nullptr /*stderr*/);
 
   // old branches will print nothing
-  if (serialized_json.empty()) {
+  if (serialized_json.empty() && res == 0) {
     serialized_json = "[{\"warning\" : \"cvd-status-unsupported device\"}]";
   }
 
-  auto instance_status_json = CF_EXPECT(ParseJson(serialized_json));
-  CF_EXPECT_EQ(instance_status_json.size(), 1ul);
-  instance_status_json = instance_status_json[0];
-  static constexpr auto kWebrtcProp = "webrtc_device_id";
-  static constexpr auto kNameProp = "instance_name";
-
-  // Check for isObject first, calling isMember on anything else causes a
-  // runtime error
-  if (instance_status_json.isObject() &&
-      !instance_status_json.isMember(kWebrtcProp) &&
-      instance_status_json.isMember(kNameProp)) {
-    // b/296644913 some cuttlefish versions printed the webrtc device id as
-    // the instance name.
-    instance_status_json[kWebrtcProp] = instance_status_json[kNameProp];
+  // Parse only if the command produced output, otherwise just produce data from
+  // the instance database.
+  Json::Value instance_status_json(Json::objectValue);
+  if (!serialized_json.empty()) {
+    Json::Value json_array = CF_EXPECT(ParseJson(serialized_json),
+                                       "Status tool returned invalid JSON");
+    CF_EXPECTF(json_array.isArray(),
+               "Status tool returned unexpected output (not an array): {}",
+               serialized_json);
+    CF_EXPECT_EQ(json_array.size(), 1ul);
+    instance_status_json = json_array[0];
   }
-  instance_status_json[kNameProp] = instance.name();
 
-  cvd::Response response;
-  response.mutable_command_response();
   if (res != 0) {
-    response.mutable_status()->set_code(cvd::Status::INTERNAL);
-    response.mutable_status()->set_message(
-        fmt::format("Exited with code {}", res));
+    LOG(ERROR) << "Status tool exited with code " << res;
     instance.set_state(cvd::INSTANCE_STATE_UNREACHABLE);
     instance_status_json["warning"] = "cvd status failed";
   }
-  OverrideInstanceJson(group, instance, instance_status_json);
+  OverrideInstanceJson(instance, instance_status_json);
 
-  return StatusFetcherOutput{
-      .stderr_buf = status_stderr,
-      .json_from_stdout = instance_status_json,
-      .response = response,
-  };
-}
-
-Result<StatusFetcherOutput> StatusFetcher::FetchStatus(
-    const CommandRequest& request) {
-  const cvd_common::Envs& env = request.Env();
-  auto [subcmd, cmd_args] = ParseInvocation(request);
-
-  // find group
-  CvdFlag<bool> all_instances_flag("all_instances");
-  auto all_instances_opt = CF_EXPECT(all_instances_flag.FilterFlag(cmd_args));
-
-  auto instance_group =
-      CF_EXPECT(instance_manager_.SelectGroup(request.Selectors(), env));
-
-  std::vector<selector::LocalInstance> instances;
-  auto instance_record_result =
-      instance_manager_.SelectInstance(request.Selectors(), env);
-
-  bool status_the_group_flag = all_instances_opt && *all_instances_opt;
-  if (instance_record_result.ok() && !status_the_group_flag) {
-    instances.emplace_back(instance_record_result->first);
-  } else {
-    if (status_the_group_flag) {
-      instances = instance_group.Instances();
-    } else {
-      std::map<int, const selector::LocalInstance> sorted_id_instance_map;
-      for (const auto& instance : instance_group.Instances()) {
-        sorted_id_instance_map.emplace(instance.id(), instance);
-      }
-      auto first_itr = sorted_id_instance_map.begin();
-      instances.emplace_back(first_itr->second);
-    }
-  }
-
-  std::string entire_stderr_msg;
-  Json::Value instances_json(Json::arrayValue);
-  for (auto& instance : instances) {
-    auto [status_stderr, instance_status_json, response] =
-        CF_EXPECT(FetchOneInstanceStatus(request, instance_group, instance));
-    instances_json.append(instance_status_json);
-    entire_stderr_msg.append(status_stderr);
-  }
-  instance_manager_.UpdateInstanceGroup(instance_group);
-
-  cvd::Response response;
-  response.mutable_command_response();
-  response.mutable_status()->set_code(cvd::Status::OK);
-  return StatusFetcherOutput{
-      .stderr_buf = entire_stderr_msg,
-      .json_from_stdout = instances_json,
-      .response = response,
-  };
-}
-
-Result<Json::Value> StatusFetcher::FetchGroupStatus(
-    const CommandRequest& original_request,
-    selector::LocalInstanceGroup& group) {
-  Json::Value group_json(Json::objectValue);
-  group_json["group_name"] = group.GroupName();
-  group_json["start_time"] = selector::Format(group.StartTime());
-
-  CommandRequest group_request = CF_EXPECT(
-      CommandRequestBuilder()
-          .AddArguments({"cvd", "status", "--print", "--all_instances"})
-          .SetEnv(original_request.Env())
-          .AddSelectorArguments({"--group_name", group.GroupName()})
-          .Build());
-
-  auto [_, instances_json, group_response] =
-      CF_EXPECT(FetchStatus(group_request));
-  group_json["instances"] = instances_json;
-  return group_json;
-}
-
-Result<std::string> StatusFetcher::GetBin(
-    const std::string& host_artifacts_path) const {
-  return CF_EXPECT(HostToolTarget(host_artifacts_path).GetStatusBinName());
+  return instance_status_json;
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/status_fetcher.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/status_fetcher.h
@@ -18,38 +18,24 @@
 
 #include <sys/types.h>
 
-#include <string>
+#include <chrono>
 
 #include "common/libs/utils/result.h"
-#include "host/commands/cvd/command_request.h"
-#include "host/commands/cvd/instance_manager.h"
 #include "host/commands/cvd/selector/instance_group_record.h"
 #include "host/commands/cvd/selector/instance_record.h"
 
 namespace cuttlefish {
 
-struct StatusFetcherOutput {
-  std::string stderr_buf;
-  Json::Value json_from_stdout;
-  cvd::Response response;
-};
+// Fetches status from all instances in the group. Waits for the launcher to
+// respond for at most timeout seconds.
+Result<Json::Value> FetchStatus(
+    selector::LocalInstanceGroup& group,
+    std::chrono::seconds timeout = std::chrono::seconds(5));
 
-class StatusFetcher {
- public:
-  StatusFetcher(InstanceManager& instance_manager)
-      : instance_manager_(instance_manager) {}
-  Result<StatusFetcherOutput> FetchStatus(const CommandRequest&);
-
-  Result<Json::Value> FetchGroupStatus(const CommandRequest& original_request,
-                                       selector::LocalInstanceGroup& group);
-
- private:
-  Result<std::string> GetBin(const std::string& host_artifacts_path) const;
-  Result<StatusFetcherOutput> FetchOneInstanceStatus(
-      const CommandRequest&, const InstanceManager::LocalInstanceGroup& group,
-      selector::LocalInstance&);
-
-  InstanceManager& instance_manager_;
-};
+// Fetches status from a single instance. Waits for the launcher to respond
+// for at most timeout seconds.
+Result<Json::Value> FetchStatus(
+    selector::LocalInstance& instance,
+    std::chrono::seconds timeout = std::chrono::seconds(5));
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/status_fetcher.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/status_fetcher.h
@@ -21,21 +21,13 @@
 #include <chrono>
 
 #include "common/libs/utils/result.h"
-#include "host/commands/cvd/selector/instance_group_record.h"
 #include "host/commands/cvd/selector/instance_record.h"
 
 namespace cuttlefish {
 
-// Fetches status from all instances in the group. Waits for the launcher to
-// respond for at most timeout seconds.
-Result<Json::Value> FetchStatus(
-    selector::LocalInstanceGroup& group,
-    std::chrono::seconds timeout = std::chrono::seconds(5));
-
-// Fetches status from a single instance. Waits for the launcher to respond
-// for at most timeout seconds.
-Result<Json::Value> FetchStatus(
-    selector::LocalInstance& instance,
-    std::chrono::seconds timeout = std::chrono::seconds(5));
+// Fetches status from a single instance. Waits for each run_cvd process to
+// respond within the given timeout.
+Result<Json::Value> FetchInstanceStatus(selector::LocalInstance& instance,
+                                        std::chrono::seconds timeout);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/utils.cpp
@@ -240,4 +240,11 @@ Result<cvd::Response> NoTTYResponse(const CommandRequest& request) {
   return response;
 }
 
+cvd::Response SuccessResponse() {
+  cvd::Response response;
+  response.mutable_command_response();
+  response.mutable_status()->set_code(cvd::Status::OK);
+  return response;
+}
+
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/server_command/utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/server_command/utils.h
@@ -80,6 +80,8 @@ cvd::Response NoGroupResponse(const CommandRequest& request);
 // not sufficients to choose one from. The function does not verify that.
 Result<cvd::Response> NoTTYResponse(const CommandRequest& request);
 
+cvd::Response SuccessResponse();
+
 class TerminalColors {
  public:
   TerminalColors(bool is_tty): is_tty_(is_tty){}


### PR DESCRIPTION
Separates the argument parsing and handling from actually getting the status of the running instances.

Reusing the status fetching logic from `start` and `fleet` is simplified as a result.