### PR TITLE
Fold `CommandInvocation` into `CommandRequest`

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/acloud/converter.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/acloud/converter.cpp
@@ -145,7 +145,7 @@ namespace acloud_impl {
 
 Result<ConvertedAcloudCreateCommand> ConvertAcloudCreate(
     const CommandRequest& request) {
-  auto arguments = ParseInvocation(request).arguments;
+  std::vector<std::string> arguments = request.SubcommandArguments();
   CF_EXPECT(!arguments.empty());
   CF_EXPECT(arguments[0] == "create");
   arguments.erase(arguments.begin());

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/command_request.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/command_request.cpp
@@ -25,53 +25,25 @@
 #include "host/commands/cvd/cli/selector/selector_common_parser.h"
 
 namespace cuttlefish {
-namespace {
-
-struct CommandInvocation {
-  std::string command;
-  std::vector<std::string> arguments;
-};
-
-CommandInvocation ParseInvocation(const CommandRequest& request) {
-  CommandInvocation invocation;
-  invocation.arguments = request.Args();
-  if (invocation.arguments.empty()) {
-    return invocation;
-  }
-  invocation.arguments[0] = cpp_basename(invocation.arguments[0]);
-  if (invocation.arguments[0] == "cvd" && invocation.arguments.size() > 1) {
-    invocation.command = invocation.arguments[1];
-    invocation.arguments.erase(invocation.arguments.begin());
-    invocation.arguments.erase(invocation.arguments.begin());
-  } else {
-    invocation.command = invocation.arguments[0];
-    invocation.arguments.erase(invocation.arguments.begin());
-  }
-  return invocation;
-}
-
-}  // namespace
 
 CommandRequest::CommandRequest(cvd_common::Args args, cvd_common::Envs env,
                                selector::SelectorOptions selectors)
     : args_(std::move(args)),
       env_(std::move(env)),
-      selectors_(std::move(selectors)) {}
-
-const cvd_common::Args& CommandRequest::Args() const { return args_; }
-
-const selector::SelectorOptions& CommandRequest::Selectors() const {
-  return selectors_;
-}
-
-const cvd_common::Envs& CommandRequest::Env() const { return env_; }
-
-std::string CommandRequest::Subcommand() const {
-  return ParseInvocation(*this).command;
-}
-
-std::vector<std::string> CommandRequest::SubcommandArguments() const {
-  return ParseInvocation(*this).arguments;
+      selectors_(std::move(selectors)) {
+  subcommand_arguments_ = args_;
+  if (subcommand_arguments_.empty()) {
+    return;
+  }
+  subcommand_arguments_[0] = cpp_basename(subcommand_arguments_[0]);
+  if (subcommand_arguments_[0] == "cvd" && subcommand_arguments_.size() > 1) {
+    subcommand_ = subcommand_arguments_[1];
+    subcommand_arguments_.erase(subcommand_arguments_.begin());
+    subcommand_arguments_.erase(subcommand_arguments_.begin());
+  } else {
+    subcommand_ = subcommand_arguments_[0];
+    subcommand_arguments_.erase(subcommand_arguments_.begin());
+  }
 }
 
 CommandRequestBuilder& CommandRequestBuilder::AddArguments(

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/command_request.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/command_request.cpp
@@ -22,6 +22,7 @@
 #include "common/libs/utils/result.h"
 #include "host/commands/cvd/cli/command_request.h"
 #include "host/commands/cvd/cli/selector/selector_common_parser.h"
+#include "host/commands/cvd/cli/utils.h"
 
 namespace cuttlefish {
 
@@ -38,6 +39,14 @@ const selector::SelectorOptions& CommandRequest::Selectors() const {
 }
 
 const cvd_common::Envs& CommandRequest::Env() const { return env_; }
+
+std::string CommandRequest::Subcommand() const {
+  return ParseInvocation(*this).command;
+}
+
+std::vector<std::string> CommandRequest::SubcommandArguments() const {
+  return ParseInvocation(*this).arguments;
+}
 
 CommandRequestBuilder& CommandRequestBuilder::AddArguments(
     std::initializer_list<std::string_view> args) & {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/command_request.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/command_request.cpp
@@ -19,12 +19,38 @@
 #include <string>
 #include <vector>
 
+#include "common/libs/utils/files.h"
 #include "common/libs/utils/result.h"
 #include "host/commands/cvd/cli/command_request.h"
 #include "host/commands/cvd/cli/selector/selector_common_parser.h"
-#include "host/commands/cvd/cli/utils.h"
 
 namespace cuttlefish {
+namespace {
+
+struct CommandInvocation {
+  std::string command;
+  std::vector<std::string> arguments;
+};
+
+CommandInvocation ParseInvocation(const CommandRequest& request) {
+  CommandInvocation invocation;
+  invocation.arguments = request.Args();
+  if (invocation.arguments.empty()) {
+    return invocation;
+  }
+  invocation.arguments[0] = cpp_basename(invocation.arguments[0]);
+  if (invocation.arguments[0] == "cvd" && invocation.arguments.size() > 1) {
+    invocation.command = invocation.arguments[1];
+    invocation.arguments.erase(invocation.arguments.begin());
+    invocation.arguments.erase(invocation.arguments.begin());
+  } else {
+    invocation.command = invocation.arguments[0];
+    invocation.arguments.erase(invocation.arguments.begin());
+  }
+  return invocation;
+}
+
+}  // namespace
 
 CommandRequest::CommandRequest(cvd_common::Args args, cvd_common::Envs env,
                                selector::SelectorOptions selectors)

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/command_request.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/command_request.h
@@ -36,14 +36,16 @@ namespace cuttlefish {
 
 class CommandRequest {
  public:
-  const cvd_common::Args& Args() const;
+  const cvd_common::Args& Args() const { return args_; }
 
-  const cvd_common::Envs& Env() const;
+  const cvd_common::Envs& Env() const { return env_; }
 
-  const selector::SelectorOptions& Selectors() const;
+  const selector::SelectorOptions& Selectors() const { return selectors_; }
 
-  std::string Subcommand() const;
-  std::vector<std::string> SubcommandArguments() const;
+  const std::string& Subcommand() const { return subcommand_; }
+  const std::vector<std::string>& SubcommandArguments() const {
+    return subcommand_arguments_;
+  }
 
  private:
   friend class CommandRequestBuilder;
@@ -53,6 +55,9 @@ class CommandRequest {
   cvd_common::Args args_;
   cvd_common::Envs env_;
   selector::SelectorOptions selectors_;
+
+  std::string subcommand_;
+  std::vector<std::string> subcommand_arguments_;
 };
 
 class CommandRequestBuilder {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/command_request.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/command_request.h
@@ -42,6 +42,9 @@ class CommandRequest {
 
   const selector::SelectorOptions& Selectors() const;
 
+  std::string Subcommand() const;
+  std::vector<std::string> SubcommandArguments() const;
+
  private:
   friend class CommandRequestBuilder;
   CommandRequest(cvd_common::Args args, cvd_common::Envs env,

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_command.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_command.cpp
@@ -58,15 +58,15 @@ class AcloudCommand : public CvdServerHandler {
   ~AcloudCommand() = default;
 
   Result<bool> CanHandle(const CommandRequest& request) const override {
-    auto invocation = ParseInvocation(request);
-    if (invocation.arguments.size() >= 2) {
-      if (invocation.command == "acloud" &&
-          (invocation.arguments[0] == "translator" ||
-           invocation.arguments[0] == "mix-super-image")) {
+    std::vector<std::string> subcmd_args = request.SubcommandArguments();
+    if (subcmd_args.size() >= 2) {
+      if (request.Subcommand() == "acloud" &&
+          (subcmd_args[0] == "translator" ||
+           subcmd_args[0] == "mix-super-image")) {
         return false;
       }
     }
-    return invocation.command == "acloud";
+    return request.Subcommand() == "acloud";
   }
 
   cvd_common::Args CmdList() const override { return {"acloud"}; }
@@ -162,7 +162,7 @@ Result<ConvertedAcloudCreateCommand> AcloudCommand::ValidateLocal(
 }
 
 bool AcloudCommand::ValidateRemoteArgs(const CommandRequest& request) {
-  auto args = ParseInvocation(request).arguments;
+  std::vector<std::string> args = request.SubcommandArguments();
   return acloud_impl::CompileFromAcloudToCvdr(args).ok();
 }
 
@@ -236,7 +236,7 @@ Result<void> AcloudCommand::PrepareForDeleteCommand(
 
 Result<cvd::Response> AcloudCommand::HandleRemote(
     const CommandRequest& request) {
-  auto args = ParseInvocation(request).arguments;
+  std::vector<std::string> args = request.SubcommandArguments();
   args = CF_EXPECT(acloud_impl::CompileFromAcloudToCvdr(args));
   Command cmd = Command("cvdr");
   for (auto a : args) {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_common.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_common.cpp
@@ -16,16 +16,13 @@
 
 #include "host/commands/cvd/cli/commands/acloud_common.h"
 
-#include "host/commands/cvd/cli/utils.h"
-
 namespace cuttlefish {
 
 bool IsSubOperationSupported(const CommandRequest& request) {
-  auto invocation = ParseInvocation(request);
-  if (invocation.arguments.empty()) {
+  if (request.SubcommandArguments().empty()) {
     return false;
   }
-  return invocation.arguments[0] == "create";
+  return request.Subcommand() == "create";
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_mixsuperimage.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_mixsuperimage.cpp
@@ -158,10 +158,10 @@ class AcloudMixSuperImageCommand : public CvdServerHandler {
   ~AcloudMixSuperImageCommand() = default;
 
   Result<bool> CanHandle(const CommandRequest& request) const override {
-    auto invocation = ParseInvocation(request);
-    if (invocation.arguments.size() >= 2) {
-      if (invocation.command == "acloud" &&
-          invocation.arguments[0] == "mix-super-image") {
+    std::vector<std::string> subcmd_args = request.SubcommandArguments();
+    if (subcmd_args.size() >= 2) {
+      if (request.Subcommand() == "acloud" &&
+          subcmd_args[0] == "mix-super-image") {
         return true;
       }
     }
@@ -179,8 +179,8 @@ class AcloudMixSuperImageCommand : public CvdServerHandler {
 
   Result<cvd::Response> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
-    auto invocation = ParseInvocation(request);
-    if (invocation.arguments.empty() || invocation.arguments.size() < 2) {
+    std::vector<std::string> subcmd_args = request.SubcommandArguments();
+    if (subcmd_args.empty() || subcmd_args.size() < 2) {
       return CF_ERR("Acloud mix-super-image command not support");
     }
 
@@ -193,7 +193,7 @@ class AcloudMixSuperImageCommand : public CvdServerHandler {
         GflagsCompatFlag("help", help),
         GflagsCompatFlag("super_image", flag_paths),
     };
-    CF_EXPECT(ConsumeFlags(mixsuperimage_flags, invocation.arguments),
+    CF_EXPECT(ConsumeFlags(mixsuperimage_flags, subcmd_args),
               "Failed to process mix-super-image flag.");
     if (help) {
       std::cout << kMixSuperImageHelpMessage;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_translator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_translator.cpp
@@ -43,10 +43,9 @@ class AcloudTranslatorCommand : public CvdServerHandler {
   ~AcloudTranslatorCommand() = default;
 
   Result<bool> CanHandle(const CommandRequest& request) const override {
-    auto invocation = ParseInvocation(request);
-    if (invocation.arguments.size() >= 2) {
-      if (invocation.command == "acloud" &&
-          invocation.arguments[0] == "translator") {
+    std::vector<std::string> subcmd_args = request.SubcommandArguments();
+    if (subcmd_args.size() >= 2) {
+      if (request.Subcommand() == "acloud" && subcmd_args[0] == "translator") {
         return true;
       }
     }
@@ -64,8 +63,8 @@ class AcloudTranslatorCommand : public CvdServerHandler {
 
   Result<cvd::Response> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
-    auto invocation = ParseInvocation(request);
-    if (invocation.arguments.empty() || invocation.arguments.size() < 2) {
+    std::vector<std::string> subcmd_args = request.SubcommandArguments();
+    if (subcmd_args.empty() || subcmd_args.size() < 2) {
       return CF_ERR("Translator command not support");
     }
 
@@ -81,7 +80,7 @@ class AcloudTranslatorCommand : public CvdServerHandler {
         GflagsCompatFlag("opt-out", flag_optout),
         GflagsCompatFlag("opt-in", flag_optin),
     };
-    CF_EXPECT(ConsumeFlags(translator_flags, invocation.arguments),
+    CF_EXPECT(ConsumeFlags(translator_flags, subcmd_args),
               "Failed to process translator flag.");
     if (help) {
       std::cout << kTranslatorHelpMessage;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/bugreport.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/bugreport.cpp
@@ -72,8 +72,7 @@ CvdBugreportCommandHandler::CvdBugreportCommandHandler(
 
 Result<bool> CvdBugreportCommandHandler::CanHandle(
     const CommandRequest& request) const {
-  auto invocation = ParseInvocation(request);
-  return Contains(commands_, invocation.command);
+  return Contains(commands_, request.Subcommand());
 }
 
 Result<cvd::Response> CvdBugreportCommandHandler::Handle(
@@ -83,7 +82,7 @@ Result<cvd::Response> CvdBugreportCommandHandler::Handle(
   cvd::Response response;
   response.mutable_command_response();
 
-  auto [subcmd, cmd_args] = ParseInvocation(request);
+  std::vector<std::string> cmd_args = request.SubcommandArguments();
   cvd_common::Envs env = request.Env();
 
   std::string android_host_out;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/clear.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/clear.cpp
@@ -32,7 +32,7 @@
 namespace cuttlefish {
 namespace {
 
-constexpr char clearCmd[] = "clear";
+constexpr char kClearCmd[] = "clear";
 constexpr char kSummaryHelpText[] =
     "Clears the instance databaase, stopping any running instances first.";
 
@@ -57,8 +57,7 @@ CvdClearCommandHandler::CvdClearCommandHandler(
 
 Result<bool> CvdClearCommandHandler::CanHandle(
     const CommandRequest& request) const {
-  auto invocation = ParseInvocation(request);
-  return invocation.command == clearCmd;
+  return request.Subcommand() == kClearCmd;
 }
 
 Result<cvd::Response> CvdClearCommandHandler::Handle(
@@ -68,7 +67,7 @@ Result<cvd::Response> CvdClearCommandHandler::Handle(
   cvd::Response response;
   response.mutable_command_response();
 
-  auto [subcmd, cmd_args] = ParseInvocation(request);
+  std::vector<std::string> cmd_args = request.SubcommandArguments();
 
   if (CF_EXPECT(IsHelpSubcmd(cmd_args))) {
     std::cout << kSummaryHelpText << std::endl;
@@ -80,7 +79,7 @@ Result<cvd::Response> CvdClearCommandHandler::Handle(
 }
 
 std::vector<std::string> CvdClearCommandHandler::CmdList() const {
-  return {clearCmd};
+  return {kClearCmd};
 }
 
 Result<std::string> CvdClearCommandHandler::SummaryHelp() const {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/cmd_list.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/cmd_list.cpp
@@ -22,7 +22,6 @@
 #include <json/value.h>
 
 #include "host/commands/cvd/cli/commands/server_handler.h"
-#include "host/commands/cvd/cli/utils.h"
 #include "host/commands/cvd/cli/types.h"
 
 namespace cuttlefish {
@@ -32,8 +31,7 @@ class CvdCmdlistHandler : public CvdServerHandler {
   CvdCmdlistHandler(CommandSequenceExecutor& executor) : executor_(executor) {}
 
   Result<bool> CanHandle(const CommandRequest& request) const override {
-    auto invocation = ParseInvocation(request);
-    return (invocation.command == "cmd-list");
+    return request.Subcommand() == "cmd-list";
   }
 
   Result<cvd::Response> Handle(const CommandRequest& request) override {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
@@ -267,8 +267,7 @@ void CvdCreateCommandHandler::MarkLockfiles(
 
 Result<bool> CvdCreateCommandHandler::CanHandle(
     const CommandRequest& request) const {
-  auto invocation = ParseInvocation(request);
-  return Contains(CmdList(), invocation.command);
+  return Contains(CmdList(), request.Subcommand());
 }
 
 Result<LocalInstanceGroup> CvdCreateCommandHandler::GetOrCreateGroup(
@@ -360,7 +359,7 @@ Result<void> CvdCreateCommandHandler::CreateSymlinks(
 Result<cvd::Response> CvdCreateCommandHandler::Handle(
     const CommandRequest& request) {
   CF_EXPECT(CanHandle(request));
-  auto [subcmd, subcmd_args] = ParseInvocation(request);
+  std::vector<std::string> subcmd_args = request.SubcommandArguments();
   bool is_help = CF_EXPECT(IsHelpSubcmd(subcmd_args));
   CF_EXPECT(!is_help);
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/display.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/display.cpp
@@ -57,15 +57,14 @@ class CvdDisplayCommandHandler : public CvdServerHandler {
         cvd_display_operations_{"display"} {}
 
   Result<bool> CanHandle(const CommandRequest& request) const override {
-    auto invocation = ParseInvocation(request);
-    return Contains(cvd_display_operations_, invocation.command);
+    return Contains(cvd_display_operations_, request.Subcommand());
   }
 
   Result<cvd::Response> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
     const cvd_common::Envs& env = request.Env();
 
-    auto [_, subcmd_args] = ParseInvocation(request);
+    std::vector<std::string> subcmd_args = request.SubcommandArguments();
 
     bool is_help = CF_EXPECT(IsHelp(subcmd_args));
     // may modify subcmd_args by consuming in parsing

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/env.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/env.cpp
@@ -50,15 +50,14 @@ class CvdEnvCommandHandler : public CvdServerHandler {
       : instance_manager_{instance_manager}, cvd_env_operations_{"env"} {}
 
   Result<bool> CanHandle(const CommandRequest& request) const override {
-    auto invocation = ParseInvocation(request);
-    return Contains(cvd_env_operations_, invocation.command);
+    return Contains(cvd_env_operations_, request.Subcommand());
   }
 
   Result<cvd::Response> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
     const cvd_common::Envs& env = request.Env();
 
-    auto [_, subcmd_args] = ParseInvocation(request);
+    std::vector<std::string> subcmd_args = request.SubcommandArguments();
 
     /*
      * cvd_env --help only. Not --helpxml, etc.

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.cpp
@@ -46,8 +46,7 @@ class CvdFetchCommandHandler : public CvdServerHandler {
 
 Result<bool> CvdFetchCommandHandler::CanHandle(
     const CommandRequest& request) const {
-  auto invocation = ParseInvocation(request);
-  return Contains(fetch_cmd_list_, invocation.command);
+  return Contains(fetch_cmd_list_, request.Subcommand());
 }
 
 Result<cvd::Response> CvdFetchCommandHandler::Handle(
@@ -57,7 +56,7 @@ Result<cvd::Response> CvdFetchCommandHandler::Handle(
   std::vector<std::string> args;
   args.emplace_back("fetch_cvd");
 
-  for (const auto& argument : ParseInvocation(request).arguments) {
+  for (const auto& argument : request.SubcommandArguments()) {
     args.emplace_back(argument);
   }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fleet.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fleet.cpp
@@ -23,7 +23,6 @@
 #include "common/libs/utils/result.h"
 #include "host/commands/cvd/cli/command_request.h"
 #include "host/commands/cvd/cli/commands/server_handler.h"
-#include "host/commands/cvd/cli/utils.h"
 #include "host/commands/cvd/cli/types.h"
 
 namespace cuttlefish {
@@ -63,8 +62,7 @@ class CvdFleetCommandHandler : public CvdServerHandler {
 
 Result<bool> CvdFleetCommandHandler::CanHandle(
     const CommandRequest& request) const {
-  auto invocation = ParseInvocation(request);
-  return invocation.command == kFleetSubcmd;
+  return request.Subcommand() == kFleetSubcmd;
 }
 
 Result<cvd::Response> CvdFleetCommandHandler::Handle(
@@ -76,7 +74,7 @@ Result<cvd::Response> CvdFleetCommandHandler::Handle(
   auto& status = *ok_response.mutable_status();
   status.set_code(cvd::Status::OK);
 
-  auto [sub_cmd, args] = ParseInvocation(request);
+  std::vector<std::string> args = request.SubcommandArguments();
 
   if (IsHelp(args)) {
     std::cout << kHelpMessage;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/help.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/help.cpp
@@ -77,14 +77,13 @@ class CvdHelpHandler : public CvdServerHandler {
       : request_handlers_(request_handlers) {}
 
   Result<bool> CanHandle(const CommandRequest& request) const override {
-    auto invocation = ParseInvocation(request);
-    return (invocation.command == "help");
+    return request.Subcommand() == "help";
   }
 
   Result<cvd::Response> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
 
-    auto args = ParseInvocation(request).arguments;
+    std::vector<std::string> args = request.SubcommandArguments();
     if (args.empty()) {
       std::cout << CF_EXPECT(TopLevelHelp());
     } else {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/lint.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/lint.cpp
@@ -22,10 +22,9 @@
 
 #include "common/libs/utils/files.h"
 #include "common/libs/utils/result.h"
-#include "host/commands/cvd/cli/parser/load_configs_parser.h"
 #include "host/commands/cvd/cli/command_request.h"
 #include "host/commands/cvd/cli/commands/server_handler.h"
-#include "host/commands/cvd/cli/utils.h"
+#include "host/commands/cvd/cli/parser/load_configs_parser.h"
 #include "host/commands/cvd/cli/types.h"
 
 namespace cuttlefish {
@@ -48,14 +47,13 @@ class LintCommandHandler : public CvdServerHandler {
   LintCommandHandler() {}
 
   Result<bool> CanHandle(const CommandRequest& request) const override {
-    auto invocation = ParseInvocation(request);
-    return invocation.command == kLintSubCmd;
+    return request.Subcommand() == kLintSubCmd;
   }
 
   Result<cvd::Response> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
 
-    auto args = ParseInvocation(request).arguments;
+    std::vector<std::string> args = request.SubcommandArguments();
     auto working_directory = CurrentDirectory();
     const auto config_path = CF_EXPECT(ValidateConfig(args, working_directory));
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.cpp
@@ -53,7 +53,7 @@ The --override flag can be used to give new values for properties in the config 
 )";
 
 Result<CvdFlags> GetCvdFlags(const CommandRequest& request) {
-  auto args = ParseInvocation(request).arguments;
+  std::vector<std::string> args = request.SubcommandArguments();
   auto working_directory = CurrentDirectory();
   const LoadFlags flags = CF_EXPECT(GetFlags(args, working_directory));
   return CF_EXPECT(GetCvdFlags(flags));
@@ -69,8 +69,7 @@ class LoadConfigsCommand : public CvdServerHandler {
   ~LoadConfigsCommand() = default;
 
   Result<bool> CanHandle(const CommandRequest& request) const override {
-    auto invocation = ParseInvocation(request);
-    return invocation.command == kLoadSubCmd;
+    return request.Subcommand() == kLoadSubCmd;
   }
 
   Result<cvd::Response> Handle(const CommandRequest& request) override {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/login.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/login.cpp
@@ -22,10 +22,11 @@
 
 #include <zlib.h>
 
+#include <android-base/strings.h>
+
 #include "common/libs/utils/environment.h"
 #include "common/libs/utils/flag_parser.h"
 #include "host/commands/cvd/cli/commands/server_handler.h"
-#include "host/commands/cvd/cli/utils.h"
 #include "host/libs/web/http_client/curl_global_init.h"
 #include "host/libs/web/http_client/http_client.h"
 #include "host/libs/web/oauth2_consent.h"
@@ -47,8 +48,7 @@ usage: cvd login --client_id=CLIENT_ID --client_secret=SECRET --scopes=SCOPES [-
 class CvdLoginCommand : public CvdServerHandler {
  public:
   Result<bool> CanHandle(const CommandRequest& request) const override {
-    CommandInvocation invocation = ParseInvocation(request);
-    return invocation.command == "login";
+    return request.Subcommand() == "login";
   }
 
   Result<cvd::Response> Handle(const CommandRequest& request) override {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/noop.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/noop.cpp
@@ -20,7 +20,6 @@
 
 #include "common/libs/utils/contains.h"
 #include "common/libs/utils/result.h"
-#include "host/commands/cvd/cli/utils.h"
 
 namespace cuttlefish {
 namespace {
@@ -33,14 +32,12 @@ class CvdNoopHandler : public CvdServerHandler {
   CvdNoopHandler() = default;
 
   Result<bool> CanHandle(const CommandRequest& request) const override {
-    auto invocation = ParseInvocation(request);
-    return Contains(CmdList(), invocation.command);
+    return Contains(CmdList(), request.Subcommand());
   }
 
   Result<cvd::Response> Handle(const CommandRequest& request) override {
-    auto invocation = ParseInvocation(request);
     fmt::print(std::cout, "DEPRECATED: The {} command is a no-op",
-               invocation.command);
+               request.Subcommand());
     cvd::Response response;
     response.mutable_status()->set_code(cvd::Status::OK);
     return response;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/power.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/power.cpp
@@ -62,15 +62,15 @@ class CvdDevicePowerCommandHandler : public CvdServerHandler {
   }
 
   Result<bool> CanHandle(const CommandRequest& request) const override {
-    auto invocation = ParseInvocation(request);
-    return Contains(cvd_power_operations_, invocation.command);
+    return Contains(cvd_power_operations_, request.Subcommand());
   }
 
   Result<cvd::Response> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
     const cvd_common::Envs& env = request.Env();
 
-    auto [op, subcmd_args] = ParseInvocation(request);
+    std::string op = request.Subcommand();
+    std::vector<std::string> subcmd_args = request.SubcommandArguments();
     bool is_help = CF_EXPECT(IsHelp(subcmd_args));
 
     // may modify subcmd_args by consuming in parsing

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/remove.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/remove.cpp
@@ -63,13 +63,12 @@ class RemoveCvdCommandHandler : public CvdServerHandler {
   bool ShouldInterceptHelp() const override { return false; }
 
   Result<bool> CanHandle(const CommandRequest& request) const override {
-    auto invocation = ParseInvocation(request);
-    return Contains(CmdList(), invocation.command);
+    return Contains(CmdList(), request.Subcommand());
   }
 
   Result<cvd::Response> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
-    auto [op, subcmd_args] = ParseInvocation(request);
+    std::vector<std::string> subcmd_args = request.SubcommandArguments();
 
     if (CF_EXPECT(IsHelpSubcmd(subcmd_args))) {
       std::vector<std::string> unused;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/reset.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/reset.cpp
@@ -20,11 +20,10 @@
 
 #include "common/libs/utils/files.h"
 #include "common/libs/utils/flag_parser.h"
-#include "host/commands/cvd/utils/common.h"
+#include "host/commands/cvd/cli/commands/server_handler.h"
 #include "host/commands/cvd/instances/instance_manager.h"
 #include "host/commands/cvd/instances/reset_client_utils.h"
-#include "host/commands/cvd/cli/commands/server_handler.h"
-#include "host/commands/cvd/cli/utils.h"
+#include "host/commands/cvd/utils/common.h"
 
 namespace cuttlefish {
 namespace {
@@ -119,14 +118,13 @@ class CvdResetCommandHandler : public CvdServerHandler {
       : instance_manager_(instance_manager) {}
 
   Result<bool> CanHandle(const CommandRequest& request) const override {
-    auto invocation = ParseInvocation(request);
-    return invocation.command == kResetSubcmd;
+    return request.Subcommand() == kResetSubcmd;
   }
 
   Result<cvd::Response> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
-    auto invocation = ParseInvocation(request);
-    auto options = CF_EXPECT(ParseResetFlags(invocation.arguments));
+    std::vector<std::string> subcmd_args = request.SubcommandArguments();
+    auto options = CF_EXPECT(ParseResetFlags(subcmd_args));
     if (options.log_level) {
       SetMinimumVerbosity(options.log_level.value());
     }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/snapshot.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/snapshot.cpp
@@ -69,14 +69,14 @@ class CvdSnapshotCommandHandler : public CvdServerHandler {
         cvd_snapshot_operations_{"suspend", "resume", "snapshot_take"} {}
 
   Result<bool> CanHandle(const CommandRequest& request) const override {
-    auto invocation = ParseInvocation(request);
-    return Contains(cvd_snapshot_operations_, invocation.command);
+    return Contains(cvd_snapshot_operations_, request.Subcommand());
   }
 
   Result<cvd::Response> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
 
-    auto [subcmd, subcmd_args] = ParseInvocation(request);
+    std::string subcmd = request.Subcommand();
+    std::vector<std::string> subcmd_args = request.SubcommandArguments();
 
     std::stringstream ss;
     for (const auto& arg : subcmd_args) {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -353,8 +353,7 @@ Result<void> CvdStartCommandHandler::AcloudCompatActions(
 
 Result<bool> CvdStartCommandHandler::CanHandle(
     const CommandRequest& request) const {
-  auto invocation = ParseInvocation(request);
-  return Contains(supported_commands_, invocation.command);
+  return Contains(supported_commands_, request.Subcommand());
 }
 
 Result<void> CvdStartCommandHandler::UpdateArgs(cvd_common::Args& args,
@@ -486,7 +485,8 @@ Result<cvd::Response> CvdStartCommandHandler::Handle(
     const CommandRequest& request) {
   CF_EXPECT(CanHandle(request));
 
-  auto [subcmd, subcmd_args] = ParseInvocation(request);
+  std::string subcmd = request.Subcommand();
+  std::vector<std::string> subcmd_args = request.SubcommandArguments();
   CF_EXPECT(!GetConfigPath(subcmd_args).has_value(),
             "The 'start' command doesn't accept --config_file, did you mean "
             "'create'?");

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/status.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/status.cpp
@@ -135,16 +135,14 @@ CvdStatusCommandHandler::CvdStatusCommandHandler(
 
 Result<bool> CvdStatusCommandHandler::CanHandle(
     const CommandRequest& request) const {
-  auto invocation = ParseInvocation(request);
-  return Contains(supported_subcmds_, invocation.command);
+  return Contains(supported_subcmds_, request.Subcommand());
 }
 
 Result<cvd::Response> CvdStatusCommandHandler::Handle(
     const CommandRequest& request) {
   CF_EXPECT(CanHandle(request));
 
-  auto [subcmd, cmd_args] = ParseInvocation(request);
-  CF_EXPECT(Contains(supported_subcmds_, subcmd));
+  std::vector<std::string> cmd_args = request.SubcommandArguments();
   StatusCommandOptions flags = CF_EXPECT(ParseFlags(cmd_args));
 
   if (flags.help) {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/stop.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/stop.cpp
@@ -80,13 +80,13 @@ CvdStopCommandHandler::CvdStopCommandHandler(InstanceManager& instance_manager)
 
 Result<bool> CvdStopCommandHandler::CanHandle(
     const CommandRequest& request) const {
-  auto invocation = ParseInvocation(request);
-  return Contains(CmdList(), invocation.command);
+  return Contains(CmdList(), request.Subcommand());
 }
 
 Result<cvd::Response> CvdStopCommandHandler::HandleHelpCmd(
     const CommandRequest& request) {
-  auto [subcmd, cmd_args] = ParseInvocation(request);
+  std::string subcmd = request.Subcommand();
+  std::vector<std::string> cmd_args = request.SubcommandArguments();
   const cvd_common::Envs& env = request.Env();
 
   const auto [bin, bin_path] = CF_EXPECT(CvdHelpBinPath(subcmd, env));
@@ -109,7 +109,7 @@ Result<cvd::Response> CvdStopCommandHandler::HandleHelpCmd(
 Result<cvd::Response> CvdStopCommandHandler::Handle(
     const CommandRequest& request) {
   CF_EXPECT(CanHandle(request));
-  auto [subcmd, cmd_args] = ParseInvocation(request);
+  std::vector<std::string> cmd_args = request.SubcommandArguments();
 
   if (CF_EXPECT(IsHelpSubcmd(cmd_args))) {
     return CF_EXPECT(HandleHelpCmd(request));

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/try_acloud.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/try_acloud.cpp
@@ -63,8 +63,7 @@ class TryAcloudCommand : public CvdServerHandler {
   ~TryAcloudCommand() = default;
 
   Result<bool> CanHandle(const CommandRequest& request) const override {
-    auto invocation = ParseInvocation(request);
-    return invocation.command == "try-acloud";
+    return request.Subcommand() == "try-acloud";
   }
 
   cvd_common::Args CmdList() const override { return {"try-acloud"}; }
@@ -113,7 +112,7 @@ Result<cvd::Response> TryAcloudCommand::VerifyWithCvdRemote(
   auto config = CF_EXPECT(LoadAcloudConfig(filename));
   CF_EXPECT(config.use_legacy_acloud == false);
   CF_EXPECT(CheckIfCvdrExist());
-  auto args = ParseInvocation(request).arguments;
+  std::vector<std::string> args = request.SubcommandArguments();
   CF_EXPECT(acloud_impl::CompileFromAcloudToCvdr(args));
   std::string cvdr_service_url =
       CF_EXPECT(RunCvdRemoteGetConfig("service_url"));

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/version.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/version.cpp
@@ -21,11 +21,10 @@
 
 #include "common/libs/utils/proto.h"
 #include "common/libs/utils/result.h"
-#include "host/commands/cvd/utils/common.h"
 #include "host/commands/cvd/cli/commands/server_handler.h"
-#include "host/commands/cvd/cli/utils.h"
-#include "host/commands/cvd/legacy/server_constants.h"
 #include "host/commands/cvd/cli/types.h"
+#include "host/commands/cvd/legacy/server_constants.h"
+#include "host/commands/cvd/utils/common.h"
 #include "host/libs/config/host_tools_version.h"
 
 namespace cuttlefish {
@@ -39,8 +38,7 @@ class CvdVersionHandler : public CvdServerHandler {
   CvdVersionHandler() = default;
 
   Result<bool> CanHandle(const CommandRequest& request) const override {
-    auto invocation = ParseInvocation(request);
-    return "version" == invocation.command;
+    return request.Subcommand() == "version";
   }
 
   Result<cvd::Response> Handle(const CommandRequest& request) override {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
@@ -28,24 +28,6 @@
 
 namespace cuttlefish {
 
-CommandInvocation ParseInvocation(const CommandRequest& request) {
-  CommandInvocation invocation;
-  invocation.arguments = request.Args();
-  if (invocation.arguments.empty()) {
-    return invocation;
-  }
-  invocation.arguments[0] = cpp_basename(invocation.arguments[0]);
-  if (invocation.arguments[0] == "cvd" && invocation.arguments.size() > 1) {
-    invocation.command = invocation.arguments[1];
-    invocation.arguments.erase(invocation.arguments.begin());
-    invocation.arguments.erase(invocation.arguments.begin());
-  } else {
-    invocation.command = invocation.arguments[0];
-    invocation.arguments.erase(invocation.arguments.begin());
-  }
-  return invocation;
-}
-
 cuttlefish::cvd::Response ResponseFromSiginfo(siginfo_t infop) {
   cvd::Response response;
   response.mutable_command_response();  // set oneof field

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
@@ -32,13 +32,6 @@
 
 namespace cuttlefish {
 
-struct CommandInvocation {
-  std::string command;
-  std::vector<std::string> arguments;
-};
-
-CommandInvocation ParseInvocation(const CommandRequest& request);
-
 cuttlefish::cvd::Response ResponseFromSiginfo(siginfo_t infop);
 
 struct ConstructCommandParam {

--- a/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
@@ -72,7 +72,7 @@ Result<cvd::Response> Cvd::HandleCommand(
   RequestContext context(instance_lockfile_manager_, instance_manager_);
   auto handler = CF_EXPECT(context.Handler(request));
   if (handler->ShouldInterceptHelp()) {
-    auto invocation_args = ParseInvocation(request).arguments;
+    std::vector<std::string> invocation_args = request.SubcommandArguments();
     if (CF_EXPECT(IsHelpSubcmd(invocation_args))) {
       std::cout << CF_EXPECT(handler->DetailedHelp(invocation_args))
                 << std::endl;


### PR DESCRIPTION
There was overlap between these types in the public interface.

Bug: b/382745645