### PR TITLE
Enable more clang tidy checks

### DIFF
--- a/base/cvd/.clang-tidy
+++ b/base/cvd/.clang-tidy
@@ -1,13 +1,20 @@
-# Bad interaction with the `parse_headers` bazel feature
-Checks: '-clang-diagnostic-pragma-once-outside-header'
+# "clang-diagnostic-pragma-once-outside-header" has a bad interaction with the
+# `parse_headers` bazel feature.
 
-# Using the bazel clang-tidy helper, warnings seem to be ignored entirely.
-# Default warnings are converted to errors here for visibility.
-WarningsAsErrors: >
+Checks: &checks >-
   clang-analyzer-*,
+  clang-diagnostic-*,
+  -clang-diagnostic-pragma-once-outside-header,
+
+UseColor: true
+
+# Using the bazel clang-tidy helper, warnings are not shown from files that
+# don't have any errors.  "*" here treats everything from `Checks` as an error,
+# and from there some exclusions are added.
+WarningsAsErrors: >
+  *,
   -clang-analyzer-core.uninitialized.Assign,
   -clang-analyzer-core.UndefinedBinaryOperatorResult,
-  clang-diagnostic-*,
   -clang-diagnostic-pragma-once-outside-header,
   -clang-diagnostic-unused-const-variable,
   -clang-diagnostic-unused-variable,

--- a/base/cvd/.clang-tidy
+++ b/base/cvd/.clang-tidy
@@ -8,6 +8,7 @@ Checks: &checks >-
   readability-avoid-const-params-in-decls,
   readability-const-return-type,
   readability-container-size-empty,
+  readability-inconsistent-declaration-parameter-name,
 
 UseColor: true
 

--- a/base/cvd/.clang-tidy
+++ b/base/cvd/.clang-tidy
@@ -6,6 +6,7 @@ Checks: &checks >-
   clang-diagnostic-*,
   -clang-diagnostic-pragma-once-outside-header,
   readability-avoid-const-params-in-decls,
+  readability-const-return-type,
 
 UseColor: true
 

--- a/base/cvd/.clang-tidy
+++ b/base/cvd/.clang-tidy
@@ -7,6 +7,7 @@ Checks: &checks >-
   -clang-diagnostic-pragma-once-outside-header,
   readability-avoid-const-params-in-decls,
   readability-const-return-type,
+  readability-container-size-empty,
 
 UseColor: true
 

--- a/base/cvd/.clang-tidy
+++ b/base/cvd/.clang-tidy
@@ -5,6 +5,7 @@ Checks: &checks >-
   clang-analyzer-*,
   clang-diagnostic-*,
   -clang-diagnostic-pragma-once-outside-header,
+  readability-avoid-const-params-in-decls,
 
 UseColor: true
 

--- a/base/cvd/cuttlefish/common/libs/fs/shared_buf.h
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_buf.h
@@ -176,6 +176,6 @@ bool SendAll(SharedFD sock, const std::string& msg);
  *
  * If a Recv error is encountered, returns the empty string
  */
