### PR TITLE
Enable some clang-tidy checks

### DIFF
--- a/base/cvd/.clang-tidy
+++ b/base/cvd/.clang-tidy
@@ -10,6 +10,5 @@ WarningsAsErrors: >
   -clang-analyzer-deadcode.DeadStores,
   clang-diagnostic-*,
   -clang-diagnostic-pragma-once-outside-header,
-  -clang-diagnostic-unneeded-internal-declaration,
   -clang-diagnostic-unused-const-variable,
   -clang-diagnostic-unused-variable,

--- a/base/cvd/.clang-tidy
+++ b/base/cvd/.clang-tidy
@@ -12,5 +12,4 @@ WarningsAsErrors: >
   -clang-diagnostic-pragma-once-outside-header,
   -clang-diagnostic-unneeded-internal-declaration,
   -clang-diagnostic-unused-const-variable,
-  -clang-diagnostic-unused-private-field,
   -clang-diagnostic-unused-variable,

--- a/base/cvd/.clang-tidy
+++ b/base/cvd/.clang-tidy
@@ -9,7 +9,6 @@ WarningsAsErrors: >
   -clang-analyzer-core.UndefinedBinaryOperatorResult,
   -clang-analyzer-deadcode.DeadStores,
   clang-diagnostic-*,
-  -clang-diagnostic-inconsistent-missing-override,
   -clang-diagnostic-pragma-once-outside-header,
   -clang-diagnostic-unneeded-internal-declaration,
   -clang-diagnostic-unused-const-variable,

--- a/base/cvd/.clang-tidy
+++ b/base/cvd/.clang-tidy
@@ -7,7 +7,6 @@ WarningsAsErrors: >
   clang-analyzer-*,
   -clang-analyzer-core.uninitialized.Assign,
   -clang-analyzer-core.UndefinedBinaryOperatorResult,
-  -clang-analyzer-deadcode.DeadStores,
   clang-diagnostic-*,
   -clang-diagnostic-pragma-once-outside-header,
   -clang-diagnostic-unused-const-variable,

--- a/base/cvd/MODULE.bazel.lock
+++ b/base/cvd/MODULE.bazel.lock
@@ -85,19 +85,19 @@
     "@@apple_support~//crosstool:setup.bzl%apple_cc_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "PjIds3feoYE8SGbbIq2SFTZy3zmxeO2tQevJZNDo7iY=",
-        "usagesDigest": "aLmqbvowmHkkBPve05yyDNGN7oh7QE9kBADr3QIZTZs=",
+        "usagesDigest": "+hz7IHWN6A1oVJJWNDB6yZRG+RYhF76wAYItpAeIUIg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "local_config_apple_cc": {
-            "bzlFile": "@@apple_support~//crosstool:setup.bzl",
-            "ruleClassName": "_apple_cc_autoconf",
-            "attributes": {}
-          },
           "local_config_apple_cc_toolchains": {
             "bzlFile": "@@apple_support~//crosstool:setup.bzl",
             "ruleClassName": "_apple_cc_autoconf_toolchains",
+            "attributes": {}
+          },
+          "local_config_apple_cc": {
+            "bzlFile": "@@apple_support~//crosstool:setup.bzl",
+            "ruleClassName": "_apple_cc_autoconf",
             "attributes": {}
           }
         },
