### PR TITLE
Mark 0.9.31 branch as stable

### DIFF
--- a/base/debian/changelog
+++ b/base/debian/changelog
@@ -20,7 +20,7 @@ cuttlefish-common (1.0.0) unstable; urgency=medium
 
  -- Jorge Moreira <jemoreira@google.com>  Thu, 05 Sep 2024 11:05:25 -0700
 
-cuttlefish-common (0.9.31) unstable; urgency=medium
+cuttlefish-common (0.9.31) stable; urgency=medium
 
   [ Chad Reynolds ]
   * Help command improvements


### PR DESCRIPTION
This needs to be updated on the `main` branch to trigger building a new stable host image for the ARM servers

Bug: 298447306