### PR TITLE
Support apt install in docker image

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -4,6 +4,7 @@ on:
     paths:
       - '.github/workflows/artifacts.yaml'
       - 'tools/buildimage/**'
+      - 'docker/**'
   push:
     branches:
       - main
@@ -60,14 +61,11 @@ jobs:
       run: |
         short_sha=$(echo ${{ github.sha }} | cut -c1-8)
         echo "x86_64_image_path=orchestration-image-x86_64-${short_sha}.tar" >> $GITHUB_ENV
-    - name: Install bazel
-      run: sudo bash tools/buildutils/installbazel.sh
-    - name: bazel version
-      run: bazel version
+        echo "image_name=cuttlefish-orchestration:${short_sha}" >> $GITHUB_ENV
     - name: Build docker image
-      run: bazel build --sandbox_writable_path=$HOME //docker:orchestration_image_tar
-    - name: Set filename of docker image
-      run: mv bazel-bin/docker/orchestration-image.tar ${{ env.x86_64_image_path }}
+      run: docker/image-builder.sh -t ${{ env.image_name }}
+    - name: Save docker image
+      run: docker save --output ${{ env.x86_64_image_path }} ${{ env.image_name }}
     - name: Publish docker image
       uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # aka v4.0.0
       with:
@@ -82,14 +80,11 @@ jobs:
       run: |
         short_sha=$(echo ${{ github.sha }} | cut -c1-8)
         echo "arm64_image_path=orchestration-image-arm64-${short_sha}.tar" >> $GITHUB_ENV
-    - name: Install bazel
-      run: sudo bash tools/buildutils/installbazel.sh
-    - name: bazel version
-      run: bazel version
+        echo "image_name=cuttlefish-orchestration:${short_sha}" >> $GITHUB_ENV
     - name: Build docker image
-      run: bazel build --sandbox_writable_path=$HOME //docker:orchestration_image_tar
-    - name: Set filename of docker image
-      run: mv bazel-bin/docker/orchestration-image.tar ${{ env.arm64_image_path }}
+      run: docker/image-builder.sh -t ${{ env.image_name }}
+    - name: Save docker image
+      run: docker save --output ${{ env.arm64_image_path }} ${{ env.image_name }}
     - name: Publish docker image
       uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # aka v4.0.0
       with:

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -104,7 +104,7 @@ jobs:
         # Overall action timing breakdown:
         #
         # [614 / 616] Executing genrule @@images//docker/debs-builder-docker:debs_tar [for tool]; 608s linux-sandbox
-        # [615 / 616] Executing genrule @@images//docker:orchestration_image_tar; 11s linux-sandbox
+        # [615 / 616] Executing genrule @@images//docker:orchestration_image_dev_tar; 11s linux-sandbox
         # //orchestration:create_fixed_build_id_and_target                         PASSED in 99.9s
         # //orchestration:create_local_image                                       PASSED in 92.4s
         # 

