### PR TITLE
Remove egrep usage

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/network.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/network.cpp
@@ -142,7 +142,7 @@ SharedFD OpenTapInterface(const std::string& interface_name) {
 std::set<std::string> TapInterfacesInUse() {
   Command cmd("/bin/bash");
   cmd.AddParameter("-c");
-  cmd.AddParameter("egrep -h -e \"^iff:.*\" /proc/*/fdinfo/*");
+  cmd.AddParameter("grep -E -h -e \"^iff:.*\" /proc/*/fdinfo/*");
   std::string stdin_str, stdout_str, stderr_str;
   RunWithManagedStdio(std::move(cmd), &stdin_str, &stdout_str, &stderr_str);
   auto lines = android::base::Split(stdout_str, "\n");


### PR DESCRIPTION
Per aosp/3277253 `egrep` has been deprecated in favor of `grep -E` since
2007.  Newer `grep` versions issue warning messages warning about eventual removal.

changelog from 2022 including the deprecation warnings announcement: https://lists.gnu.org/archive/html/info-gnu/2022-09/msg00001.html

Test: launch_cvd --resume=false