@@ -113,7 +113,7 @@
     "@@platforms//host:extension.bzl%host_platform": {
       "general": {
         "bzlTransitiveDigest": "xelQcPZH8+tmuOHVjL9vDxMnnQNMlwj0SlvgoqBkm4U=",
-        "usagesDigest": "meSzxn3DUCcYEhq4HQwExWkWtU4EjriRBQLsZN+Q0SU=",
+        "usagesDigest": "pCYpDQmqMbmiiPI1p2Kd3VLm5T48rRAht5WdW0X2GlA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/base/cvd/cuttlefish/common/libs/utils/files.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/files.cpp
@@ -246,9 +246,8 @@ bool IsDirectoryEmpty(const std::string& path) {
     return false;
   }
 
-  decltype(::readdir(direc)) sub = nullptr;
   int cnt {0};
-  while ( (sub = ::readdir(direc)) ) {
+  while (::readdir(direc)) {
     cnt++;
     if (cnt > 2) {
     LOG(ERROR) << "IsDirectoryEmpty test failed with " << path

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/cmd_list.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/cmd_list.cpp
@@ -43,7 +43,6 @@ class CvdCmdlistHandler : public CvdServerHandler {
 
     CF_EXPECT(CanHandle(request));
 
-    auto [subcmd, subcmd_args] = ParseInvocation(request);
     const auto subcmds = executor_.CmdList();
 
     std::vector<std::string> subcmds_vec{subcmds.begin(), subcmds.end()};

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/try_acloud.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/try_acloud.cpp
@@ -60,7 +60,6 @@ bool CheckIfCvdrExist() {
 
 class TryAcloudCommand : public CvdServerHandler {
  public:
-  TryAcloudCommand(InstanceManager& im) : instance_manager_(im) {}
   ~TryAcloudCommand() = default;
 
   Result<bool> CanHandle(const CommandRequest& request) const override {
@@ -90,8 +89,6 @@ class TryAcloudCommand : public CvdServerHandler {
   Result<cvd::Response> VerifyWithCvd(const CommandRequest& request);
   Result<cvd::Response> VerifyWithCvdRemote(const CommandRequest& request);
   Result<std::string> RunCvdRemoteGetConfig(const std::string& name);
-
-  InstanceManager& instance_manager_;
 };
 
 Result<cvd::Response> TryAcloudCommand::VerifyWithCvd(
@@ -161,9 +158,8 @@ Result<std::string> TryAcloudCommand::RunCvdRemoteGetConfig(
   return stdout_;
 }
 
-std::unique_ptr<CvdServerHandler> NewTryAcloudCommand(
-InstanceManager& instance_manager) {
-  return std::unique_ptr<CvdServerHandler>(new TryAcloudCommand(instance_manager));
+std::unique_ptr<CvdServerHandler> NewTryAcloudCommand() {
+  return std::unique_ptr<CvdServerHandler>(new TryAcloudCommand());
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/try_acloud.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/try_acloud.h
@@ -19,10 +19,9 @@
 #include <memory>
 
 #include "host/commands/cvd/cli/commands/server_handler.h"
-#include "host/commands/cvd/instances/instance_manager.h"
 
 namespace cuttlefish {
 
-std::unique_ptr<CvdServerHandler> NewTryAcloudCommand(InstanceManager&);
+std::unique_ptr<CvdServerHandler> NewTryAcloudCommand();
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/request_context.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/request_context.cpp
@@ -89,7 +89,7 @@ RequestContext::RequestContext(
       NewCvdSnapshotCommandHandler(instance_manager_));
   request_handlers_.emplace_back(NewCvdStartCommandHandler(instance_manager_));
   request_handlers_.emplace_back(NewCvdStatusCommandHandler(instance_manager_));
-  request_handlers_.emplace_back(NewTryAcloudCommand(instance_manager));
+  request_handlers_.emplace_back(NewTryAcloudCommand());
   request_handlers_.emplace_back(NewCvdVersionHandler());
   request_handlers_.emplace_back(NewCvdNoopHandler());
 }

--- a/base/cvd/cuttlefish/host/libs/web/caching_build_api.h
+++ b/base/cvd/cuttlefish/host/libs/web/caching_build_api.h
@@ -35,7 +35,7 @@ class CachingBuildApi : public BuildApi {
                   std::string cache_base_path);
 
   Result<Build> GetBuild(const BuildString& build_string,
-                         const std::string& fallback_target);
+                         const std::string& fallback_target) override;
   Result<std::string> DownloadFile(const Build& build,
                                    const std::string& target_directory,
                                    const std::string& artifact_name) override;
@@ -45,7 +45,7 @@ class CachingBuildApi : public BuildApi {
       const std::string& backup_artifact_name) override;
 
   Result<std::string> GetBuildZipName(const Build& build,
-                                      const std::string& name);
+                                      const std::string& name) override;
 
  private:
   Result<bool> CanCache(const std::string& target_directory);

--- a/base/cvd/cuttlefish/host/libs/web/http_client/http_client.h
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/http_client.h
@@ -28,16 +28,12 @@
 
 namespace cuttlefish {
 
-static inline bool IsHttpSuccess(int http_code) {
-  return http_code >= 200 && http_code <= 299;
-};
-
 struct HttpVoidResponse {};
 
 template <typename T>
 struct HttpResponse {
   bool HttpInfo() { return http_code >= 100 && http_code <= 199; }
-  bool HttpSuccess() { return IsHttpSuccess(http_code); }
+  bool HttpSuccess() { return http_code >= 200 && http_code <= 299; }
   bool HttpRedirect() { return http_code >= 300 && http_code <= 399; }
   bool HttpClientError() { return http_code >= 400 && http_code <= 499; }
   bool HttpServerError() { return http_code >= 500 && http_code <= 599; }


### PR DESCRIPTION
Enables:

- `clang-analyzer-deadcode.DeadStores`
- `clang-diagnostic-inconsistent-missing-override`
- `clang-diagnostic-unneeded-internal-declaration`
- `clang-diagnostic-unused-private-field`