### PR TITLE
Remove the `merge_group` event from our actions

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -1,6 +1,6 @@
 name: Artifacts
 on:
-  pull_request: &reusable_block_anchor
+  pull_request:
     paths:
       - '.github/workflows/artifacts.yaml'
       - 'tools/buildimage/**'
@@ -90,5 +90,3 @@ jobs:
       with:
         name: docker-image-arm64
         path: ${{ env.arm64_image_path }}
-  # identical to the `pull_request` block above using YAML anchor there and alias here
-  merge_group: *reusable_block_anchor

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -1,6 +1,6 @@
 name: Presubmit 
 
-on: [merge_group, pull_request, push]
+on: [pull_request, push]
 
 jobs:
   build-orchestrator:


### PR DESCRIPTION
This change fixes a broken job and removes a duplicate job run.

The anchor and alias syntax appears to have broken the `artifacts` job. That syntax might not be supported, or it is not done in the correct way for Github's parsing.

For the merge queue, since "entering" the merge queue involves a temporary branch being created we are already getting the `presubmit` jobs triggered by `push`.  So PRs in the queue are double running jobs.

Bug: 341333157