### PR TITLE
Remove `CommandRequest::Args`

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/command_request.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/command_request.h
@@ -36,8 +36,6 @@ namespace cuttlefish {
 
 class CommandRequest {
  public:
-  const cvd_common::Args& Args() const { return args_; }
-
   const cvd_common::Envs& Env() const { return env_; }
 
   const selector::SelectorOptions& Selectors() const { return selectors_; }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/command_sequence.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/command_sequence.cpp
@@ -59,18 +59,11 @@ std::string FormattedCommand(const CommandRequest& command) {
       effective_command << BashEscape(name) << "=" << BashEscape(val) << " ";
     }
   }
-  auto args = command.Args();
-  auto selector_args = command.Selectors().AsArgs();
-  if (args.empty()) {
-    return effective_command.str();
-  }
-  const auto& cmd = args.front();
-  cvd_common::Args cmd_args{args.begin() + 1, args.end()};
-  effective_command << BashEscape(cmd) << " ";
-  for (const auto& selector_arg : selector_args) {
+  effective_command << "cvd " << BashEscape(command.Subcommand()) << " ";
+  for (const auto& selector_arg : command.Selectors().AsArgs()) {
     effective_command << BashEscape(selector_arg) << " ";
   }
-  for (const auto& cmd_arg : cmd_args) {
+  for (const auto& cmd_arg : command.SubcommandArguments()) {
     effective_command << BashEscape(cmd_arg) << " ";
   }
   effective_command.seekp(-1, effective_command.cur);

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/login.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/login.cpp
@@ -50,7 +50,7 @@ class CvdLoginCommand : public CvdServerHandler {
   Result<void> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
 
-    std::vector<std::string> args = request.Args();
+    std::vector<std::string> args = request.SubcommandArguments();
 
     // Imperfect detection: the user may ssh into an existing `screen` or `tmux`
     // session.

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
@@ -186,8 +186,9 @@ std::string_view TerminalColors::Cyan() const {
 std::string NoGroupMessage(const CommandRequest& request) {
   TerminalColors colors(isatty(1));
   return fmt::format("Command `{}{}{}` is not applicable: {}{}{}", colors.Red(),
-                     fmt::join(request.Args(), " "), colors.Reset(),
-                     colors.BoldRed(), "no device", colors.Reset());
+                     fmt::join(request.SubcommandArguments(), " "),
+                     colors.Reset(), colors.BoldRed(), "no device",
+                     colors.Reset());
 }
 
 }  // namespace cuttlefish


### PR DESCRIPTION
Bug: b/385223580
Test: /usr/bin/bazel run '//cuttlefish/host/commands/cvd' -- acloud create --local-instance --local-image