### PR TITLE
Fix `GetDiskUsage` and add flag parsing overload

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/files.h
+++ b/base/cvd/cuttlefish/common/libs/utils/files.h
@@ -19,6 +19,7 @@
 #include <sys/types.h>
 
 #include <chrono>
+#include <cstddef>
 #include <optional>
 #include <string>
 #include <vector>
@@ -78,8 +79,8 @@ std::string cpp_basename(const std::string& str);
 bool FileIsSocket(const std::string& path);
 // Get disk usage of a path. If this path is a directory, disk usage will
 // account for all files under this folder(recursively).
-Result<long> GetDiskUsageBytes(const std::string& path);
-Result<long> GetDiskUsageGigabytes(const std::string& path);
+Result<std::size_t> GetDiskUsageBytes(const std::string& path);
+Result<std::size_t> GetDiskUsageGigabytes(const std::string& path);
 
 // acloud related API
 std::string FindImage(const std::string& search_path,

--- a/base/cvd/cuttlefish/common/libs/utils/flag_parser.h
+++ b/base/cvd/cuttlefish/common/libs/utils/flag_parser.h
@@ -173,6 +173,7 @@ Flag UnexpectedArgumentGuard();
 Flag GflagsCompatFlag(const std::string& name);
 Flag GflagsCompatFlag(const std::string& name, std::string& value);
 Flag GflagsCompatFlag(const std::string& name, std::int32_t& value);
+Flag GflagsCompatFlag(const std::string& name, std::size_t& value);
 Flag GflagsCompatFlag(const std::string& name, bool& value);
 Flag GflagsCompatFlag(const std::string& name, std::vector<std::string>& value);
 Flag GflagsCompatFlag(const std::string& name, std::vector<bool>& value,


### PR DESCRIPTION
`ParseInt` was failing on the output of `du` because it is in a format like: "<total num> <filepath>".  This version splits that and takes the first portion.  We should update this later to not rely on `du`, b/385384942 should encompass that.

Returning to the `atoi` implementation was not a good idea for the bytes version, because it was still susceptible to overflow issues.

Changed the return value to be a `size_t` instead of a signed number, because the sizes will not (should not?) ever be negative.

Added a `GflagsCompatFlag` overload for reading in flags that can be compared to the output of this helper.

The `GetDiskUsageGigabytes` will still be used in the upcoming `cvd cache`, while the `*Bytes` version will be used when we sync these changes back to AOSP.

Test: use the `cvd_cache` branch from #834 and run `cvd cache size`