### PR TITLE
Default `CanHandle` implementation

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/BUILD.bazel
@@ -78,6 +78,7 @@ cc_library(
         "cli/commands/power.cpp",
         "cli/commands/remove.cpp",
         "cli/commands/reset.cpp",
+        "cli/commands/server_handler.cpp",
         "cli/commands/snapshot.cpp",
         "cli/commands/start.cpp",
         "cli/commands/status.cpp",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/bugreport.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/bugreport.cpp
@@ -48,7 +48,6 @@ class CvdBugreportCommandHandler : public CvdServerHandler {
  public:
   CvdBugreportCommandHandler(InstanceManager& instance_manager);
 
-  Result<bool> CanHandle(const CommandRequest& request) const override;
   Result<cvd::Response> Handle(const CommandRequest& request) override;
   cvd_common::Args CmdList() const override;
   Result<std::string> SummaryHelp() const override;
@@ -59,7 +58,6 @@ class CvdBugreportCommandHandler : public CvdServerHandler {
   InstanceManager& instance_manager_;
   using BinGeneratorType = std::function<Result<std::string>(
       const std::string& host_artifacts_path)>;
-  std::set<std::string> commands_;
   std::unique_ptr<InterruptibleTerminal> terminal_ = nullptr;
 
   static constexpr char kHostBugreportBin[] = "cvd_internal_host_bugreport";
@@ -67,13 +65,7 @@ class CvdBugreportCommandHandler : public CvdServerHandler {
 
 CvdBugreportCommandHandler::CvdBugreportCommandHandler(
     InstanceManager& instance_manager)
-    : instance_manager_(instance_manager),
-      commands_{{"bugreport", "host_bugreport", "cvd_host_bugreport"}} {}
-
-Result<bool> CvdBugreportCommandHandler::CanHandle(
-    const CommandRequest& request) const {
-  return Contains(commands_, request.Subcommand());
-}
+    : instance_manager_(instance_manager) {}
 
 Result<cvd::Response> CvdBugreportCommandHandler::Handle(
     const CommandRequest& request) {
@@ -117,12 +109,7 @@ Result<cvd::Response> CvdBugreportCommandHandler::Handle(
 }
 
 std::vector<std::string> CvdBugreportCommandHandler::CmdList() const {
-  std::vector<std::string> subcmd_list;
-  subcmd_list.reserve(commands_.size());
-  for (const auto& cmd : commands_) {
-    subcmd_list.emplace_back(cmd);
-  }
-  return subcmd_list;
+  return {"bugreport", "host_bugreport", "cvd_host_bugreport"};
 }
 
 Result<std::string> CvdBugreportCommandHandler::SummaryHelp() const {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/clear.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/clear.cpp
@@ -40,11 +40,10 @@ class CvdClearCommandHandler : public CvdServerHandler {
  public:
   CvdClearCommandHandler(InstanceManager& instance_manager);
 
-  Result<bool> CanHandle(const CommandRequest& request) const override;
   Result<cvd::Response> Handle(const CommandRequest& request) override;
-  cvd_common::Args CmdList() const override;
-  Result<std::string> SummaryHelp() const override;
-  bool ShouldInterceptHelp() const override;
+  cvd_common::Args CmdList() const override { return {kClearCmd}; }
+  Result<std::string> SummaryHelp() const override { return kSummaryHelpText; }
+  bool ShouldInterceptHelp() const override { return false; }
   Result<std::string> DetailedHelp(std::vector<std::string>&) const override;
 
  private:
@@ -54,11 +53,6 @@ class CvdClearCommandHandler : public CvdServerHandler {
 CvdClearCommandHandler::CvdClearCommandHandler(
     InstanceManager& instance_manager)
     : instance_manager_(instance_manager) {}
-
-Result<bool> CvdClearCommandHandler::CanHandle(
-    const CommandRequest& request) const {
-  return request.Subcommand() == kClearCmd;
-}
 
 Result<cvd::Response> CvdClearCommandHandler::Handle(
     const CommandRequest& request) {
@@ -77,16 +71,6 @@ Result<cvd::Response> CvdClearCommandHandler::Handle(
   *response.mutable_status() = instance_manager_.CvdClear(request);
   return response;
 }
-
-std::vector<std::string> CvdClearCommandHandler::CmdList() const {
-  return {kClearCmd};
-}
-
-Result<std::string> CvdClearCommandHandler::SummaryHelp() const {
-  return kSummaryHelpText;
-}
-
-bool CvdClearCommandHandler::ShouldInterceptHelp() const { return false; }
 
 Result<std::string> CvdClearCommandHandler::DetailedHelp(
     std::vector<std::string>& arguments) const {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
@@ -232,9 +232,8 @@ class CvdCreateCommandHandler : public CvdServerHandler {
       : instance_manager_(instance_manager),
         command_executor_(command_executor) {}
 
-  Result<bool> CanHandle(const CommandRequest& request) const override;
   Result<cvd::Response> Handle(const CommandRequest& request) override;
-  std::vector<std::string> CmdList() const override;
+  std::vector<std::string> CmdList() const override { return {"create"}; }
   Result<std::string> SummaryHelp() const override;
   bool ShouldInterceptHelp() const override;
   Result<std::string> DetailedHelp(std::vector<std::string>&) const override;
@@ -263,11 +262,6 @@ void CvdCreateCommandHandler::MarkLockfiles(
       LOG(ERROR) << result.error().FormatForEnv();
     }
   }
-}
-
-Result<bool> CvdCreateCommandHandler::CanHandle(
-    const CommandRequest& request) const {
-  return Contains(CmdList(), request.Subcommand());
 }
 
 Result<LocalInstanceGroup> CvdCreateCommandHandler::GetOrCreateGroup(
@@ -411,10 +405,6 @@ Result<cvd::Response> CvdCreateCommandHandler::Handle(
   *response.mutable_command_response()->mutable_instance_group_info() =
       GroupInfoFromGroup(group);
   return response;
-}
-
-std::vector<std::string> CvdCreateCommandHandler::CmdList() const {
-  return {"create"};
 }
 
 Result<std::string> CvdCreateCommandHandler::SummaryHelp() const {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/display.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/display.cpp
@@ -53,12 +53,7 @@ Commands:
 class CvdDisplayCommandHandler : public CvdServerHandler {
  public:
   CvdDisplayCommandHandler(InstanceManager& instance_manager)
-      : instance_manager_{instance_manager},
-        cvd_display_operations_{"display"} {}
-
-  Result<bool> CanHandle(const CommandRequest& request) const override {
-    return Contains(cvd_display_operations_, request.Subcommand());
-  }
+      : instance_manager_{instance_manager} {}
 
   Result<cvd::Response> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
@@ -78,10 +73,7 @@ class CvdDisplayCommandHandler : public CvdServerHandler {
     return ResponseFromSiginfo(infop);
   }
 
-  cvd_common::Args CmdList() const override {
-    return cvd_common::Args(cvd_display_operations_.begin(),
-                            cvd_display_operations_.end());
-  }
+  cvd_common::Args CmdList() const override { return {"display"}; }
 
   Result<std::string> SummaryHelp() const override { return kSummaryHelpText; }
 
@@ -166,7 +158,6 @@ class CvdDisplayCommandHandler : public CvdServerHandler {
   }
 
   InstanceManager& instance_manager_;
-  std::vector<std::string> cvd_display_operations_;
   static constexpr char kDisplayBin[] = "cvd_internal_display";
 };
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/env.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/env.cpp
@@ -47,11 +47,7 @@ cvd env type $SERVICE_NAME $REQUEST_MESSAGE_TYPE - outputs the proto the specifi
 class CvdEnvCommandHandler : public CvdServerHandler {
  public:
   CvdEnvCommandHandler(InstanceManager& instance_manager)
-      : instance_manager_{instance_manager}, cvd_env_operations_{"env"} {}
-
-  Result<bool> CanHandle(const CommandRequest& request) const override {
-    return Contains(cvd_env_operations_, request.Subcommand());
-  }
+      : instance_manager_{instance_manager} {}
 
   Result<cvd::Response> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
@@ -79,10 +75,7 @@ class CvdEnvCommandHandler : public CvdServerHandler {
     return ResponseFromSiginfo(infop);
   }
 
-  cvd_common::Args CmdList() const override {
-    return cvd_common::Args(cvd_env_operations_.begin(),
-                            cvd_env_operations_.end());
-  }
+  cvd_common::Args CmdList() const override { return {"env"}; }
 
   Result<std::string> SummaryHelp() const override { return kSummaryHelpText; }
 
@@ -129,7 +122,6 @@ class CvdEnvCommandHandler : public CvdServerHandler {
   }
 
   InstanceManager& instance_manager_;
-  std::vector<std::string> cvd_env_operations_;
 
   static constexpr char kCvdEnvBin[] = "cvd_internal_env";
 };

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.cpp
@@ -18,36 +18,22 @@
 
 #include <android-base/strings.h>
 
-#include "common/libs/utils/contains.h"
 #include "common/libs/utils/result.h"
 #include "common/libs/utils/subprocess.h"
-#include "host/commands/cvd/fetch/fetch_cvd.h"
 #include "host/commands/cvd/cli/commands/server_handler.h"
-#include "host/commands/cvd/cli/utils.h"
 #include "host/commands/cvd/cli/types.h"
+#include "host/commands/cvd/fetch/fetch_cvd.h"
 
 namespace cuttlefish {
 
 class CvdFetchCommandHandler : public CvdServerHandler {
  public:
-  CvdFetchCommandHandler()
-      : fetch_cmd_list_{std::vector<std::string>{"fetch", "fetch_cvd"}} {}
-
-  Result<bool> CanHandle(const CommandRequest& request) const override;
   Result<cvd::Response> Handle(const CommandRequest& request) override;
-  cvd_common::Args CmdList() const override { return fetch_cmd_list_; }
+  cvd_common::Args CmdList() const override { return {"fetch", "fetch_cvd"}; }
   Result<std::string> SummaryHelp() const override;
   bool ShouldInterceptHelp() const override { return true; }
   Result<std::string> DetailedHelp(std::vector<std::string>&) const override;
-
- private:
-  std::vector<std::string> fetch_cmd_list_;
 };
-
-Result<bool> CvdFetchCommandHandler::CanHandle(
-    const CommandRequest& request) const {
-  return Contains(fetch_cmd_list_, request.Subcommand());
-}
 
 Result<cvd::Response> CvdFetchCommandHandler::Handle(
     const CommandRequest& request) {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fleet.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fleet.cpp
@@ -41,7 +41,6 @@ class CvdFleetCommandHandler : public CvdServerHandler {
   CvdFleetCommandHandler(InstanceManager& instance_manager)
       : instance_manager_(instance_manager) {}
 
-  Result<bool> CanHandle(const CommandRequest& request) const override;
   Result<cvd::Response> Handle(const CommandRequest& request) override;
   cvd_common::Args CmdList() const override { return {kFleetSubcmd}; }
 
@@ -59,11 +58,6 @@ class CvdFleetCommandHandler : public CvdServerHandler {
   static constexpr char kFleetSubcmd[] = "fleet";
   bool IsHelp(const cvd_common::Args& cmd_args) const;
 };
-
-Result<bool> CvdFleetCommandHandler::CanHandle(
-    const CommandRequest& request) const {
-  return request.Subcommand() == kFleetSubcmd;
-}
 
 Result<cvd::Response> CvdFleetCommandHandler::Handle(
     const CommandRequest& request) {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/help.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/help.cpp
@@ -29,7 +29,6 @@
 #include "common/libs/utils/result.h"
 #include "cuttlefish/host/commands/cvd/legacy/cvd_server.pb.h"
 #include "host/commands/cvd/cli/request_context.h"
-#include "host/commands/cvd/cli/utils.h"
 #include "host/commands/cvd/cli/types.h"
 
 namespace cuttlefish {
@@ -75,10 +74,6 @@ class CvdHelpHandler : public CvdServerHandler {
   CvdHelpHandler(
       const std::vector<std::unique_ptr<CvdServerHandler>>& request_handlers)
       : request_handlers_(request_handlers) {}
-
-  Result<bool> CanHandle(const CommandRequest& request) const override {
-    return request.Subcommand() == "help";
-  }
 
   Result<cvd::Response> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/lint.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/lint.cpp
@@ -44,12 +44,6 @@ Usage: cvd lint /path/to/input.json
 
 class LintCommandHandler : public CvdServerHandler {
  public:
-  LintCommandHandler() {}
-
-  Result<bool> CanHandle(const CommandRequest& request) const override {
-    return request.Subcommand() == kLintSubCmd;
-  }
-
   Result<cvd::Response> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.cpp
@@ -25,9 +25,7 @@
 #include "host/commands/cvd/cli/command_request.h"
 #include "host/commands/cvd/cli/command_sequence.h"
 #include "host/commands/cvd/cli/parser/load_configs_parser.h"
-#include "host/commands/cvd/cli/selector/selector_constants.h"
 #include "host/commands/cvd/cli/types.h"
-#include "host/commands/cvd/cli/utils.h"
 #include "host/commands/cvd/fetch/fetch_cvd.h"
 #include "host/commands/cvd/instances/instance_manager.h"
 #include "host/commands/cvd/utils/common.h"
@@ -67,10 +65,6 @@ class LoadConfigsCommand : public CvdServerHandler {
                      InstanceManager& instance_manager)
       : executor_(executor), instance_manager_(instance_manager) {}
   ~LoadConfigsCommand() = default;
-
-  Result<bool> CanHandle(const CommandRequest& request) const override {
-    return request.Subcommand() == kLoadSubCmd;
-  }
 
   Result<cvd::Response> Handle(const CommandRequest& request) override {
     bool can_handle_request = CF_EXPECT(CanHandle(request));

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/login.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/login.cpp
@@ -47,10 +47,6 @@ usage: cvd login --client_id=CLIENT_ID --client_secret=SECRET --scopes=SCOPES [-
 
 class CvdLoginCommand : public CvdServerHandler {
  public:
-  Result<bool> CanHandle(const CommandRequest& request) const override {
-    return request.Subcommand() == "login";
-  }
-
   Result<cvd::Response> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/noop.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/noop.cpp
@@ -18,7 +18,6 @@
 
 #include <memory>
 
-#include "common/libs/utils/contains.h"
 #include "common/libs/utils/result.h"
 
 namespace cuttlefish {
@@ -29,12 +28,6 @@ constexpr char kSummaryHelpText[] =
 
 class CvdNoopHandler : public CvdServerHandler {
  public:
-  CvdNoopHandler() = default;
-
-  Result<bool> CanHandle(const CommandRequest& request) const override {
-    return Contains(CmdList(), request.Subcommand());
-  }
-
   Result<cvd::Response> Handle(const CommandRequest& request) override {
     fmt::print(std::cout, "DEPRECATED: The {} command is a no-op",
                request.Subcommand());

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/remove.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/remove.cpp
@@ -62,10 +62,6 @@ class RemoveCvdCommandHandler : public CvdServerHandler {
 
   bool ShouldInterceptHelp() const override { return false; }
 
-  Result<bool> CanHandle(const CommandRequest& request) const override {
-    return Contains(CmdList(), request.Subcommand());
-  }
-
   Result<cvd::Response> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
     std::vector<std::string> subcmd_args = request.SubcommandArguments();

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/reset.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/reset.cpp
@@ -117,10 +117,6 @@ class CvdResetCommandHandler : public CvdServerHandler {
   CvdResetCommandHandler(InstanceManager& instance_manager)
       : instance_manager_(instance_manager) {}
 
-  Result<bool> CanHandle(const CommandRequest& request) const override {
-    return request.Subcommand() == kResetSubcmd;
-  }
-
   Result<cvd::Response> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
     std::vector<std::string> subcmd_args = request.SubcommandArguments();

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/server_handler.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/server_handler.cpp
@@ -14,29 +14,16 @@
  * limitations under the License.
  */
 
-#pragma once
+#include "host/commands/cvd/cli/commands/server_handler.h"
 
-#include <string>
-#include <vector>
-
+#include "common/libs/utils/contains.h"
 #include "common/libs/utils/result.h"
 #include "host/commands/cvd/cli/command_request.h"
-#include "host/commands/cvd/cli/types.h"
 
 namespace cuttlefish {
 
-class CvdServerHandler {
- public:
-  virtual ~CvdServerHandler() = default;
-
-  virtual Result<bool> CanHandle(const CommandRequest&) const;
-  virtual Result<cvd::Response> Handle(const CommandRequest&) = 0;
-  // returns the list of subcommand it can handle
-  virtual cvd_common::Args CmdList() const = 0;
-  // used for command help text
-  virtual Result<std::string> SummaryHelp() const = 0;
-  virtual bool ShouldInterceptHelp() const = 0;
-  virtual Result<std::string> DetailedHelp(std::vector<std::string>&) const = 0;
-};
+Result<bool> CvdServerHandler::CanHandle(const CommandRequest& request) const {
+  return Contains(CmdList(), request.Subcommand());
+}
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/snapshot.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/snapshot.cpp
@@ -65,12 +65,7 @@ QEMU:
 class CvdSnapshotCommandHandler : public CvdServerHandler {
  public:
   CvdSnapshotCommandHandler(InstanceManager& instance_manager)
-      : instance_manager_{instance_manager},
-        cvd_snapshot_operations_{"suspend", "resume", "snapshot_take"} {}
-
-  Result<bool> CanHandle(const CommandRequest& request) const override {
-    return Contains(cvd_snapshot_operations_, request.Subcommand());
-  }
+      : instance_manager_{instance_manager} {}
 
   Result<cvd::Response> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
@@ -95,8 +90,7 @@ class CvdSnapshotCommandHandler : public CvdServerHandler {
   }
 
   cvd_common::Args CmdList() const override {
-    return cvd_common::Args(cvd_snapshot_operations_.begin(),
-                            cvd_snapshot_operations_.end());
+    return {"suspend", "resume", "snapshot_take"};
   }
 
   Result<std::string> SummaryHelp() const override { return kSummaryHelpText; }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -229,9 +229,10 @@ class CvdStartCommandHandler : public CvdServerHandler {
   CvdStartCommandHandler(InstanceManager& instance_manager)
       : instance_manager_(instance_manager) {}
 
-  Result<bool> CanHandle(const CommandRequest& request) const override;
   Result<cvd::Response> Handle(const CommandRequest& request) override;
-  std::vector<std::string> CmdList() const override;
+  std::vector<std::string> CmdList() const override {
+    return {"start", "launch_cvd"};
+  }
   Result<std::string> SummaryHelp() const override;
   bool ShouldInterceptHelp() const override;
   Result<std::string> DetailedHelp(std::vector<std::string>&) const override;
@@ -271,7 +272,6 @@ class CvdStartCommandHandler : public CvdServerHandler {
                                    const CommandRequest& request);
   InstanceManager& instance_manager_;
   SubprocessWaiter subprocess_waiter_;
-  static const std::array<std::string, 2> supported_commands_;
 };
 
 Result<void> CvdStartCommandHandler::AcloudCompatActions(
@@ -349,11 +349,6 @@ Result<void> CvdStartCommandHandler::AcloudCompatActions(
     }
   }
   return {};
-}
-
-Result<bool> CvdStartCommandHandler::CanHandle(
-    const CommandRequest& request) const {
-  return Contains(supported_commands_, request.Subcommand());
 }
 
 Result<void> CvdStartCommandHandler::UpdateArgs(cvd_common::Args& args,
@@ -521,8 +516,6 @@ Result<cvd::Response> CvdStartCommandHandler::Handle(
   }
   // update DB if not help
   // collect group creation infos
-  CF_EXPECT(Contains(supported_commands_, subcmd),
-            "subcmd should be start but is " << subcmd);
   const bool is_help = CF_EXPECT(IsHelpSubcmd(subcmd_args));
 
   if (is_help) {
@@ -710,15 +703,6 @@ Result<cvd::Response> CvdStartCommandHandler::FillOutNewInstanceInfo(
   return new_response;
 }
 
-std::vector<std::string> CvdStartCommandHandler::CmdList() const {
-  std::vector<std::string> subcmd_list;
-  subcmd_list.reserve(supported_commands_.size());
-  for (const auto& cmd : supported_commands_) {
-    subcmd_list.emplace_back(cmd);
-  }
-  return subcmd_list;
-}
-
 Result<std::string> CvdStartCommandHandler::SummaryHelp() const {
   return kSummaryHelpText;
 }
@@ -731,9 +715,6 @@ Result<std::string> CvdStartCommandHandler::DetailedHelp(
     std::vector<std::string>&) const {
   return kDetailedHelpText;
 }
-
-const std::array<std::string, 2> CvdStartCommandHandler::supported_commands_{
-    "start", "launch_cvd"};
 
 std::unique_ptr<CvdServerHandler> NewCvdStartCommandHandler(
     InstanceManager& instance_manager) {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/status.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/status.cpp
@@ -21,7 +21,6 @@
 #include <android-base/parseint.h>
 #include <android-base/strings.h>
 
-#include "common/libs/utils/contains.h"
 #include "common/libs/utils/flag_parser.h"
 #include "common/libs/utils/result.h"
 #include "cuttlefish/host/commands/cvd/legacy/cvd_server.pb.h"
@@ -111,9 +110,8 @@ class CvdStatusCommandHandler : public CvdServerHandler {
  public:
   CvdStatusCommandHandler(InstanceManager& instance_manager);
 
-  Result<bool> CanHandle(const CommandRequest& request) const override;
   Result<cvd::Response> Handle(const CommandRequest& request) override;
-  cvd_common::Args CmdList() const override;
+  cvd_common::Args CmdList() const override { return {"status", "cvd_status"}; }
 
   Result<std::string> SummaryHelp() const override { return kSummaryHelpText; }
 
@@ -125,18 +123,11 @@ class CvdStatusCommandHandler : public CvdServerHandler {
 
  private:
   InstanceManager& instance_manager_;
-  std::vector<std::string> supported_subcmds_;
 };
 
 CvdStatusCommandHandler::CvdStatusCommandHandler(
     InstanceManager& instance_manager)
-    : instance_manager_(instance_manager),
-      supported_subcmds_{"status", "cvd_status"} {}
-
-Result<bool> CvdStatusCommandHandler::CanHandle(
-    const CommandRequest& request) const {
-  return Contains(supported_subcmds_, request.Subcommand());
-}
+    : instance_manager_(instance_manager) {}
 
 Result<cvd::Response> CvdStatusCommandHandler::Handle(
     const CommandRequest& request) {
@@ -188,10 +179,6 @@ Result<cvd::Response> CvdStatusCommandHandler::Handle(
   }
 
   return SuccessResponse();
-}
-
-std::vector<std::string> CvdStatusCommandHandler::CmdList() const {
-  return supported_subcmds_;
 }
 
 std::unique_ptr<CvdServerHandler> NewCvdStatusCommandHandler(

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/stop.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/stop.cpp
@@ -50,9 +50,8 @@ class CvdStopCommandHandler : public CvdServerHandler {
  public:
   CvdStopCommandHandler(InstanceManager& instance_manager);
 
-  Result<bool> CanHandle(const CommandRequest& request) const override;
   Result<cvd::Response> Handle(const CommandRequest& request) override;
-  cvd_common::Args CmdList() const override;
+  cvd_common::Args CmdList() const override { return {"stop", "stop_cvd"}; }
   Result<std::string> SummaryHelp() const override;
   bool ShouldInterceptHelp() const override;
   Result<std::string> DetailedHelp(std::vector<std::string>&) const override;
@@ -77,11 +76,6 @@ class CvdStopCommandHandler : public CvdServerHandler {
 
 CvdStopCommandHandler::CvdStopCommandHandler(InstanceManager& instance_manager)
     : instance_manager_(instance_manager) {}
-
-Result<bool> CvdStopCommandHandler::CanHandle(
-    const CommandRequest& request) const {
-  return Contains(CmdList(), request.Subcommand());
-}
 
 Result<cvd::Response> CvdStopCommandHandler::HandleHelpCmd(
     const CommandRequest& request) {
@@ -144,10 +138,6 @@ Result<cvd::Response> CvdStopCommandHandler::Handle(
   }
 
   return response;
-}
-
-std::vector<std::string> CvdStopCommandHandler::CmdList() const {
-  return {"stop", "stop_cvd"};
 }
 
 Result<std::string> CvdStopCommandHandler::SummaryHelp() const {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/try_acloud.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/try_acloud.cpp
@@ -62,10 +62,6 @@ class TryAcloudCommand : public CvdServerHandler {
  public:
   ~TryAcloudCommand() = default;
 
-  Result<bool> CanHandle(const CommandRequest& request) const override {
-    return request.Subcommand() == "try-acloud";
-  }
-
   cvd_common::Args CmdList() const override { return {"try-acloud"}; }
 
   Result<std::string> SummaryHelp() const override { return kSummaryHelpText; }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/version.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/version.cpp
@@ -37,10 +37,6 @@ class CvdVersionHandler : public CvdServerHandler {
  public:
   CvdVersionHandler() = default;
 
-  Result<bool> CanHandle(const CommandRequest& request) const override {
-    return request.Subcommand() == "version";
-  }
-
   Result<cvd::Response> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
 


### PR DESCRIPTION
Deduplicates many identical `CanHandle` implementations, and also cleans up some local variables that were used only to return data from a function.

Bug: b/382794638