### PR TITLE
Fix non-`cvd login` credentials

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd.cc
@@ -359,9 +359,10 @@ Result<std::unique_ptr<BuildApi>> GetBuildApi(const BuildApiFlags& flags) {
       StringFromEnv("HOME", ".") + "/.acloud_oauth2.dat";
 
   std::unique_ptr<CredentialSource> credential_source =
-      cvd_creds.ok() ? std::move(*cvd_creds)
-                     : CF_EXPECT(GetCredentialSourceFromFlags(
-                           *retrying_http_client, flags, oauth_filepath));
+      cvd_creds.ok() && cvd_creds->get()
+          ? std::move(*cvd_creds)
+          : CF_EXPECT(GetCredentialSourceFromFlags(*retrying_http_client, flags,
+                                                   oauth_filepath));
 
   const auto cache_base_path = PerUserDir() + "/cache";
   return CreateBuildApi(std::move(retrying_http_client), std::move(curl),

--- a/base/cvd/cuttlefish/host/libs/web/oauth2_consent.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/oauth2_consent.cpp
@@ -286,7 +286,7 @@ Result<std::unique_ptr<CredentialSource>> CredentialForScopes(
       return std::move(*credential);
     }
   }
-  return {};
+  return CF_ERR("No credentials found.");
 }
 
 }  // namespace cuttlefish


### PR DESCRIPTION
Credential selection was interpreting missing `cvd login` crdentials as valid, and would only fall back when `cvd login` credentials were present but invalid.

Bug: b/378069857
Test: cvd fetch --credential_source=gce