### PR TITLE
Improve `GetDiskUsage`

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/files.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/files.cpp
@@ -557,12 +557,14 @@ bool FileIsSocket(const std::string& path) {
   return stat(path.c_str(), &st) == 0 && S_ISSOCK(st.st_mode);
 }
 
-Result<int> GetDiskUsage(const std::string& path) {
+// return unit determined by the `--block-size` argument
+Result<long> GetDiskUsage(const std::string& path,
+                          const std::string& size_arg) {
   Command du_cmd("du");
   du_cmd.AddParameter("-s");  // summarize, only output total
   du_cmd.AddParameter(
       "--apparent-size");  // apparent size rather than device usage
-  du_cmd.AddParameter("--block-size=1");  // bytes unit
+  du_cmd.AddParameter("--block-size=" + size_arg);
   du_cmd.AddParameter(path);
   SharedFD read_fd;
   SharedFD write_fd;
@@ -577,6 +579,14 @@ Result<int> GetDiskUsage(const std::string& path) {
   CF_EXPECTF(android::base::ParseInt(text_output.data(), &result),
              "Failure parsing \"{}\" to integer.", text_output.data());
   return result;
+}
+
+Result<long> GetDiskUsageBytes(const std::string& path) {
+  return GetDiskUsage(path, "1");
+}
+
+Result<long> GetDiskUsageGigabytes(const std::string& path) {
+  return GetDiskUsage(path, "1G");
 }
 
 /**

--- a/base/cvd/cuttlefish/common/libs/utils/files.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/files.cpp
@@ -57,6 +57,7 @@
 #include <android-base/file.h>
 #include <android-base/logging.h>
 #include <android-base/macros.h>
+#include <android-base/parseint.h>
 #include <android-base/strings.h>
 #include <android-base/unique_fd.h>
 
@@ -556,11 +557,12 @@ bool FileIsSocket(const std::string& path) {
   return stat(path.c_str(), &st) == 0 && S_ISSOCK(st.st_mode);
 }
 
-int GetDiskUsage(const std::string& path) {
+Result<int> GetDiskUsage(const std::string& path) {
   Command du_cmd("du");
-  du_cmd.AddParameter("-b");
-  du_cmd.AddParameter("-k");
-  du_cmd.AddParameter("-s");
+  du_cmd.AddParameter("-s");  // summarize, only output total
+  du_cmd.AddParameter(
+      "--apparent-size");  // apparent size rather than device usage
+  du_cmd.AddParameter("--block-size=1");  // bytes unit
   du_cmd.AddParameter(path);
   SharedFD read_fd;
   SharedFD write_fd;
@@ -569,9 +571,12 @@ int GetDiskUsage(const std::string& path) {
   auto subprocess = du_cmd.Start();
   std::array<char, 1024> text_output{};
   const auto bytes_read = read_fd->Read(text_output.data(), text_output.size());
-  CHECK_GT(bytes_read, 0) << "Failed to read from pipe " << strerror(errno);
+  CF_EXPECTF(bytes_read > 0, "Failed to read from pipe: {}", strerror(errno));
   std::move(subprocess).Wait();
-  return atoi(text_output.data()) * 1024;
+  int result;
+  CF_EXPECTF(android::base::ParseInt(text_output.data(), &result),
+             "Failure parsing \"{}\" to integer.", text_output.data());
+  return result;
 }
 
 /**

--- a/base/cvd/cuttlefish/common/libs/utils/files.h
+++ b/base/cvd/cuttlefish/common/libs/utils/files.h
@@ -65,7 +65,8 @@ std::string cpp_basename(const std::string& str);
 bool FileIsSocket(const std::string& path);
 // Get disk usage of a path. If this path is a directory, disk usage will
 // account for all files under this folder(recursively).
-Result<int> GetDiskUsage(const std::string& path);
+Result<long> GetDiskUsageBytes(const std::string& path);
+Result<long> GetDiskUsageGigabytes(const std::string& path);
 
 // acloud related API
 std::string FindImage(const std::string& search_path,

--- a/base/cvd/cuttlefish/common/libs/utils/files.h
+++ b/base/cvd/cuttlefish/common/libs/utils/files.h
@@ -65,7 +65,7 @@ std::string cpp_basename(const std::string& str);
 bool FileIsSocket(const std::string& path);
 // Get disk usage of a path. If this path is a directory, disk usage will
 // account for all files under this folder(recursively).
-int GetDiskUsage(const std::string& path);
+Result<int> GetDiskUsage(const std::string& path);
 
 // acloud related API
 std::string FindImage(const std::string& search_path,


### PR DESCRIPTION
The function relies on `du`, but it was not clear what the result would be without seeing what flags were passed (and looking up those flags).  The new helpers should be clearer from their signatures in the header.

The `Bytes` version (equivalent to the original) is not actually used in this codebase, but is [used in](https://cs.android.com/android/platform/superproject/main/+/f5a340da1590b497d6c619c8e105a403ffb9be1f:device/google/cuttlefish/host/commands/assemble_cvd/vendor_dlkm_utils.cc;l=355;drc=f5a340da1590b497d6c619c8e105a403ffb9be1f)  `device/google/cuttlefish`, so keeping it for the eventual library syncing.  I intend to use the `Gigabytes` version in the upcoming `cvd cache`.

`du -b -k -s <path>` was essentially equivalent to `du --apparent-size --block-size=1 --block-size=1K -s <path>`, where the second `--block-size` shadows the first.  Then the resulting kilobytes value was multiplied by 1024 to get back to bytes.

reference: https://man7.org/linux/man-pages/man1/du.1.html

Swapped from `CHECK` to `CF_EXPECT` (+`Result` return) and `atoi` to `ParseInt` to match current practices.

Also swapped to returning a `long` to avoid size issues for returning a large bytes value.

