### PR TITLE
Use a prebuilt clang/LLVM to make the build hermetic

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -61,7 +61,7 @@ jobs:
     - name: Setup apt
       run: apt update -y && apt upgrade -y
     - name: Install dependencies
-      run: apt install -y git clang libcurl4-openssl-dev clang-tidy
+      run: apt install -y git clang libcurl4-openssl-dev clang-tidy libtinfo5
     - name: Install bazel
       run: bash tools/buildutils/installbazel.sh
     - name: Build cvd

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -27,6 +27,12 @@ jobs:
       # debian:bullseye
       image: debian@sha256:3b6053ca925336c804e2d3f080af177efcdc9f51198a627569bfc7c7e730ef7e
     steps:
+    - name: Common bazel setup
+      uses: bazel-contrib/setup-bazel@f3f50ea6791b9b0f4c4eeabba4507422426462f5 #aka 0.9.1
+      with:
+        bazelisk-cache: true # Avoid downloading Bazel every time.
+        disk-cache: ${{ github.workflow }} # Store build cache per workflow.
+        repository-cache: true # Share repository cache between workflows.
     - name: Check for dockerenv file
       run: (ls /.dockerenv && echo 'Found dockerenv') || (echo 'No dockerenv')
     - name: setup apt
@@ -56,6 +62,12 @@ jobs:
     container: 
       image: debian@sha256:3b6053ca925336c804e2d3f080af177efcdc9f51198a627569bfc7c7e730ef7e
     steps:
+    - name: Common bazel setup
+      uses: bazel-contrib/setup-bazel@f3f50ea6791b9b0f4c4eeabba4507422426462f5 #aka 0.9.1
+      with:
+        bazelisk-cache: true # Avoid downloading Bazel every time.
+        disk-cache: ${{ github.workflow }} # Store build cache per workflow.
+        repository-cache: true # Share repository cache between workflows.
     - name: Checkout repository
       uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
     - name: Setup apt
@@ -78,6 +90,12 @@ jobs:
   e2e-tests-orchestration:
     runs-on: ubuntu-22.04 
     steps:
+    - name: Common bazel setup
+      uses: bazel-contrib/setup-bazel@f3f50ea6791b9b0f4c4eeabba4507422426462f5 #aka 0.9.1
+      with:
+        bazelisk-cache: true # Avoid downloading Bazel every time.
+        disk-cache: ${{ github.workflow }} # Store build cache per workflow.
+        repository-cache: true # Share repository cache between workflows.
     - name: Free space
       run: |
         echo "disk space before cleanup:"

--- a/base/cvd/.bazelrc
+++ b/base/cvd/.bazelrc
@@ -1,6 +1,6 @@
 build --copt=-fdiagnostics-color=always
-build --repo_env=CC=clang
 
 build:clang-tidy --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
 build:clang-tidy --output_groups=report
 build:clang-tidy --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config
+build:clang-tidy --@bazel_clang_tidy//:clang_tidy_executable=@llvm_toolchain//:clang-tidy

--- a/base/cvd/MODULE.bazel
+++ b/base/cvd/MODULE.bazel
@@ -33,3 +33,15 @@ git_override(
     commit = "f23d924918c581c68cd5cda5f12b4f8198ac0c35",
     remote = "https://github.com/erenon/bazel_clang_tidy.git",
 )
+
+bazel_dep(name = "toolchains_llvm", version = "1.2.0")
+
+# Configure and register the toolchain.
+llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
+llvm.toolchain(
+   llvm_version = "16.0.0",
+)
+
+use_repo(llvm, "llvm_toolchain")
+
+register_toolchains("@llvm_toolchain//:all")

--- a/base/cvd/MODULE.bazel.lock
+++ b/base/cvd/MODULE.bazel.lock
@@ -148,6 +148,8 @@
     "https://bcr.bazel.build/modules/stardoc/0.7.1/source.json": "b6500ffcd7b48cd72c29bb67bcac781e12701cc0d6d55d266a652583cfcdab01",
     "https://bcr.bazel.build/modules/tinyxml2/10.0.0/MODULE.bazel": "7c2c2fd7f9bd767e5c98eeb46385dba08c81be321d885ed077da9383e85aebc7",
     "https://bcr.bazel.build/modules/tinyxml2/10.0.0/source.json": "e6f10ec3ed2d93b165a6556ec0cca75f3f1f1b508494c618ed398d38919947a0",
