### PR TITLE
Fix many golint errors

### DIFF
--- a/e2etests/orchestration/create_from_images_zip_test/main_test.go
+++ b/e2etests/orchestration/create_from_images_zip_test/main_test.go
@@ -44,11 +44,11 @@ func TestInstance(t *testing.T) {
 	if err := common.UploadAndExtract(srv, uploadDir, "../artifacts/cvd-host_package.tar.gz"); err != nil {
 		t.Fatal(err)
 	}
-	const group_name = "foo"
+	const groupName = "foo"
 	config := `
   {
     "common": {
-      "group_name": "` + group_name + `",
+      "group_name": "` + groupName + `",
       "host_package": "@user_artifacts/` + uploadDir + `"
 
     },
@@ -79,7 +79,7 @@ func TestInstance(t *testing.T) {
 
 	got, createErr := srv.CreateCVD(createReq, &hoclient.AccessTokenBuildAPICreds{})
 
-	if err := common.DownloadHostBugReport(srv, group_name); err != nil {
+	if err := common.DownloadHostBugReport(srv, groupName); err != nil {
 		t.Errorf("failed creating bugreport: %s\n", err)
 	}
 	if createErr != nil {

--- a/e2etests/orchestration/create_local_image_test/main_test.go
+++ b/e2etests/orchestration/create_local_image_test/main_test.go
@@ -50,11 +50,11 @@ func TestInstance(t *testing.T) {
 	if err := common.UploadAndExtract(srv, uploadDir, "../artifacts/cvd-host_package.tar.gz"); err != nil {
 		t.Fatal(err)
 	}
-	const group_name = "foo"
+	const groupName = "foo"
 	config := `
   {
     "common": {
-      "group_name": "` + group_name + `",
+      "group_name": "` + groupName + `",
       "host_package": "@user_artifacts/` + uploadDir + `"
     },
     "instances": [
@@ -84,19 +84,19 @@ func TestInstance(t *testing.T) {
 
 	got, createErr := srv.CreateCVD(createReq, &hoclient.AccessTokenBuildAPICreds{})
 
-	if err := common.DownloadHostBugReport(srv, group_name); err != nil {
+	if err := common.DownloadHostBugReport(srv, groupName); err != nil {
 		t.Errorf("failed creating bugreport: %s\n", err)
 	}
 	if createErr != nil {
 		t.Fatal(createErr)
 	}
-	if err := common.VerifyLogsEndpoint(ctx.ServiceURL, group_name, "1"); err != nil {
+	if err := common.VerifyLogsEndpoint(ctx.ServiceURL, groupName, "1"); err != nil {
 		t.Fatalf("failed verifying /logs endpoint: %s", err)
 	}
 	want := &hoapi.CreateCVDResponse{
 		CVDs: []*hoapi.CVD{
 			&hoapi.CVD{
-				Group:          group_name,
+				Group:          groupName,
 				Name:           "1",
 				BuildSource:    &hoapi.BuildSource{},
 				Status:         "Running",

--- a/e2etests/orchestration/snapshot_test/main_test.go
+++ b/e2etests/orchestration/snapshot_test/main_test.go
@@ -124,11 +124,11 @@ func uploadArtifacts(srv hoclient.HostOrchestratorService) (string, error) {
 	return uploadDir, nil
 }
 
-func createDevice(srv hoclient.HostOrchestratorService, group_name, artifactsDir string) (*hoapi.CVD, error) {
+func createDevice(srv hoclient.HostOrchestratorService, groupName, artifactsDir string) (*hoapi.CVD, error) {
 	config := `
   {
     "common": {
-      "group_name": "` + group_name + `",
+      "group_name": "` + groupName + `",
       "host_package": "@user_artifacts/` + artifactsDir + `"
     },
     "instances": [
@@ -155,7 +155,7 @@ func createDevice(srv hoclient.HostOrchestratorService, group_name, artifactsDir
 	createReq := &hoapi.CreateCVDRequest{EnvConfig: envConfig}
 	res, createErr := srv.CreateCVD(createReq, &hoclient.AccessTokenBuildAPICreds{})
 	if createErr != nil {
-		if err := common.DownloadHostBugReport(srv, group_name); err != nil {
+		if err := common.DownloadHostBugReport(srv, groupName); err != nil {
 			log.Printf("error downloading cvd bugreport: %v", err)
 		}
 		return nil, createErr

--- a/frontend/src/host_orchestrator/main.go
+++ b/frontend/src/host_orchestrator/main.go
@@ -47,14 +47,14 @@ func defaultCVDArtifactsDir() string {
 	return fmt.Sprintf("/tmp/cvd/%s/artifacts", u.Uid)
 }
 
-func startHttpServer(addr string, port int) error {
+func startHTTPServer(addr string, port int) error {
 	log.Printf("Host Orchestrator is listening at http://%s:%d", addr, port)
 
 	// handler is nil, so DefaultServeMux is used.
 	return http.ListenAndServe(fmt.Sprintf("%s:%d", addr, port), nil)
 }
 
-func startHttpsServer(addr string, port int, certPath string, keyPath string) error {
+func startHTTPSServer(addr string, port int, certPath string, keyPath string) error {
 	log.Printf("Host Orchestrator is listening at https://%s:%d", addr, port)
 	return http.ListenAndServeTLS(fmt.Sprintf("%s:%d", addr, port),
 		certPath,
@@ -174,7 +174,7 @@ func main() {
 	http.Handle("/", r)
 
 	starters := []func() error{
-		func() error { return startHttpServer(*address, *httpPort) },
+		func() error { return startHTTPServer(*address, *httpPort) },
 	}
 	start(starters)
 }

--- a/frontend/src/host_orchestrator/orchestrator/artifacts/artifacts.go
+++ b/frontend/src/host_orchestrator/orchestrator/artifacts/artifacts.go
@@ -184,9 +184,8 @@ func createNewDir(dir string) error {
 }
 
 func createDir(dir string) error {
-	if err := createNewDir(dir); os.IsExist(err) {
-		return nil
-	} else {
+	if err := createNewDir(dir); !os.IsExist(err) {
 		return err
 	}
+	return nil
 }

--- a/frontend/src/host_orchestrator/orchestrator/artifacts/buildapi.go
+++ b/frontend/src/host_orchestrator/orchestrator/artifacts/buildapi.go
@@ -77,10 +77,10 @@ func (s *AndroidCIBuildAPI) GetLatestGreenBuildID(branch, target string) (string
 	url := fmt.Sprintf(format, s.BaseURL, url.PathEscape(branch), url.PathEscape(target))
 	res := listBuildResponse{}
 	if err := s.doGETToJSON(url, &res); err != nil {
-		return "", fmt.Errorf("Failed to get the latest green build id for `%s/%s`: %w", branch, target, err)
+		return "", fmt.Errorf("failed to get the latest green build id for `%s/%s`: %w", branch, target, err)
 	}
 	if len(res.Builds) != 1 {
-		return "", fmt.Errorf("Unexpected number of build: expected 1 and got %d", len(res.Builds))
+		return "", fmt.Errorf("unexpected number of build: expected 1 and got %d", len(res.Builds))
 	}
 	return res.Builds[0].BuildID, nil
 }
@@ -99,7 +99,7 @@ func (s *AndroidCIBuildAPI) getSignedURL(name, buildID, target string) (string, 
 		SignedURL string `json:"signedUrl"`
 	}{}
 	if err := s.doGETToJSON(url, &res); err != nil {
-		return "", fmt.Errorf("Failed to get the download artifact signed url for %q (%s/%s): %w", name, buildID, target, err)
+		return "", fmt.Errorf("failed to get the download artifact signed url for %q (%s/%s): %w", name, buildID, target, err)
 	}
 	return res.SignedURL, nil
 }

--- a/frontend/src/host_orchestrator/orchestrator/createcvdaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/createcvdaction.go
@@ -63,7 +63,7 @@ type CreateCVDAction struct {
 	hostValidator            Validator
 	paths                    IMPaths
 	om                       OperationManager
-	execContext              cvd.CVDExecContext
+	execContext              cvd.ExecContext
 	buildAPI                 artifacts.BuildAPI
 	artifactsFetcher         artifacts.Fetcher
 	cvdBundleFetcher         artifacts.CVDBundleFetcher
@@ -337,7 +337,7 @@ func createTempFile(pattern string, data []byte, mode os.FileMode) (*os.File, er
 }
 
 // Create the credential file so it's owned by the configured `cvd user`, e.g: `_cvd-executor`.
-func createCredsFile(ctx cvd.CVDExecContext) (string, error) {
+func createCredsFile(ctx cvd.ExecContext) (string, error) {
 	name, err := tempFilename("cvdload*.creds")
 	if err != nil {
 		return "", err
@@ -352,7 +352,7 @@ func createCredsFile(ctx cvd.CVDExecContext) (string, error) {
 }
 
 // Write into credential files by granting temporary write permission to `cvdnetwork` group.
-func writeCredsFile(ctx cvd.CVDExecContext, name string, data []byte) error {
+func writeCredsFile(ctx cvd.ExecContext, name string, data []byte) error {
 	info, err := os.Stat(name)
 	if err != nil {
 		return err
@@ -394,7 +394,7 @@ func writeCredsFile(ctx cvd.CVDExecContext, name string, data []byte) error {
 	return nil
 }
 
-func removeCredsFile(ctx cvd.CVDExecContext, name string) error {
+func removeCredsFile(ctx cvd.ExecContext, name string) error {
 	_, err := cvd.Exec(ctx, "rm", name)
 	return err
 }

--- a/frontend/src/host_orchestrator/orchestrator/createcvdbugreportaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/createcvdbugreportaction.go
@@ -27,7 +27,7 @@ type CreateCVDBugReportActionOpts struct {
 	Group            string
 	Paths            IMPaths
 	OperationManager OperationManager
-	ExecContext      cvd.CVDExecContext
+	ExecContext      cvd.ExecContext
 	UUIDGen          func() string
 }
 
@@ -35,7 +35,7 @@ type CreateCVDBugReportAction struct {
 	group       string
 	paths       IMPaths
 	om          OperationManager
-	execContext cvd.CVDExecContext
+	execContext cvd.ExecContext
 	uuidgen     func() string
 }
 

--- a/frontend/src/host_orchestrator/orchestrator/createsnapshotaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/createsnapshotaction.go
@@ -36,7 +36,7 @@ type CreateSnapshotAction struct {
 	selector    CVDSelector
 	paths       IMPaths
 	om          OperationManager
-	execContext cvd.CVDExecContext
+	execContext cvd.ExecContext
 }
 
 func NewCreateSnapshotAction(opts CreateSnapshotActionOpts) *CreateSnapshotAction {

--- a/frontend/src/host_orchestrator/orchestrator/cvd/cvd.go
+++ b/frontend/src/host_orchestrator/orchestrator/cvd/cvd.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 )
 
-type CVDExecContext = func(ctx context.Context, env []string, name string, arg ...string) *exec.Cmd
+type ExecContext = func(ctx context.Context, env []string, name string, arg ...string) *exec.Cmd
 
 const (
 	CVDBin      = "/usr/bin/cvd"
@@ -43,13 +43,13 @@ type CommandOpts struct {
 }
 
 type Command struct {
-	execContext CVDExecContext
+	execContext ExecContext
 	cvdBin      string
 	args        []string
 	opts        CommandOpts
 }
 
-func NewCommand(execContext CVDExecContext, args []string, opts CommandOpts) *Command {
+func NewCommand(execContext ExecContext, args []string, opts CommandOpts) *Command {
 	return &Command{
 		execContext: execContext,
 		cvdBin:      CVDBin,
@@ -117,7 +117,7 @@ func LogCombinedStdoutStderr(cmd *exec.Cmd, val string) {
 	log.Printf(msg, strings.Join(cmd.Args, " "), OutputLogMessage(val))
 }
 
-func Exec(ctx CVDExecContext, name string, args ...string) (string, error) {
+func Exec(ctx ExecContext, name string, args ...string) (string, error) {
 	cmd := ctx(context.TODO(), nil, name, args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/frontend/src/host_orchestrator/orchestrator/execcvdcommandaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/execcvdcommandaction.go
@@ -37,7 +37,7 @@ type ExecCVDCommandAction struct {
 	selector    CVDSelector
 	paths       IMPaths
 	om          OperationManager
-	execContext cvd.CVDExecContext
+	execContext cvd.ExecContext
 }
 
 func NewExecCVDCommandAction(opts ExecCVDCommandActionOpts) *ExecCVDCommandAction {

--- a/frontend/src/host_orchestrator/orchestrator/listcvdsaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/listcvdsaction.go
@@ -33,7 +33,7 @@ type ListCVDsActionOpts struct {
 type ListCVDsAction struct {
 	group       string
 	paths       IMPaths
-	execContext cvd.CVDExecContext
+	execContext cvd.ExecContext
 }
 
 func NewListCVDsAction(opts ListCVDsActionOpts) *ListCVDsAction {

--- a/frontend/src/host_orchestrator/orchestrator/startcvdaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/startcvdaction.go
@@ -38,7 +38,7 @@ type StartCVDAction struct {
 	selector    CVDSelector
 	paths       IMPaths
 	om          OperationManager
-	execContext cvd.CVDExecContext
+	execContext cvd.ExecContext
 }
 
 func NewStartCVDAction(opts StartCVDActionOpts) *StartCVDAction {

--- a/frontend/src/libhoclient/host_orchestrator_client.go
+++ b/frontend/src/libhoclient/host_orchestrator_client.go
@@ -30,13 +30,13 @@ import (
 	"github.com/pion/webrtc/v3"
 )
 
-type ApiCallError struct {
+type APICallError struct {
 	Code     int    `json:"code,omitempty"`
 	ErrorMsg string `json:"error,omitempty"`
 	Details  string `json:"details,omitempty"`
 }
 
-func (e *ApiCallError) Error() string {
+func (e *APICallError) Error() string {
 	str := fmt.Sprintf("api call error %d: %s", e.Code, e.ErrorMsg)
 	if e.Details != "" {
 		str += fmt.Sprintf("\n\nDETAILS: %s", e.Details)
@@ -183,14 +183,14 @@ func (c *HostOrchestratorServiceImpl) ConnectADBWebSocket(device string) (*webso
 	if c.ProxyURL != "" {
 		proxyURL, err := url.Parse(c.ProxyURL)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to parse proxy %s: %w", c.ProxyURL, err)
+			return nil, fmt.Errorf("failed to parse proxy %s: %w", c.ProxyURL, err)
 		}
 		dialer.Proxy = http.ProxyURL(proxyURL)
 	}
 
 	url, err := url.Parse(c.HTTPHelper.RootEndpoint)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to parse URL %s: %w", c.HTTPHelper.RootEndpoint, err)
+		return nil, fmt.Errorf("failed to parse URL %s: %w", c.HTTPHelper.RootEndpoint, err)
 	}
 	switch p := &url.Scheme; *p {
 	case "https":
@@ -198,19 +198,19 @@ func (c *HostOrchestratorServiceImpl) ConnectADBWebSocket(device string) (*webso
 	case "http":
 		*p = "ws"
 	default:
-		return nil, fmt.Errorf("Unknown scheme %s", *p)
+		return nil, fmt.Errorf("unknown scheme %s", *p)
 	}
 	url = url.JoinPath("devices", device, "adb")
 
 	// Get auth header for WebSocket connection
 	rb := c.HTTPHelper.NewGetRequest("")
 	if err := rb.setAuthz(); err != nil {
-		return nil, fmt.Errorf("Failed to set authorization header: %w", err)
+		return nil, fmt.Errorf("failed to set authorization header: %w", err)
 	}
 	// Connect to the WebSocket
 	wsConn, _, err := dialer.Dial(url.String(), rb.request.Header)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to connect WebSocket %s: %w", url.String(), err)
+		return nil, fmt.Errorf("failed to connect WebSocket %s: %w", url.String(), err)
 	}
 	return wsConn, nil
 }
@@ -528,7 +528,7 @@ func (c *HostOrchestratorServiceImpl) CreateBugreport(group string, dst io.Write
 		return err
 	}
 	if res.StatusCode < 200 || res.StatusCode > 299 {
-		return &ApiCallError{ErrorMsg: res.Status}
+		return &APICallError{ErrorMsg: res.Status}
 	}
 	return nil
 }

--- a/frontend/src/libhoclient/httputils.go
+++ b/frontend/src/libhoclient/httputils.go
@@ -181,7 +181,7 @@ func (rb *HTTPRequestBuilder) JSONResDoWithRetries(ret any, retryOpts RetryOptio
 		}
 		return nil
 	}
-	apiError := &ApiCallError{}
+	apiError := &APICallError{}
 	if err := decoder.Decode(apiError); err != nil {
 		return fmt.Errorf("failed decoding unsuccessful response(%d), body: %s, error: %w", res.StatusCode, string(b), err)
 	}

--- a/frontend/src/libhoclient/webrtcclient/client.go
+++ b/frontend/src/libhoclient/webrtcclient/client.go
@@ -128,9 +128,8 @@ func (c *Controller) recvLoop() error {
 		default:
 			if errMsg, errPresent := msg["error"]; errPresent {
 				return fmt.Errorf("received error from signaling server: %v", errMsg)
-			} else {
-				return fmt.Errorf("unknown message type: %v", msg["type"])
 			}
+			return fmt.Errorf("unknown message type: %v", msg["type"])
 		}
 	}
 }

--- a/frontend/src/liboperator/operator/clients.go
+++ b/frontend/src/liboperator/operator/clients.go
@@ -37,7 +37,7 @@ type PolledClient struct {
 	// Synchronizes access to the messages list
 	msgMtx sync.Mutex
 	// The id given to this client by the device
-	clientId int
+	clientID int
 	// A reference to the polled set to clean up when the device disconnects
 	polledSet *PolledSet
 }
@@ -76,12 +76,12 @@ func (c *PolledClient) GetMessages(start int, count int) []interface{} {
 	return ret
 }
 
-func (c *PolledClient) Id() string {
+func (c *PolledClient) ID() string {
 	return c.id
 }
 
-func (c *PolledClient) ClientId() int {
-	return c.clientId
+func (c *PolledClient) ClientID() int {
+	return c.clientID
 }
 
 // Basically a map of polled clients by id.
@@ -104,7 +104,7 @@ func (s *PolledSet) NewConnection(d *Device) *PolledClient {
 				polledSet: s,
 			}
 			s.connections[id] = conn
-			conn.clientId = d.Register(conn)
+			conn.clientID = d.Register(conn)
 			return conn
 		}
 	}

--- a/frontend/src/liboperator/operator/clients_test.go
+++ b/frontend/src/liboperator/operator/clients_test.go
@@ -29,7 +29,7 @@ func TestNewPolledConnection(t *testing.T) {
 	if c2 == nil {
 		t.Error("Failed to create polled connection")
 	}
-	if c1.Id() == c2.Id() {
+	if c1.ID() == c2.ID() {
 		t.Error("Polled connections have the same id")
 	}
 }
@@ -37,23 +37,23 @@ func TestNewPolledConnection(t *testing.T) {
 func TestGetConnection(t *testing.T) {
 	ps := NewPolledSet()
 	c1 := ps.NewConnection(newDevice("d1", nil, 0, ""))
-	if ps.GetConnection(c1.Id()) != c1 {
+	if ps.GetConnection(c1.ID()) != c1 {
 		t.Error("Failed to get connection by id")
 	}
-	if ps.GetConnection(c1.Id()+"some suffix") == c1 {
+	if ps.GetConnection(c1.ID()+"some suffix") == c1 {
 		t.Error("Returned connection with wrong id")
 	}
 	c2 := ps.NewConnection(newDevice("d1", nil, 0, ""))
-	if ps.GetConnection(c1.Id()) == c2 || ps.GetConnection(c2.Id()) == c1 {
+	if ps.GetConnection(c1.ID()) == c2 || ps.GetConnection(c2.ID()) == c1 {
 		t.Error("Returned the wrong connection")
 	}
-	ps.Destroy(c2.Id())
-	if ps.GetConnection(c2.Id()) != nil {
+	ps.Destroy(c2.ID())
+	if ps.GetConnection(c2.ID()) != nil {
 		t.Error("Returned unregistered connection")
 	}
 	// should have no effect
-	ps.Destroy(c2.Id())
-	if ps.GetConnection(c1.Id()) != c1 {
+	ps.Destroy(c2.ID())
+	if ps.GetConnection(c1.ID()) != c1 {
 		t.Error("Failed to get connection after destruction of another")
 	}
 }
@@ -82,7 +82,7 @@ func TestDestroy(t *testing.T) {
 	ps := NewPolledSet()
 	c := ps.NewConnection(newDevice("d1", nil, 0, ""))
 	c.OnDeviceDisconnected()
-	if ps.GetConnection(c.Id()) != nil {
+	if ps.GetConnection(c.ID()) != nil {
 		t.Error("connection was not destroyed after device disconnect")
 	}
 }

--- a/frontend/src/liboperator/operator/devices.go
+++ b/frontend/src/liboperator/operator/devices.go
@@ -45,7 +45,7 @@ type Group struct {
 	deviceIds []string
 }
 
-const DEFAULT_GROUP_ID = "default"
+const DefaultGroupID = "default"
 
 func newDevice(id string, conn *JSONUnix, port int, privateData interface{}) *Device {
 	url, err := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", port))
@@ -60,14 +60,14 @@ func newDevice(id string, conn *JSONUnix, port int, privateData interface{}) *De
 		w.Header().Add("x-cutf-proxy", "op-device")
 		w.WriteHeader(http.StatusBadGateway)
 	}
-	groupId := groupIdFromPrivateData(privateData)
+	groupID := groupIDFromPrivateData(privateData)
 	return &Device{
 		conn:        conn,
 		Proxy:       proxy,
 		privateData: privateData,
 		Descriptor: apiv1.DeviceDescriptor{
 			DeviceId:  id,
-			GroupName: groupId,
+			GroupName: groupID,
 		},
 		clients:     make(map[int]Client),
 		clientCount: 0,
@@ -82,7 +82,7 @@ func (d *Device) Send(msg interface{}) error {
 func (d *Device) Register(c Client) int {
 	d.clientsMtx.Lock()
 	defer d.clientsMtx.Unlock()
-	d.clientCount += 1
+	d.clientCount++
 	d.clients[d.clientCount] = c
 	return d.clientCount
 }
@@ -140,18 +140,18 @@ func NewDevicePool() *DevicePool {
 	}
 }
 
-func groupIdFromPrivateData(privateData interface{}) string {
+func groupIDFromPrivateData(privateData interface{}) string {
 	deviceInfo, ok := privateData.(map[string]interface{})
 	if !ok {
-		return DEFAULT_GROUP_ID
+		return DefaultGroupID
 	}
 
-	groupId, ok := deviceInfo["group_id"].(string)
-	if !ok || len(groupId) == 0 {
-		return DEFAULT_GROUP_ID
+	groupID, ok := deviceInfo["group_id"].(string)
+	if !ok || len(groupID) == 0 {
+		return DefaultGroupID
 	}
 
-	return groupId
+	return groupID
 }
 
 // PreRegister accepts a channel of boolean which it closes if the pre-registration is cancelled or
@@ -164,11 +164,11 @@ func (p *DevicePool) PreRegister(Descriptor *apiv1.DeviceDescriptor, regCh chan 
 	p.preDevicesMtx.Lock()
 	defer p.preDevicesMtx.Unlock()
 	if _, found := p.preDevices[d.Desc.DeviceId]; found {
-		return fmt.Errorf("Device Id already pre-registered")
+		return fmt.Errorf("device ID already pre-registered")
 	}
 	// This locks devicesMtx after preDevicesMtx, which is the right order
 	if d := p.GetDevice(d.Desc.DeviceId); d != nil {
-		return fmt.Errorf("Device Id already registered")
+		return fmt.Errorf("device ID already registered")
 	}
 	p.preDevices[d.Desc.DeviceId] = d
 	return nil
@@ -254,11 +254,11 @@ func (p *DevicePool) GetDeviceDescList() []*apiv1.DeviceDescriptor {
 	return ret
 }
 
-func (p *DevicePool) GetDeviceDescByGroupId(groupId string) []*apiv1.DeviceDescriptor {
+func (p *DevicePool) GetDeviceDescByGroupID(groupID string) []*apiv1.DeviceDescriptor {
 	ret := make([]*apiv1.DeviceDescriptor, 0)
 	devs := p.GetDeviceDescList()
 	for _, d := range devs {
-		if d.GroupName == groupId {
+		if d.GroupName == groupID {
 			ret = append(ret, d)
 		}
 	}

--- a/frontend/src/liboperator/operator/devices_test.go
+++ b/frontend/src/liboperator/operator/devices_test.go
@@ -199,9 +199,9 @@ func TestListDevices(t *testing.T) {
 	}
 }
 
-func MakeInfo(groupId string) map[string]interface{} {
+func MakeInfo(groupID string) map[string]interface{} {
 	return map[string]interface{}{
-		"group_id": groupId,
+		"group_id": groupID,
 	}
 }
 
@@ -214,11 +214,11 @@ func TestListDevicesByGroup(t *testing.T) {
 	p.Register("4", nil, 0, MakeInfo("bar"))
 	p.Register("5", nil, 0, MakeInfo("bar"))
 
-	if deviceCnt := len(p.GetDeviceDescByGroupId("foo")); deviceCnt != 2 {
+	if deviceCnt := len(p.GetDeviceDescByGroupID("foo")); deviceCnt != 2 {
 		t.Error("List of devices in group foo should have size of 2, but have ", deviceCnt)
 	}
 
-	if deviceCnt := len(p.GetDeviceDescByGroupId("bar")); deviceCnt != 3 {
+	if deviceCnt := len(p.GetDeviceDescByGroupID("bar")); deviceCnt != 3 {
 		t.Error("List of devices in group bar should have size of 3, but have ", deviceCnt)
 	}
 }
@@ -232,16 +232,16 @@ func TestListDevicesEmpty(t *testing.T) {
 		t.Error("List of all devices should have size of 0, but have ", deviceCnt)
 	}
 
-	if deviceCnt := len(p.GetDeviceDescByGroupId("foo")); deviceCnt != 0 {
+	if deviceCnt := len(p.GetDeviceDescByGroupID("foo")); deviceCnt != 0 {
 		t.Error("List of devices in group foo should have size of 0, but have ", deviceCnt)
 	}
 }
 
 func TestGroupIdFromPrivateData(t *testing.T) {
 	info := MakeInfo("foo")
-	groupId := groupIdFromPrivateData(info)
+	groupID := groupIDFromPrivateData(info)
 
-	if groupId != "foo" {
+	if groupID != "foo" {
 		t.Error("info should have group_id as foo")
 	}
 
@@ -288,11 +288,11 @@ func TestDefaultGroup(t *testing.T) {
 		t.Error("Error listing after 4 device registrations - expected 4 but ", len(p.devices))
 	}
 
-	if defaultDeviceCount := len(p.GetDeviceDescByGroupId(DEFAULT_GROUP_ID)); defaultDeviceCount != 3 {
+	if defaultDeviceCount := len(p.GetDeviceDescByGroupID(DefaultGroupID)); defaultDeviceCount != 3 {
 		t.Error("Error after 3 device in default group - expected 3 but ", defaultDeviceCount)
 	}
 
-	if defaultDeviceCount := len(p.GetDeviceDescByGroupId(DEFAULT_GROUP_ID)); defaultDeviceCount != 3 {
+	if defaultDeviceCount := len(p.GetDeviceDescByGroupID(DefaultGroupID)); defaultDeviceCount != 3 {
 		t.Error("Error after 3 device in default group - expected 3 but ", defaultDeviceCount)
 	}
 

--- a/frontend/src/liboperator/operator/utils.go
+++ b/frontend/src/liboperator/operator/utils.go
@@ -62,16 +62,16 @@ func ReplyJSON(w http.ResponseWriter, obj interface{}, statusCode int) error {
 }
 
 // Connect ControlEnvProxyServer
-func ConnectControlEnvProxyServer(devId string, pool *DevicePool) (*grpc.ClientConn, error) {
-	dev := pool.GetDevice(devId)
+func ConnectControlEnvProxyServer(devID string, pool *DevicePool) (*grpc.ClientConn, error) {
+	dev := pool.GetDevice(devID)
 	if dev == nil {
-		return nil, errors.New("Device not found")
+		return nil, errors.New("device not found")
 	}
 
 	devInfo := dev.privateData.(map[string]interface{})
 	serverPath, ok := devInfo["control_env_proxy_server_path"].(string)
 	if !ok {
-		return nil, errors.New("ControlEnvProxyServer path not found")
+		return nil, errors.New("path of ControlEnvProxyServer not found")
 	}
 	return grpc.Dial("unix://"+serverPath, grpc.WithInsecure())
 }


### PR DESCRIPTION
Removed all errors shown in: \
`$ golint -min_confidence 0 ./... | grep -v comment | grep -v api/v1/messages.go`

Reasoning:
- Fixing lint errors for writing comment takes too much effort.
- Fixing lint errors in `api/v1/messages.go` can break API surface used by `cloud-android-orchestration` repo.