-std::string RecvAll(SharedFD sock, const size_t count);
+std::string RecvAll(SharedFD sock, size_t count);
 
 } // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd.cpp
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd.cpp
@@ -187,13 +187,13 @@ void FileInstance::Close() {
     errno_ = EBADF;
   } else if (close(fd_) == -1) {
     errno_ = errno;
-    if (identity_.size()) {
+    if (!identity_.empty()) {
       message << __FUNCTION__ << ": " << identity_ << " failed (" << StrError() << ")";
       std::string message_str = message.str();
       Log(message_str.c_str());
     }
   } else {
-    if (identity_.size()) {
+    if (!identity_.empty()) {
       message << __FUNCTION__ << ": " << identity_ << "succeeded";
       std::string message_str = message.str();
       Log(message_str.c_str());

--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd.h
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd.h
@@ -157,7 +157,7 @@ class SharedFD {
   static SharedFD MemfdCreateWithData(const std::string& name, const std::string& data, unsigned int flags = 0);
   static SharedFD Mkstemp(std::string* path);
   static Result<std::pair<SharedFD, std::string>> Mkostemp(
-      const std::string_view path, const int flags = O_CLOEXEC);
+      std::string_view path, int flags = O_CLOEXEC);
   static int Poll(PollSharedFd* fds, size_t num_fds, int timeout);
   static int Poll(std::vector<PollSharedFd>& fds, int timeout);
   static bool SocketPair(int domain, int type, int protocol, SharedFD* fd0,

--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd.h
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd.h
@@ -249,7 +249,7 @@ class WeakFD {
 class ScopedMMap {
  public:
   ScopedMMap();
-  ScopedMMap(void* ptr, size_t size);
+  ScopedMMap(void* ptr, size_t len);
   ScopedMMap(const ScopedMMap& other) = delete;
   ScopedMMap& operator=(const ScopedMMap& other) = delete;
   ScopedMMap(ScopedMMap&& other);

--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd_stream.cpp
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd_stream.cpp
@@ -57,7 +57,7 @@ int SharedFDStreambuf::underflow() {
   return static_cast<int>(*gptr());
 }
 
-std::streamsize SharedFDStreambuf::xsgetn(char* dst, std::streamsize count) {
+std::streamsize SharedFDStreambuf::xsgetn(char* dest, std::streamsize count) {
   std::streamsize bytes_read = 0;
   while (bytes_read < count) {
     if (in_avail() == 0) {
@@ -67,7 +67,7 @@ std::streamsize SharedFDStreambuf::xsgetn(char* dst, std::streamsize count) {
     }
     std::streamsize buffer_count =
         std::min(static_cast<std::streamsize>(in_avail()), count - bytes_read);
-    std::memcpy(dst + bytes_read, gptr(), buffer_count);
+    std::memcpy(dest + bytes_read, gptr(), buffer_count);
     gbump(buffer_count);
     bytes_read += buffer_count;
   }
@@ -84,10 +84,10 @@ int SharedFDStreambuf::overflow(int c) {
   return c;
 }
 
-std::streamsize SharedFDStreambuf::xsputn(const char* src,
+std::streamsize SharedFDStreambuf::xsputn(const char* source,
                                           std::streamsize count) {
   return static_cast<std::streamsize>(
-    WriteAll(shared_fd_, src, static_cast<std::size_t>(count)));
+      WriteAll(shared_fd_, source, static_cast<std::size_t>(count)));
 }
 
 int SharedFDStreambuf::pbackfail(int c) {
@@ -107,4 +107,4 @@ SharedFDOstream::SharedFDOstream(SharedFD shared_fd)
 SharedFDIstream::SharedFDIstream(SharedFD shared_fd)
   : std::istream(nullptr), buf_(shared_fd) { rdbuf(&buf_); }
 
-} // namespace cuttlefish
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/archive.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/archive.cpp
@@ -37,7 +37,7 @@ Result<std::vector<std::string>> ExtractHelper(
 
   auto it = files.begin();
   while (it != files.end()) {
-    if (*it == "" || android::base::EndsWith(*it, "/")) {
+    if (it->empty() || android::base::EndsWith(*it, "/")) {
       it = files.erase(it);
     } else {
       *it = target_directory + "/" + *it;

--- a/base/cvd/cuttlefish/common/libs/utils/files.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/files.cpp
@@ -211,7 +211,7 @@ Result<void> EnsureDirectoryExists(const std::string& directory_path,
              "Failed to set permission on {}: {}", directory_path,
              strerror(errno));
 
-  if (group_name != "") {
+  if (!group_name.empty()) {
     CF_EXPECT(ChangeGroup(directory_path, group_name));
   }
 
@@ -694,7 +694,7 @@ static Result<void> WaitForFileInternal(const std::string& path, int timeoutSec,
 
     auto names = GetCreatedFileListFromInotifyFd(inotify);
 
-    CF_EXPECT(names.size() > 0,
+    CF_EXPECT(!names.empty(),
               "Failed to get names from inotify " << strerror(errno));
 
     if (Contains(names, filename)) {

--- a/base/cvd/cuttlefish/common/libs/utils/files.h
+++ b/base/cvd/cuttlefish/common/libs/utils/files.h
@@ -28,9 +28,11 @@
 namespace cuttlefish {
 bool FileExists(const std::string& path, bool follow_symlinks = true);
 Result<dev_t> FileDeviceId(const std::string& path);
-Result<bool> CanHardLink(const std::string& path1, const std::string& path2);
+Result<bool> CanHardLink(const std::string& source,
+                         const std::string& destination);
 Result<ino_t> FileInodeNumber(const std::string& path);
-Result<bool> AreHardLinked(const std::string& path1, const std::string& path2);
+Result<bool> AreHardLinked(const std::string& source,
+                           const std::string& destination);
 Result<std::string> CreateHardLink(const std::string& target,
                                    const std::string& hardlink,
                                    bool overwrite_existing = false);

--- a/base/cvd/cuttlefish/common/libs/utils/files.h
+++ b/base/cvd/cuttlefish/common/libs/utils/files.h
@@ -33,19 +33,19 @@ Result<ino_t> FileInodeNumber(const std::string& path);
 Result<bool> AreHardLinked(const std::string& path1, const std::string& path2);
 Result<std::string> CreateHardLink(const std::string& target,
                                    const std::string& hardlink,
-                                   const bool overwrite_existing = false);
+                                   bool overwrite_existing = false);
 Result<void> CreateSymLink(const std::string& target, const std::string& link,
-                           const bool overwrite_existing = false);
+                           bool overwrite_existing = false);
 bool FileHasContent(const std::string& path);
 Result<std::vector<std::string>> DirectoryContents(const std::string& path);
 bool DirectoryExists(const std::string& path, bool follow_symlinks = true);
 Result<void> EnsureDirectoryExists(const std::string& directory_path,
-                                   const mode_t mode = S_IRWXU | S_IRWXG |
-                                                       S_IROTH | S_IXOTH,
+                                   mode_t mode = S_IRWXU | S_IRWXG | S_IROTH |
+                                                 S_IXOTH,
                                    const std::string& group_name = "");
 Result<void> ChangeGroup(const std::string& path,
                          const std::string& group_name);
-bool CanAccess(const std::string& path, const int mode);
+bool CanAccess(const std::string& path, int mode);
 bool IsDirectoryEmpty(const std::string& path);
 Result<void> RecursivelyRemoveDirectory(const std::string& path);
 bool Copy(const std::string& from, const std::string& to);

--- a/base/cvd/cuttlefish/common/libs/utils/flag_parser.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/flag_parser.cpp
@@ -150,7 +150,7 @@ Result<Flag::FlagProcessResult> Flag::Process(
     const std::string& arg, const std::optional<std::string>& next_arg) const {
   using android::base::StringReplace;
   auto normalized_arg = StringReplace(arg, "-", "_", true);
-  if (!setter_ && aliases_.size() > 0) {
+  if (!setter_ && !aliases_.empty()) {
     return CF_ERRF("No setter for flag with alias {}", aliases_[0].name);
   }
   for (auto& alias : aliases_) {
@@ -423,7 +423,7 @@ Flag VerbosityFlag(android::base::LogSeverity& value) {
 
 Flag HelpFlag(const std::vector<Flag>& flags, std::string text) {
   auto setter = [&flags, text](FlagMatch) -> Result<void> {
-    if (text.size() > 0) {
+    if (!text.empty()) {
       LOG(INFO) << text;
     }
     for (const auto& flag : flags) {
@@ -535,7 +535,7 @@ Flag GflagsCompatFlag(const std::string& name, std::string& value) {
 
 template <typename T>
 std::optional<T> ParseInteger(const std::string& value) {
-  if (value.size() == 0) {
+  if (value.empty()) {
     return {};
   }
   const char* base = value.c_str();

--- a/base/cvd/cuttlefish/common/libs/utils/flag_parser.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/flag_parser.cpp
@@ -591,10 +591,11 @@ Flag GflagsCompatFlag(const std::string& name,
 }
 
 Flag GflagsCompatFlag(const std::string& name, std::vector<bool>& value,
-                      const bool def_val) {
+                      const bool default_value) {
   return GflagsCompatFlag(name)
       .Getter([&value]() { return fmt::format("{}", fmt::join(value, ",")); })
-      .Setter([&name, &value, def_val](const FlagMatch& match) -> Result<void> {
+      .Setter([&name, &value,
+               default_value](const FlagMatch& match) -> Result<void> {
         if (match.value.empty()) {
           value.clear();
           return {};
@@ -606,7 +607,7 @@ Flag GflagsCompatFlag(const std::string& name, std::vector<bool>& value,
         output_vals.reserve(str_vals.size());
         for (const auto& str_val : str_vals) {
           if (str_val.empty()) {
-            output_vals.push_back(def_val);
+            output_vals.push_back(default_value);
           } else {
             output_vals.push_back(CF_EXPECT(ParseBool(str_val, name)));
           }

--- a/base/cvd/cuttlefish/common/libs/utils/flag_parser.h
+++ b/base/cvd/cuttlefish/common/libs/utils/flag_parser.h
@@ -137,10 +137,10 @@ Result<bool> ParseBool(const std::string& value, const std::string& name);
  * unmatched arguments. */
 Result<void> ConsumeFlags(const std::vector<Flag>& flags,
                           std::vector<std::string>& args,
-                          const bool recognize_end_of_option_mark = false);
+                          bool recognize_end_of_option_mark = false);
 Result<void> ConsumeFlags(const std::vector<Flag>& flags,
                           std::vector<std::string>&&,
-                          const bool recognize_end_of_option_mark = false);
+                          bool recognize_end_of_option_mark = false);
 
 bool WriteGflagsCompatXml(const std::vector<Flag>&, std::ostream&);
 
@@ -176,6 +176,6 @@ Flag GflagsCompatFlag(const std::string& name, std::int32_t& value);
 Flag GflagsCompatFlag(const std::string& name, bool& value);
 Flag GflagsCompatFlag(const std::string& name, std::vector<std::string>& value);
 Flag GflagsCompatFlag(const std::string& name, std::vector<bool>& value,
-                      const bool default_value);
+                      bool default_value);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/flag_parser.h
+++ b/base/cvd/cuttlefish/common/libs/utils/flag_parser.h
@@ -89,8 +89,8 @@ class Flag {
   /* Examines a list of arguments, removing any matches from the list and
    * invoking the `Setter` for every match. Returns `false` if the callback ever
    * returns `false`. Non-matches are left in place. */
-  Result<void> Parse(std::vector<std::string>& flags) const;
-  Result<void> Parse(std::vector<std::string>&& flags) const;
+  Result<void> Parse(std::vector<std::string>& arguments) const;
+  Result<void> Parse(std::vector<std::string>&& arguments) const;
 
   /* Write gflags `--helpxml` style output for a string-type flag. */
   bool WriteGflagsCompatXml(std::ostream&) const;

--- a/base/cvd/cuttlefish/common/libs/utils/proc_file_utils.h
+++ b/base/cvd/cuttlefish/common/libs/utils/proc_file_utils.h
@@ -42,10 +42,10 @@ struct ProcInfo {
   std::unordered_map<std::string, std::string> envs_;
   std::vector<std::string> args_;
 };
-Result<ProcInfo> ExtractProcInfo(const pid_t pid);
+Result<ProcInfo> ExtractProcInfo(pid_t pid);
 
 // collects all pids whose owner is uid
-Result<std::vector<pid_t>> CollectPids(const uid_t uid = getuid());
+Result<std::vector<pid_t>> CollectPids(uid_t uid = getuid());
 
 /* collects all pids that meet the following:
  *
@@ -54,7 +54,7 @@ Result<std::vector<pid_t>> CollectPids(const uid_t uid = getuid());
  *
  */
 Result<std::vector<pid_t>> CollectPidsByExecName(const std::string& exec_name,
-                                                 const uid_t uid = getuid());
+                                                 uid_t uid = getuid());
 
 /* collects all pids that meet the following:
  *
@@ -63,27 +63,27 @@ Result<std::vector<pid_t>> CollectPidsByExecName(const std::string& exec_name,
  *
  */
 Result<std::vector<pid_t>> CollectPidsByExecPath(const std::string& exec_path,
-                                                 const uid_t uid = getuid());
+                                                 uid_t uid = getuid());
 
 /**
  * When argv[0] != exec_path, collects PIDs based on argv[0]
  *
  */
 Result<std::vector<pid_t>> CollectPidsByArgv0(const std::string& expected_argv0,
-                                              const uid_t uid = getuid());
+                                              uid_t uid = getuid());
 
-Result<uid_t> OwnerUid(const pid_t pid);
+Result<uid_t> OwnerUid(pid_t pid);
 
 // retrieves command line args for the pid
-Result<std::vector<std::string>> GetCmdArgs(const pid_t pid);
+Result<std::vector<std::string>> GetCmdArgs(pid_t pid);
 
 // retrieves the path to the executable file used for the pid
 // this does not work for the defunct processes
-Result<std::string> GetExecutablePath(const pid_t pid);
+Result<std::string> GetExecutablePath(pid_t pid);
 
 // retrieves the environment variables of the process, pid
-Result<std::unordered_map<std::string, std::string>> GetEnvs(const pid_t pid);
+Result<std::unordered_map<std::string, std::string>> GetEnvs(pid_t pid);
 
-Result<pid_t> Ppid(const pid_t pid);
+Result<pid_t> Ppid(pid_t pid);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/subprocess.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/subprocess.cpp
@@ -131,12 +131,12 @@ SubprocessOptions SubprocessOptions::Verbose(bool verbose) && {
 }
 
 #ifdef __linux__
-SubprocessOptions& SubprocessOptions::ExitWithParent(bool v) & {
-  exit_with_parent_ = v;
+SubprocessOptions& SubprocessOptions::ExitWithParent(bool exit_with_parent) & {
+  exit_with_parent_ = exit_with_parent;
   return *this;
 }
-SubprocessOptions SubprocessOptions::ExitWithParent(bool v) && {
-  exit_with_parent_ = v;
+SubprocessOptions SubprocessOptions::ExitWithParent(bool exit_with_parent) && {
+  exit_with_parent_ = exit_with_parent;
   return std::move(*this);
 }
 #endif

--- a/base/cvd/cuttlefish/common/libs/utils/subprocess.h
+++ b/base/cvd/cuttlefish/common/libs/utils/subprocess.h
@@ -340,7 +340,7 @@ std::ostream& operator<<(std::ostream& out, const Command& command);
  * If some setup fails, `command` fails to start, or `command` exits due to a
  * signal, the return value will be negative.
  */
-int RunWithManagedStdio(Command&& command, const std::string* stdin,
+int RunWithManagedStdio(Command&& cmd_tmp, const std::string* stdin,
                         std::string* stdout, std::string* stderr,
                         SubprocessOptions options = SubprocessOptions());
 

--- a/base/cvd/cuttlefish/common/libs/utils/subprocess.h
+++ b/base/cvd/cuttlefish/common/libs/utils/subprocess.h
@@ -90,8 +90,8 @@ class Subprocess {
   pid_t pid() const { return pid_; }
   StopperResult Stop() { return stopper_(this); }
 
-  Result<void> SendSignal(const int signal);
-  Result<void> SendSignalToGroup(const int signal);
+  Result<void> SendSignal(int signal);
+  Result<void> SendSignalToGroup(int signal);
 
  private:
   // Copy is disabled to avoid waiting twice for the same pid (the first wait

--- a/base/cvd/cuttlefish/common/libs/utils/tcp_socket.h
+++ b/base/cvd/cuttlefish/common/libs/utils/tcp_socket.h
@@ -83,10 +83,10 @@ class ServerSocket {
   SharedFD fd_;
 };
 
-void AppendInNetworkByteOrder(Message* msg, const std::uint8_t b);
-void AppendInNetworkByteOrder(Message* msg, const std::uint16_t s);
-void AppendInNetworkByteOrder(Message* msg, const std::uint32_t w);
-void AppendInNetworkByteOrder(Message* msg, const std::int32_t w);
+void AppendInNetworkByteOrder(Message* msg, std::uint8_t b);
+void AppendInNetworkByteOrder(Message* msg, std::uint16_t s);
+void AppendInNetworkByteOrder(Message* msg, std::uint32_t w);
+void AppendInNetworkByteOrder(Message* msg, std::int32_t w);
 void AppendInNetworkByteOrder(Message* msg, const std::string& str);
 
 inline void AppendToMessage(Message*) {}

--- a/base/cvd/cuttlefish/common/libs/utils/tee_logging.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/tee_logging.cpp
@@ -274,19 +274,19 @@ static std::vector<SeverityTarget> SeverityTargetsForFiles(
 }
 
 TeeLogger LogToFiles(const std::vector<std::string>& files,
-                     const std::string& prefix) {
-  return TeeLogger(SeverityTargetsForFiles(files), prefix);
+                     const std::string& log_prefix) {
+  return TeeLogger(SeverityTargetsForFiles(files), log_prefix);
 }
 
 TeeLogger LogToStderrAndFiles(
-    const std::vector<std::string>& files, const std::string& prefix,
+    const std::vector<std::string>& files, const std::string& log_prefix,
     MetadataLevel stderr_level,
     std::optional<android::base::LogSeverity> stderr_severity) {
   std::vector<SeverityTarget> log_severities = SeverityTargetsForFiles(files);
   log_severities.push_back(
       SeverityTarget{stderr_severity ? *stderr_severity : ConsoleSeverity(),
                      SharedFD::Dup(/* stderr */ 2), stderr_level});
-  return TeeLogger(log_severities, prefix);
+  return TeeLogger(log_severities, log_prefix);
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/tee_logging.h
+++ b/base/cvd/cuttlefish/common/libs/utils/tee_logging.h
@@ -67,7 +67,7 @@ TeeLogger LogToFiles(const std::vector<std::string>& files,
 TeeLogger LogToStderrAndFiles(
     const std::vector<std::string>& files, const std::string& log_prefix = "",
     MetadataLevel stderr_level = MetadataLevel::ONLY_MESSAGE,
-    std::optional<android::base::LogSeverity> stderr_serverity = std::nullopt);
+    std::optional<android::base::LogSeverity> stderr_severity = std::nullopt);
 
 std::string StripColorCodes(const std::string& str);
 

--- a/base/cvd/cuttlefish/common/libs/utils/tee_logging.h
+++ b/base/cvd/cuttlefish/common/libs/utils/tee_logging.h
@@ -26,7 +26,7 @@
 
 namespace cuttlefish {
 
-std::string FromSeverity(const android::base::LogSeverity severity);
+std::string FromSeverity(android::base::LogSeverity severity);
 Result<android::base::LogSeverity> ToSeverity(const std::string& value);
 
 std::string StderrOutputGenerator(const struct tm& now, int pid, uint64_t tid,

--- a/base/cvd/cuttlefish/common/libs/utils/unix_sockets.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/unix_sockets.cpp
@@ -192,7 +192,7 @@ Result<ucred> UnixSocketMessage::Credentials() {
       credentials.push_back(creds);
     }
   }
-  if (credentials.size() == 0) {
+  if (credentials.empty()) {
     return CF_ERR("No credentials present");
   } else if (credentials.size() == 1) {
     return credentials[0];

--- a/base/cvd/cuttlefish/host/commands/cvd/acloud/converter.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/acloud/converter.cpp
@@ -146,7 +146,7 @@ namespace acloud_impl {
 Result<ConvertedAcloudCreateCommand> ConvertAcloudCreate(
     const CommandRequest& request) {
   auto arguments = ParseInvocation(request).arguments;
-  CF_EXPECT(arguments.size() > 0);
+  CF_EXPECT(!arguments.empty());
   CF_EXPECT(arguments[0] == "create");
   arguments.erase(arguments.begin());
 
@@ -312,9 +312,9 @@ Result<ConvertedAcloudCreateCommand> ConvertAcloudCreate(
           }));
 
   CF_EXPECT(ConsumeFlags(flags, arguments));
-  CF_EXPECT(arguments.size() == 0, "Unrecognized arguments:'"
-                                       << android::base::Join(arguments, "', '")
-                                       << "'");
+  CF_EXPECT(arguments.empty(), "Unrecognized arguments:'"
+                                   << android::base::Join(arguments, "', '")
+                                   << "'");
 
   CF_EXPECT_EQ(parsed_flags.local_instance.is_set, true,
                "Only '--local-instance' is supported");
@@ -391,7 +391,7 @@ Result<ConvertedAcloudCreateCommand> ConvertAcloudCreate(
     if (system_branch || system_build_id || system_build_target) {
       auto target =
           system_build_target.value_or(parsed_flags.build_target.value_or(""));
-      if (target != "") {
+      if (!target.empty()) {
         target = "/" + target;
       }
       auto build =
@@ -402,7 +402,7 @@ Result<ConvertedAcloudCreateCommand> ConvertAcloudCreate(
     if (parsed_flags.bootloader.branch || parsed_flags.bootloader.build_id ||
         parsed_flags.bootloader.build_target) {
       auto target = parsed_flags.bootloader.build_target.value_or("");
-      if (target != "") {
+      if (!target.empty()) {
         target = "/" + target;
       }
       auto build = parsed_flags.bootloader.build_id.value_or(
@@ -412,7 +412,7 @@ Result<ConvertedAcloudCreateCommand> ConvertAcloudCreate(
     }
     if (boot_branch || boot_build_id || boot_build_target) {
       auto target = boot_build_target.value_or("");
-      if (target != "") {
+      if (!target.empty()) {
         target = "/" + target;
       }
       auto build = boot_build_id.value_or(boot_branch.value_or("aosp-main"));
@@ -428,7 +428,7 @@ Result<ConvertedAcloudCreateCommand> ConvertAcloudCreate(
     }
     if (ota_branch || ota_build_id || ota_build_target) {
       auto target = ota_build_target.value_or("");
-      if (target != "") {
+      if (!target.empty()) {
         target = "/" + target;
       }
       auto build = ota_build_id.value_or(ota_branch.value_or(""));
@@ -530,7 +530,7 @@ Result<ConvertedAcloudCreateCommand> ConvertAcloudCreate(
         // there are some very old kernels that are built without
         // an initramfs.img file,
         // e.g. aosp_kernel-common-android-4.14-stable
-        if (kernel_image != "" && initramfs_image != "") {
+        if (!kernel_image.empty() && !initramfs_image.empty()) {
           start_request_builder.AddArguments({"-kernel_path", kernel_image,
                                       "-initramfs_path", initramfs_image});
         } else {
@@ -542,7 +542,7 @@ Result<ConvertedAcloudCreateCommand> ConvertAcloudCreate(
                                         kVendorBootImageName);
           start_request_builder.AddArguments({"-boot_image", local_boot_image});
           // vendor boot image may not exist
-          if (vendor_boot_image != "") {
+          if (!vendor_boot_image.empty()) {
             start_request_builder.AddArguments(
                 {"-vendor_boot_image", vendor_boot_image});
           }
@@ -567,7 +567,7 @@ Result<ConvertedAcloudCreateCommand> ConvertAcloudCreate(
   if (launch_args) {
     start_request_builder.AddArguments(CF_EXPECT(BashTokenize(*launch_args)));
   }
-  if (acloud_config.launch_args != "") {
+  if (!acloud_config.launch_args.empty()) {
     start_request_builder.AddArguments(
         CF_EXPECT(BashTokenize(acloud_config.launch_args)));
   }

--- a/base/cvd/cuttlefish/host/commands/cvd/acloud/create_converter_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/acloud/create_converter_parser.cpp
@@ -225,7 +225,7 @@ Result<ConverterParsed> ParseAcloudCreateFlags(cvd_common::Args& arguments) {
 }
 
 Result<cvd_common::Args> CompileFromAcloudToCvdr(cvd_common::Args& arguments) {
-  CF_EXPECT(arguments.size() > 0);
+  CF_EXPECT(!arguments.empty());
   CF_EXPECT(arguments[0] == kAcloudCmdCreate);
   std::string main_cmd = arguments[0];
   arguments.erase(arguments.begin());

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/command_request.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/command_request.h
@@ -45,7 +45,7 @@ class CommandRequest {
  private:
   friend class CommandRequestBuilder;
   CommandRequest(cvd_common::Args args, cvd_common::Envs env,
-                 selector::SelectorOptions cvd_args);
+                 selector::SelectorOptions selectors);
 
   cvd_common::Args args_;
   cvd_common::Envs env_;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_command.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_command.cpp
@@ -287,7 +287,7 @@ Result<void> AcloudCommand::RunAcloudConnect(const CommandRequest& request,
                                              const std::string& hostname) {
   auto build_top = StringFromEnv("ANDROID_BUILD_TOP", "");
   CF_EXPECT(
-      build_top != "",
+      !build_top.empty(),
       "Missing ANDROID_BUILD_TOP environment variable. Please run `source "
       "build/envsetup.sh`");
   Command cmd =

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_mixsuperimage.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_mixsuperimage.cpp
@@ -99,7 +99,7 @@ Result<std::string> GetImageForPartition(
       search != image_paths.end()) {
     result_path = search->second;
   }
-  if (result_path == "") {
+  if (result_path.empty()) {
     result_path = image_dir + partition_name + ".img";
   }
 
@@ -139,7 +139,7 @@ Result<void> _RewriteMiscInfo(
   }
   input_fs.close();
 
-  if (partition_names.size() == 0) {
+  if (partition_names.empty()) {
     LOG(INFO) << "No dynamic partition list in misc info.";
   }
 
@@ -265,7 +265,7 @@ class AcloudMixSuperImageCommand : public CvdServerHandler {
       index++;
     }
     // no specific image directory, use $ANDROID_PRODUCT_OUT
-    if (image_dir == "") {
+    if (image_dir.empty()) {
       image_dir = DefaultGuestImagePath("/");
     }
     if (!android::base::EndsWith(image_dir, "/")) {
@@ -274,7 +274,7 @@ class AcloudMixSuperImageCommand : public CvdServerHandler {
     misc_info = CF_EXPECT(FindMiscInfo(image_dir));
     image_dir = CF_EXPECT(FindImageDir(image_dir));
     system_image_path = FindImage(local_system_image, {_SYSTEM_IMAGE_NAME_PATTERN});
-    CF_EXPECT(system_image_path != "",
+    CF_EXPECT(!system_image_path.empty(),
               "Cannot find system.img in " << local_system_image);
     std::string system_ext_image_path =
         FindImage(local_system_image, {_SYSTEM_EXT_IMAGE_NAME_PATTERN});

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
@@ -246,7 +246,7 @@ class CvdCreateCommandHandler : public CvdServerHandler {
   Result<void> CreateSymlinks(const LocalInstanceGroup& group);
 
   static void MarkLockfiles(std::vector<InstanceLockFile>& lock_files,
-                            const InUseState state);
+                            InUseState state);
   static void MarkLockfilesInUse(std::vector<InstanceLockFile>& lock_files) {
     MarkLockfiles(lock_files, InUseState::kInUse);
   }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/help.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/help.cpp
@@ -147,9 +147,8 @@ class CvdHelpHandler : public CvdServerHandler {
 };
 
 std::unique_ptr<CvdServerHandler> NewCvdHelpHandler(
-    const std::vector<std::unique_ptr<CvdServerHandler>>& request_handlers) {
-  return std::unique_ptr<CvdServerHandler>(
-      new CvdHelpHandler(request_handlers));
+    const std::vector<std::unique_ptr<CvdServerHandler>>& server_handlers) {
+  return std::unique_ptr<CvdServerHandler>(new CvdHelpHandler(server_handlers));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.cpp
@@ -59,9 +59,9 @@ Result<std::unique_ptr<FrontlineParser>> FrontlineParser::Parse(
   return frontline_parser;
 }
 
-FrontlineParser::FrontlineParser(const ParserParam& param)
-    : server_supported_subcmds_{param.server_supported_subcmds},
-      all_args_(param.all_args) {}
+FrontlineParser::FrontlineParser(const ParserParam& parser_param)
+    : server_supported_subcmds_{parser_param.server_supported_subcmds},
+      all_args_(parser_param.all_args) {}
 
 Result<void> FrontlineParser::Separate() {
   arguments_separator_ = CF_EXPECT(CallSeparator());

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.h
@@ -62,7 +62,7 @@ class FrontlineParser {
   const cvd_common::Args& CvdArgs() const;
 
  private:
-  FrontlineParser(const ParserParam& parser);
+  FrontlineParser(const ParserParam& parser_param);
 
   // internal workers in order
   Result<void> Separate();

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/cf_configs_instances.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/cf_configs_instances.h
@@ -25,6 +25,6 @@
 namespace cuttlefish {
 
 Result<std::vector<std::string>> GenerateInstancesFlags(
-    const cvd::config::EnvironmentSpecification& config);
+    const cvd::config::EnvironmentSpecification& cfg);
 
 };  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_security_configs.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_security_configs.h
@@ -24,6 +24,6 @@
 namespace cuttlefish {
 
 std::vector<std::string> GenerateSecurityFlags(
-    const cvd::config::EnvironmentSpecification& root);
+    const cvd::config::EnvironmentSpecification& cfg);
 
 };  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/launch_cvd_templates.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/launch_cvd_templates.cpp
@@ -252,7 +252,7 @@ static Result<Json::Value> LoadTemplateByName(const std::string& template_name) 
 Result<EnvironmentSpecification> ExtractLaunchTemplates(
     EnvironmentSpecification config) {
   for (auto& ins : *config.mutable_instances()) {
-    if (ins.has_import_template() && ins.import_template() != "") {
+    if (ins.has_import_template() && !ins.import_template().empty()) {
       auto tmpl_json = CF_EXPECT(LoadTemplateByName(ins.import_template()));
       // TODO: b/337089452 - handle repeated merges within protos
       // `proto.MergeFrom` concatenates repeated fields, but we want index-wise

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.cpp
@@ -174,7 +174,7 @@ std::vector<Flag> GetFlagsVector(LoadFlags& load_flags) {
 }
 
 void MakeAbsolute(std::string& path, const std::string& working_dir) {
-  if (path.size() > 0 && path[0] == '/') {
+  if (!path.empty() && path[0] == '/') {
     return;
   }
   path.insert(0, working_dir + "/");
@@ -218,7 +218,7 @@ Result<Json::Value> GetOverriddenConfig(
     const std::vector<Override>& override_flags) {
   Json::Value result = CF_EXPECT(ParseJsonFile(config_path));
 
-  if (override_flags.size() > 0) {
+  if (!override_flags.empty()) {
     for (const auto& flag : override_flags) {
       MergeTwoJsonObjs(result,
                        OverrideToJson(flag.config_path, flag.new_value));
@@ -333,7 +333,7 @@ Result<LoadFlags> GetFlags(std::vector<std::string>& args,
   auto flags = GetFlagsVector(load_flags);
   CF_EXPECT(ConsumeFlags(flags, args));
   CF_EXPECT(
-      args.size() > 0,
+      !args.empty(),
       "No arguments provided to cvd command, please provide path to json file");
 
   if (load_flags.base_dir.empty()) {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.cpp
@@ -57,7 +57,7 @@ Result<std::unique_ptr<ArgumentsSeparator>> ArgumentsSeparator::Parse(
 
 Result<std::unique_ptr<ArgumentsSeparator>> ArgumentsSeparator::Parse(
     const FlagsRegistration& flag_registration, const std::string& input_args,
-    const std::string delim) {
+    const std::string& delim) {
   std::vector<std::string> input_args_vec =
       android::base::Tokenize(input_args, delim);
   auto arg_separator = CF_EXPECT(Parse(flag_registration, input_args_vec));

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.h
@@ -82,7 +82,7 @@ class ArgumentsSeparator {
       const CvdProtobufArg& input_args);
   static Result<std::unique_ptr<ArgumentsSeparator>> Parse(
       const FlagsRegistration& flag_registration, const std::string& input_args,
-      const std::string delim = " ");
+      const std::string& delim = " ");
 
   const std::string& ProgPath() const { return prog_path_; }
   const std::vector<std::string>& CvdArgs() const { return cvd_args_; }
@@ -94,7 +94,7 @@ class ArgumentsSeparator {
                      const std::vector<std::string>& input_args,
                      const FlagsRegistration& flag_registration);
 
-  bool IsFlag(const ArgType arg_type) const;
+  bool IsFlag(ArgType arg_type) const;
   struct Output {
     std::string prog_path;
     std::vector<std::string> cvd_args;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/creation_analyzer.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/creation_analyzer.cpp
@@ -46,10 +46,10 @@ Result<CreationAnalyzer> CreationAnalyzer::Create(
 CreationAnalyzer::CreationAnalyzer(
     const CreationAnalyzerParam& param,
     StartSelectorParser&& selector_options_parser,
-    InstanceLockFileManager& instance_file_lock_manager)
+    InstanceLockFileManager& instance_lock_file_manager)
     : envs_(param.envs),
       selector_options_parser_{std::move(selector_options_parser)},
-      instance_file_lock_manager_{instance_file_lock_manager} {}
+      instance_lock_file_manager_{instance_lock_file_manager} {}
 
 static std::unordered_map<unsigned, InstanceLockFile> ConstructIdLockFileMap(
     std::vector<InstanceLockFile>&& lock_files) {
@@ -91,7 +91,7 @@ CreationAnalyzer::AnalyzeInstanceIdsInternal(
     return instance_info;
   }
   auto acquired_all_file_locks =
-      CF_EXPECT(instance_file_lock_manager_.LockAllAvailable());
+      CF_EXPECT(instance_lock_file_manager_.LockAllAvailable());
   auto id_to_lockfile_map =
       ConstructIdLockFileMap(std::move(acquired_all_file_locks));
   for (const auto& [id, instance_name] : id_name_pairs) {
@@ -113,7 +113,7 @@ CreationAnalyzer::AnalyzeInstanceIdsInternal(bool acquire_file_locks) {
   // As this test was done earlier, this line must not fail
   const auto n_instances = selector_options_parser_.RequestedNumInstances();
   auto acquired_all_file_locks =
-      CF_EXPECT(instance_file_lock_manager_.LockAllAvailable());
+      CF_EXPECT(instance_lock_file_manager_.LockAllAvailable());
   auto id_to_lockfile_map =
       ConstructIdLockFileMap(std::move(acquired_all_file_locks));
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/creation_analyzer.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/creation_analyzer.h
@@ -161,7 +161,7 @@ class CreationAnalyzer {
 
   // internal, temporary
   StartSelectorParser selector_options_parser_;
-  InstanceLockFileManager& instance_file_lock_manager_;
+  InstanceLockFileManager& instance_lock_file_manager_;
 };
 
 }  // namespace selector

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.h
@@ -117,9 +117,8 @@ class StartSelectorParser {
     std::optional<std::string> instance_nums_flag;
   };
 
-  Result<unsigned> VerifyNumOfInstances(
-      const VerifyNumOfInstancesParam& params,
-      const unsigned default_n_instances = 1) const;
+  Result<unsigned> VerifyNumOfInstances(const VerifyNumOfInstancesParam& params,
+                                        unsigned default_n_instances = 1) const;
   bool CalcMayBeDefaultGroup();
 
   /**

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
@@ -31,7 +31,7 @@ namespace cuttlefish {
 CommandInvocation ParseInvocation(const CommandRequest& request) {
   CommandInvocation invocation;
   invocation.arguments = request.Args();
-  if (invocation.arguments.size() == 0) {
+  if (invocation.arguments.empty()) {
     return invocation;
   }
   invocation.arguments[0] = cpp_basename(invocation.arguments[0]);

--- a/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
@@ -34,8 +34,9 @@ namespace cuttlefish {
 namespace {
 [[noreturn]] void CallPythonAcloud(std::vector<std::string>& args) {
   auto android_top = StringFromEnv("ANDROID_BUILD_TOP", "");
-  CHECK(android_top != "") << "Could not find android environment. Please run "
-                           << "\"source build/envsetup.sh\".";
+  CHECK(!android_top.empty())
+      << "Could not find android environment. Please run "
+      << "\"source build/envsetup.sh\".";
   // TODO(b/206893146): Detect what the platform actually is.
   auto py_acloud_path =
       android_top + "/prebuilts/asuite/acloud/linux-x86/acloud";

--- a/base/cvd/cuttlefish/host/commands/cvd/cvd.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cvd.h
@@ -27,7 +27,7 @@ namespace cuttlefish {
 
 class Cvd {
  public:
-  Cvd(const android::base::LogSeverity verbosity,
+  Cvd(android::base::LogSeverity verbosity,
       InstanceLockFileManager& instance_lockfile_manager,
       InstanceManager& instance_manager);
 

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_database.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_database.h
@@ -95,7 +95,7 @@ class InstanceDatabase {
   }
 
   static std::vector<LocalInstanceGroup> FindGroups(
-      const cvd::PersistentData& data, const Filter& param);
+      const cvd::PersistentData& data, const Filter& filter);
 
   DataViewer viewer_;
 };

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_database_types.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_database_types.h
@@ -28,7 +28,7 @@ namespace cuttlefish {
 using CvdServerClock = std::chrono::system_clock;
 using TimeStamp = std::chrono::time_point<CvdServerClock>;
 
-Result<TimeStamp> DeserializeTimePoint(const Json::Value& group_json);
+Result<TimeStamp> DeserializeTimePoint(const Json::Value& time_point_json);
 std::string Format(const TimeStamp&);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_database_utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_database_utils.h
@@ -53,7 +53,7 @@ Result<DeviceName> BreakDeviceName(const std::string& device_name);
  * "Only up to n must match by field " + FieldName
  *
  */
-std::string GenerateTooManyInstancesErrorMsg(const int n,
+std::string GenerateTooManyInstancesErrorMsg(int n,
                                              const std::string& field_name);
 
 template <typename RetSet, typename AnyContainer>

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_group_record.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_group_record.h
@@ -60,7 +60,7 @@ class LocalInstanceGroup {
 
   std::string AssemblyDir() const;
 
-  Result<LocalInstance> FindInstanceById(const unsigned id) const;
+  Result<LocalInstance> FindInstanceById(unsigned id) const;
   /**
    * Find by per-instance name.
    *

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_lock.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_lock.h
@@ -35,7 +35,7 @@ class InstanceLockFile {
   bool operator<(const InstanceLockFile&) const;
 
  private:
-  InstanceLockFile(LockFile&& lock_file, const int instance_num);
+  InstanceLockFile(LockFile&& lock_file, int instance_num);
   LockFile lock_file_;
   const int instance_num_;
 };

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/reset_client_utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/reset_client_utils.cpp
@@ -121,9 +121,9 @@ Result<void> RunCvdProcessManager::RunStopCvd(const GroupProcInfo& group_info,
   return {};
 }
 
-Result<void> RunCvdProcessManager::RunStopCvdAll(bool clear_instance_dirs) {
+Result<void> RunCvdProcessManager::RunStopCvdAll(bool clear_runtime_dirs) {
   for (const auto& group_info : run_cvd_process_collector_.CfGroups()) {
-    auto stop_cvd_result = RunStopCvd(group_info, clear_instance_dirs);
+    auto stop_cvd_result = RunStopCvd(group_info, clear_runtime_dirs);
     if (!stop_cvd_result.ok()) {
       LOG(ERROR) << stop_cvd_result.error().FormatForEnv();
       continue;
@@ -194,9 +194,9 @@ Result<void> RunCvdProcessManager::DeleteLockFile(
   return {};
 }
 
-Result<void> KillAllCuttlefishInstances(bool clear_instance_dirs) {
+Result<void> KillAllCuttlefishInstances(bool clear_runtime_dirs) {
   RunCvdProcessManager manager = CF_EXPECT(RunCvdProcessManager::Get());
-  CF_EXPECT(manager.KillAllCuttlefishInstances(clear_instance_dirs));
+  CF_EXPECT(manager.KillAllCuttlefishInstances(clear_runtime_dirs));
   return {};
 }
 
@@ -269,10 +269,12 @@ Result<void> RunCvdProcessManager::KillAllCuttlefishInstances(
   return {};
 }
 
-Result<void> RunCvdProcessManager::ForcefullyStopGroup(const uid_t id) {
+Result<void> RunCvdProcessManager::ForcefullyStopGroup(
+    const uid_t any_id_in_group) {
   auto groups_info = run_cvd_process_collector_.CfGroups();
   for (const auto& group_info : groups_info) {
-    if (!Contains(group_info.instances_, static_cast<unsigned>(id))) {
+    if (!Contains(group_info.instances_,
+                  static_cast<unsigned>(any_id_in_group))) {
       continue;
     }
     CF_EXPECT(ForcefullyStopGroup(group_info));

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/reset_client_utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/reset_client_utils.h
@@ -36,7 +36,7 @@ class RunCvdProcessManager {
  private:
   RunCvdProcessManager() = delete;
   RunCvdProcessManager(RunCvdProcessCollector&&);
-  static Result<void> RunStopCvd(const GroupProcInfo& run_cvd_info,
+  static Result<void> RunStopCvd(const GroupProcInfo& group_info,
                                  bool clear_runtime_dirs);
   Result<void> RunStopCvdAll(bool clear_runtime_dirs);
   Result<void> SendSignal(const GroupProcInfo&);

--- a/base/cvd/cuttlefish/host/commands/cvd/legacy/client.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/legacy/client.h
@@ -38,7 +38,7 @@ namespace cuttlefish {
  */
 class CvdClient {
  public:
-  CvdClient(const android::base::LogSeverity verbosity,
+  CvdClient(android::base::LogSeverity verbosity,
             const std::string& server_socket_path = ServerSocketPath());
 
   Result<void> ConnectToServer();

--- a/base/cvd/cuttlefish/host/commands/cvd/unittests/selector/instance_database_helper.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/unittests/selector/instance_database_helper.h
@@ -82,7 +82,7 @@ class CvdInstanceDatabaseTest : public ::testing::Test {
   bool InitWorkspace();
   bool InitMockAndroidHostOut();
   // set error_ when there is an error
-  void SetErrorCode(const ErrorCode error_code, const std::string& msg);
+  void SetErrorCode(ErrorCode error_code, const std::string& msg);
 
   std::string android_artifacts_path_;
   std::string workspace_dir_;

--- a/base/cvd/cuttlefish/host/commands/cvd/utils/common.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/utils/common.cpp
@@ -67,7 +67,7 @@ Result<std::string> AndroidHostPath(const cvd_common::Envs& envs) {
 }
 
 cvd::Response CommandResponse(const cvd::Status_Code code,
-                              const std::string message) {
+                              const std::string& message) {
   cvd::Response response;
   response.mutable_command_response();  // set oneof field
   auto& status = *response.mutable_status();

--- a/base/cvd/cuttlefish/host/commands/cvd/utils/common.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/utils/common.h
@@ -37,8 +37,8 @@ struct Overload : Ts... {
 template <typename... Ts>
 Overload(Ts...) -> Overload<Ts...>;
 
-cvd::Response CommandResponse(const cvd::Status_Code,
-                              const std::string message = "");
+cvd::Response CommandResponse(cvd::Status_Code,
+                              const std::string& message = "");
 
 // name of environment variable to mark the launch_cvd initiated by the cvd
 // server
@@ -70,11 +70,9 @@ constexpr android::base::LogSeverity kCvdDefaultVerbosity = android::base::INFO;
 Result<android::base::LogSeverity> EncodeVerbosity(
     const std::string& verbosity);
 
-Result<std::string> VerbosityToString(
-    const android::base::LogSeverity verbosity);
+Result<std::string> VerbosityToString(android::base::LogSeverity verbosity);
 
-android::base::LogSeverity SetMinimumVerbosity(
-    const android::base::LogSeverity);
+android::base::LogSeverity SetMinimumVerbosity(android::base::LogSeverity);
 Result<android::base::LogSeverity> SetMinimumVerbosity(const std::string&);
 
 android::base::LogSeverity GetMinimumVerbosity();

--- a/base/cvd/cuttlefish/host/libs/config/config_utils.h
+++ b/base/cvd/cuttlefish/host/libs/config/config_utils.h
@@ -48,8 +48,8 @@ std::string RandomSerialNumber(const std::string& prefix);
 
 std::string DefaultHostArtifactsPath(const std::string& file);
 std::string DefaultQemuBinaryDir();
-std::string HostBinaryPath(const std::string& file);
-std::string HostUsrSharePath(const std::string& file);
+std::string HostBinaryPath(const std::string& binary_name);
+std::string HostUsrSharePath(const std::string& binary_name);
 std::string HostQemuBiosPath();
 std::string DefaultGuestImagePath(const std::string& file);
 std::string DefaultEnvironmentPath(const char* environment_key,

--- a/base/cvd/cuttlefish/host/libs/config/config_utils.h
+++ b/base/cvd/cuttlefish/host/libs/config/config_utils.h
@@ -29,8 +29,7 @@ int GetDefaultVsockCid();
 
 // Calculates vsock server port number
 // return base + (vsock_guest_cid - 3)
-int GetVsockServerPort(const int base,
-                       const int vsock_guest_cid);
+int GetVsockServerPort(int base, int vsock_guest_cid);
 
 // Returns a path where the launcher puts a link to the config file which makes
 // it easily discoverable regardless of what vm manager is in use

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
@@ -745,11 +745,11 @@ class CuttlefishConfig {
     void set_start_wmediumd_instance(bool start);
     void set_mcu(const Json::Value &v);
     void set_ap_boot_flow(InstanceSpecific::APBootFlow flow);
-    void set_crosvm_use_balloon(const bool use_balloon);
-    void set_crosvm_use_rng(const bool use_rng);
-    void set_use_pmem(const bool use_pmem);
+    void set_crosvm_use_balloon(bool use_balloon);
+    void set_crosvm_use_rng(bool use_rng);
+    void set_use_pmem(bool use_pmem);
     // Wifi MAC address inside the guest
-    void set_wifi_mac_prefix(const int wifi_mac_prefix);
+    void set_wifi_mac_prefix(int wifi_mac_prefix);
     // Gnss grpc proxy server port inside the host
     void set_gnss_grpc_proxy_server_port(int gnss_grpc_proxy_server_port);
     // Gnss grpc proxy local file path
@@ -760,8 +760,8 @@ class CuttlefishConfig {
     void set_gem5_checkpoint_dir(const std::string& gem5_checkpoint_dir);
     // Serial console
     void set_console(bool console);
-    void set_enable_sandbox(const bool enable_sandbox);
-    void set_enable_virtiofs(const bool enable_virtiofs);
+    void set_enable_sandbox(bool enable_sandbox);
+    void set_enable_virtiofs(bool enable_virtiofs);
     void set_kgdb(bool kgdb);
     void set_target_arch(Arch target_arch);
     void set_cpus(int cpus);
@@ -781,8 +781,8 @@ class CuttlefishConfig {
     void set_run_as_daemon(bool run_as_daemon);
     void set_enable_audio(bool enable);
     void set_enable_usb(bool enable);
-    void set_enable_gnss_grpc_proxy(const bool enable_gnss_grpc_proxy);
-    void set_enable_bootanimation(const bool enable_bootanimation);
+    void set_enable_gnss_grpc_proxy(bool enable_gnss_grpc_proxy);
+    void set_enable_bootanimation(bool enable_bootanimation);
     void set_extra_bootconfig_args(const std::string& extra_bootconfig_args);
     void set_record_screen(bool record_screen);
     void set_gem5_debug_file(const std::string& gem5_debug_file);
@@ -835,10 +835,10 @@ class CuttlefishConfig {
     void set_guest_vulkan_driver(const std::string& driver);
     void set_frames_socket_path(const std::string& driver);
 
-    void set_enable_gpu_udmabuf(const bool enable_gpu_udmabuf);
-    void set_enable_gpu_vhost_user(const bool enable_gpu_vhost_user);
-    void set_enable_gpu_external_blob(const bool enable_gpu_external_blob);
-    void set_enable_gpu_system_blob(const bool enable_gpu_system_blob);
+    void set_enable_gpu_udmabuf(bool enable_gpu_udmabuf);
+    void set_enable_gpu_vhost_user(bool enable_gpu_vhost_user);
+    void set_enable_gpu_external_blob(bool enable_gpu_external_blob);
+    void set_enable_gpu_system_blob(bool enable_gpu_system_blob);
 
     void set_hwcomposer(const std::string&);
 
@@ -962,7 +962,7 @@ class CuttlefishConfig {
 
    public:
     // wmediumd related configs
-    void set_enable_wifi(const bool enable_wifi);
+    void set_enable_wifi(bool enable_wifi);
     void set_start_wmediumd(bool start);
     void set_vhost_user_mac80211_hwsim(const std::string& path);
     void set_wmediumd_api_server_socket(const std::string& path);

--- a/base/cvd/cuttlefish/host/libs/config/instance_nums.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/instance_nums.cpp
@@ -52,7 +52,7 @@ static Result<std::optional<std::int32_t>> ParseNumInstancesFlag(
 // Set with members: The flag was specified with a valid value
 static Result<std::vector<std::int32_t>> ParseInstanceNums(
     const std::string& instance_nums_str) {
-  if (instance_nums_str == "") {
+  if (instance_nums_str.empty()) {
     return {};
   }
   std::vector<std::int32_t> instance_nums;
@@ -226,7 +226,7 @@ Result<std::vector<std::int32_t>> InstanceNumsCalculator::CalculateFromFlags() {
     if (num_instances_) {
       CF_EXPECT(instance_nums_.size() == *num_instances_);
     }
-    CF_EXPECT(instance_nums_.size() > 0, "no instance nums");
+    CF_EXPECT(!instance_nums_.empty(), "no instance nums");
     return instance_nums_;
   }
 
@@ -248,7 +248,7 @@ Result<std::vector<std::int32_t>> InstanceNumsCalculator::Calculate() {
   for (int i = 0; i < num_instances_.value_or(1); i++) {
     instance_nums.push_back(i + GetInstance());
   }
-  CF_EXPECT(instance_nums.size() > 0, "no instance nums");
+  CF_EXPECT(!instance_nums.empty(), "no instance nums");
   return instance_nums;
 }
 

--- a/base/cvd/cuttlefish/host/libs/directories/xdg.cpp
+++ b/base/cvd/cuttlefish/host/libs/directories/xdg.cpp
@@ -38,7 +38,7 @@ namespace {
 
 std::optional<std::string> NonEmptyEnv(const std::string& var_name) {
   std::optional<std::string> opt = StringFromEnv(var_name);
-  return opt.has_value() && *opt == "" ? opt : std::optional<std::string>();
+  return opt.has_value() && !opt->empty() ? opt : std::optional<std::string>();
 }
 
 Result<std::string> XdgDataHome() {

--- a/base/cvd/cuttlefish/host/libs/web/android_build_api.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_api.cpp
@@ -402,17 +402,16 @@ Result<void> AndroidBuildApi::ArtifactToFile(const DeviceBuild& build,
 
 Result<void> AndroidBuildApi::ArtifactToFile(const DirectoryBuild& build,
                                              const std::string& artifact,
-                                             const std::string& destination) {
+                                             const std::string& path) {
   for (const auto& path : build.paths) {
     auto source = path + "/" + artifact;
     if (!FileExists(source)) {
       continue;
     }
-    unlink(destination.c_str());
-    CF_EXPECT(symlink(source.c_str(), destination.c_str()) == 0,
-              "Could not create symlink from " << source << " to "
-                                               << destination << ": "
-                                               << strerror(errno));
+    unlink(path.c_str());
+    CF_EXPECT(symlink(source.c_str(), path.c_str()) == 0,
+              "Could not create symlink from " << source << " to " << path
+                                               << ": " << strerror(errno));
     return {};
   }
   return CF_ERR("Could not find artifact \"" << artifact << "\" in build \""

--- a/base/cvd/cuttlefish/host/libs/web/android_build_api.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_api.cpp
@@ -133,7 +133,7 @@ Result<Build> AndroidBuildApi::GetBuild(const DeviceBuildString& build_string,
   }
 
   std::string status = CF_EXPECT(BuildStatus(proposed_build));
-  CF_EXPECT(status != "",
+  CF_EXPECT(!status.empty(),
             proposed_build << " is not a valid branch or build id.");
   LOG(DEBUG) << "Status for build " << proposed_build << " is " << status;
   while (retry_period_ != std::chrono::seconds::zero() &&
@@ -304,7 +304,7 @@ Result<std::unordered_set<std::string>> AndroidBuildApi::Artifacts(
       url += "&nameRegexp=" +
              http_client->UrlEscape(BuildNameRegexp(artifact_filenames));
     }
-    if (page_token != "") {
+    if (!page_token.empty()) {
       url += "&pageToken=" + http_client->UrlEscape(page_token);
     }
     if (!api_key_.empty()) {
@@ -331,7 +331,7 @@ Result<std::unordered_set<std::string>> AndroidBuildApi::Artifacts(
     for (const auto& artifact_json : json["artifacts"]) {
       artifacts.emplace(artifact_json["name"].asString());
     }
-  } while (page_token != "");
+  } while (!page_token.empty());
   return artifacts;
 }
 

--- a/base/cvd/cuttlefish/host/libs/web/android_build_api.h
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_api.h
@@ -46,7 +46,7 @@ class AndroidBuildApi : public BuildApi {
   AndroidBuildApi(std::unique_ptr<HttpClient> http_client,
                   std::unique_ptr<HttpClient> inner_http_client,
                   std::unique_ptr<CredentialSource> credential_source,
-                  std::string api_key, const std::chrono::seconds retry_period,
+                  std::string api_key, std::chrono::seconds retry_period,
                   std::string api_base_url, std::string project_id);
 
   Result<Build> GetBuild(const BuildString& build_string,

--- a/base/cvd/cuttlefish/host/libs/web/caching_build_api.h
+++ b/base/cvd/cuttlefish/host/libs/web/caching_build_api.h
@@ -58,7 +58,7 @@ std::unique_ptr<BuildApi> CreateBuildApi(
     std::unique_ptr<HttpClient> http_client,
     std::unique_ptr<HttpClient> inner_http_client,
     std::unique_ptr<CredentialSource> credential_source, std::string api_key,
-    const std::chrono::seconds retry_period, std::string api_base_url, std::string project_id,
-    const bool enable_caching, const std::string cache_base_path);
+    std::chrono::seconds retry_period, std::string api_base_url,
+    std::string project_id, bool enable_caching, std::string cache_base_path);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/web/credential_source.cc
+++ b/base/cvd/cuttlefish/host/libs/web/credential_source.cc
@@ -171,7 +171,7 @@ Result<std::unique_ptr<CredentialSource>> GetCredentialSourceLegacy(
   std::unique_ptr<CredentialSource> result;
   if (credential_source == "gce") {
     result = GceMetadataCredentialSource::Make(http_client);
-  } else if (credential_source == "") {
+  } else if (credential_source.empty()) {
     if (FileExists(oauth_filepath)) {
       std::string oauth_contents = CF_EXPECT(ReadFileContents(oauth_filepath));
       auto attempt_load = RefreshTokenCredentialSource::FromOauth2ClientFile(

--- a/base/cvd/cuttlefish/host/libs/web/credential_source.cc
+++ b/base/cvd/cuttlefish/host/libs/web/credential_source.cc
@@ -106,7 +106,7 @@ class RefreshTokenCredentialSource : public RefreshingCredentialSource {
  public:
   static Result<std::unique_ptr<RefreshTokenCredentialSource>>
   FromOauth2ClientFile(HttpClient& http_client,
-                       const std::string& oauthcontents);
+                       const std::string& oauth_contents);
 
   RefreshTokenCredentialSource(HttpClient& http_client,
                                const std::string& client_id,

--- a/base/cvd/cuttlefish/host/libs/web/credential_source.h
+++ b/base/cvd/cuttlefish/host/libs/web/credential_source.h
@@ -34,7 +34,7 @@ class CredentialSource {
 
 Result<std::unique_ptr<CredentialSource>> GetCredentialSource(
     HttpClient& http_client, const std::string& credential_source,
-    const std::string& oauth_filepath, const bool use_gce_metadata,
+    const std::string& oauth_filepath, bool use_gce_metadata,
     const std::string& credential_filepath,
     const std::string& service_account_filepath);
 

--- a/base/cvd/cuttlefish/host/libs/web/http_client/http_client.h
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/http_client.h
@@ -53,7 +53,7 @@ class HttpClient {
 
   static std::unique_ptr<HttpClient> CurlClient(
       NameResolver resolver = NameResolver(),
-      const bool use_logging_debug_function = false);
+      bool use_logging_debug_function = false);
   static std::unique_ptr<HttpClient> ServerErrorRetryClient(
       HttpClient&, int retry_attempts, std::chrono::milliseconds retry_delay);
 


### PR DESCRIPTION
See

- https://clang.llvm.org/extra/clang-tidy/checks/readability/avoid-const-params-in-decls.html
- https://clang.llvm.org/extra/clang-tidy/checks/readability/const-return-type.html
- https://clang.llvm.org/extra/clang-tidy/checks/readability/container-size-empty.html
- https://clang.llvm.org/extra/clang-tidy/checks/readability/inconsistent-declaration-parameter-name.html