+    "https://bcr.bazel.build/modules/toolchains_llvm/1.2.0/MODULE.bazel": "7b271b71e50de47fa47159a7f58165e80fcebe1196c014a14af0a08a867d1635",
+    "https://bcr.bazel.build/modules/toolchains_llvm/1.2.0/source.json": "0328cfc67075d6a016980be4011bbc1dcfba933e357568002542dff22abdd3a1",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/MODULE.bazel": "af322bc08976524477c79d1e45e241b6efbeb918c497e8840b8ab116802dda79",
@@ -285,6 +287,81 @@
             "rules_kotlin+",
             "bazel_tools",
             "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@toolchains_llvm+//toolchain/extensions:llvm.bzl%llvm": {
+      "general": {
+        "bzlTransitiveDigest": "2UD8x0LHy2fgOvBmCL8R0HPa9/omkySg1/dsFBzYcH8=",
+        "usagesDigest": "9uerx+N6WC51RoP/GFW9yrmbz7iqRVrx491KRDuxIsE=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "llvm_toolchain_llvm": {
+            "repoRuleId": "@@toolchains_llvm+//toolchain:rules.bzl%llvm",
+            "attributes": {
+              "alternative_llvm_sources": [],
+              "auth_patterns": {},
+              "distribution": "auto",
+              "exec_arch": "",
+              "exec_os": "",
+              "llvm_mirror": "",
+              "llvm_version": "16.0.0",
+              "llvm_versions": {},
+              "netrc": "",
+              "sha256": {},
+              "strip_prefix": {},
+              "urls": {}
+            }
+          },
+          "llvm_toolchain": {
+            "repoRuleId": "@@toolchains_llvm+//toolchain:rules.bzl%toolchain",
+            "attributes": {
+              "absolute_paths": false,
+              "archive_flags": {},
+              "compile_flags": {},
+              "coverage_compile_flags": {},
+              "coverage_link_flags": {},
+              "cxx_builtin_include_directories": {},
+              "cxx_flags": {},
+              "cxx_standard": {},
+              "dbg_compile_flags": {},
+              "exec_arch": "",
+              "exec_os": "",
+              "extra_exec_compatible_with": {},
+              "extra_target_compatible_with": {},
+              "link_flags": {},
+              "link_libs": {},
+              "llvm_versions": {
+                "": "16.0.0"
+              },
+              "opt_compile_flags": {},
+              "opt_link_flags": {},
+              "stdlib": {},
+              "target_settings": {},
+              "unfiltered_compile_flags": {},
+              "toolchain_roots": {},
+              "sysroot": {}
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "toolchains_llvm+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "toolchains_llvm+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "toolchains_llvm+",
+            "toolchains_llvm",
+            "toolchains_llvm+"
           ]
         ]
       }

--- a/base/debian/control
+++ b/base/debian/control
@@ -2,26 +2,27 @@ Source: cuttlefish-common
 Maintainer: Cuttlefish Team
 Section: misc
 Priority: optional
-Build-Depends: config-package-dev,
-               debhelper-compat (= 12),
+Build-Depends: bazel [amd64],
                clang,
-               pkg-config,
+               config-package-dev,
+               debhelper-compat (= 12),
+               git,
+               libcurl4-openssl-dev,
                libfmt-dev,
                libgflags-dev,
-               libjsoncpp-dev,
-               libcurl4-openssl-dev,
                libgoogle-glog-dev,
                libgtest-dev,
+               libjsoncpp-dev,
+               libtinfo5,
+               libprotobuf-c-dev,
+               libprotobuf-dev,
                libssl-dev,
                libxml2-dev,
-               uuid-dev,
-               libprotobuf-dev,
-               libprotobuf-c-dev,
-               protobuf-compiler,
                libz3-dev,
+               pkg-config,
+               protobuf-compiler,
                sed,
-               git,
-               bazel [amd64]
+               uuid-dev
 Standards-Version: 4.5.0
 
 Package: cuttlefish-base

--- a/base/debian/control
+++ b/base/debian/control
@@ -3,7 +3,6 @@ Maintainer: Cuttlefish Team
 Section: misc
 Priority: optional
 Build-Depends: bazel [amd64],
-               clang,
                config-package-dev,
                debhelper-compat (= 12),
                git,


### PR DESCRIPTION
LLVM version 16.0.4 was chosen for parity with our current developer desktop setup.

This makes the behavior of the compiler and clang-tidy more comparable between developer workstations and CI.