### PR TITLE
Fix fetch help

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/flag_parser.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/flag_parser.cpp
@@ -431,7 +431,9 @@ Flag HelpFlag(const std::vector<Flag>& flags, std::string text) {
     for (const auto& flag : flags) {
       LOG(INFO) << flag;
     }
-    return CF_ERR("user requested early exit");
+    // return value of 1 matches gflags --help flag behavior
+    std::exit(1);
+    return {};
   };
   return Flag()
       .Alias({FlagAliasMode::kFlagExact, "-help"})

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.cpp
@@ -61,14 +61,16 @@ Result<std::string> CvdFetchCommandHandler::SummaryHelp() const {
 
 Result<std::string> CvdFetchCommandHandler::DetailedHelp(
     std::vector<std::string>&) const {
-  Command fetch_command("/proc/self/exe");
-  fetch_command.SetName("fetch_cvd");
-  fetch_command.SetExecutable("/proc/self/exe");
-  fetch_command.AddParameter("--help");
-
-  std::string output;
-  RunWithManagedStdio(std::move(fetch_command), nullptr, nullptr, &output);
-  return output;
+  std::vector<std::string> args;
+  args.emplace_back("fetch_cvd");
+  args.emplace_back("--help");
+  std::vector<char*> args_data;
+  for (auto& argument : args) {
+    args_data.emplace_back(argument.data());
+  }
+  // TODO: b/389119573 - Should return the help text instead of printing it
+  CF_EXPECT(FetchCvdMain(args_data.size(), args_data.data()));
+  return {};
 }
 
 std::unique_ptr<CvdCommandHandler> NewCvdFetchCommandHandler() {


### PR DESCRIPTION
It was hanging when invoked, presumably in an endless loop calling itself.

Test: cvd help fetch
Test: cvd fetch --help