### PR TITLE
Ignore push events to `main` for presubmit

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -1,6 +1,10 @@
 name: Presubmit 
 
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - main  # push events to main branch occur after PRs are merged, when the same checks were run
 
 jobs:
   build-orchestrator:


### PR DESCRIPTION
These jobs are already run before PRs are merged into `main`.  The `pull_request`, `push` to topic branches, and `push` to temporary merge queue branches already covers the verification steps.  The extra run on `push` to `main` is non-blocking.

Bug: 341333157