--- a/docker/BUILD.bazel
+++ b/docker/BUILD.bazel
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 genrule(
-    name = "orchestration_image_tar",
-    outs = ["orchestration-image.tar"],
-    cmd = "$(location :orchestration_image_builder) -o $@",
-    tools = [":orchestration_image_builder"],
+    name = "orchestration_image_dev_tar",
+    outs = ["orchestration-image-dev.tar"],
+    cmd = "$(location :orchestration_image_dev_builder) -o $@",
+    tools = [":orchestration_image_dev_builder"],
     visibility = ["//visibility:public"],
 )
 
 sh_binary(
-    name = "orchestration_image_builder",
+    name = "orchestration_image_dev_builder",
     srcs = ["image-build-bazel-wrapper.sh"],
     deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,10 @@
 # Docker image includes HO(Host Orchestrator) inside,
 # so it could execute CF instance with API in HO.
 
-FROM debian:12 AS cuttlefish-hostpkg-builder
+ARG BUILD_OPTION=prod
+
+
+FROM debian:12 AS host-package-builder
 
 USER root
 WORKDIR /root
@@ -15,11 +18,12 @@ RUN apt install -y --no-install-recommends \
     equivs \
     sudo
 
-# Build CF debian packages 
+# Build CF debian packages
 COPY . /root/android-cuttlefish
 RUN ["/bin/bash", "-c", "/root/android-cuttlefish/tools/buildutils/build_packages.sh"]
 
-FROM debian:12 AS cuttlefish-orchestration
+
+FROM debian:12 AS runner-base
 
 # Expose Operator Port (HTTP:1080, HTTPS:1443)
 EXPOSE 1080 1443
@@ -44,19 +48,36 @@ RUN apt install -y --no-install-recommends \
     sudo
 RUN update-ca-certificates
 
+COPY ./docker/guest/run_services.sh /root/
+RUN chmod +x /root/run_services.sh
+
+
+FROM runner-base AS runner-dev
+
 # Install CF debian packages.
-COPY --from=cuttlefish-hostpkg-builder /root/android-cuttlefish/cuttlefish-*.deb /root/debian/
+COPY --from=host-package-builder /root/android-cuttlefish/cuttlefish-*.deb /root/debian/
 RUN apt install -y --no-install-recommends -f \
     /root/debian/cuttlefish-base_*.deb \
     /root/debian/cuttlefish-user_*.deb \
     /root/debian/cuttlefish-orchestration_*.deb
 
-RUN echo "num_cvd_accounts=100" >> /etc/default/cuttlefish-host-resources
 
+FROM runner-base AS runner-prod
+
+RUN apt install -y --no-install-recommends \
+    wget
+RUN wget -qO- https://artifacts.codelinaro.org/artifactory/linaro-372-googlelt-gigabyte-ampere-cuttlefish-installer/gigabyte-ampere-cuttlefish-installer/latest/debian/linaro-glt-gig-archive-bookworm.asc \
+    | tee /etc/apt/trusted.gpg.d/linaro-glt-gig-archive-bookworm.asc
+RUN echo "deb https://artifacts.codelinaro.org/linaro-372-googlelt-gigabyte-ampere-cuttlefish-installer/gigabyte-ampere-cuttlefish-installer/latest/debian bookworm main" \
+    | tee /etc/apt/sources.list.d/linaro-glt-gig-archive-bookworm.list
+RUN apt update
+RUN apt install -y --no-install-recommends \
+    cuttlefish-base cuttlefish-user cuttlefish-orchestration
+
+
+FROM runner-${BUILD_OPTION} AS runner
+
+RUN echo "num_cvd_accounts=100" >> /etc/default/cuttlefish-host-resources
 RUN usermod -aG kvm root
 RUN usermod -aG cvdnetwork root
-
-COPY --from=cuttlefish-hostpkg-builder /root/android-cuttlefish/docker/guest/run_services.sh /root/
-RUN chmod +x /root/run_services.sh
-RUN rm -rf /root/android-cuttlefish
 ENTRYPOINT ["/root/run_services.sh"]

--- a/docker/image-build-bazel-wrapper.sh
+++ b/docker/image-build-bazel-wrapper.sh
@@ -38,11 +38,11 @@ fi
 # --- end runfiles.bash initialization ---
 
 usage() {
-  echo "usage: $0 -o /path/to/image.tar"
+  echo "usage: $0 -o <output>"
+  echo "  -o: path for tar format output"
 }
 
 output=
-
 while getopts ":ho:" opt; do
   case "${opt}" in
     h)
