### PR TITLE
Add scoped logger to avoid manual logger managing

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/tee_logging.h
+++ b/base/cvd/cuttlefish/common/libs/utils/tee_logging.h
@@ -62,6 +62,20 @@ class TeeLogger {
   std::string prefix_;
 };
 
+class ScopedTeeLogger {
+ public:
+  ScopedTeeLogger(TeeLogger tee_logger);
+  ~ScopedTeeLogger();
+
+ private:
+  android::base::LogFunction old_logger_;
+  android::base::ScopedLogSeverity scoped_severity_;
+};
+
+TeeLogger LogToStderr(
+    const std::string& log_prefix = "",
+    MetadataLevel stderr_level = MetadataLevel::ONLY_MESSAGE,
+    std::optional<android::base::LogSeverity> stderr_severity = std::nullopt);
 TeeLogger LogToFiles(const std::vector<std::string>& files,
                      const std::string& log_prefix = "");
 TeeLogger LogToStderrAndFiles(

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd.cc
@@ -981,22 +981,10 @@ Result<void> FetchCvdMain(int argc, char** argv) {
   MetadataLevel metadata_level =
       isatty(0) ? MetadataLevel::ONLY_MESSAGE : MetadataLevel::FULL;
 
-  auto old_logger = android::base::SetLogger(
+  ScopedTeeLogger logger(
       LogToStderrAndFiles({log_file}, "", metadata_level, flags.verbosity));
-  // Set the android logger to full verbosity, the tee logger will choose
-  // whether to write each line.
-  auto old_severity =
-      android::base::SetMinimumLogSeverity(android::base::VERBOSE);
+  CF_EXPECT(Fetch(flags, host_target, targets));
 
-  auto fetch_res = Fetch(flags, host_target, targets);
-
-  // This function is no longer only called direcly from a main function, so the
-  // previous logger must be restored. This also ensures logs from other
-  // components don't land in fetch.log.
-  android::base::SetLogger(std::move(old_logger));
-  android::base::SetMinimumLogSeverity(old_severity);
-
-  CF_EXPECT(std::move(fetch_res));
   return {};
 }
 


### PR DESCRIPTION
The manual managing leaves more opportunity for a mistake or error to cause the previous logger to never be reset.

Also, for tee logging we always wanted to set the Android LogSeverity to `VERBOSE` because the levels are managed internal to those loggers. This is automatically handled as well, which is why the `ScopedLogSeverity` is a member instead of being instantiated alongside the logger.

The new `LogToStderr` (and `ScopedTeeLogger`) will be used in the upcoming `cvd cache`, because it will eventually be called from `cvd fetch` invocations.

Test: TBD, I think a `cvd load` call will have successive logger setups?