### PR TITLE
libcvd build error

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/BUILD.bazel
@@ -264,6 +264,7 @@ cc_library(
         "@jsoncpp",
         "@protobuf//:protobuf",
         "@protobuf//:protobuf_lite",
+        "@protobuf//:json_util",
         "@tinyxml2",
         "@zlib",
     ],


### PR DESCRIPTION
```
ERROR: .../android-cuttlefish/base/cvd/cuttlefish/host/commands/cvd/BUILD.bazel:51:11: Compiling cuttlefish/host/commands/cvd/cli/parser/cf_flags_validator.cpp failed: (Exit 1): clang failed: error executing CppCompile command (from target //cuttlefish/host/commands/cvd:libcvd) /usr/lib/llvm-14/bin/clang -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics -fno-omit-frame-pointer ... (remaining 192 arguments skipped)
cuttlefish/host/commands/cvd/cli/parser/cf_flags_validator.cpp:19:10: error: module //cuttlefish/host/commands/cvd:libcvd does not depend on a module exporting 'google/protobuf/util/json_util.h'
#include <google/protobuf/util/json_util.h>
         ^
```