### PR TITLE
Add nginx configuration for WebSocket proxy

### DIFF
--- a/frontend/host/packages/cuttlefish-orchestration/etc/nginx/conf.d/cuttlefish-orchestration.conf
+++ b/frontend/host/packages/cuttlefish-orchestration/etc/nginx/conf.d/cuttlefish-orchestration.conf
@@ -36,6 +36,15 @@ server {
 
     # Host Orchestrator
     location / {
+        # ADB websocket backend
+        location ~* ^/.*/adb$ {
+            proxy_pass http://127.0.0.1:2081;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_set_header Host $host;
+        }
+
         proxy_pass http://127.0.0.1:2081;
 
         # This is required for uploading huge artifacts.


### PR DESCRIPTION
While connecting to ADB via WebSocket, it also need to set additional header for nginx proxy. Change nginx config for that.