@@ -84,6 +84,6 @@ function remove_image() {
 trap remove_image EXIT
 
 # Build docker image
-${repo_root_dir}/docker/image-builder.sh "${name}"
+${repo_root_dir}/docker/image-builder.sh -t "${name}" -d
 
 docker save --output ${output} ${name} 

--- a/docker/image-builder.sh
+++ b/docker/image-builder.sh
@@ -7,18 +7,49 @@
 script_location=`realpath -s $(dirname ${BASH_SOURCE[0]})`
 android_cuttlefish_root_dir=$(realpath -s $script_location/..)
 
-if [[ "$1" == "" ]]; then
-    tag=cuttlefish-orchestration
-else
-    tag=$1
-fi
+usage() {
+  echo "usage: $0 [-t <tag>] [-d]"
+  echo "  -t: name or name:tag of docker image (default cuttlefish-orchestration)"
+  echo "  -d: build dev image instead of prod image"
+  echo "      Dev image builds host packages from the local source"
+  echo "      Prod image downloads and installs host packages"
+}
+
+name=cuttlefish-orchestration
+build_option=prod
+while getopts ":hdt:" opt; do
+  case "${opt}" in
+    h)
+      usage
+      exit 0
+      ;;
+    d)
+      build_option=dev
+      ;;
+    t)
+      name="${OPTARG}"
+      ;;
+    \?)
+      echo "Invalid option: ${OPTARG}" >&2
+      usage
+      exit 1
+      ;;
+    :)
+      echo "Invalid option: ${OPTARG} requires an argument" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
 
 # Build docker image
 pushd $android_cuttlefish_root_dir
-docker build \
+DOCKER_BUILDKIT=1 docker build \
     --force-rm \
     --no-cache \
     -f docker/Dockerfile \
-    -t $tag \
+    -t $name \
+    --target runner \
+    --build-arg BUILD_OPTION=$build_option \
     .
 popd

--- a/e2etests/orchestration/common/common.go
+++ b/e2etests/orchestration/common/common.go
@@ -79,7 +79,7 @@ func NewDockerHelper() (*DockerHelper, error) {
 }
 
 func (h *DockerHelper) LoadImage() (string, error) {
-	imgFile, err := os.Open("../../external/images/docker/orchestration-image.tar")
+	imgFile, err := os.Open("../../external/images/docker/orchestration-image-dev.tar")
 	if err != nil {
 		return "", err
 	}

--- a/e2etests/orchestration/create_from_images_zip_test/BUILD.bazel
+++ b/e2etests/orchestration/create_from_images_zip_test/BUILD.bazel
@@ -20,7 +20,7 @@ go_test(
     data = [
         "//orchestration/artifacts:cvd_host_package",
         "//orchestration/artifacts:images_zip",
-        "@images//docker:orchestration_image_tar",
+        "@images//docker:orchestration_image_dev_tar",
     ],
     deps = [
         "//orchestration/common",

--- a/e2etests/orchestration/create_local_image_test/BUILD.bazel
+++ b/e2etests/orchestration/create_local_image_test/BUILD.bazel
@@ -20,7 +20,7 @@ go_test(
     data = [
         "//orchestration/artifacts:cvd_host_package",
         "//orchestration/artifacts:images_zip",
-        "@images//docker:orchestration_image_tar",
+        "@images//docker:orchestration_image_dev_tar",
     ],
     deps = [
         "//orchestration/common",

--- a/e2etests/orchestration/create_single_instance_test/def.bzl
+++ b/e2etests/orchestration/create_single_instance_test/def.bzl
@@ -19,7 +19,7 @@ def create_single_instance_test(name, build_id, build_target):
         name = name,
         srcs = ["main_test.go"],
         data = [
-            "@images//docker:orchestration_image_tar",
+            "@images//docker:orchestration_image_dev_tar",
         ],
         env = {
             "BUILD_ID": build_id,

--- a/e2etests/orchestration/snapshot_test/BUILD.bazel
+++ b/e2etests/orchestration/snapshot_test/BUILD.bazel
@@ -20,7 +20,7 @@ go_test(
     data = [
         "//orchestration/artifacts:cvd_host_package",
         "//orchestration/artifacts:images_zip",
-        "@images//docker:orchestration_image_tar",
+        "@images//docker:orchestration_image_dev_tar",
     ],
     deps = [
         "//orchestration/common",


### PR DESCRIPTION
With this PR, docker image could be built within various way.
- `docker/image-builder.sh cuttlefish-orchestration # For downloading packages from remote repository`
- `docker/image-builder.sh cuttlefish-orchestration -d # For building packages from local source`