### PR TITLE
Automatically prune the fetch cache after fetches

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cache/cache.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cache/cache.h
@@ -23,6 +23,8 @@
 
 namespace cuttlefish {
 
+inline constexpr std::size_t kDefaultCacheSizeGb = 25;
+
 Result<std::string> EmptyCache(const std::string& cache_directory);
 Result<std::string> GetCacheInfo(const std::string& cache_directory,
                                  bool json_formatted);

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/cache.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/cache.cpp
@@ -39,8 +39,6 @@ namespace cuttlefish {
 
 namespace {
 
-constexpr int kDefaultCacheSizeGB = 25;
-
 constexpr char kSummaryHelpText[] = "Manage the files cached by cvd";
 
 enum class Action {
@@ -51,7 +49,7 @@ enum class Action {
 
 struct CacheArguments {
   Action action = Action::Info;
-  std::size_t allowed_size_GB = kDefaultCacheSizeGB;
+  std::size_t allowed_size_gb = kDefaultCacheSizeGb;
   bool json_formatted = false;
 };
 
@@ -82,7 +80,7 @@ Result<CacheArguments> ProcessArguments(
   };
 
   std::vector<Flag> flags;
-  flags.emplace_back(GflagsCompatFlag("allowed_size_GB", result.allowed_size_GB)
+  flags.emplace_back(GflagsCompatFlag("allowed_size_gb", result.allowed_size_gb)
                          .Help("Allowed size of the cache during prune "
                                "operation, in gigabytes."));
   flags.emplace_back(GflagsCompatFlag("json", result.json_formatted)
@@ -122,9 +120,9 @@ Result<void> CvdCacheCommandHandler::Handle(const CommandRequest& request) {
       break;
     case Action::Prune:
       std::cout << CF_EXPECTF(
-          PruneCache(cache_directory, arguments.allowed_size_GB),
+          PruneCache(cache_directory, arguments.allowed_size_gb),
           "Error pruning cache at {} to {}GB", cache_directory,
-          arguments.allowed_size_GB);
+          arguments.allowed_size_gb);
       break;
   }
 
@@ -146,13 +144,13 @@ Example usage:
     cvd cache info --json - the same as above, but in JSON format
 
     cvd cache prune - caps the cache at the default size ({}GB)
-    cvd cache prune --allowed_size_GB=<n> - caps the cache at the given size
+    cvd cache prune --allowed_size_gb=<n> - caps the cache at the given size
 
 **Notes**:
     - info and prune round the cache size up to the nearest gigabyte
     - prune uses last modification time to remove oldest files first
 )",
-                     kDefaultCacheSizeGB);
+                     kDefaultCacheSizeGb);
 }
 
 }  // namespace

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd_parser.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd_parser.cc
@@ -119,6 +119,11 @@ std::vector<Flag> GetFlagsVector(FetchFlags& fetch_flags,
   flags.emplace_back(
       GflagsCompatFlag("enable_caching", build_api_flags.enable_caching)
           .Help("Whether to enable local fetch file caching or not"));
+  flags.emplace_back(
+      GflagsCompatFlag("max_cache_size_gb", build_api_flags.max_cache_size_gb)
+          .Help("Max allowed size(in gigabytes) of the local fetch file cache. "
+                " If the cache grows beyond this size it will be pruned after "
+                "the fetches complete."));
 
   CredentialFlags& credential_flags = build_api_flags.credential_flags;
   flags.emplace_back(

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd_parser.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd_parser.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <chrono>
+#include <cstddef>
 #include <optional>
 #include <string>
 #include <vector>
@@ -23,6 +24,7 @@
 #include <android-base/logging.h>
 
 #include "common/libs/utils/result.h"
+#include "host/commands/cvd/cache/cache.h"
 #include "host/libs/web/android_build_api.h"
 #include "host/libs/web/android_build_string.h"
 #include "host/libs/web/cas/cas_downloader.h"
@@ -69,6 +71,7 @@ struct BuildApiFlags {
   bool external_dns_resolver = kDefaultExternalDnsResolver;
   std::string api_base_url = kAndroidBuildServiceUrl;
   bool enable_caching = kDefaultEnableCaching;
+  std::size_t max_cache_size_gb = kDefaultCacheSizeGb;
   CasDownloaderFlags cas_downloader_flags;
 };
 


### PR DESCRIPTION
Keeps the fetch cache from growing unbounded.

Test: # populate cache if necessary
Test: cvd fetch --target_directory=/tmp/cvd/fetch_test
--default_build=12924704,12924909,12924919
Test: cvd cache info
Test: cvd fetch --target_directory=/tmp/cvd/fetch_test2
--default_build=12924921 --max_cache_size_GB=2
Test: # only prunes when caching is enabled
Test: cvd fetch --target_directory=/tmp/cvd/fetch_test3
--default_build=12924578 --max_cache_size_GB=0 --enable_caching=false
Test: cvd cache info