### PR TITLE
Mark the 0.9.31 release as "stable"

### DIFF
--- a/base/debian/changelog
+++ b/base/debian/changelog
@@ -1,4 +1,4 @@
-cuttlefish-common (0.9.31) unstable; urgency=medium
+cuttlefish-common (0.9.31) stable; urgency=medium
 
   [ Chad Reynolds ]
   * Help command improvements


### PR DESCRIPTION
The release must be stable in the `changelog` file to trigger the ARM package workflow

Bug: 298447306