### PR TITLE
Fix deadlock on cvd fetch

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/subprocess.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/subprocess.cpp
@@ -453,6 +453,8 @@ Subprocess Command::Start(SubprocessOptions options) const {
 
   pid_t pid = fork();
   if (!pid) {
+    // LOG(...) can't be used in the child process because it may block waiting
+    // for other threads which don't exist in the child process.
 #ifdef __linux__
     if (options.ExitWithParent()) {
       prctl(PR_SET_PDEATHSIG, SIGHUP); // Die when parent dies
@@ -464,19 +466,17 @@ Subprocess Command::Start(SubprocessOptions options) const {
     if (options.InGroup()) {
       // This call should never fail (see SETPGID(2))
       if (setpgid(0, 0) != 0) {
-        auto error = errno;
-        LOG(ERROR) << "setpgid failed (" << strerror(error) << ")";
+        exit(-errno);
       }
     }
     for (const auto& entry : inherited_fds_) {
       if (fcntl(entry.second, F_SETFD, 0)) {
-        int error_num = errno;
-        LOG(ERROR) << "fcntl failed: " << strerror(error_num);
+        exit(-errno);
       }
     }
     if (working_directory_->IsOpen()) {
       if (SharedFD::Fchdir(working_directory_) != 0) {
-        LOG(ERROR) << "Fchdir failed: " << working_directory_->StrError();
+        exit(-errno);
       }
     }
     int rval;
@@ -491,9 +491,7 @@ Subprocess Command::Start(SubprocessOptions options) const {
 #else
 #error "Unsupported architecture"
 #endif
-    // No need for an if: if exec worked it wouldn't have returned
-    LOG(ERROR) << "exec of " << cmd[0] << " with path \"" << executable
-               << "\" failed (" << strerror(errno) << ")";
+    // No need to check for error, execvpe/execve don't return on success.
     exit(rval);
   }
   if (pid == -1) {

--- a/base/cvd/cuttlefish/common/libs/utils/subprocess.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/subprocess.cpp
@@ -451,6 +451,8 @@ Subprocess Command::Start(SubprocessOptions options) const {
     }
   }
 
+  // ToCharPointers allocates memory so it can't be called in the child process.
+  auto envp = ToCharPointers(env_);
   pid_t pid = fork();
   if (!pid) {
     // LOG(...) can't be used in the child process because it may block waiting
@@ -480,7 +482,6 @@ Subprocess Command::Start(SubprocessOptions options) const {
       }
     }
     int rval;
-    auto envp = ToCharPointers(env_);
     const char* executable = executable_ ? executable_->c_str() : cmd[0];
 #ifdef __linux__
     rval = execvpe(executable, const_cast<char* const*>(cmd.data()),


### PR DESCRIPTION
Avoids logging, memory allocation and running callables between fork and exec (which could block waiting for other threads).