### PR TITLE
Expose `gpu_mode` parameter in env config.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags_defaults.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags_defaults.h
@@ -136,7 +136,7 @@
 
 // Graphics default parameters
 #define CF_DEFAULTS_HWCOMPOSER cuttlefish::kHwComposerAuto
-#define CF_DEFAULTS_GPU_MODE cuttlefish::kGpuModeAuto
+#define CF_DEFAULTS_GPU_MODE "auto"
 #define CF_DEFAULTS_GPU_VHOST_USER_MODE cuttlefish::kGpuVhostUserModeAuto
 #define CF_DEFAULTS_RECORD_SCREEN false
 #define CF_DEFAULTS_GPU_CAPTURE_BINARY CF_DEFAULTS_DYNAMIC_STRING

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_graphics_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_graphics_configs.cpp
@@ -89,11 +89,19 @@ bool RecordScreen(const Instance& instance) {
   }
 }
 
+std::string GpuMode(const Instance& instance) {
+  if (instance.graphics().has_gpu_mode()) {
+    return instance.graphics().gpu_mode();
+  }
+  return CF_DEFAULTS_GPU_MODE;
+}
+
 Result<std::vector<std::string>> GenerateGraphicsFlags(
     const EnvironmentSpecification& cfg) {
   return std::vector<std::string>{
       CF_EXPECT(GenerateDisplayFlag(cfg)),
       GenerateInstanceFlag("record_screen", cfg, RecordScreen),
+      GenerateInstanceFlag("gpu_mode", cfg, GpuMode),
   };
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_config.proto
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_config.proto
@@ -78,6 +78,7 @@ message Vsock {
 message Graphics {
   repeated Display displays = 1;
   optional bool record_screen = 2;
+  optional string gpu_mode = 3;
 }
 
 message Display {


### PR DESCRIPTION
- Allow to snapshot devices created with environment configurations.  When using an environment configuration file there's no way to fixate `guest_swiftshader` as the gpu mode, hence in machines where the gpu mode does not resolve to `guest_swiftshader` we cannot create snapshotable instances when using environment configuration file, e.g.  `cvd create --config_file=/tmp/config.json`