### PR TITLE
Add merge-group event to support merge queues

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -1,6 +1,6 @@
 name: Presubmit 
 
-on: [pull_request, push]
+on: [merge_group, pull_request, push]
 
 jobs:
   build-orchestrator:


### PR DESCRIPTION
reference:
https://github.com/google/android-cuttlefish/blob/main/.github/workflows/presubmit.yaml


If I have understood correctly, once this is merged our Github presubmit checks will trigger when we add completed PRs to the Merge Queue.  Cody already submitted the necessary Kokoro changes.

With that in place, we can add "Require merge queue" to our branch ruleset and have presubmits run against queued PRs.  Then we will no longer need to manually rebase and update PRs when multiple changes are submitted

Bug: 341333157