### PR TITLE
Run clang-tidy in github actions on debian testing

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -1,0 +1,39 @@
+name: Clang-tidy on debian testing
+
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - main  # push events to main branch occur after PRs are merged, when the same checks were run
+
+jobs:
+  cvd-clang-tidy:
+    runs-on: ubuntu-latest
+    container: 
+      image: debian@sha256:e400e96695f74dbad8fd4f30e2e5b7a16e3489638cb640180eac76d14251be67 # debian 13 trixie-20241202
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
+    - name: Setup apt
+      run: apt update -y && apt upgrade -y
+    - name: Install dependencies
+      run: apt install -y git clang libcurl4-openssl-dev clang-tidy
+    - name: Install bazel
+      run: bash tools/buildutils/installbazel.sh
+    - name: Log dependency versions
+      run: |
+        bazel --version
+        clang --version
+        clang-tidy --version
+        g++ --version
+    - name: Build cvd
+      run: cd base/cvd && bazel build ...
+    - name: Test cvd
+      run: cd base/cvd && bazel test --sandbox_writable_path=$HOME --test_output=errors ...
+    - name: Upload test logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: testlogs
+        path: bazel-testlogs
+    - name: Run clang-tidy
+      run: cd base/cvd && bazel build //cuttlefish/... --config clang-tidy --keep_going

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -61,7 +61,7 @@ jobs:
     - name: Setup apt
       run: apt update -y && apt upgrade -y
     - name: Install dependencies
-      run: apt install -y git clang libcurl4-openssl-dev clang-tidy
+      run: apt install -y git clang libcurl4-openssl-dev
     - name: Install bazel
       run: bash tools/buildutils/installbazel.sh
     - name: Build cvd
@@ -73,8 +73,6 @@ jobs:
       with:
         name: testlogs
         path: bazel-testlogs
-    - name: Run clang-tidy
-      run: cd base/cvd && bazel build //cuttlefish/... --config clang-tidy
   e2e-tests-orchestration:
     runs-on: ubuntu-22.04 
     steps:

--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd.cpp
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd.cpp
@@ -911,8 +911,8 @@ int FileInstance::LinkAtCwd(const std::string& path) {
   std::string name = "/proc/self/fd/";
   name += std::to_string(fd_);
   errno = 0;
-  int rval =
-      linkat(-1, name.c_str(), AT_FDCWD, path.c_str(), AT_SYMLINK_FOLLOW);
+  /* argument 0 is ignored because `name` is absolute */
+  int rval = linkat(0, name.c_str(), AT_FDCWD, path.c_str(), AT_SYMLINK_FOLLOW);
   errno_ = errno;
   return rval;
 }

--- a/base/cvd/cuttlefish/common/libs/utils/files.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/files.cpp
@@ -484,10 +484,11 @@ Result<std::string> ReadFileContents(const std::string& filepath) {
 }
 
 std::string CurrentDirectory() {
-  std::unique_ptr<char, void (*)(void*)> cwd(getcwd(nullptr, 0), &free);
+  char unused_buffer[2];
+  std::unique_ptr<char, void (*)(void*)> cwd(getcwd(unused_buffer, 0), &free);
   std::string process_cwd(cwd.get());
   if (!cwd) {
-    PLOG(ERROR) << "`getcwd(nullptr, 0)` failed";
+    PLOG(ERROR) << "`getcwd(unused_buffer, 0)` failed";
     return "";
   }
   return process_cwd;


### PR DESCRIPTION
This has more parity with our developer workflow, and later clang-tidy supports better checks and fewer false positive errors.

The clang-tidy run is separated into a separate workflow so we can keep validation on the older debian environment, for parity with what we support for users.

Bug: b/384076029