### PR TITLE
Fix include path for consistency

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
@@ -22,7 +22,6 @@
 #include "common/libs/utils/contains.h"
 #include "common/libs/utils/files.h"
 #include "common/libs/utils/flag_parser.h"
-#include "cuttlefish/host/commands/cvd/cli/utils.h"
 #include "host/commands/cvd/instances/instance_manager.h"
 #include "host/commands/cvd/utils/common.h"
 #include "host/libs/config/config_constants.h"


### PR DESCRIPTION
Other includes don't use the `cuttlefish/` prefix. This file is already included under the other name.