### PR TITLE
clang-tidy in `.bazelrc` and a github workflow

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -57,7 +57,7 @@ jobs:
     - name: Setup apt
       run: apt update -y && apt upgrade -y
     - name: Install dependencies
-      run: apt install -y git clang libcurl4-openssl-dev
+      run: apt install -y git clang libcurl4-openssl-dev clang-tidy
     - name: Install bazel
       run: bash tools/buildutils/installbazel.sh
     - name: Build cvd
@@ -69,6 +69,8 @@ jobs:
       with:
         name: testlogs
         path: bazel-testlogs
+    - name: Run clang-tidy
+      run: cd base/cvd && bazel build //cuttlefish/... --config clang-tidy
   e2e-tests-orchestration:
     runs-on: ubuntu-22.04 
     steps:

--- a/base/cvd/.bazelrc
+++ b/base/cvd/.bazelrc
@@ -1,2 +1,6 @@
 build --copt=-fdiagnostics-color=always
 build --repo_env=CC=clang
+
+build:clang-tidy --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
+build:clang-tidy --output_groups=report
+build:clang-tidy --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config

--- a/base/cvd/.clang-tidy
+++ b/base/cvd/.clang-tidy
@@ -1,0 +1,17 @@
+# Bad interaction with the `parse_headers` bazel feature
+Checks: '-clang-diagnostic-pragma-once-outside-header'
+
+# Using the bazel clang-tidy helper, warnings seem to be ignored entirely.
+# Default warnings are converted to errors here for visibility.
+WarningsAsErrors: >
+  clang-analyzer-*,
+  -clang-analyzer-core.uninitialized.Assign,
+  -clang-analyzer-core.UndefinedBinaryOperatorResult,
+  -clang-analyzer-deadcode.DeadStores,
+  clang-diagnostic-*,
+  -clang-diagnostic-inconsistent-missing-override,
+  -clang-diagnostic-pragma-once-outside-header,
+  -clang-diagnostic-unneeded-internal-declaration,
+  -clang-diagnostic-unused-const-variable,
+  -clang-diagnostic-unused-private-field,
+  -clang-diagnostic-unused-variable,

--- a/base/cvd/BUILD.bazel
+++ b/base/cvd/BUILD.bazel
@@ -8,3 +8,9 @@ genrule(
     outs = ["build/version.h"],
     cmd = "sed -e \"s|@VCS_TAG@|`git describe`|\" $< > $@",
 )
+
+filegroup(
+   name = "clang_tidy_config",
+   srcs = [".clang-tidy"],
+   visibility = ["//visibility:public"],
+)

--- a/base/cvd/MODULE.bazel
+++ b/base/cvd/MODULE.bazel
@@ -24,3 +24,12 @@ git_override(
     remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
     # Replace the commit hash (above) with the latest (https://github.com/hedronvision/bazel-compile-commands-extractor/commits/main).
 )
+
+# clang-tidy
+# https://github.com/erenon/bazel_clang_tidy
+bazel_dep(name = "bazel_clang_tidy", dev_dependency = True)
+git_override(
+    module_name = "bazel_clang_tidy",
+    commit = "f23d924918c581c68cd5cda5f12b4f8198ac0c35",
+    remote = "https://github.com/erenon/bazel_clang_tidy.git",
+)


### PR DESCRIPTION
References:
- https://github.com/erenon/bazel_clang_tidy
- https://clang.llvm.org/extra/clang-tidy/

Run locally with
```
bazel build //cuttlefish/... --config clang-tidy
```

The `clang-diagnostic-pragma-once-outside-header` check is disabled as bazel's `parse_headers` feature tries to compile every header as a source file.

We could re-enable that check if we switch to an include guard system, which would also better satisfy the style guide:

https://google.github.io/styleguide/cppguide.html#The__define_Guard