### PR TITLE
Remove usage of `cvd::Response` outside of `cvd/legacy`

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/acloud/converter.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/acloud/converter.cpp
@@ -501,8 +501,9 @@ Result<ConvertedAcloudCreateCommand> ConvertAcloudCreate(
 
   CommandRequestBuilder start_request_builder;
   start_request_builder.AddArguments({"cvd", "create", "--daemon", "--undefok",
-                              "report_anonymous_usage_stats",
-                              "--report_anonymous_usage_stats", "y"});
+                                      "report_anonymous_usage_stats",
+                                      "--report_anonymous_usage_stats", "y",
+                                      "--internal_prepare_for_acloud_delete"});
   if (parsed_flags.flavor) {
     start_request_builder.AddArguments({"-config", *parsed_flags.flavor});
   }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/command_sequence.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/command_sequence.cpp
@@ -86,7 +86,6 @@ CommandSequenceExecutor::CommandSequenceExecutor(
 
 Result<void> CommandSequenceExecutor::Execute(
     const std::vector<CommandRequest>& requests, std::ostream& report) {
-  std::vector<cvd::Response> responses;
   for (const auto& request : requests) {
     report << FormattedCommand(request);
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/command_sequence.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/command_sequence.cpp
@@ -92,13 +92,12 @@ Result<std::vector<cvd::Response>> CommandSequenceExecutor::Execute(
 
     auto handler = CF_EXPECT(RequestHandler(request, server_handlers_));
     handler_stack_.push_back(handler);
-    auto response = CF_EXPECT(handler->Handle(request));
+    CF_EXPECT(handler->HandleVoid(request));
     handler_stack_.pop_back();
 
-    CF_EXPECT(response.status().code() == cvd::Status::OK,
-              "Reason: \"" << response.status().message() << "\"");
-
-    responses.emplace_back(std::move(response));
+    cvd::Response& response = responses.emplace_back();
+    response.mutable_command_response();
+    response.mutable_status()->set_code(cvd::Status::OK);
   }
   return {responses};
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/command_sequence.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/command_sequence.cpp
@@ -92,7 +92,7 @@ Result<std::vector<cvd::Response>> CommandSequenceExecutor::Execute(
 
     auto handler = CF_EXPECT(RequestHandler(request, server_handlers_));
     handler_stack_.push_back(handler);
-    CF_EXPECT(handler->HandleVoid(request));
+    CF_EXPECT(handler->Handle(request));
     handler_stack_.pop_back();
 
     cvd::Response& response = responses.emplace_back();

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/command_sequence.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/command_sequence.cpp
@@ -84,7 +84,7 @@ CommandSequenceExecutor::CommandSequenceExecutor(
     const std::vector<std::unique_ptr<CvdServerHandler>>& server_handlers)
     : server_handlers_(server_handlers) {}
 
-Result<std::vector<cvd::Response>> CommandSequenceExecutor::Execute(
+Result<void> CommandSequenceExecutor::Execute(
     const std::vector<CommandRequest>& requests, std::ostream& report) {
   std::vector<cvd::Response> responses;
   for (const auto& request : requests) {
@@ -94,19 +94,14 @@ Result<std::vector<cvd::Response>> CommandSequenceExecutor::Execute(
     handler_stack_.push_back(handler);
     CF_EXPECT(handler->Handle(request));
     handler_stack_.pop_back();
-
-    cvd::Response& response = responses.emplace_back();
-    response.mutable_command_response();
-    response.mutable_status()->set_code(cvd::Status::OK);
   }
-  return {responses};
+  return {};
 }
 
-Result<cvd::Response> CommandSequenceExecutor::ExecuteOne(
-    const CommandRequest& request, std::ostream& report) {
-  auto response_in_vector = CF_EXPECT(Execute({request}, report));
-  CF_EXPECT_EQ(response_in_vector.size(), 1ul);
-  return response_in_vector.front();
+Result<void> CommandSequenceExecutor::ExecuteOne(const CommandRequest& request,
+                                                 std::ostream& report) {
+  CF_EXPECT(Execute({request}, report));
+  return {};
 }
 
 std::vector<std::string> CommandSequenceExecutor::CmdList() const {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/command_sequence.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/command_sequence.h
@@ -19,7 +19,6 @@
 #include <ostream>
 #include <vector>
 
-#include "cuttlefish/host/commands/cvd/legacy/cvd_server.pb.h"
 #include "host/commands/cvd/cli/command_request.h"
 #include "host/commands/cvd/cli/commands/server_handler.h"
 
@@ -30,10 +29,9 @@ class CommandSequenceExecutor {
   CommandSequenceExecutor(
       const std::vector<std::unique_ptr<CvdServerHandler>>& server_handlers);
 
-  Result<std::vector<cvd::Response>> Execute(
-      const std::vector<CommandRequest>&, std::ostream& report);
-  Result<cvd::Response> ExecuteOne(const CommandRequest&,
-                                   std::ostream& report);
+  Result<void> Execute(const std::vector<CommandRequest>&,
+                       std::ostream& report);
+  Result<void> ExecuteOne(const CommandRequest&, std::ostream& report);
 
   std::vector<std::string> CmdList() const;
   Result<CvdServerHandler*> GetHandler(const CommandRequest& request);

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_command.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_command.cpp
@@ -100,8 +100,6 @@ class AcloudCommand : public CvdServerHandler {
   }
 
  private:
-  Result<cvd::InstanceGroupInfo> ParseStartResponse(
-      const cvd::Response& start_response);
   Result<ConvertedAcloudCreateCommand> ValidateLocal(
       const CommandRequest& request);
   bool ValidateRemoteArgs(const CommandRequest& request);
@@ -113,18 +111,6 @@ class AcloudCommand : public CvdServerHandler {
 
   CommandSequenceExecutor& executor_;
 };
-
-Result<cvd::InstanceGroupInfo> AcloudCommand::ParseStartResponse(
-    const cvd::Response& start_response) {
-  CF_EXPECT(start_response.has_command_response(),
-            "cvd start did not return a command response.");
-  const auto& start_command_response = start_response.command_response();
-  CF_EXPECT(start_command_response.has_instance_group_info(),
-            "cvd start command response did not return instance_group_info.");
-  cvd::InstanceGroupInfo group_info =
-      start_command_response.instance_group_info();
-  return group_info;
-}
 
 Result<ConvertedAcloudCreateCommand> AcloudCommand::ValidateLocal(
     const CommandRequest& request) {
@@ -150,12 +136,6 @@ Result<void> AcloudCommand::HandleLocal(
     using android::base::WriteStringToFile;
     CF_EXPECT(WriteStringToFile(command.fetch_command_str,
                                 command.fetch_cvd_args_file));
-  }
-
-  auto group_info_result = ParseStartResponse(start_response);
-  if (!group_info_result.ok()) {
-    LOG(ERROR) << "Failed to analyze the cvd start response.";
-    return {};
   }
   return {};
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_command.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_command.cpp
@@ -157,15 +157,6 @@ Result<void> AcloudCommand::HandleLocal(
     LOG(ERROR) << "Failed to analyze the cvd start response.";
     return {};
   }
-  auto prepare_delete_result =
-      PrepareForAcloudDeleteCommand(*group_info_result);
-  if (!prepare_delete_result.ok()) {
-    LOG(ERROR) << prepare_delete_result.error().FormatForEnv();
-    LOG(WARNING) << "Failed to prepare for execution of `acloud delete`, use "
-                    "`cvd rm` instead";
-  }
-  // print
-  std::optional<SharedFD> fd_opt;
   return {};
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_command.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_command.cpp
@@ -127,29 +127,6 @@ Result<cvd::InstanceGroupInfo> AcloudCommand::ParseStartResponse(
   return group_info;
 }
 
-Result<void> PrintBriefSummary(const cvd::InstanceGroupInfo& group_info) {
-  const std::string& group_name = group_info.group_name();
-  CF_EXPECT_EQ(group_info.home_directories().size(), 1);
-  const std::string home_dir = (group_info.home_directories())[0];
-  std::vector<std::string> instance_names;
-  std::vector<unsigned> instance_ids;
-  instance_names.reserve(group_info.instances().size());
-  instance_ids.reserve(group_info.instances().size());
-  for (const auto& instance : group_info.instances()) {
-    instance_names.push_back(instance.name());
-    instance_ids.push_back(instance.instance_id());
-  }
-  std::cerr << std::endl << "Created instance group: " << group_name << std::endl;
-  for (size_t i = 0; i != instance_ids.size(); i++) {
-    std::string device_name = group_name + "-" + instance_names[i];
-    std::cerr << "  " << device_name << " (local-instance-" << instance_ids[i] << ")"
-        << std::endl;
-  }
-  std::cerr << std::endl
-      << "acloud list or cvd fleet for more information." << std::endl;
-  return {};
-}
-
 Result<ConvertedAcloudCreateCommand> AcloudCommand::ValidateLocal(
     const CommandRequest& request) {
   CF_EXPECT(CanHandle(request));
@@ -189,9 +166,6 @@ Result<void> AcloudCommand::HandleLocal(
   }
   // print
   std::optional<SharedFD> fd_opt;
-  if (command.verbose) {
-    PrintBriefSummary(*group_info_result);
-  }
   return {};
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_command.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_command.cpp
@@ -86,7 +86,7 @@ class AcloudCommand : public CvdServerHandler {
    * 2. Or `cvdr` for remote instance management.
    *
    */
-  Result<void> HandleVoid(const CommandRequest& request) override {
+  Result<void> Handle(const CommandRequest& request) override {
     auto result = ValidateLocal(request);
     if (result.ok()) {
       CF_EXPECT(HandleLocal(*result, request));

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_common.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_common.cpp
@@ -16,6 +16,13 @@
 
 #include "host/commands/cvd/cli/commands/acloud_common.h"
 
+#include <string>
+
+#include "common/libs/fs/shared_buf.h"
+#include "common/libs/fs/shared_fd.h"
+#include "common/libs/utils/files.h"
+#include "cuttlefish/host/commands/cvd/legacy/cvd_server.pb.h"
+
 namespace cuttlefish {
 
 bool IsSubOperationSupported(const CommandRequest& request) {
@@ -23,6 +30,34 @@ bool IsSubOperationSupported(const CommandRequest& request) {
     return false;
   }
   return request.SubcommandArguments()[0] == "create";
+}
+
+Result<void> PrepareForAcloudDeleteCommand(
+    const cvd::InstanceGroupInfo& group_info) {
+  std::string host_path = group_info.host_artifacts_path();
+  std::string stop_cvd_path = fmt::format("{}/bin/stop_cvd", host_path);
+  std::string cvd_internal_stop_path =
+      fmt::format("{}/bin/cvd_internal_stop", host_path);
+  if (FileExists(cvd_internal_stop_path)) {
+    // cvd_internal_stop exists, stop_cvd is just a symlink to it
+    CF_EXPECT(RemoveFile(stop_cvd_path), "Failed to remove stop_cvd file");
+  } else {
+    // cvd_internal_stop doesn't exist, stop_cvd is the actual executable file
+    CF_EXPECT(RenameFile(stop_cvd_path, cvd_internal_stop_path),
+              "Failed to rename stop_cvd as cvd_internal_stop");
+  }
+  SharedFD stop_cvd_fd = SharedFD::Creat(stop_cvd_path, 0775);
+  CF_EXPECTF(stop_cvd_fd->IsOpen(), "Failed to create stop_cvd executable: {}",
+             stop_cvd_fd->StrError());
+  // Don't include the group name in the rm command, it's not needed for a
+  // single instance group and won't know which group needs to be removed if
+  // multiple groups exist. Acloud delete will set the HOME variable, which
+  // means cvd rm will pick the right group.
+  std::string stop_cvd_content = "#!/bin/sh\ncvd rm";
+  auto ret = WriteAll(stop_cvd_fd, stop_cvd_content);
+  CF_EXPECT(ret == (ssize_t)stop_cvd_content.size(),
+            "Failed to write to stop_cvd script");
+  return {};
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_common.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_common.cpp
@@ -32,12 +32,10 @@ bool IsSubOperationSupported(const CommandRequest& request) {
   return request.SubcommandArguments()[0] == "create";
 }
 
-Result<void> PrepareForAcloudDeleteCommand(
-    const cvd::InstanceGroupInfo& group_info) {
-  std::string host_path = group_info.host_artifacts_path();
-  std::string stop_cvd_path = fmt::format("{}/bin/stop_cvd", host_path);
+Result<void> PrepareForAcloudDeleteCommand(const std::string& host_artifacts) {
+  std::string stop_cvd_path = fmt::format("{}/bin/stop_cvd", host_artifacts);
   std::string cvd_internal_stop_path =
-      fmt::format("{}/bin/cvd_internal_stop", host_path);
+      fmt::format("{}/bin/cvd_internal_stop", host_artifacts);
   if (FileExists(cvd_internal_stop_path)) {
     // cvd_internal_stop exists, stop_cvd is just a symlink to it
     CF_EXPECT(RemoveFile(stop_cvd_path), "Failed to remove stop_cvd file");

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_common.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_common.cpp
@@ -22,7 +22,7 @@ bool IsSubOperationSupported(const CommandRequest& request) {
   if (request.SubcommandArguments().empty()) {
     return false;
   }
-  return request.Subcommand() == "create";
+  return request.SubcommandArguments()[0] == "create";
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_common.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_common.h
@@ -18,10 +18,19 @@
 
 #include "host/commands/cvd/cli/command_request.h"
 
+#include "cuttlefish/host/commands/cvd/legacy/cvd_server.pb.h"
+
 namespace cuttlefish {
 
 struct AcloudTranslatorOptOut {};
 
 bool IsSubOperationSupported(const CommandRequest& request);
+
+// Acloud delete is not translated because it needs to handle remote cases.
+// Python acloud implements delete by calling stop_cvd
+// This function replaces stop_cvd with a script that calls `cvd rm`, which in
+// turn calls cvd_internal_stop if necessary.
+Result<void> PrepareForAcloudDeleteCommand(
+    const cvd::InstanceGroupInfo& group_info);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_common.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_common.h
@@ -18,8 +18,6 @@
 
 #include "host/commands/cvd/cli/command_request.h"
 
-#include "cuttlefish/host/commands/cvd/legacy/cvd_server.pb.h"
-
 namespace cuttlefish {
 
 struct AcloudTranslatorOptOut {};
@@ -30,7 +28,6 @@ bool IsSubOperationSupported(const CommandRequest& request);
 // Python acloud implements delete by calling stop_cvd
 // This function replaces stop_cvd with a script that calls `cvd rm`, which in
 // turn calls cvd_internal_stop if necessary.
-Result<void> PrepareForAcloudDeleteCommand(
-    const cvd::InstanceGroupInfo& group_info);
+Result<void> PrepareForAcloudDeleteCommand(const std::string& host_artifacts);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_mixsuperimage.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_mixsuperimage.cpp
@@ -177,7 +177,7 @@ class AcloudMixSuperImageCommand : public CvdServerHandler {
     return "";
   }
 
-  Result<cvd::Response> Handle(const CommandRequest& request) override {
+  Result<void> HandleVoid(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
     std::vector<std::string> subcmd_args = request.SubcommandArguments();
     if (subcmd_args.empty() || subcmd_args.size() < 2) {
@@ -185,8 +185,6 @@ class AcloudMixSuperImageCommand : public CvdServerHandler {
     }
 
     // cvd acloud mix-super-image --super_image path
-    cvd::Response response;
-    response.mutable_command_response();
     bool help = false;
     std::string flag_paths = "";
     std::vector<Flag> mixsuperimage_flags = {
@@ -197,13 +195,14 @@ class AcloudMixSuperImageCommand : public CvdServerHandler {
               "Failed to process mix-super-image flag.");
     if (help) {
       std::cout << kMixSuperImageHelpMessage;
-      return response;
+      return {};
     }
 
     CF_EXPECT(MixSuperImage(flag_paths),
               "Build mixed super image failed");
-    return response;
+    return {};
   }
+
  private:
   /*
    * Use build_super_image to create a super image.

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_mixsuperimage.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_mixsuperimage.cpp
@@ -177,7 +177,7 @@ class AcloudMixSuperImageCommand : public CvdServerHandler {
     return "";
   }
 
-  Result<void> HandleVoid(const CommandRequest& request) override {
+  Result<void> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
     std::vector<std::string> subcmd_args = request.SubcommandArguments();
     if (subcmd_args.empty() || subcmd_args.size() < 2) {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_translator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_translator.cpp
@@ -61,7 +61,7 @@ class AcloudTranslatorCommand : public CvdServerHandler {
     return "";
   }
 
-  Result<void> HandleVoid(const CommandRequest& request) override {
+  Result<void> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
     std::vector<std::string> subcmd_args = request.SubcommandArguments();
     if (subcmd_args.empty() || subcmd_args.size() < 2) {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_translator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_translator.cpp
@@ -61,7 +61,7 @@ class AcloudTranslatorCommand : public CvdServerHandler {
     return "";
   }
 
-  Result<cvd::Response> Handle(const CommandRequest& request) override {
+  Result<void> HandleVoid(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
     std::vector<std::string> subcmd_args = request.SubcommandArguments();
     if (subcmd_args.empty() || subcmd_args.size() < 2) {
@@ -70,8 +70,6 @@ class AcloudTranslatorCommand : public CvdServerHandler {
 
     // cvd acloud translator --opt-out
     // cvd acloud translator --opt-in
-    cvd::Response response;
-    response.mutable_command_response();
     bool help = false;
     bool flag_optout = false;
     bool flag_optin = false;
@@ -84,12 +82,12 @@ class AcloudTranslatorCommand : public CvdServerHandler {
               "Failed to process translator flag.");
     if (help) {
       std::cout << kTranslatorHelpMessage;
-      return response;
+      return {};
     }
     CF_EXPECT(flag_optout != flag_optin,
               "Only one of --opt-out or --opt-in should be given.");
     CF_EXPECT(instance_manager_.SetAcloudTranslatorOptout(flag_optout));
-    return response;
+    return {};
   }
 
  private:

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/bugreport.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/bugreport.cpp
@@ -48,7 +48,7 @@ class CvdBugreportCommandHandler : public CvdServerHandler {
  public:
   CvdBugreportCommandHandler(InstanceManager& instance_manager);
 
-  Result<void> HandleVoid(const CommandRequest& request) override;
+  Result<void> Handle(const CommandRequest& request) override;
   cvd_common::Args CmdList() const override;
   Result<std::string> SummaryHelp() const override;
   bool ShouldInterceptHelp() const override;
@@ -67,8 +67,7 @@ CvdBugreportCommandHandler::CvdBugreportCommandHandler(
     InstanceManager& instance_manager)
     : instance_manager_(instance_manager) {}
 
-Result<void> CvdBugreportCommandHandler::HandleVoid(
-    const CommandRequest& request) {
+Result<void> CvdBugreportCommandHandler::Handle(const CommandRequest& request) {
   CF_EXPECT(CanHandle(request));
 
   std::vector<std::string> cmd_args = request.SubcommandArguments();

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/clear.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/clear.cpp
@@ -40,7 +40,7 @@ class CvdClearCommandHandler : public CvdServerHandler {
  public:
   CvdClearCommandHandler(InstanceManager& instance_manager);
 
-  Result<void> HandleVoid(const CommandRequest& request) override;
+  Result<void> Handle(const CommandRequest& request) override;
   cvd_common::Args CmdList() const override { return {kClearCmd}; }
   Result<std::string> SummaryHelp() const override { return kSummaryHelpText; }
   bool ShouldInterceptHelp() const override { return false; }
@@ -54,7 +54,7 @@ CvdClearCommandHandler::CvdClearCommandHandler(
     InstanceManager& instance_manager)
     : instance_manager_(instance_manager) {}
 
-Result<void> CvdClearCommandHandler::HandleVoid(const CommandRequest& request) {
+Result<void> CvdClearCommandHandler::Handle(const CommandRequest& request) {
   CF_EXPECT(CanHandle(request));
 
   std::vector<std::string> cmd_args = request.SubcommandArguments();

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/clear.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/clear.cpp
@@ -40,7 +40,7 @@ class CvdClearCommandHandler : public CvdServerHandler {
  public:
   CvdClearCommandHandler(InstanceManager& instance_manager);
 
-  Result<cvd::Response> Handle(const CommandRequest& request) override;
+  Result<void> HandleVoid(const CommandRequest& request) override;
   cvd_common::Args CmdList() const override { return {kClearCmd}; }
   Result<std::string> SummaryHelp() const override { return kSummaryHelpText; }
   bool ShouldInterceptHelp() const override { return false; }
@@ -54,22 +54,18 @@ CvdClearCommandHandler::CvdClearCommandHandler(
     InstanceManager& instance_manager)
     : instance_manager_(instance_manager) {}
 
-Result<cvd::Response> CvdClearCommandHandler::Handle(
-    const CommandRequest& request) {
+Result<void> CvdClearCommandHandler::HandleVoid(const CommandRequest& request) {
   CF_EXPECT(CanHandle(request));
-
-  cvd::Response response;
-  response.mutable_command_response();
 
   std::vector<std::string> cmd_args = request.SubcommandArguments();
 
   if (CF_EXPECT(IsHelpSubcmd(cmd_args))) {
     std::cout << kSummaryHelpText << std::endl;
-    response.mutable_status()->set_code(cvd::Status::OK);
-    return response;
+    return {};
   }
-  *response.mutable_status() = instance_manager_.CvdClear(request);
-  return response;
+  CF_EXPECT_EQ(instance_manager_.CvdClear(request).code(), cvd::Status::OK);
+
+  return {};
 }
 
 Result<std::string> CvdClearCommandHandler::DetailedHelp(

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/cmd_list.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/cmd_list.cpp
@@ -34,7 +34,7 @@ class CvdCmdlistHandler : public CvdServerHandler {
     return request.Subcommand() == "cmd-list";
   }
 
-  Result<void> HandleVoid(const CommandRequest& request) override {
+  Result<void> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
 
     const auto subcmds = executor_.CmdList();

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/cmd_list.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/cmd_list.cpp
@@ -34,11 +34,7 @@ class CvdCmdlistHandler : public CvdServerHandler {
     return request.Subcommand() == "cmd-list";
   }
 
-  Result<cvd::Response> Handle(const CommandRequest& request) override {
-    cvd::Response response;
-    response.mutable_command_response();  // Sets oneof member
-    response.mutable_status()->set_code(cvd::Status::OK);
-
+  Result<void> HandleVoid(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
 
     const auto subcmds = executor_.CmdList();
@@ -48,7 +44,7 @@ class CvdCmdlistHandler : public CvdServerHandler {
     Json::Value subcmd_info;
     subcmd_info["subcmd"] = subcmds_str;
     std::cout << subcmd_info.toStyledString();
-    return response;
+    return {};
   }
 
   // not intended to be used by the user

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
@@ -223,7 +223,7 @@ class CvdCreateCommandHandler : public CvdServerHandler {
       : instance_manager_(instance_manager),
         command_executor_(command_executor) {}
 
-  Result<void> HandleVoid(const CommandRequest& request) override;
+  Result<void> Handle(const CommandRequest& request) override;
   std::vector<std::string> CmdList() const override { return {"create"}; }
   Result<std::string> SummaryHelp() const override;
   bool ShouldInterceptHelp() const override;
@@ -341,8 +341,7 @@ Result<void> CvdCreateCommandHandler::CreateSymlinks(
   return {};
 }
 
-Result<void> CvdCreateCommandHandler::HandleVoid(
-    const CommandRequest& request) {
+Result<void> CvdCreateCommandHandler::Handle(const CommandRequest& request) {
   CF_EXPECT(CanHandle(request));
   std::vector<std::string> subcmd_args = request.SubcommandArguments();
   bool is_help = CF_EXPECT(IsHelpSubcmd(subcmd_args));

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
@@ -409,7 +409,7 @@ Result<cvd::Response> CvdCreateCommandHandler::Handle(
 
   if (flags.prepare_for_acloud_delete) {
     Result<void> prepare_delete_result =
-        PrepareForAcloudDeleteCommand(GroupInfoFromGroup(group));
+        PrepareForAcloudDeleteCommand(group.HostArtifactsPath());
     if (!prepare_delete_result.ok()) {
       LOG(ERROR) << prepare_delete_result.error().FormatForEnv();
       LOG(WARNING) << "Failed to prepare for execution of `acloud delete`, use "

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
@@ -197,20 +197,6 @@ Result<cvd_common::Envs> GetEnvs(const CommandRequest& request) {
   return envs;
 }
 
-cvd::InstanceGroupInfo GroupInfoFromGroup(const LocalInstanceGroup& group) {
-  cvd::InstanceGroupInfo info;
-  info.set_group_name(group.GroupName());
-  for (const auto& instance : group.Instances()) {
-    cvd::InstanceGroupInfo::PerInstanceInfo instance_info;
-    instance_info.set_name(instance.name());
-    instance_info.set_instance_id(instance.id());
-    *info.add_instances() = instance_info;
-  }
-  info.add_home_directories(group.HomeDir());
-  info.set_host_artifacts_path(group.HostArtifactsPath());
-  return info;
-}
-
 // link might be a directory, so we clean that up, and create a link from
 // target to link
 Result<void> EnsureSymlink(const std::string& target, const std::string link) {
@@ -417,8 +403,6 @@ Result<cvd::Response> CvdCreateCommandHandler::Handle(
     }
   }
 
-  *response.mutable_command_response()->mutable_instance_group_info() =
-      GroupInfoFromGroup(group);
   return response;
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/display.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/display.cpp
@@ -55,7 +55,7 @@ class CvdDisplayCommandHandler : public CvdServerHandler {
   CvdDisplayCommandHandler(InstanceManager& instance_manager)
       : instance_manager_{instance_manager} {}
 
-  Result<void> HandleVoid(const CommandRequest& request) override {
+  Result<void> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
     const cvd_common::Envs& env = request.Env();
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/display.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/display.cpp
@@ -55,7 +55,7 @@ class CvdDisplayCommandHandler : public CvdServerHandler {
   CvdDisplayCommandHandler(InstanceManager& instance_manager)
       : instance_manager_{instance_manager} {}
 
-  Result<cvd::Response> Handle(const CommandRequest& request) override {
+  Result<void> HandleVoid(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
     const cvd_common::Envs& env = request.Env();
 
@@ -70,7 +70,8 @@ class CvdDisplayCommandHandler : public CvdServerHandler {
     siginfo_t infop;
     command.Start().Wait(&infop, WEXITED);
 
-    return ResponseFromSiginfo(infop);
+    CF_EXPECT(CheckProcessExitedNormally(infop));
+    return {};
   }
 
   cvd_common::Args CmdList() const override { return {"display"}; }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/env.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/env.cpp
@@ -49,7 +49,7 @@ class CvdEnvCommandHandler : public CvdServerHandler {
   CvdEnvCommandHandler(InstanceManager& instance_manager)
       : instance_manager_{instance_manager} {}
 
-  Result<void> HandleVoid(const CommandRequest& request) override {
+  Result<void> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
     const cvd_common::Envs& env = request.Env();
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/env.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/env.cpp
@@ -49,7 +49,7 @@ class CvdEnvCommandHandler : public CvdServerHandler {
   CvdEnvCommandHandler(InstanceManager& instance_manager)
       : instance_manager_{instance_manager} {}
 
-  Result<cvd::Response> Handle(const CommandRequest& request) override {
+  Result<void> HandleVoid(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
     const cvd_common::Envs& env = request.Env();
 
@@ -72,7 +72,8 @@ class CvdEnvCommandHandler : public CvdServerHandler {
     siginfo_t infop;
     command.Start().Wait(&infop, WEXITED);
 
-    return ResponseFromSiginfo(infop);
+    CF_EXPECT(CheckProcessExitedNormally(infop));
+    return {};
   }
 
   cvd_common::Args CmdList() const override { return {"env"}; }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.cpp
@@ -28,15 +28,14 @@ namespace cuttlefish {
 
 class CvdFetchCommandHandler : public CvdServerHandler {
  public:
-  Result<cvd::Response> Handle(const CommandRequest& request) override;
+  Result<void> HandleVoid(const CommandRequest& request) override;
   cvd_common::Args CmdList() const override { return {"fetch", "fetch_cvd"}; }
   Result<std::string> SummaryHelp() const override;
   bool ShouldInterceptHelp() const override { return true; }
   Result<std::string> DetailedHelp(std::vector<std::string>&) const override;
 };
 
-Result<cvd::Response> CvdFetchCommandHandler::Handle(
-    const CommandRequest& request) {
+Result<void> CvdFetchCommandHandler::HandleVoid(const CommandRequest& request) {
   CF_EXPECT(CanHandle(request));
 
   std::vector<std::string> args;
@@ -53,10 +52,7 @@ Result<cvd::Response> CvdFetchCommandHandler::Handle(
 
   CF_EXPECT(FetchCvdMain(args_data.size(), args_data.data()));
 
-  cvd::Response response;
-  response.mutable_command_response();
-  response.mutable_status()->set_code(cvd::Status::OK);
-  return response;
+  return {};
 }
 
 Result<std::string> CvdFetchCommandHandler::SummaryHelp() const {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.cpp
@@ -28,14 +28,14 @@ namespace cuttlefish {
 
 class CvdFetchCommandHandler : public CvdServerHandler {
  public:
-  Result<void> HandleVoid(const CommandRequest& request) override;
+  Result<void> Handle(const CommandRequest& request) override;
   cvd_common::Args CmdList() const override { return {"fetch", "fetch_cvd"}; }
   Result<std::string> SummaryHelp() const override;
   bool ShouldInterceptHelp() const override { return true; }
   Result<std::string> DetailedHelp(std::vector<std::string>&) const override;
 };
 
-Result<void> CvdFetchCommandHandler::HandleVoid(const CommandRequest& request) {
+Result<void> CvdFetchCommandHandler::Handle(const CommandRequest& request) {
   CF_EXPECT(CanHandle(request));
 
   std::vector<std::string> args;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fleet.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fleet.cpp
@@ -41,7 +41,7 @@ class CvdFleetCommandHandler : public CvdServerHandler {
   CvdFleetCommandHandler(InstanceManager& instance_manager)
       : instance_manager_(instance_manager) {}
 
-  Result<cvd::Response> Handle(const CommandRequest& request) override;
+  Result<void> HandleVoid(const CommandRequest& request) override;
   cvd_common::Args CmdList() const override { return {kFleetSubcmd}; }
 
   Result<std::string> SummaryHelp() const override { return kSummaryHelpText; }
@@ -59,20 +59,14 @@ class CvdFleetCommandHandler : public CvdServerHandler {
   bool IsHelp(const cvd_common::Args& cmd_args) const;
 };
 
-Result<cvd::Response> CvdFleetCommandHandler::Handle(
-    const CommandRequest& request) {
+Result<void> CvdFleetCommandHandler::HandleVoid(const CommandRequest& request) {
   CF_EXPECT(CanHandle(request));
-
-  cvd::Response ok_response;
-  ok_response.mutable_command_response();
-  auto& status = *ok_response.mutable_status();
-  status.set_code(cvd::Status::OK);
 
   std::vector<std::string> args = request.SubcommandArguments();
 
   if (IsHelp(args)) {
     std::cout << kHelpMessage;
-    return ok_response;
+    return {};
   }
 
   auto all_groups = CF_EXPECT(instance_manager_.FindGroups({}));
@@ -85,7 +79,7 @@ Result<cvd::Response> CvdFleetCommandHandler::Handle(
 
   std::cout << output_json.toStyledString();
 
-  return ok_response;
+  return {};
 }
 
 bool CvdFleetCommandHandler::IsHelp(const cvd_common::Args& args) const {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fleet.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fleet.cpp
@@ -41,7 +41,7 @@ class CvdFleetCommandHandler : public CvdServerHandler {
   CvdFleetCommandHandler(InstanceManager& instance_manager)
       : instance_manager_(instance_manager) {}
 
-  Result<void> HandleVoid(const CommandRequest& request) override;
+  Result<void> Handle(const CommandRequest& request) override;
   cvd_common::Args CmdList() const override { return {kFleetSubcmd}; }
 
   Result<std::string> SummaryHelp() const override { return kSummaryHelpText; }
@@ -59,7 +59,7 @@ class CvdFleetCommandHandler : public CvdServerHandler {
   bool IsHelp(const cvd_common::Args& cmd_args) const;
 };
 
-Result<void> CvdFleetCommandHandler::HandleVoid(const CommandRequest& request) {
+Result<void> CvdFleetCommandHandler::Handle(const CommandRequest& request) {
   CF_EXPECT(CanHandle(request));
 
   std::vector<std::string> args = request.SubcommandArguments();

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/help.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/help.cpp
@@ -75,7 +75,7 @@ class CvdHelpHandler : public CvdServerHandler {
       const std::vector<std::unique_ptr<CvdServerHandler>>& request_handlers)
       : request_handlers_(request_handlers) {}
 
-  Result<void> HandleVoid(const CommandRequest& request) override {
+  Result<void> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
 
     std::vector<std::string> args = request.SubcommandArguments();

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/help.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/help.cpp
@@ -75,7 +75,7 @@ class CvdHelpHandler : public CvdServerHandler {
       const std::vector<std::unique_ptr<CvdServerHandler>>& request_handlers)
       : request_handlers_(request_handlers) {}
 
-  Result<cvd::Response> Handle(const CommandRequest& request) override {
+  Result<void> HandleVoid(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
 
     std::vector<std::string> args = request.SubcommandArguments();
@@ -85,10 +85,7 @@ class CvdHelpHandler : public CvdServerHandler {
       std::cout << CF_EXPECT(SubCommandHelp(args));
     }
 
-    cvd::Response response;
-    response.mutable_command_response();  // Sets oneof member
-    response.mutable_status()->set_code(cvd::Status::OK);
-    return response;
+    return {};
   }
 
   cvd_common::Args CmdList() const override { return {"help"}; }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/lint.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/lint.cpp
@@ -44,7 +44,7 @@ Usage: cvd lint /path/to/input.json
 
 class LintCommandHandler : public CvdServerHandler {
  public:
-  Result<cvd::Response> Handle(const CommandRequest& request) override {
+  Result<void> HandleVoid(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
 
     std::vector<std::string> args = request.SubcommandArguments();
@@ -54,10 +54,7 @@ class LintCommandHandler : public CvdServerHandler {
     std::cout << "Lint of flags and config \"" << config_path
                   << "\" succeeded\n";
 
-    cvd::Response response;
-    response.mutable_command_response();
-    response.mutable_status()->set_code(cvd::Status::OK);
-    return response;
+    return {};
   }
 
   cvd_common::Args CmdList() const override { return {kLintSubCmd}; }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/lint.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/lint.cpp
@@ -44,7 +44,7 @@ Usage: cvd lint /path/to/input.json
 
 class LintCommandHandler : public CvdServerHandler {
  public:
-  Result<void> HandleVoid(const CommandRequest& request) override {
+  Result<void> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
 
     std::vector<std::string> args = request.SubcommandArguments();

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.cpp
@@ -57,8 +57,6 @@ Result<CvdFlags> GetCvdFlags(const CommandRequest& request) {
   return CF_EXPECT(GetCvdFlags(flags));
 }
 
-}  // namespace
-
 class LoadConfigsCommand : public CvdServerHandler {
  public:
   LoadConfigsCommand(CommandSequenceExecutor& executor,
@@ -66,7 +64,7 @@ class LoadConfigsCommand : public CvdServerHandler {
       : executor_(executor), instance_manager_(instance_manager) {}
   ~LoadConfigsCommand() = default;
 
-  Result<cvd::Response> Handle(const CommandRequest& request) override {
+  Result<void> HandleVoid(const CommandRequest& request) override {
     bool can_handle_request = CF_EXPECT(CanHandle(request));
     CF_EXPECT_EQ(can_handle_request, true);
 
@@ -130,9 +128,7 @@ class LoadConfigsCommand : public CvdServerHandler {
     }
     listener_handle.reset();
 
-    cvd::Response response;
-    response.mutable_command_response();
-    return response;
+    return {};
   }
 
   Result<void> LoadGroup(const CommandRequest& request,
@@ -241,6 +237,8 @@ class LoadConfigsCommand : public CvdServerHandler {
   CommandSequenceExecutor& executor_;
   InstanceManager& instance_manager_;
 };
+
+}  // namespace
 
 std::unique_ptr<CvdServerHandler> NewLoadConfigsCommand(
     CommandSequenceExecutor& executor, InstanceManager& instance_manager) {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.cpp
@@ -64,7 +64,7 @@ class LoadConfigsCommand : public CvdServerHandler {
       : executor_(executor), instance_manager_(instance_manager) {}
   ~LoadConfigsCommand() = default;
 
-  Result<void> HandleVoid(const CommandRequest& request) override {
+  Result<void> Handle(const CommandRequest& request) override {
     bool can_handle_request = CF_EXPECT(CanHandle(request));
     CF_EXPECT_EQ(can_handle_request, true);
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/login.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/login.cpp
@@ -47,7 +47,7 @@ usage: cvd login --client_id=CLIENT_ID --client_secret=SECRET --scopes=SCOPES [-
 
 class CvdLoginCommand : public CvdServerHandler {
  public:
-  Result<void> HandleVoid(const CommandRequest& request) override {
+  Result<void> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
 
     std::vector<std::string> args = request.Args();

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/login.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/login.cpp
@@ -47,7 +47,7 @@ usage: cvd login --client_id=CLIENT_ID --client_secret=SECRET --scopes=SCOPES [-
 
 class CvdLoginCommand : public CvdServerHandler {
  public:
-  Result<cvd::Response> Handle(const CommandRequest& request) override {
+  Result<void> HandleVoid(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
 
     std::vector<std::string> args = request.Args();

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/noop.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/noop.cpp
@@ -28,12 +28,10 @@ constexpr char kSummaryHelpText[] =
 
 class CvdNoopHandler : public CvdServerHandler {
  public:
-  Result<cvd::Response> Handle(const CommandRequest& request) override {
-    fmt::print(std::cout, "DEPRECATED: The {} command is a no-op",
+  Result<void> HandleVoid(const CommandRequest& request) override {
+    fmt::print(std::cout, "DEPRECATED: The {} command is a no-op\n",
                request.Subcommand());
-    cvd::Response response;
-    response.mutable_status()->set_code(cvd::Status::OK);
-    return response;
+    return {};
   }
 
   cvd_common::Args CmdList() const override {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/noop.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/noop.cpp
@@ -28,7 +28,7 @@ constexpr char kSummaryHelpText[] =
 
 class CvdNoopHandler : public CvdServerHandler {
  public:
-  Result<void> HandleVoid(const CommandRequest& request) override {
+  Result<void> Handle(const CommandRequest& request) override {
     fmt::print(std::cout, "DEPRECATED: The {} command is a no-op\n",
                request.Subcommand());
     return {};

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/power.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/power.cpp
@@ -65,7 +65,7 @@ class CvdDevicePowerCommandHandler : public CvdServerHandler {
     return Contains(cvd_power_operations_, request.Subcommand());
   }
 
-  Result<void> HandleVoid(const CommandRequest& request) override {
+  Result<void> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
     const cvd_common::Envs& env = request.Env();
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/power.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/power.cpp
@@ -65,7 +65,7 @@ class CvdDevicePowerCommandHandler : public CvdServerHandler {
     return Contains(cvd_power_operations_, request.Subcommand());
   }
 
-  Result<cvd::Response> Handle(const CommandRequest& request) override {
+  Result<void> HandleVoid(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
     const cvd_common::Envs& env = request.Env();
 
@@ -81,7 +81,8 @@ class CvdDevicePowerCommandHandler : public CvdServerHandler {
     siginfo_t infop;
     command.Start().Wait(&infop, WEXITED);
 
-    return ResponseFromSiginfo(infop);
+    CF_EXPECT(CheckProcessExitedNormally(infop));
+    return {};
   }
 
   cvd_common::Args CmdList() const override {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/remove.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/remove.cpp
@@ -52,7 +52,7 @@ class RemoveCvdCommandHandler : public CvdServerHandler {
 
   bool ShouldInterceptHelp() const override { return false; }
 
-  Result<void> HandleVoid(const CommandRequest& request) override {
+  Result<void> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
     std::vector<std::string> subcmd_args = request.SubcommandArguments();
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/reset.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/reset.cpp
@@ -110,14 +110,13 @@ static bool GetUserConfirm() {
                  ::tolower);
   return (user_confirm == "y" || user_confirm == "yes");
 }
-}  // namespace
 
 class CvdResetCommandHandler : public CvdServerHandler {
  public:
   CvdResetCommandHandler(InstanceManager& instance_manager)
       : instance_manager_(instance_manager) {}
 
-  Result<cvd::Response> Handle(const CommandRequest& request) override {
+  Result<void> HandleVoid(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
     std::vector<std::string> subcmd_args = request.SubcommandArguments();
     auto options = CF_EXPECT(ParseResetFlags(subcmd_args));
@@ -147,10 +146,7 @@ class CvdResetCommandHandler : public CvdServerHandler {
     }
     CF_EXPECT(KillAllCuttlefishInstances(
         /* clear_instance_dirs*/ options.clean_runtime_dir));
-    cvd::Response response;
-    response.mutable_command_response();
-    response.mutable_status()->set_code(cvd::Status::OK);
-    return response;
+    return {};
   }
   cvd_common::Args CmdList() const override { return {kResetSubcmd}; }
 
@@ -166,6 +162,8 @@ class CvdResetCommandHandler : public CvdServerHandler {
   static constexpr char kResetSubcmd[] = "reset";
   InstanceManager& instance_manager_;
 };
+
+}  // namespace
 
 std::unique_ptr<CvdServerHandler> NewCvdResetCommandHandler(
     InstanceManager& instance_manager) {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/reset.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/reset.cpp
@@ -116,7 +116,7 @@ class CvdResetCommandHandler : public CvdServerHandler {
   CvdResetCommandHandler(InstanceManager& instance_manager)
       : instance_manager_(instance_manager) {}
 
-  Result<void> HandleVoid(const CommandRequest& request) override {
+  Result<void> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
     std::vector<std::string> subcmd_args = request.SubcommandArguments();
     auto options = CF_EXPECT(ParseResetFlags(subcmd_args));

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/server_handler.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/server_handler.cpp
@@ -26,4 +26,21 @@ Result<bool> CvdServerHandler::CanHandle(const CommandRequest& request) const {
   return Contains(CmdList(), request.Subcommand());
 }
 
+Result<void> CvdServerHandler::HandleVoid(const CommandRequest& request) {
+  cvd::Response response = CF_EXPECT(Handle(request));
+  CF_EXPECT_EQ(response.status().code(), cvd::Status::OK,
+               response.status().message());
+  return {};
+}
+
+Result<cvd::Response> CvdServerHandler::Handle(const CommandRequest& request) {
+  CF_EXPECT(HandleVoid(request));
+
+  cvd::Response response;
+  response.mutable_command_response();
+  response.mutable_status()->set_code(cvd::Status::OK);
+
+  return response;
+}
+
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/server_handler.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/server_handler.cpp
@@ -26,21 +26,4 @@ Result<bool> CvdServerHandler::CanHandle(const CommandRequest& request) const {
   return Contains(CmdList(), request.Subcommand());
 }
 
-Result<void> CvdServerHandler::HandleVoid(const CommandRequest& request) {
-  cvd::Response response = CF_EXPECT(Handle(request));
-  CF_EXPECT_EQ(response.status().code(), cvd::Status::OK,
-               response.status().message());
-  return {};
-}
-
-Result<cvd::Response> CvdServerHandler::Handle(const CommandRequest& request) {
-  CF_EXPECT(HandleVoid(request));
-
-  cvd::Response response;
-  response.mutable_command_response();
-  response.mutable_status()->set_code(cvd::Status::OK);
-
-  return response;
-}
-
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/server_handler.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/server_handler.h
@@ -30,7 +30,7 @@ class CvdServerHandler {
   virtual ~CvdServerHandler() = default;
 
   virtual Result<bool> CanHandle(const CommandRequest&) const;
-  virtual Result<void> HandleVoid(const CommandRequest&) = 0;
+  virtual Result<void> Handle(const CommandRequest&) = 0;
   // returns the list of subcommand it can handle
   virtual cvd_common::Args CmdList() const = 0;
   // used for command help text

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/server_handler.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/server_handler.h
@@ -30,10 +30,7 @@ class CvdServerHandler {
   virtual ~CvdServerHandler() = default;
 
   virtual Result<bool> CanHandle(const CommandRequest&) const;
-  // Either `HandleVoid` or `Handle` should be implemented. The default
-  // implementations of these methods call each other.
-  virtual Result<void> HandleVoid(const CommandRequest&);
-  virtual Result<cvd::Response> Handle(const CommandRequest&);
+  virtual Result<void> HandleVoid(const CommandRequest&) = 0;
   // returns the list of subcommand it can handle
   virtual cvd_common::Args CmdList() const = 0;
   // used for command help text

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/server_handler.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/server_handler.h
@@ -30,7 +30,10 @@ class CvdServerHandler {
   virtual ~CvdServerHandler() = default;
 
   virtual Result<bool> CanHandle(const CommandRequest&) const;
-  virtual Result<cvd::Response> Handle(const CommandRequest&) = 0;
+  // Either `HandleVoid` or `Handle` should be implemented. The default
+  // implementations of these methods call each other.
+  virtual Result<void> HandleVoid(const CommandRequest&);
+  virtual Result<cvd::Response> Handle(const CommandRequest&);
   // returns the list of subcommand it can handle
   virtual cvd_common::Args CmdList() const = 0;
   // used for command help text

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/snapshot.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/snapshot.cpp
@@ -67,7 +67,7 @@ class CvdSnapshotCommandHandler : public CvdServerHandler {
   CvdSnapshotCommandHandler(InstanceManager& instance_manager)
       : instance_manager_{instance_manager} {}
 
-  Result<cvd::Response> Handle(const CommandRequest& request) override {
+  Result<void> HandleVoid(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
 
     std::string subcmd = request.Subcommand();
@@ -86,7 +86,8 @@ class CvdSnapshotCommandHandler : public CvdServerHandler {
     siginfo_t infop;
     command.Start().Wait(&infop, WEXITED);
 
-    return ResponseFromSiginfo(infop);
+    CF_EXPECT(CheckProcessExitedNormally(infop));
+    return {};
   }
 
   cvd_common::Args CmdList() const override {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/snapshot.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/snapshot.cpp
@@ -67,7 +67,7 @@ class CvdSnapshotCommandHandler : public CvdServerHandler {
   CvdSnapshotCommandHandler(InstanceManager& instance_manager)
       : instance_manager_{instance_manager} {}
 
-  Result<void> HandleVoid(const CommandRequest& request) override {
+  Result<void> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
 
     std::string subcmd = request.Subcommand();

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -257,9 +257,6 @@ class CvdStartCommandHandler : public CvdServerHandler {
     std::vector<InstanceLockFile> lock_files;
   };
 
-  Result<cvd::Response> FillOutNewInstanceInfo(cvd::Response&& response,
-                                               const LocalInstanceGroup& group);
-
   Result<void> UpdateArgs(cvd_common::Args& args, LocalInstanceGroup& group);
 
   Result<void> UpdateEnvs(cvd_common::Envs& envs,
@@ -588,7 +585,7 @@ Result<cvd::Response> CvdStartCommandHandler::Handle(
   auto group_json = CF_EXPECT(group.FetchStatus());
   std::cout << group_json.toStyledString();
 
-  return FillOutNewInstanceInfo(std::move(response), group);
+  return response;
 }
 
 static constexpr char kCollectorFailure[] = R"(
@@ -685,22 +682,6 @@ Result<cvd::Response> CvdStartCommandHandler::LaunchDeviceInterruptible(
   }
 
   return response;
-}
-
-Result<cvd::Response> CvdStartCommandHandler::FillOutNewInstanceInfo(
-    cvd::Response&& response, const LocalInstanceGroup& group) {
-  auto new_response = std::move(response);
-  auto& command_response = *(new_response.mutable_command_response());
-  auto& instance_group_info =
-      *(CF_EXPECT(command_response.mutable_instance_group_info()));
-  instance_group_info.set_group_name(group.GroupName());
-  instance_group_info.add_home_directories(group.HomeDir());
-  for (const auto& instance : group.Instances()) {
-    auto* new_entry = CF_EXPECT(instance_group_info.add_instances());
-    new_entry->set_name(instance.name());
-    new_entry->set_instance_id(instance.id());
-  }
-  return new_response;
 }
 
 Result<std::string> CvdStartCommandHandler::SummaryHelp() const {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -229,7 +229,7 @@ class CvdStartCommandHandler : public CvdServerHandler {
   CvdStartCommandHandler(InstanceManager& instance_manager)
       : instance_manager_(instance_manager) {}
 
-  Result<void> HandleVoid(const CommandRequest& request) override;
+  Result<void> Handle(const CommandRequest& request) override;
   std::vector<std::string> CmdList() const override {
     return {"start", "launch_cvd"};
   }
@@ -474,7 +474,7 @@ static Result<void> ConsumeDaemonModeFlag(cvd_common::Args& args) {
   return {};
 }
 
-Result<void> CvdStartCommandHandler::HandleVoid(const CommandRequest& request) {
+Result<void> CvdStartCommandHandler::Handle(const CommandRequest& request) {
   CF_EXPECT(CanHandle(request));
 
   std::string subcmd = request.Subcommand();

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/status.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/status.cpp
@@ -110,7 +110,7 @@ class CvdStatusCommandHandler : public CvdServerHandler {
  public:
   CvdStatusCommandHandler(InstanceManager& instance_manager);
 
-  Result<void> HandleVoid(const CommandRequest& request) override;
+  Result<void> Handle(const CommandRequest& request) override;
   cvd_common::Args CmdList() const override { return {"status", "cvd_status"}; }
 
   Result<std::string> SummaryHelp() const override { return kSummaryHelpText; }
@@ -129,8 +129,7 @@ CvdStatusCommandHandler::CvdStatusCommandHandler(
     InstanceManager& instance_manager)
     : instance_manager_(instance_manager) {}
 
-Result<void> CvdStatusCommandHandler::HandleVoid(
-    const CommandRequest& request) {
+Result<void> CvdStatusCommandHandler::Handle(const CommandRequest& request) {
   CF_EXPECT(CanHandle(request));
 
   std::vector<std::string> cmd_args = request.SubcommandArguments();

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/status.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/status.cpp
@@ -110,7 +110,7 @@ class CvdStatusCommandHandler : public CvdServerHandler {
  public:
   CvdStatusCommandHandler(InstanceManager& instance_manager);
 
-  Result<cvd::Response> Handle(const CommandRequest& request) override;
+  Result<void> HandleVoid(const CommandRequest& request) override;
   cvd_common::Args CmdList() const override { return {"status", "cvd_status"}; }
 
   Result<std::string> SummaryHelp() const override { return kSummaryHelpText; }
@@ -129,7 +129,7 @@ CvdStatusCommandHandler::CvdStatusCommandHandler(
     InstanceManager& instance_manager)
     : instance_manager_(instance_manager) {}
 
-Result<cvd::Response> CvdStatusCommandHandler::Handle(
+Result<void> CvdStatusCommandHandler::HandleVoid(
     const CommandRequest& request) {
   CF_EXPECT(CanHandle(request));
 
@@ -138,11 +138,11 @@ Result<cvd::Response> CvdStatusCommandHandler::Handle(
 
   if (flags.help) {
     std::cout << kDetailedHelpText << std::endl;
-    return SuccessResponse();
+    return {};
   }
 
   if (!CF_EXPECT(instance_manager_.HasInstanceGroups())) {
-    return NoGroupResponse(request);
+    return CF_ERR(NoGroupMessage(request));
   }
 
   if (request.Selectors().instance_names && !flags.instance_name.empty()) {
@@ -178,7 +178,7 @@ Result<cvd::Response> CvdStatusCommandHandler::Handle(
     std::cout << status_array.toStyledString();
   }
 
-  return SuccessResponse();
+  return {};
 }
 
 std::unique_ptr<CvdServerHandler> NewCvdStatusCommandHandler(

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/stop.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/stop.cpp
@@ -48,7 +48,7 @@ class CvdStopCommandHandler : public CvdServerHandler {
  public:
   CvdStopCommandHandler(InstanceManager& instance_manager);
 
-  Result<void> HandleVoid(const CommandRequest& request) override;
+  Result<void> Handle(const CommandRequest& request) override;
   cvd_common::Args CmdList() const override { return {"stop", "stop_cvd"}; }
   Result<std::string> SummaryHelp() const override;
   bool ShouldInterceptHelp() const override;
@@ -99,8 +99,7 @@ Result<void> CvdStopCommandHandler::HandleHelpCmd(
   return {};
 }
 
-Result<void> CvdStopCommandHandler::HandleVoid(
-    const CommandRequest& request) {
+Result<void> CvdStopCommandHandler::Handle(const CommandRequest& request) {
   CF_EXPECT(CanHandle(request));
   std::vector<std::string> cmd_args = request.SubcommandArguments();
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/try_acloud.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/try_acloud.cpp
@@ -72,7 +72,7 @@ class TryAcloudCommand : public CvdServerHandler {
     return kDetailedHelpText;
   }
 
-  Result<void> HandleVoid(const CommandRequest& request) override {
+  Result<void> Handle(const CommandRequest& request) override {
 #if ENABLE_CVDR_TRANSLATION
     Result<void> res = VerifyWithCvdRemote(request);
     if (res.ok()) {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/version.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/version.cpp
@@ -37,7 +37,7 @@ class CvdVersionHandler : public CvdServerHandler {
  public:
   CvdVersionHandler() = default;
 
-  Result<cvd::Response> Handle(const CommandRequest& request) override {
+  Result<void> HandleVoid(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
 
     fmt::print(std::cout, "major: {}\n", cvd::kVersionMajor);
@@ -49,9 +49,7 @@ class CvdVersionHandler : public CvdServerHandler {
     }
     fmt::print(std::cout, "crc32: {}\n", FileCrc(kServerExecPath));
 
-    cvd::Response response;
-    response.mutable_status()->set_code(cvd::Status::OK);
-    return response;
+    return {};
   }
 
   cvd_common::Args CmdList() const override { return {"version"}; }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/version.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/version.cpp
@@ -37,7 +37,7 @@ class CvdVersionHandler : public CvdServerHandler {
  public:
   CvdVersionHandler() = default;
 
-  Result<void> HandleVoid(const CommandRequest& request) override {
+  Result<void> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
 
     fmt::print(std::cout, "major: {}\n", cvd::kVersionMajor);

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/request_context.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/request_context.cpp
@@ -102,7 +102,6 @@ Result<CvdServerHandler*> RequestContext::Handler(
 Result<CvdServerHandler*> RequestHandler(
     const CommandRequest& request,
     const std::vector<std::unique_ptr<CvdServerHandler>>& handlers) {
-  Result<cvd::Response> response;
   std::vector<CvdServerHandler*> compatible_handlers;
   for (auto& handler : handlers) {
     if (CF_EXPECT(handler->CanHandle(request))) {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
@@ -209,15 +209,19 @@ cvd::Response NoGroupResponse(const CommandRequest& request) {
   cvd::Response response;
   response.mutable_command_response();
   response.mutable_status()->set_code(cvd::Status::OK);
-  TerminalColors colors(isatty(1));
-  std::string notice =
-      fmt::format("Command `{}{}{}` is not applicable: {}{}{}", colors.Red(),
-                  fmt::join(request.Args(), " "), colors.Reset(),
-                  colors.BoldRed(), "no device", colors.Reset());
+
+  std::string notice = NoGroupMessage(request);
   std::cout << notice << "\n";
 
   response.mutable_status()->set_message(notice);
   return response;
+}
+
+std::string NoGroupMessage(const CommandRequest& request) {
+  TerminalColors colors(isatty(1));
+  return fmt::format("Command `{}{}{}` is not applicable: {}{}{}", colors.Red(),
+                     fmt::join(request.Args(), " "), colors.Reset(),
+                     colors.BoldRed(), "no device", colors.Reset());
 }
 
 Result<cvd::Response> NoTTYResponse(const CommandRequest& request) {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
@@ -29,27 +29,6 @@
 
 namespace cuttlefish {
 
-cuttlefish::cvd::Response ResponseFromSiginfo(siginfo_t infop) {
-  cvd::Response response;
-  response.mutable_command_response();  // set oneof field
-  auto& status = *response.mutable_status();
-  if (infop.si_code == CLD_EXITED && infop.si_status == 0) {
-    status.set_code(cvd::Status::OK);
-    return response;
-  }
-
-  status.set_code(cvd::Status::INTERNAL);
-  std::string status_code_str = std::to_string(infop.si_status);
-  if (infop.si_code == CLD_EXITED) {
-    status.set_message("Exited with code " + status_code_str);
-  } else if (infop.si_code == CLD_KILLED) {
-    status.set_message("Exited with signal " + status_code_str);
-  } else {
-    status.set_message("Quit with code " + status_code_str);
-  }
-  return response;
-}
-
 Result<void> CheckProcessExitedNormally(siginfo_t infop) {
   if (infop.si_code == CLD_EXITED && infop.si_status == 0) {
     return {};
@@ -203,18 +182,6 @@ std::string_view TerminalColors::Red() const {
 
 std::string_view TerminalColors::Cyan() const {
   return is_tty_ ? kTerminalCyan : "";
-}
-
-cvd::Response NoGroupResponse(const CommandRequest& request) {
-  cvd::Response response;
-  response.mutable_command_response();
-  response.mutable_status()->set_code(cvd::Status::OK);
-
-  std::string notice = NoGroupMessage(request);
-  std::cout << notice << "\n";
-
-  response.mutable_status()->set_message(notice);
-  return response;
 }
 
 std::string NoGroupMessage(const CommandRequest& request) {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
@@ -191,21 +191,4 @@ std::string NoGroupMessage(const CommandRequest& request) {
                      colors.BoldRed(), "no device", colors.Reset());
 }
 
-Result<cvd::Response> NoTTYResponse(const CommandRequest& request) {
-  cvd::Response response;
-  response.mutable_command_response();
-  response.mutable_status()->set_code(cvd::Status::OK);
-  const uid_t uid = getuid();
-  TerminalColors colors(isatty(1));
-  auto notice = fmt::format(
-      "Command `{}{}{}` is not applicable:\n  {}{}{} (uid: '{}{}{}')",
-      colors.Red(), fmt::join(request.Args(), " "), colors.Reset(),
-      colors.BoldRed(),
-      "No terminal/tty for selecting one of multiple Cuttlefish groups",
-      colors.Reset(), colors.Cyan(), uid, colors.Reset());
-  std::cout << notice << "\n";
-  response.mutable_status()->set_message(notice);
-  return response;
-}
-
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
@@ -22,8 +22,9 @@
 #include "common/libs/utils/contains.h"
 #include "common/libs/utils/files.h"
 #include "common/libs/utils/flag_parser.h"
-#include "host/commands/cvd/utils/common.h"
+#include "cuttlefish/host/commands/cvd/cli/utils.h"
 #include "host/commands/cvd/instances/instance_manager.h"
+#include "host/commands/cvd/utils/common.h"
 #include "host/libs/config/config_constants.h"
 
 namespace cuttlefish {
@@ -47,6 +48,20 @@ cuttlefish::cvd::Response ResponseFromSiginfo(siginfo_t infop) {
     status.set_message("Quit with code " + status_code_str);
   }
   return response;
+}
+
+Result<void> CheckProcessExitedNormally(siginfo_t infop) {
+  if (infop.si_code == CLD_EXITED && infop.si_status == 0) {
+    return {};
+  }
+
+  if (infop.si_code == CLD_EXITED) {
+    return CF_ERRF("Exited with code '{}'", infop.si_status);
+  } else if (infop.si_code == CLD_KILLED) {
+    return CF_ERRF("Exited with signal '{}'", infop.si_status);
+  } else {
+    return CF_ERRF("Quit with code '{}'", infop.si_status);
+  }
 }
 
 Result<Command> ConstructCommand(const ConstructCommandParam& param) {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
@@ -241,11 +241,4 @@ Result<cvd::Response> NoTTYResponse(const CommandRequest& request) {
   return response;
 }
 
-cvd::Response SuccessResponse() {
-  cvd::Response response;
-  response.mutable_command_response();
-  response.mutable_status()->set_code(cvd::Status::OK);
-  return response;
-}
-
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
@@ -32,7 +32,6 @@
 
 namespace cuttlefish {
 
-cvd::Response ResponseFromSiginfo(siginfo_t infop);
 Result<void> CheckProcessExitedNormally(siginfo_t infop);
 
 struct ConstructCommandParam {
@@ -68,7 +67,6 @@ Result<bool> IsHelpSubcmd(const std::vector<std::string>& args);
 
 // Call this when there is no instance group is running
 // The function does not verify that.
-cvd::Response NoGroupResponse(const CommandRequest& request);
 std::string NoGroupMessage(const CommandRequest& request);
 
 // Call this when there is more than one group, which the selector flags are

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
@@ -75,8 +75,6 @@ std::string NoGroupMessage(const CommandRequest& request);
 // not sufficients to choose one from. The function does not verify that.
 Result<cvd::Response> NoTTYResponse(const CommandRequest& request);
 
-cvd::Response SuccessResponse();
-
 class TerminalColors {
  public:
   TerminalColors(bool is_tty): is_tty_(is_tty){}

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
@@ -80,6 +80,4 @@ class TerminalColors {
   bool is_tty_;
 };
 
-Result<cvd::Response> WriteToFd(SharedFD fd, const std::string& output);
-
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
@@ -69,10 +69,6 @@ Result<bool> IsHelpSubcmd(const std::vector<std::string>& args);
 // The function does not verify that.
 std::string NoGroupMessage(const CommandRequest& request);
 
-// Call this when there is more than one group, which the selector flags are
-// not sufficients to choose one from. The function does not verify that.
-Result<cvd::Response> NoTTYResponse(const CommandRequest& request);
-
 class TerminalColors {
  public:
   TerminalColors(bool is_tty): is_tty_(is_tty){}

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
@@ -69,6 +69,7 @@ Result<bool> IsHelpSubcmd(const std::vector<std::string>& args);
 // Call this when there is no instance group is running
 // The function does not verify that.
 cvd::Response NoGroupResponse(const CommandRequest& request);
+std::string NoGroupMessage(const CommandRequest& request);
 
 // Call this when there is more than one group, which the selector flags are
 // not sufficients to choose one from. The function does not verify that.

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
@@ -32,7 +32,8 @@
 
 namespace cuttlefish {
 
-cuttlefish::cvd::Response ResponseFromSiginfo(siginfo_t infop);
+cvd::Response ResponseFromSiginfo(siginfo_t infop);
+Result<void> CheckProcessExitedNormally(siginfo_t infop);
 
 struct ConstructCommandParam {
   const std::string& bin_path;

--- a/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
@@ -59,7 +59,7 @@ Cvd::Cvd(const android::base::LogSeverity verbosity,
       instance_lockfile_manager_(instance_lockfile_manager),
       instance_manager_(instance_manager) {}
 
-Result<cvd::Response> Cvd::HandleCommand(
+Result<void> Cvd::HandleCommand(
     const std::vector<std::string>& cvd_process_args,
     const std::unordered_map<std::string, std::string>& env,
     const std::vector<std::string>& selector_args) {
@@ -76,10 +76,11 @@ Result<cvd::Response> Cvd::HandleCommand(
     if (CF_EXPECT(IsHelpSubcmd(invocation_args))) {
       std::cout << CF_EXPECT(handler->DetailedHelp(invocation_args))
                 << std::endl;
-      return SuccessResponse();
+      return {};
     }
   }
-  return handler->Handle(request);
+  CF_EXPECT(handler->HandleVoid(request));
+  return {};
 }
 
 Result<void> Cvd::HandleCvdCommand(
@@ -102,7 +103,7 @@ Result<void> Cvd::HandleAcloud(
   std::vector<std::string> args_copy{args};
   args_copy[0] = "try-acloud";
 
-  auto attempt = HandleCommand(args_copy, env, {});
+  Result<void> attempt = HandleCommand(args_copy, env, {});
   if (!attempt.ok()) {
     CallPythonAcloud(args_copy);
     // no return

--- a/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
@@ -79,7 +79,7 @@ Result<void> Cvd::HandleCommand(
       return {};
     }
   }
-  CF_EXPECT(handler->HandleVoid(request));
+  CF_EXPECT(handler->Handle(request));
   return {};
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cvd.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cvd.h
@@ -31,7 +31,7 @@ class Cvd {
       InstanceLockFileManager& instance_lockfile_manager,
       InstanceManager& instance_manager);
 
-  Result<cvd::Response> HandleCommand(
+  Result<void> HandleCommand(
       const std::vector<std::string>& cvd_process_args,
       const std::unordered_map<std::string, std::string>& env,
       const std::vector<std::string>& selector_args);

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_group_record.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_group_record.cpp
@@ -188,7 +188,7 @@ Result<LocalInstanceGroup> LocalInstanceGroup::Deserialize(
     CF_EXPECT(instance_json.isMember(kJsonInstanceId));
     const std::string instance_id = instance_json[kJsonInstanceId].asString();
 
-    int id;
+    int id = -1;
     CF_EXPECTF(android::base::ParseInt(instance_id, std::addressof(id)),
                "Invalid instance ID in instance json: {}", instance_id);
     auto instance = group_proto.add_instances();

--- a/base/cvd/cuttlefish/host/commands/cvd/legacy/cvd_server.proto
+++ b/base/cvd/cuttlefish/host/commands/cvd/legacy/cvd_server.proto
@@ -91,22 +91,6 @@ message CommandRequest {
   SelectorOption selector_opts = 5;
 }
 
-/*
- * The fields are required to be filled only for a successful "cvd start" cmd
- */
-message InstanceGroupInfo {
-  string group_name = 1;
-  message PerInstanceInfo {
-    string name = 1;
-    uint32 instance_id = 2;
-  }
-  repeated PerInstanceInfo instances = 2;
-  repeated string home_directories = 3;
-  string host_artifacts_path = 4;
-}
-
 message CommandResponse {
-  oneof response_report {
-    InstanceGroupInfo instance_group_info = 1;
-  }
+  reserved 1;
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/legacy/run_server.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/legacy/run_server.cpp
@@ -25,6 +25,7 @@
 #include "common/libs/utils/json.h"
 #include "common/libs/utils/shared_fd_flag.h"
 #include "common/libs/utils/unix_sockets.h"
+#include "cuttlefish/host/commands/cvd/legacy/cvd_server.pb.h"
 #include "host/commands/cvd/instances/instance_database.h"
 #include "host/commands/cvd/metrics/metrics_notice.h"
 #include "host/commands/cvd/utils/common.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/utils/common.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/utils/common.cpp
@@ -66,16 +66,6 @@ Result<std::string> AndroidHostPath(const cvd_common::Envs& envs) {
   return current_dir;
 }
 
-cvd::Response CommandResponse(const cvd::Status_Code code,
-                              const std::string& message) {
-  cvd::Response response;
-  response.mutable_command_response();  // set oneof field
-  auto& status = *response.mutable_status();
-  status.set_code(code);
-  status.set_message(message);
-  return response;
-}
-
 template <typename T>
 std::ostream& operator<<(std::ostream& out, const std::vector<T>& v) {
   if (v.empty()) {

--- a/base/cvd/cuttlefish/host/commands/cvd/utils/common.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/utils/common.h
@@ -23,7 +23,6 @@
 #include <android-base/logging.h>
 
 #include "common/libs/utils/result.h"
-#include "cuttlefish/host/commands/cvd/legacy/cvd_server.pb.h"
 #include "host/commands/cvd/cli/types.h"
 
 namespace cuttlefish {
@@ -36,9 +35,6 @@ struct Overload : Ts... {
 
 template <typename... Ts>
 Overload(Ts...) -> Overload<Ts...>;
-
-cvd::Response CommandResponse(cvd::Status_Code,
-                              const std::string& message = "");
 
 // name of environment variable to mark the launch_cvd initiated by the cvd
 // server


### PR DESCRIPTION
This simplifies the `CvdServerHandler` interface.

Bug: b/383619080