### PR TITLE
Enforce more clang-tidy checks that are already conformed to

### DIFF
--- a/base/cvd/.clang-tidy
+++ b/base/cvd/.clang-tidy
@@ -5,10 +5,16 @@ Checks: &checks >-
   clang-analyzer-*,
   clang-diagnostic-*,
   -clang-diagnostic-pragma-once-outside-header,
+  misc-definitions-in-headers,
+  misc-static-assert,
+  misc-unused-alias-decls,
   readability-avoid-const-params-in-decls,
   readability-const-return-type,
   readability-container-size-empty,
   readability-inconsistent-declaration-parameter-name,
+  readability-misleading-indentation,
+  readability-redundant-control-flow,
+  readability-string-compare,
 
 UseColor: true
 


### PR DESCRIPTION
- https://clang.llvm.org/extra/clang-tidy/checks/misc/definitions-in-headers.html
- https://clang.llvm.org/extra/clang-tidy/checks/misc/static-assert.html
- https://clang.llvm.org/extra/clang-tidy/checks/misc/unused-alias-decls.html
- https://clang.llvm.org/extra/clang-tidy/checks/readability/misleading-indentation.html
- https://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-control-flow.html
- https://clang.llvm.org/extra/clang-tidy/checks/readability/string-compare.html

Bug: b/379161812