### PR TITLE
Simplify selectors

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.cpp
@@ -30,7 +30,8 @@
 #include "host/commands/cvd/cli/types.h"
 
 namespace cuttlefish {
-namespace {
+
+using selector::ArgumentsSeparator;
 
 /* the very first command line parser
  *
@@ -43,62 +44,10 @@ namespace {
  *     b) non-selector flags
  *  3. subcommand
  *  4. subcommand arguments
- *
- * This is currently on the client side but will be moved to the server
- * side.
  */
-class FrontlineParser {
-  using ArgumentsSeparator = selector::ArgumentsSeparator;
+Result<cvd_common::Args> ExtractCvdArgs(cvd_common::Args& args) {
+  CF_EXPECT(!args.empty());
 
- public:
-  // This call must guarantee all public methods will be valid
-  static Result<std::unique_ptr<FrontlineParser>> Parse(
-      const cvd_common::Args& all_args);
-
-  const std::string& ProgPath() const;
-  std::optional<std::string> SubCmd() const;
-  const cvd_common::Args& SubCmdArgs() const;
-  const cvd_common::Args& CvdArgs() const;
-
- private:
-  FrontlineParser(const cvd_common::Args& all_args);
-
-  // internal workers in order
-  Result<void> Separate();
-  Result<std::unique_ptr<ArgumentsSeparator>> CallSeparator();
-  struct FilterOutput {
-    bool clean;
-    bool help;
-    cvd_common::Args selector_args;
-  };
-  Result<FilterOutput> FilterNonSelectorArgs();
-
-  const cvd_common::Args all_args_;
-  const std::vector<std::string> internal_cmds_;
-  std::unique_ptr<ArgumentsSeparator> arguments_separator_;
-};
-
-Result<std::unique_ptr<FrontlineParser>> FrontlineParser::Parse(
-    const cvd_common::Args& all_args) {
-  CF_EXPECT(!all_args.empty());
-  std::unique_ptr<FrontlineParser> frontline_parser(
-      new FrontlineParser(all_args));
-  CF_EXPECT(frontline_parser != nullptr,
-            "Memory allocation for FrontlineParser failed.");
-  CF_EXPECT(frontline_parser->Separate());
-  return frontline_parser;
-}
-
-FrontlineParser::FrontlineParser(const cvd_common::Args& all_args)
-    : all_args_(all_args) {}
-
-Result<void> FrontlineParser::Separate() {
-  arguments_separator_ = CF_EXPECT(CallSeparator());
-  return {};
-}
-
-Result<std::unique_ptr<selector::ArgumentsSeparator>>
-FrontlineParser::CallSeparator() {
   ArgumentsSeparator::FlagsRegistration flag_registration{
       .known_boolean_flags = {},
       .known_value_flags = {selector::SelectorFlags::kGroupName,
@@ -106,44 +55,21 @@ FrontlineParser::CallSeparator() {
                             selector::SelectorFlags::kVerbosity},
   };
   auto arguments_separator =
-      CF_EXPECT(ArgumentsSeparator::Parse(flag_registration, all_args_));
+      CF_EXPECT(ArgumentsSeparator::Parse(flag_registration, args));
   CF_EXPECT(arguments_separator != nullptr);
-  return arguments_separator;
-}
 
-const std::string& FrontlineParser::ProgPath() const {
-  return arguments_separator_->ProgPath();
-}
+  cvd_common::Args new_exec_args{arguments_separator->ProgPath()};
 
-std::optional<std::string> FrontlineParser::SubCmd() const {
-  return arguments_separator_->SubCmd();
-}
-
-const cvd_common::Args& FrontlineParser::SubCmdArgs() const {
-  return arguments_separator_->SubCmdArgs();
-}
-
-const cvd_common::Args& FrontlineParser::CvdArgs() const {
-  return arguments_separator_->CvdArgs();
-}
-
-}  // namespace
-
-Result<cvd_common::Args> ExtractCvdArgs(cvd_common::Args& args) {
-  auto frontline_parser = CF_EXPECT(FrontlineParser::Parse(args));
-  CF_EXPECT(frontline_parser != nullptr);
-
-  const auto prog_path = frontline_parser->ProgPath();
-  const auto new_sub_cmd = frontline_parser->SubCmd();
-  cvd_common::Args cmd_args{frontline_parser->SubCmdArgs()};
-
-  cvd_common::Args new_exec_args{prog_path};
+  const auto new_sub_cmd = arguments_separator->SubCmd();
   if (new_sub_cmd) {
     new_exec_args.push_back(*new_sub_cmd);
   }
+
+  cvd_common::Args cmd_args{arguments_separator->SubCmdArgs()};
   new_exec_args.insert(new_exec_args.end(), cmd_args.begin(), cmd_args.end());
+
   args = new_exec_args;
-  return frontline_parser->CvdArgs();
+  return arguments_separator->CvdArgs();
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.cpp
@@ -73,43 +73,19 @@ Result<cvd_common::Args> FrontlineParser::ValidSubcmdsList() {
   return valid_subcmds;
 }
 
-static Result<std::unordered_set<std::string>> BoolFlagNames(
-    const std::vector<CvdFlagProxy>& flags) {
-  std::unordered_set<std::string> output;
-  for (const auto& flag : flags) {
-    if (flag.GetType() == CvdFlagProxy::FlagType::kBool) {
-      output.insert(CF_EXPECT(flag.Name()));
-    }
-  }
-  return output;
-}
-
-static Result<std::unordered_set<std::string>> ValueFlagNames(
-    const std::vector<CvdFlagProxy>& flags) {
-  std::unordered_set<std::string> output;
-  for (const auto& flag : flags) {
-    if (flag.GetType() == CvdFlagProxy::FlagType::kInt32 ||
-        flag.GetType() == CvdFlagProxy::FlagType::kString) {
-      output.insert(CF_EXPECT(flag.Name()));
-    }
-  }
-  return output;
-}
-
 Result<std::unique_ptr<selector::ArgumentsSeparator>>
 FrontlineParser::CallSeparator() {
   auto valid_subcmds_vector = CF_EXPECT(ValidSubcmdsList());
   std::unordered_set<std::string> valid_subcmds{valid_subcmds_vector.begin(),
                                                 valid_subcmds_vector.end()};
-  auto cvd_flags = CF_EXPECT(selector::SelectorFlags::New()).Flags();
-
-  auto known_bool_flags = CF_EXPECT(BoolFlagNames(cvd_flags));
-  auto known_value_flags = CF_EXPECT(ValueFlagNames(cvd_flags));
 
   ArgumentsSeparator::FlagsRegistration flag_registration{
-      .known_boolean_flags = known_bool_flags,
-      .known_value_flags = known_value_flags,
-      .valid_subcommands = valid_subcmds};
+      .known_boolean_flags = {},
+      .known_value_flags = {selector::SelectorFlags::kGroupName,
+                            selector::SelectorFlags::kInstanceName,
+                            selector::SelectorFlags::kVerbosity},
+      .valid_subcommands = valid_subcmds,
+  };
   auto arguments_separator =
       CF_EXPECT(ArgumentsSeparator::Parse(flag_registration, all_args_));
   CF_EXPECT(arguments_separator != nullptr);

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.cpp
@@ -48,14 +48,7 @@ using selector::ArgumentsSeparator;
 Result<cvd_common::Args> ExtractCvdArgs(cvd_common::Args& args) {
   CF_EXPECT(!args.empty());
 
-  ArgumentsSeparator::FlagsRegistration flag_registration{
-      .known_boolean_flags = {},
-      .known_value_flags = {selector::SelectorFlags::kGroupName,
-                            selector::SelectorFlags::kInstanceName,
-                            selector::SelectorFlags::kVerbosity},
-  };
-  auto arguments_separator =
-      CF_EXPECT(ArgumentsSeparator::Parse(flag_registration, args));
+  auto arguments_separator = CF_EXPECT(ArgumentsSeparator::Parse(args));
   CF_EXPECT(arguments_separator != nullptr);
 
   cvd_common::Args new_exec_args{arguments_separator->ProgPath()};

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.cpp
@@ -29,8 +29,7 @@
 namespace cuttlefish {
 
 Result<cvd_common::Args> ExtractCvdArgs(cvd_common::Args& args) {
-  FrontlineParser::ParserParam server_param{.all_args = args};
-  auto frontline_parser = CF_EXPECT(FrontlineParser::Parse(server_param));
+  auto frontline_parser = CF_EXPECT(FrontlineParser::Parse(args));
   CF_EXPECT(frontline_parser != nullptr);
 
   const auto prog_path = frontline_parser->ProgPath();
@@ -47,17 +46,18 @@ Result<cvd_common::Args> ExtractCvdArgs(cvd_common::Args& args) {
 }
 
 Result<std::unique_ptr<FrontlineParser>> FrontlineParser::Parse(
-    ParserParam param) {
-  CF_EXPECT(!param.all_args.empty());
-  std::unique_ptr<FrontlineParser> frontline_parser(new FrontlineParser(param));
+    const cvd_common::Args& all_args) {
+  CF_EXPECT(!all_args.empty());
+  std::unique_ptr<FrontlineParser> frontline_parser(
+      new FrontlineParser(all_args));
   CF_EXPECT(frontline_parser != nullptr,
             "Memory allocation for FrontlineParser failed.");
   CF_EXPECT(frontline_parser->Separate());
   return frontline_parser;
 }
 
-FrontlineParser::FrontlineParser(const ParserParam& parser_param)
-    : all_args_(parser_param.all_args) {}
+FrontlineParser::FrontlineParser(const cvd_common::Args& all_args)
+    : all_args_(all_args) {}
 
 Result<void> FrontlineParser::Separate() {
   arguments_separator_ = CF_EXPECT(CallSeparator());

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.cpp
@@ -29,10 +29,7 @@
 namespace cuttlefish {
 
 Result<cvd_common::Args> ExtractCvdArgs(cvd_common::Args& args) {
-  FrontlineParser::ParserParam server_param{
-      .server_supported_subcmds = {"*"},
-      .all_args = args
-  };
+  FrontlineParser::ParserParam server_param{.all_args = args};
   auto frontline_parser = CF_EXPECT(FrontlineParser::Parse(server_param));
   CF_EXPECT(frontline_parser != nullptr);
 
@@ -60,31 +57,20 @@ Result<std::unique_ptr<FrontlineParser>> FrontlineParser::Parse(
 }
 
 FrontlineParser::FrontlineParser(const ParserParam& parser_param)
-    : server_supported_subcmds_{parser_param.server_supported_subcmds},
-      all_args_(parser_param.all_args) {}
+    : all_args_(parser_param.all_args) {}
 
 Result<void> FrontlineParser::Separate() {
   arguments_separator_ = CF_EXPECT(CallSeparator());
   return {};
 }
 
-Result<cvd_common::Args> FrontlineParser::ValidSubcmdsList() {
-  cvd_common::Args valid_subcmds(server_supported_subcmds_);
-  return valid_subcmds;
-}
-
 Result<std::unique_ptr<selector::ArgumentsSeparator>>
 FrontlineParser::CallSeparator() {
-  auto valid_subcmds_vector = CF_EXPECT(ValidSubcmdsList());
-  std::unordered_set<std::string> valid_subcmds{valid_subcmds_vector.begin(),
-                                                valid_subcmds_vector.end()};
-
   ArgumentsSeparator::FlagsRegistration flag_registration{
       .known_boolean_flags = {},
       .known_value_flags = {selector::SelectorFlags::kGroupName,
                             selector::SelectorFlags::kInstanceName,
                             selector::SelectorFlags::kVerbosity},
-      .valid_subcommands = valid_subcmds,
   };
   auto arguments_separator =
       CF_EXPECT(ArgumentsSeparator::Parse(flag_registration, all_args_));

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.cpp
@@ -34,18 +34,6 @@ namespace cuttlefish {
 using selector::SeparateArguments;
 using selector::SeparatedArguments;
 
-/* the very first command line parser
- *
- * Being aware of valid subcommands and cvd-specific commands, it will
- * separate the command line arguments into:
- *
- *  1. program path/name
- *  2. cvd-specific arguments
- *     a) selector flags
- *     b) non-selector flags
- *  3. subcommand
- *  4. subcommand arguments
- */
 Result<cvd_common::Args> ExtractCvdArgs(cvd_common::Args& args) {
   CF_EXPECT(!args.empty());
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.cpp
@@ -31,7 +31,8 @@
 
 namespace cuttlefish {
 
-using selector::ArgumentsSeparator;
+using selector::SeparateArguments;
+using selector::SeparatedArguments;
 
 /* the very first command line parser
  *
@@ -48,21 +49,21 @@ using selector::ArgumentsSeparator;
 Result<cvd_common::Args> ExtractCvdArgs(cvd_common::Args& args) {
   CF_EXPECT(!args.empty());
 
-  auto arguments_separator = CF_EXPECT(ArgumentsSeparator::Parse(args));
-  CF_EXPECT(arguments_separator != nullptr);
+  SeparatedArguments separated_arguments = CF_EXPECT(SeparateArguments(args));
 
-  cvd_common::Args new_exec_args{arguments_separator->ProgPath()};
+  cvd_common::Args new_exec_args{separated_arguments.prog_path};
 
-  const auto new_sub_cmd = arguments_separator->SubCmd();
-  if (new_sub_cmd) {
-    new_exec_args.push_back(*new_sub_cmd);
+  const std::optional<std::string>& sub_cmd = separated_arguments.sub_cmd;
+  if (sub_cmd) {
+    new_exec_args.push_back(*sub_cmd);
   }
 
-  cvd_common::Args cmd_args{arguments_separator->SubCmdArgs()};
-  new_exec_args.insert(new_exec_args.end(), cmd_args.begin(), cmd_args.end());
+  const cvd_common::Args& sub_cmd_args{separated_arguments.sub_cmd_args};
+  new_exec_args.insert(new_exec_args.end(), sub_cmd_args.begin(),
+                       sub_cmd_args.end());
 
   args = new_exec_args;
-  return arguments_separator->CvdArgs();
+  return separated_arguments.cvd_args;
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.h
@@ -47,12 +47,9 @@ class FrontlineParser {
   using ArgumentsSeparator = selector::ArgumentsSeparator;
 
  public:
-  struct ParserParam {
-    cvd_common::Args all_args;
-  };
-
   // This call must guarantee all public methods will be valid
-  static Result<std::unique_ptr<FrontlineParser>> Parse(ParserParam param);
+  static Result<std::unique_ptr<FrontlineParser>> Parse(
+      const cvd_common::Args& all_args);
 
   const std::string& ProgPath() const;
   std::optional<std::string> SubCmd() const;
@@ -60,7 +57,7 @@ class FrontlineParser {
   const cvd_common::Args& CvdArgs() const;
 
  private:
-  FrontlineParser(const ParserParam& parser_param);
+  FrontlineParser(const cvd_common::Args& all_args);
 
   // internal workers in order
   Result<void> Separate();

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.h
@@ -48,8 +48,6 @@ class FrontlineParser {
 
  public:
   struct ParserParam {
-    // commands supported by the server
-    std::vector<std::string> server_supported_subcmds;
     cvd_common::Args all_args;
   };
 
@@ -66,7 +64,6 @@ class FrontlineParser {
 
   // internal workers in order
   Result<void> Separate();
-  Result<cvd_common::Args> ValidSubcmdsList();
   Result<std::unique_ptr<ArgumentsSeparator>> CallSeparator();
   struct FilterOutput {
     bool clean;
@@ -75,7 +72,6 @@ class FrontlineParser {
   };
   Result<FilterOutput> FilterNonSelectorArgs();
 
-  cvd_common::Args server_supported_subcmds_;
   const cvd_common::Args all_args_;
   const std::vector<std::string> internal_cmds_;
   std::unique_ptr<ArgumentsSeparator> arguments_separator_;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.h
@@ -16,62 +16,12 @@
 
 #pragma once
 
-#include <memory>
-#include <optional>
-#include <string>
-
 #include "common/libs/utils/result.h"
-#include "host/commands/cvd/cli/selector/arguments_separator.h"
 #include "host/commands/cvd/cli/types.h"
 
 namespace cuttlefish {
 
+/* Returns `cvd` arguments before the subcommand, removing them from `args`. */
 Result<cvd_common::Args> ExtractCvdArgs(cvd_common::Args& args);
-
-/* the very first command line parser
- *
- * Being aware of valid subcommands and cvd-specific commands, it will
- * separate the command line arguments into:
- *
- *  1. program path/name
- *  2. cvd-specific arguments
- *     a) selector flags
- *     b) non-selector flags
- *  3. subcommand
- *  4. subcommand arguments
- *
- * This is currently on the client side but will be moved to the server
- * side.
- */
-class FrontlineParser {
-  using ArgumentsSeparator = selector::ArgumentsSeparator;
-
- public:
-  // This call must guarantee all public methods will be valid
-  static Result<std::unique_ptr<FrontlineParser>> Parse(
-      const cvd_common::Args& all_args);
-
-  const std::string& ProgPath() const;
-  std::optional<std::string> SubCmd() const;
-  const cvd_common::Args& SubCmdArgs() const;
-  const cvd_common::Args& CvdArgs() const;
-
- private:
-  FrontlineParser(const cvd_common::Args& all_args);
-
-  // internal workers in order
-  Result<void> Separate();
-  Result<std::unique_ptr<ArgumentsSeparator>> CallSeparator();
-  struct FilterOutput {
-    bool clean;
-    bool help;
-    cvd_common::Args selector_args;
-  };
-  Result<FilterOutput> FilterNonSelectorArgs();
-
-  const cvd_common::Args all_args_;
-  const std::vector<std::string> internal_cmds_;
-  std::unique_ptr<ArgumentsSeparator> arguments_separator_;
-};
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_lexer.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_lexer.cpp
@@ -22,6 +22,7 @@
 
 #include <android-base/strings.h>
 
+#include "host/commands/cvd/cli/selector/selector_constants.h"
 #include "host/commands/cvd/instances/instance_database_utils.h"
 
 namespace cuttlefish {
@@ -79,8 +80,14 @@ ArgumentsLexerBuilder::GenerateFlagPatterns(
   return flag_patterns;
 }
 
-Result<std::unique_ptr<ArgumentsLexer>> ArgumentsLexerBuilder::Build(
-    const LexerFlagsSpecification& known_flags) {
+Result<std::unique_ptr<ArgumentsLexer>> ArgumentsLexerBuilder::Build() {
+  // Change together: ParseCommonSelectorArguments in selector_common_parser.cpp
+  LexerFlagsSpecification known_flags{
+      .known_boolean_flags = {},
+      .known_value_flags = {SelectorFlags::kGroupName,
+                            SelectorFlags::kInstanceName,
+                            SelectorFlags::kVerbosity},
+  };
   auto flag_patterns = CF_EXPECT(GenerateFlagPatterns(known_flags));
   ArgumentsLexer* new_lexer = new ArgumentsLexer(std::move(flag_patterns));
   CF_EXPECT(new_lexer != nullptr,

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_lexer.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_lexer.cpp
@@ -29,11 +29,6 @@ namespace cuttlefish {
 namespace selector {
 namespace {
 
-template <typename... Sets>
-bool Included(const std::string& item, Sets&&... containers) {
-  return ((Contains(std::forward<Sets>(containers), item)) || ... || false);
-}
-
 class ArgumentsLexer {
   friend class ArgumentsLexerBuilder;
 
@@ -53,23 +48,9 @@ class ArgumentsLexer {
      *  {"-group_name", "--group_name"}
      */
     std::unordered_set<std::string> value_patterns;
-    /* boolean flags
-     * e.g. --daemon, --nodaemon
-     *
-     * With the given example, this set shall be:
-     *  {"-daemon", "--daemon"}
-     */
-    std::unordered_set<std::string> bool_patterns;
-    // e.g. {"-nodaemon", "--nodaemon"}
-    std::unordered_set<std::string> bool_no_patterns;
   };
   ArgumentsLexer(FlagPatterns&& flag_patterns);
 
-  // preprocess boolean flags:
-  //  e.g. --help=yes --> --help
-  //       --help=faLSe --> --nohelp
-  Result<std::vector<std::string>> Preprocess(
-      const std::vector<std::string>& args) const;
   Result<ArgToken> Process(const std::string& token) const;
 
   struct FlagValuePair {
@@ -84,13 +65,11 @@ class ArgumentsLexer {
   bool Registered(const std::string& flag_string) const {
     return Registered(flag_string, flag_patterns_);
   }
-  std::unordered_set<std::string> valid_bool_values_in_lower_cases_;
   FlagPatterns flag_patterns_;
 };
 
 // input to the lexer factory function
 struct LexerFlagsSpecification {
-  std::unordered_set<std::string> known_boolean_flags;
   std::unordered_set<std::string> known_value_flags;
 };
 
@@ -121,9 +100,6 @@ class ArgumentsLexerBuilder {
  *
  * Say, the two sets are BaseSet and NoPrependedSet.
  *
- * Given a boolean flag --foo, these will happen:
- *   BaseSet = BaseSet U {"--foo", "-foo"}
- *   NoPrependedSet = NoPrependedSet U  {"--nofoo", "-nofoo"}
  * Given a non boolean flag --bar, these will happen:
  *   BaseSet = BaseSet U {"--bar", "-bar"}
  *
@@ -143,27 +119,12 @@ ArgumentsLexerBuilder::GenerateFlagPatterns(
     flag_patterns.value_patterns.insert(one_dash);
     flag_patterns.value_patterns.insert(two_dashes);
   }
-  for (const auto& bool_flag : known_flags.known_boolean_flags) {
-    const auto one_dash = "-" + bool_flag;
-    const auto two_dashes = "--" + bool_flag;
-    const auto one_dash_with_no = "-no" + bool_flag;
-    const auto two_dashes_with_no = "--no" + bool_flag;
-    CF_EXPECT(!ArgumentsLexer::Registered(one_dash, flag_patterns));
-    CF_EXPECT(!ArgumentsLexer::Registered(two_dashes, flag_patterns));
-    CF_EXPECT(!ArgumentsLexer::Registered(one_dash_with_no, flag_patterns));
-    CF_EXPECT(!ArgumentsLexer::Registered(two_dashes_with_no, flag_patterns));
-    flag_patterns.bool_patterns.insert(one_dash);
-    flag_patterns.bool_patterns.insert(two_dashes);
-    flag_patterns.bool_no_patterns.insert(one_dash_with_no);
-    flag_patterns.bool_no_patterns.insert(two_dashes_with_no);
-  }
   return flag_patterns;
 }
 
 Result<std::unique_ptr<ArgumentsLexer>> ArgumentsLexerBuilder::Build() {
   // Change together: ParseCommonSelectorArguments in selector_common_parser.cpp
   LexerFlagsSpecification known_flags{
-      .known_boolean_flags = {},
       .known_value_flags = {SelectorFlags::kGroupName,
                             SelectorFlags::kInstanceName,
                             SelectorFlags::kVerbosity},
@@ -176,15 +137,11 @@ Result<std::unique_ptr<ArgumentsLexer>> ArgumentsLexerBuilder::Build() {
 }
 
 ArgumentsLexer::ArgumentsLexer(FlagPatterns&& flag_patterns)
-    : flag_patterns_{std::move(flag_patterns)} {
-  valid_bool_values_in_lower_cases_ =
-      std::unordered_set<std::string>{"true", "false", "yes", "no", "y", "n"};
-}
+    : flag_patterns_{std::move(flag_patterns)} {}
 
 bool ArgumentsLexer::Registered(const std::string& flag_string,
                                 const FlagPatterns& flag_patterns) {
-  return Included(flag_string, flag_patterns.value_patterns,
-                  flag_patterns.bool_patterns, flag_patterns.bool_no_patterns);
+  return Contains(flag_patterns.value_patterns, flag_string);
 }
 
 Result<ArgToken> ArgumentsLexer::Process(const std::string& token) const {
@@ -212,34 +169,17 @@ Result<ArgToken> ArgumentsLexer::Process(const std::string& token) const {
   if (Contains(flag_patterns_.value_patterns, token)) {
     return ArgToken{ArgType::kKnownValueFlag, token};
   }
-  if (Contains(flag_patterns_.bool_patterns, token)) {
-    return ArgToken{ArgType::kKnownBoolFlag, token};
-  }
-  if (Contains(flag_patterns_.bool_no_patterns, token)) {
-    return ArgToken{ArgType::kKnownBoolNoFlag, token};
-  }
   return ArgToken{ArgType::kUnknownFlag, token};
 }
 
 Result<std::vector<ArgToken>> ArgumentsLexer::Tokenize(
     const std::vector<std::string>& args) const {
   std::vector<ArgToken> tokenized;
-  auto intersection =
-      Intersection(flag_patterns_.value_patterns, flag_patterns_.bool_patterns);
-  CF_EXPECT(intersection.empty());
-  auto preprocessed_args = CF_EXPECT(Preprocess(args));
-  for (const auto& arg : preprocessed_args) {
+  for (const auto& arg : args) {
     auto arg_token = CF_EXPECT(Process(arg));
     tokenized.emplace_back(arg_token);
   }
   return tokenized;
-}
-
-static std::string ToLower(const std::string& src) {
-  std::string lower_cased_value;
-  lower_cased_value.resize(src.size());
-  std::transform(src.begin(), src.end(), lower_cased_value.begin(), ::tolower);
-  return lower_cased_value;
 }
 
 Result<ArgumentsLexer::FlagValuePair> ArgumentsLexer::Separate(
@@ -249,48 +189,6 @@ Result<ArgumentsLexer::FlagValuePair> ArgumentsLexer::Separate(
   auto first_token = equal_included_string.substr(0, equal_sign_pos);
   auto second_token = equal_included_string.substr(equal_sign_pos + 1);
   return FlagValuePair{.flag_string = first_token, .value = second_token};
-}
-
-Result<std::vector<std::string>> ArgumentsLexer::Preprocess(
-    const std::vector<std::string>& args) const {
-  std::vector<std::string> new_args;
-  std::regex pattern("[\\-][\\-]?[^\\-]+.*=.*");
-  for (const auto& arg : args) {
-    if (!std::regex_match(arg, pattern)) {
-      new_args.emplace_back(arg);
-      continue;
-    }
-    // needs to split based on the first '='
-    // --something=another_thing or
-    //  -something=another_thing
-    const auto [flag_string, value] = CF_EXPECT(Separate(arg));
-
-    if (Contains(flag_patterns_.bool_patterns, flag_string)) {
-      const auto low_cased_value = ToLower(value);
-      CF_EXPECT(Contains(valid_bool_values_in_lower_cases_, low_cased_value),
-                "The value for the boolean flag " << flag_string << ", "
-                                                  << value << " is not valid");
-      if (low_cased_value == "true" || low_cased_value == "yes") {
-        new_args.emplace_back(flag_string);
-        continue;
-      }
-      auto base_pos = flag_string.find_first_not_of('-');
-      auto base = flag_string.substr(base_pos);
-      new_args.emplace_back("--no" + base);
-      continue;
-    }
-
-    if (Contains(flag_patterns_.bool_no_patterns, flag_string)) {
-      CF_EXPECT(android::base::StartsWith(flag_string, "-no") ||
-                android::base::StartsWith(flag_string, "--no"));
-      // if --nohelp=XYZ, the "=XYZ" is ignored.
-      new_args.emplace_back(flag_string);
-      continue;
-    }
-
-    new_args.emplace_back(arg);
-  }
-  return new_args;
 }
 
 Result<std::vector<ArgToken>> TokenizeArguments(

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_lexer.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_lexer.cpp
@@ -68,11 +68,6 @@ class ArgumentsLexer {
   FlagPatterns flag_patterns_;
 };
 
-// input to the lexer factory function
-struct LexerFlagsSpecification {
-  std::unordered_set<std::string> known_value_flags;
-};
-
 /*
  * At the top level, there are only two tokens: flag and positional tokens.
  *
@@ -90,7 +85,7 @@ class ArgumentsLexerBuilder {
 
  private:
   static Result<FlagPatterns> GenerateFlagPatterns(
-      const LexerFlagsSpecification& known_flags);
+      const std::unordered_set<std::string>& known_flags);
 };
 
 }  // namespace
@@ -109,9 +104,9 @@ class ArgumentsLexerBuilder {
  */
 Result<ArgumentsLexerBuilder::FlagPatterns>
 ArgumentsLexerBuilder::GenerateFlagPatterns(
-    const LexerFlagsSpecification& known_flags) {
+    const std::unordered_set<std::string>& known_flags) {
   FlagPatterns flag_patterns;
-  for (const auto& non_bool_flag : known_flags.known_value_flags) {
+  for (const auto& non_bool_flag : known_flags) {
     const auto one_dash = "-" + non_bool_flag;
     const auto two_dashes = "--" + non_bool_flag;
     CF_EXPECT(!ArgumentsLexer::Registered(one_dash, flag_patterns));
@@ -124,11 +119,9 @@ ArgumentsLexerBuilder::GenerateFlagPatterns(
 
 Result<std::unique_ptr<ArgumentsLexer>> ArgumentsLexerBuilder::Build() {
   // Change together: ParseCommonSelectorArguments in selector_common_parser.cpp
-  LexerFlagsSpecification known_flags{
-      .known_value_flags = {SelectorFlags::kGroupName,
-                            SelectorFlags::kInstanceName,
-                            SelectorFlags::kVerbosity},
-  };
+  std::unordered_set<std::string> known_flags{SelectorFlags::kGroupName,
+                                              SelectorFlags::kInstanceName,
+                                              SelectorFlags::kVerbosity};
   auto flag_patterns = CF_EXPECT(GenerateFlagPatterns(known_flags));
   ArgumentsLexer* new_lexer = new ArgumentsLexer(std::move(flag_patterns));
   CF_EXPECT(new_lexer != nullptr,

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_lexer.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_lexer.cpp
@@ -31,7 +31,7 @@ namespace {
 
 class ArgumentsLexer {
  public:
-  static Result<std::unique_ptr<ArgumentsLexer>> Build();
+  static Result<ArgumentsLexer> Build();
 
   Result<std::vector<ArgToken>> Tokenize(
       const std::vector<std::string>& args) const;
@@ -87,7 +87,7 @@ class ArgumentsLexer {
  * two sets to see if the token that is supposedly a flag is a known
  * flag.
  */
-Result<std::unique_ptr<ArgumentsLexer>> ArgumentsLexer::Build() {
+Result<ArgumentsLexer> ArgumentsLexer::Build() {
   // Change together: ParseCommonSelectorArguments in selector_common_parser.cpp
   std::unordered_set<std::string> known_flags{SelectorFlags::kGroupName,
                                               SelectorFlags::kInstanceName,
@@ -103,10 +103,7 @@ Result<std::unique_ptr<ArgumentsLexer>> ArgumentsLexer::Build() {
     flag_patterns.value_patterns.insert(two_dashes);
   }
 
-  ArgumentsLexer* new_lexer = new ArgumentsLexer(std::move(flag_patterns));
-  CF_EXPECT(new_lexer != nullptr,
-            "Memory allocation for ArgumentsLexer failed.");
-  return std::unique_ptr<ArgumentsLexer>{new_lexer};
+  return ArgumentsLexer(std::move(flag_patterns));
 }
 
 ArgumentsLexer::ArgumentsLexer(FlagPatterns&& flag_patterns)
@@ -168,10 +165,9 @@ Result<ArgumentsLexer::FlagValuePair> ArgumentsLexer::Separate(
 
 Result<std::vector<ArgToken>> TokenizeArguments(
     const std::vector<std::string>& args) {
-  std::unique_ptr<ArgumentsLexer> lexer = CF_EXPECT(ArgumentsLexer::Build());
-  CF_EXPECT(lexer.get());
+  ArgumentsLexer lexer = CF_EXPECT(ArgumentsLexer::Build());
 
-  return CF_EXPECT(lexer->Tokenize(args));
+  return CF_EXPECT(lexer.Tokenize(args));
 }
 
 }  // namespace selector

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_lexer.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_lexer.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <deque>
 #include <memory>
 #include <string>
 #include <unordered_set>
@@ -109,85 +110,8 @@ class ArgToken {
   std::string token_;
 };
 
-class ArgumentsLexer {
-  friend class ArgumentsLexerBuilder;
-
- public:
-  Result<std::vector<ArgToken>> Tokenize(
-      const std::vector<std::string>& args) const;
-
- private:
-  // Lexer factory function will internally generate this,
-  // and give it to ArgumentsLexer.
-  struct FlagPatterns {
-    /* represents flags that takes values
-     * e.g. -group_name, --group_name (which may take an additional
-     * positional arg, or use its default value.)
-     *
-     * With the given example, this set shall be:
-     *  {"-group_name", "--group_name"}
-     */
-    std::unordered_set<std::string> value_patterns;
-    /* boolean flags
-     * e.g. --daemon, --nodaemon
-     *
-     * With the given example, this set shall be:
-     *  {"-daemon", "--daemon"}
-     */
-    std::unordered_set<std::string> bool_patterns;
-    // e.g. {"-nodaemon", "--nodaemon"}
-    std::unordered_set<std::string> bool_no_patterns;
-  };
-  ArgumentsLexer(FlagPatterns&& flag_patterns);
-
-  // preprocess boolean flags:
-  //  e.g. --help=yes --> --help
-  //       --help=faLSe --> --nohelp
-  Result<std::vector<std::string>> Preprocess(
-      const std::vector<std::string>& args) const;
-  Result<ArgToken> Process(const std::string& token) const;
-
-  struct FlagValuePair {
-    std::string flag_string;
-    std::string value;
-  };
-  Result<FlagValuePair> Separate(
-      const std::string& equal_included_string) const;
-  // flag_string starts with "-" or "--"
-  static bool Registered(const std::string& flag_string,
-                         const FlagPatterns& flag_patterns);
-  bool Registered(const std::string& flag_string) const {
-    return Registered(flag_string, flag_patterns_);
-  }
-  std::unordered_set<std::string> valid_bool_values_in_lower_cases_;
-  FlagPatterns flag_patterns_;
-};
-
-// input to the lexer factory function
-struct LexerFlagsSpecification {
-  std::unordered_set<std::string> known_boolean_flags;
-  std::unordered_set<std::string> known_value_flags;
-};
-
-/*
- * At the top level, there are only two tokens: flag and positional tokens.
- *
- * A flag token starts with "-" or "--" followed by one or more non "-" letters.
- * A positional token starts with any character other than "-".
- *
- * Between flag tokens, there are "known" and "unknown" flag tokens.
- *
- */
-class ArgumentsLexerBuilder {
-  using FlagPatterns = ArgumentsLexer::FlagPatterns;
-
- public:
-  static Result<std::unique_ptr<ArgumentsLexer>> Build();
-
- private:
-  static Result<FlagPatterns> GenerateFlagPatterns(
-      const LexerFlagsSpecification& known_flags);
-};
+Result<std::vector<ArgToken>> TokenizeArguments(
+    const std::vector<std::string>& args);
 
 }  // namespace selector
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_lexer.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_lexer.h
@@ -182,8 +182,7 @@ class ArgumentsLexerBuilder {
   using FlagPatterns = ArgumentsLexer::FlagPatterns;
 
  public:
-  static Result<std::unique_ptr<ArgumentsLexer>> Build(
-      const LexerFlagsSpecification& known_flags);
+  static Result<std::unique_ptr<ArgumentsLexer>> Build();
 
  private:
   static Result<FlagPatterns> GenerateFlagPatterns(

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.cpp
@@ -44,18 +44,6 @@ Result<std::unique_ptr<ArgumentsSeparator>> ArgumentsSeparator::Parse(
 }
 
 Result<std::unique_ptr<ArgumentsSeparator>> ArgumentsSeparator::Parse(
-    const FlagsRegistration& flag_registration,
-    const CvdProtobufArg& input_args) {
-  std::vector<std::string> input_args_vec;
-  input_args_vec.reserve(input_args.size());
-  for (const auto& input_arg : input_args) {
-    input_args_vec.emplace_back(input_arg);
-  }
-  auto arg_separator = CF_EXPECT(Parse(flag_registration, input_args_vec));
-  return std::move(arg_separator);
-}
-
-Result<std::unique_ptr<ArgumentsSeparator>> ArgumentsSeparator::Parse(
     const FlagsRegistration& flag_registration, const std::string& input_args,
     const std::string& delim) {
   std::vector<std::string> input_args_vec =

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.cpp
@@ -43,15 +43,6 @@ Result<std::unique_ptr<ArgumentsSeparator>> ArgumentsSeparator::Parse(
   return std::move(arg_separator);
 }
 
-Result<std::unique_ptr<ArgumentsSeparator>> ArgumentsSeparator::Parse(
-    const FlagsRegistration& flag_registration, const std::string& input_args,
-    const std::string& delim) {
-  std::vector<std::string> input_args_vec =
-      android::base::Tokenize(input_args, delim);
-  auto arg_separator = CF_EXPECT(Parse(flag_registration, input_args_vec));
-  return std::move(arg_separator);
-}
-
 ArgumentsSeparator::ArgumentsSeparator(
     std::unique_ptr<ArgumentsLexer>&& lexer,
     const std::vector<std::string>& input_args,

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.cpp
@@ -21,20 +21,13 @@
 #include <android-base/strings.h>
 
 #include "common/libs/utils/contains.h"
-#include "host/commands/cvd/cli/selector/selector_constants.h"
 
 namespace cuttlefish {
 namespace selector {
 
 Result<std::unique_ptr<ArgumentsSeparator>> ArgumentsSeparator::Parse(
     const std::vector<std::string>& input_args) {
-  LexerFlagsSpecification lexer_flag_spec{
-      .known_boolean_flags = {},
-      .known_value_flags = {SelectorFlags::kGroupName,
-                            SelectorFlags::kInstanceName,
-                            SelectorFlags::kVerbosity},
-  };
-  auto lexer = CF_EXPECT(ArgumentsLexerBuilder::Build(lexer_flag_spec));
+  auto lexer = CF_EXPECT(ArgumentsLexerBuilder::Build());
   CF_EXPECT(lexer != nullptr);
   ArgumentsSeparator* new_arg_separator =
       new ArgumentsSeparator(std::move(lexer), input_args);

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.cpp
@@ -41,11 +41,8 @@ Result<SeparatedArguments> SeparateArguments(
     const std::vector<std::string>& input_args) {
   CF_EXPECT(!input_args.empty());
 
-  auto lexer = CF_EXPECT(ArgumentsLexerBuilder::Build());
-  CF_EXPECT(lexer != nullptr);
-
-  auto tokenized = CF_EXPECT(lexer->Tokenize(input_args));
-  std::deque<ArgToken> tokens_queue{tokenized.begin(), tokenized.end()};
+  std::vector<ArgToken> tokens_vec = CF_EXPECT(TokenizeArguments(input_args));
+  std::deque<ArgToken> tokens_queue(tokens_vec.begin(), tokens_vec.end());
 
   // take program path/name
   CF_EXPECT(!tokens_queue.empty() &&
@@ -89,8 +86,7 @@ Result<SeparatedArguments> SeparateArguments(
         cvd_flags_mode = false;
       } break;
       case ArgType::kDoubleDash: {
-        return CF_ERR("--"
-                      << " is not allowed within cvd specific flags.");
+        return CF_ERR("`--` is not allowed within cvd specific flags.");
       }
       case ArgType::kUnknownFlag:
       case ArgType::kError: {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.cpp
@@ -50,9 +50,7 @@ ArgumentsSeparator::ArgumentsSeparator(
     : lexer_(std::move(lexer)),
       input_args_(input_args),
       known_boolean_flags_(flag_registration.known_boolean_flags),
-      known_value_flags_(flag_registration.known_value_flags),
-      valid_subcmds_(flag_registration.valid_subcommands),
-      match_any_subcmd_(Contains(valid_subcmds_, "*")) {}
+      known_value_flags_(flag_registration.known_value_flags) {}
 
 Result<void> ArgumentsSeparator::Parse() {
   auto output = CF_EXPECT(ParseInternal());
@@ -120,8 +118,6 @@ Result<ArgumentsSeparator::Output> ArgumentsSeparator::ParseInternal() {
       case ArgType::kPositional: {
         output.sub_cmd = current.Token();
         CF_EXPECT(output.sub_cmd != std::nullopt);
-        CF_EXPECT(match_any_subcmd_ || Contains(valid_subcmds_, output.sub_cmd),
-                  "Subcommand " << *(output.sub_cmd) << " is not valid");
         cvd_flags_mode = false;
       } break;
       case ArgType::kDoubleDash: {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.cpp
@@ -21,21 +21,23 @@
 #include <android-base/strings.h>
 
 #include "common/libs/utils/contains.h"
+#include "host/commands/cvd/cli/selector/selector_constants.h"
 
 namespace cuttlefish {
 namespace selector {
 
 Result<std::unique_ptr<ArgumentsSeparator>> ArgumentsSeparator::Parse(
-    const FlagsRegistration& flag_registration,
     const std::vector<std::string>& input_args) {
   LexerFlagsSpecification lexer_flag_spec{
-      .known_boolean_flags = flag_registration.known_boolean_flags,
-      .known_value_flags = flag_registration.known_value_flags,
+      .known_boolean_flags = {},
+      .known_value_flags = {SelectorFlags::kGroupName,
+                            SelectorFlags::kInstanceName,
+                            SelectorFlags::kVerbosity},
   };
   auto lexer = CF_EXPECT(ArgumentsLexerBuilder::Build(lexer_flag_spec));
   CF_EXPECT(lexer != nullptr);
   ArgumentsSeparator* new_arg_separator =
-      new ArgumentsSeparator(std::move(lexer), input_args, flag_registration);
+      new ArgumentsSeparator(std::move(lexer), input_args);
   CF_EXPECT(new_arg_separator != nullptr,
             "Memory allocation failed for ArgumentSeparator");
   std::unique_ptr<ArgumentsSeparator> arg_separator{new_arg_separator};
@@ -45,12 +47,8 @@ Result<std::unique_ptr<ArgumentsSeparator>> ArgumentsSeparator::Parse(
 
 ArgumentsSeparator::ArgumentsSeparator(
     std::unique_ptr<ArgumentsLexer>&& lexer,
-    const std::vector<std::string>& input_args,
-    const FlagsRegistration& flag_registration)
-    : lexer_(std::move(lexer)),
-      input_args_(input_args),
-      known_boolean_flags_(flag_registration.known_boolean_flags),
-      known_value_flags_(flag_registration.known_value_flags) {}
+    const std::vector<std::string>& input_args)
+    : lexer_(std::move(lexer)), input_args_(input_args) {}
 
 Result<void> ArgumentsSeparator::Parse() {
   auto output = CF_EXPECT(ParseInternal());

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.h
@@ -70,7 +70,6 @@ class ArgumentsSeparator {
   struct FlagsRegistration {
     std::unordered_set<std::string> known_boolean_flags;
     std::unordered_set<std::string> known_value_flags;
-    std::unordered_set<std::string> valid_subcommands;
   };
   static Result<std::unique_ptr<ArgumentsSeparator>> Parse(
       const FlagsRegistration& flag_registration,
@@ -103,8 +102,6 @@ class ArgumentsSeparator {
   std::vector<std::string> input_args_;
   std::unordered_set<std::string> known_boolean_flags_;
   std::unordered_set<std::string> known_value_flags_;
-  std::unordered_set<std::string> valid_subcmds_;
-  bool match_any_subcmd_;
 
   // outputs
   std::string prog_path_;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.h
@@ -66,8 +66,6 @@ namespace selector {
  *
  */
 class ArgumentsSeparator {
-  using CvdProtobufArg = google::protobuf::RepeatedPtrField<std::string>;
-
  public:
   struct FlagsRegistration {
     std::unordered_set<std::string> known_boolean_flags;
@@ -77,9 +75,6 @@ class ArgumentsSeparator {
   static Result<std::unique_ptr<ArgumentsSeparator>> Parse(
       const FlagsRegistration& flag_registration,
       const std::vector<std::string>& input_args);
-  static Result<std::unique_ptr<ArgumentsSeparator>> Parse(
-      const FlagsRegistration& flag_registration,
-      const CvdProtobufArg& input_args);
   static Result<std::unique_ptr<ArgumentsSeparator>> Parse(
       const FlagsRegistration& flag_registration, const std::string& input_args,
       const std::string& delim = " ");

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.h
@@ -67,12 +67,7 @@ namespace selector {
  */
 class ArgumentsSeparator {
  public:
-  struct FlagsRegistration {
-    std::unordered_set<std::string> known_boolean_flags;
-    std::unordered_set<std::string> known_value_flags;
-  };
   static Result<std::unique_ptr<ArgumentsSeparator>> Parse(
-      const FlagsRegistration& flag_registration,
       const std::vector<std::string>& input_args);
 
   const std::string& ProgPath() const { return prog_path_; }
@@ -82,8 +77,7 @@ class ArgumentsSeparator {
 
  private:
   ArgumentsSeparator(std::unique_ptr<ArgumentsLexer>&& lexer,
-                     const std::vector<std::string>& input_args,
-                     const FlagsRegistration& flag_registration);
+                     const std::vector<std::string>& input_args);
 
   bool IsFlag(ArgType arg_type) const;
   struct Output {
@@ -100,8 +94,6 @@ class ArgumentsSeparator {
 
   // inputs
   std::vector<std::string> input_args_;
-  std::unordered_set<std::string> known_boolean_flags_;
-  std::unordered_set<std::string> known_value_flags_;
 
   // outputs
   std::string prog_path_;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.h
@@ -75,9 +75,6 @@ class ArgumentsSeparator {
   static Result<std::unique_ptr<ArgumentsSeparator>> Parse(
       const FlagsRegistration& flag_registration,
       const std::vector<std::string>& input_args);
-  static Result<std::unique_ptr<ArgumentsSeparator>> Parse(
-      const FlagsRegistration& flag_registration, const std::string& input_args,
-      const std::string& delim = " ");
 
   const std::string& ProgPath() const { return prog_path_; }
   const std::vector<std::string>& CvdArgs() const { return cvd_args_; }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.h
@@ -49,23 +49,8 @@ struct SeparatedArguments {
  *  $ program_path/name <optional cvd-specific flags> \
  *                      subcmd <optional subcmd arguments>
  *
- * For the parser's sake, there are a few more rules.
+ * For the parser's sake, there are is another rule.
  *
- * 1. All the optional cvd-specific flags should be pre-registered. Usually,
- * the subcmd arguments do not have to be registered. However, cvd-specific
- * flags must be.
- *
- *  E.g. "--clean" is the only registered cvd-specific flag, which happened
- *      to be bool.
- *       These are okay:
- *         cvd --clean start --never-exist-flag
- *         cvd --noclean stop
- *         cvd start
- *
- *       However, this is not okay:
- *        cvd --daemon start
- *
- *  2. --
  *  E.g. cvd --clean start --have --some --args -- a b c d e
  *  -- is basically for subcommands. cvd itself does not use it.
  *  If -- is within cvd arguments, it is ill-formatted. If it is within

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.h
@@ -30,6 +30,13 @@
 namespace cuttlefish {
 namespace selector {
 
+struct SeparatedArguments {
+  std::string prog_path;
+  std::vector<std::string> cvd_args;
+  std::optional<std::string> sub_cmd;
+  std::vector<std::string> sub_cmd_args;
+};
+
 /**
  * The very first parser for cmdline that separates:
  *
@@ -65,42 +72,8 @@ namespace selector {
  *  subcommands arguments, we simply forward it to the subtool as is.
  *
  */
-class ArgumentsSeparator {
- public:
-  static Result<std::unique_ptr<ArgumentsSeparator>> Parse(
-      const std::vector<std::string>& input_args);
-
-  const std::string& ProgPath() const { return prog_path_; }
-  const std::vector<std::string>& CvdArgs() const { return cvd_args_; }
-  std::optional<std::string> SubCmd() const { return sub_cmd_; }
-  const std::vector<std::string>& SubCmdArgs() const { return sub_cmd_args_; }
-
- private:
-  ArgumentsSeparator(std::unique_ptr<ArgumentsLexer>&& lexer,
-                     const std::vector<std::string>& input_args);
-
-  bool IsFlag(ArgType arg_type) const;
-  struct Output {
-    std::string prog_path;
-    std::vector<std::string> cvd_args;
-    std::optional<std::string> sub_cmd;
-    std::vector<std::string> sub_cmd_args;
-  };
-  Result<void> Parse();
-  Result<Output> ParseInternal();
-
-  // internals
-  std::unique_ptr<ArgumentsLexer> lexer_;
-
-  // inputs
-  std::vector<std::string> input_args_;
-
-  // outputs
-  std::string prog_path_;
-  std::vector<std::string> cvd_args_;
-  std::optional<std::string> sub_cmd_;
-  std::vector<std::string> sub_cmd_args_;
-};
+Result<SeparatedArguments> SeparateArguments(
+    const std::vector<std::string>& input_args);
 
 }  // namespace selector
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector_common_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector_common_parser.cpp
@@ -81,6 +81,7 @@ Result<SelectorOptions> HandleNameOpts(
 
 Result<SelectorOptions> ParseCommonSelectorArguments(
     cvd_common::Args& args) {
+  // Change together: ArgumentsLexerBuilder::Build in arguments_lexer.cpp
   // Handling name-related options
   auto group_name_flag =
       CF_EXPECT(SelectorFlags::Get().GetFlag(SelectorFlags::kGroupName));

--- a/base/cvd/cuttlefish/host/commands/cvd/unittests/selector/client_lexer_helper.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/unittests/selector/client_lexer_helper.cpp
@@ -22,7 +22,6 @@ LexerTestBase::LexerTestBase() { Init(); }
 
 void LexerTestBase::Init() {
   auto param = GetParam();
-  known_flags_ = param.known_flags_;
   lex_input_ = param.lex_input_;
   expected_tokens_ = param.expected_tokens_;
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/unittests/selector/client_lexer_helper.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/unittests/selector/client_lexer_helper.h
@@ -29,7 +29,6 @@ namespace selector {
 using Tokens = std::vector<ArgToken>;
 
 struct LexerInputOutput {
-  LexerFlagsSpecification known_flags_;
   std::string lex_input_;
   std::optional<Tokens> expected_tokens_;
 };
@@ -39,7 +38,6 @@ class LexerTestBase : public testing::TestWithParam<LexerInputOutput> {
   LexerTestBase();
   void Init();
 
-  LexerFlagsSpecification known_flags_;
   std::string lex_input_;
   std::optional<Tokens> expected_tokens_;
 };

--- a/base/cvd/cuttlefish/host/commands/cvd/unittests/server/frontline_parser_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/unittests/server/frontline_parser_test.cpp
@@ -47,9 +47,8 @@ namespace cuttlefish {
 
 TEST(FrontlineParserTest, CvdOnly) {
   cvd_common::Args input{"cvd"};
-  FrontlineParser::ParserParam parser_param{.all_args = input};
 
-  auto result = FrontlineParser::Parse(parser_param);
+  auto result = FrontlineParser::Parse(input);
 
   ASSERT_TRUE(result.ok()) << result.error().Trace();
   auto& parser_ptr = *result;

--- a/base/cvd/cuttlefish/host/commands/cvd/unittests/server/frontline_parser_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/unittests/server/frontline_parser_test.cpp
@@ -19,46 +19,19 @@
 
 #include <gtest/gtest.h>
 
+#include "common/libs/utils/result_matchers.h"
 #include "host/commands/cvd/cli/frontline_parser.h"
-
-namespace std {
-
-template <typename T>
-static std::ostream& operator<<(std::ostream& out, const std::vector<T>& v) {
-  if (v.empty()) {
-    out << "{}";
-    return out;
-  }
-  if (v.size() == 1) {
-    out << "{" << v.front() << "}";
-    return out;
-  }
-  out << "{";
-  for (size_t i = 0; i != v.size() - 1; i++) {
-    out << v.at(i) << ", ";
-  }
-  out << v.back() << "}";
-  return out;
-}
-
-}  // namespace std
 
 namespace cuttlefish {
 
-TEST(FrontlineParserTest, CvdOnly) {
-  cvd_common::Args input{"cvd"};
+TEST(FrontlineParserTest, SelectorArgs) {
+  cvd_common::Args input{"cvd", "--instance_name=1", "status"};
 
-  auto result = FrontlineParser::Parse(input);
+  auto result = ExtractCvdArgs(input);
 
-  ASSERT_TRUE(result.ok()) << result.error().Trace();
-  auto& parser_ptr = *result;
-  ASSERT_TRUE(parser_ptr);
-  ASSERT_EQ("cvd", parser_ptr->ProgPath());
-  ASSERT_EQ(std::nullopt, parser_ptr->SubCmd())
-      << (parser_ptr->SubCmd() ? std::string("nullopt")
-                               : *parser_ptr->SubCmd());
-  ASSERT_EQ(cvd_common::Args{}, parser_ptr->SubCmdArgs());
-  ASSERT_EQ(cvd_common::Args{}, parser_ptr->CvdArgs());
+  EXPECT_THAT(result, IsOk());
+  ASSERT_EQ(*result, std::vector<std::string>{"--instance_name=1"});
+  ASSERT_EQ(input, (std::vector<std::string>{"cvd", "status"}));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/unittests/server/frontline_parser_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/unittests/server/frontline_parser_test.cpp
@@ -47,8 +47,7 @@ namespace cuttlefish {
 
 TEST(FrontlineParserTest, CvdOnly) {
   cvd_common::Args input{"cvd"};
-  FrontlineParser::ParserParam parser_param{.server_supported_subcmds = {},
-                                            .all_args = {"cvd"}};
+  FrontlineParser::ParserParam parser_param{.all_args = input};
 
   auto result = FrontlineParser::Parse(parser_param);
 


### PR DESCRIPTION
Pushes down some hardcoded constants and replaces some object-oriented interfaces with imperative interfaces.

Bug: b/389804379
Test: /usr/bin/bazel run :cvd -- --instance_name=1 status