### PR TITLE
Upgrade CF host packages when running docker instance

### DIFF
--- a/docker/guest/run_services.sh
+++ b/docker/guest/run_services.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+apt update
+apt --only-upgrade install \
+  cuttlefish-base \
+  cuttlefish-user \
+  cuttlefish-orchestration
+
 service nginx start
 service cuttlefish-host-resources start
 service cuttlefish-operator start


### PR DESCRIPTION
Estimated time for `apt update`: 3 seconds
Estimated time for `apt --only-upgrade install`: 7 seconds