### PR TITLE
Improve error message when `cvd` does not find a command handler

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/request_context.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/request_context.cpp
@@ -16,6 +16,7 @@
 
 #include "host/commands/cvd/cli/request_context.h"
 
+#include <memory>
 #include <vector>
 
 #include <android-base/logging.h>
@@ -52,16 +53,12 @@
 #include "host/commands/cvd/cli/commands/stop.h"
 #include "host/commands/cvd/cli/commands/try_acloud.h"
 #include "host/commands/cvd/cli/commands/version.h"
-#include "host/commands/cvd/instances/instance_lock.h"
 #include "host/commands/cvd/instances/instance_manager.h"
 
 namespace cuttlefish {
 
-RequestContext::RequestContext(
-    InstanceLockFileManager& instance_lockfile_manager,
-    InstanceManager& instance_manager)
-    : instance_lockfile_manager_(instance_lockfile_manager),
-      instance_manager_(instance_manager),
+RequestContext::RequestContext(InstanceManager& instance_manager)
+    : instance_manager_(instance_manager),
       command_sequence_executor_(this->request_handlers_) {
   request_handlers_.emplace_back(NewAcloudCommand(command_sequence_executor_));
   request_handlers_.emplace_back(NewAcloudMixSuperImageCommand());
@@ -104,7 +101,7 @@ RequestContext::RequestContext(
 
 Result<CvdCommandHandler*> RequestContext::Handler(
     const CommandRequest& request) {
-  return RequestHandler(request, request_handlers_);
+  return CF_EXPECT(RequestHandler(request, request_handlers_));
 }
 
 Result<CvdCommandHandler*> RequestHandler(

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/request_context.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/request_context.cpp
@@ -113,9 +113,14 @@ Result<CvdCommandHandler*> RequestHandler(
       compatible_handlers.push_back(handler.get());
     }
   }
-  CF_EXPECT(compatible_handlers.size() == 1,
-            "Expected exactly one handler for message, found "
-                << compatible_handlers.size());
+  CF_EXPECT(compatible_handlers.size() < 2,
+            "The command matched multiple handlers which should not happen.  "
+            "Please open a bug with the cvd/Cuttlefish team and include the "
+            "exact command that raised the error so it can be fixed.");
+  CF_EXPECTF(compatible_handlers.size() == 1,
+             "Unable to find a matching command for \"cvd {}\".  Maybe there "
+             "is a typo?\nRun `cvd help` for a list of commands.",
+             request.Subcommand());
   return compatible_handlers[0];
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/request_context.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/request_context.h
@@ -16,31 +16,26 @@
 
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "common/libs/utils/result.h"
 #include "host/commands/cvd/cli/command_request.h"
 #include "host/commands/cvd/cli/command_sequence.h"
-#include "host/commands/cvd/instances/instance_lock.h"
-#include "host/commands/cvd/instances/instance_manager.h"
 #include "host/commands/cvd/cli/commands/command_handler.h"
+#include "host/commands/cvd/instances/instance_manager.h"
 
 namespace cuttlefish {
 
 class RequestContext {
  public:
-  RequestContext(InstanceLockFileManager& instance_lockfile_manager,
-                 InstanceManager& instance_manager);
+  RequestContext(InstanceManager& instance_manager);
 
   Result<CvdCommandHandler*> Handler(const CommandRequest& request);
 
  private:
-  void InstantiateHandlers();
-
   std::vector<std::unique_ptr<CvdCommandHandler>> request_handlers_;
-  InstanceLockFileManager& instance_lockfile_manager_;
   InstanceManager& instance_manager_;
-  InstanceLockFileManager lock_file_manager_;
   CommandSequenceExecutor command_sequence_executor_;
 };
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
@@ -16,6 +16,11 @@
 
 #include "host/commands/cvd/cvd.h"
 
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include <android-base/file.h>
 #include <android-base/logging.h>
 
@@ -26,7 +31,6 @@
 #include "host/commands/cvd/cli/frontline_parser.h"
 #include "host/commands/cvd/cli/request_context.h"
 #include "host/commands/cvd/cli/utils.h"
-#include "host/commands/cvd/instances/instance_lock.h"
 #include "host/commands/cvd/instances/instance_manager.h"
 
 namespace cuttlefish {
@@ -52,10 +56,8 @@ namespace {
 
 }  // namespace
 
-Cvd::Cvd(InstanceLockFileManager& instance_lockfile_manager,
-         InstanceManager& instance_manager)
-    : instance_lockfile_manager_(instance_lockfile_manager),
-      instance_manager_(instance_manager) {}
+Cvd::Cvd(InstanceManager& instance_manager)
+    : instance_manager_(instance_manager) {}
 
 Result<void> Cvd::HandleCommand(
     const std::vector<std::string>& cvd_process_args,
@@ -67,7 +69,7 @@ Result<void> Cvd::HandleCommand(
                                          .AddSelectorArguments(selector_args)
                                          .Build());
 
-  RequestContext context(instance_lockfile_manager_, instance_manager_);
+  RequestContext context(instance_manager_);
   auto handler = CF_EXPECT(context.Handler(request));
   if (handler->ShouldInterceptHelp()) {
     std::vector<std::string> invocation_args = request.SubcommandArguments();

--- a/base/cvd/cuttlefish/host/commands/cvd/cvd.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cvd.h
@@ -16,17 +16,19 @@
 
 #pragma once
 
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include "common/libs/utils/result.h"
 #include "cuttlefish/host/commands/cvd/legacy/cvd_server.pb.h"
-#include "host/commands/cvd/instances/instance_lock.h"
 #include "host/commands/cvd/instances/instance_manager.h"
 
 namespace cuttlefish {
 
 class Cvd {
  public:
-  Cvd(InstanceLockFileManager& instance_lockfile_manager,
-      InstanceManager& instance_manager);
+  Cvd(InstanceManager& instance_manager);
 
   Result<void> HandleCommand(
       const std::vector<std::string>& cvd_process_args,
@@ -42,7 +44,6 @@ class Cvd {
     const std::unordered_map<std::string, std::string>& env);
 
  private:
-  InstanceLockFileManager& instance_lockfile_manager_;
   InstanceManager& instance_manager_;
 };
 

--- a/base/cvd/cuttlefish/host/commands/cvd/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/main.cc
@@ -22,6 +22,7 @@
 
 #include <iostream>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <android-base/file.h>
@@ -195,7 +196,7 @@ Result<void> CvdMain(int argc, char** argv, char** envp) {
   InstanceLockFileManager instance_lockfile_manager;
   InstanceDatabase instance_db(InstanceDatabasePath());
   InstanceManager instance_manager(instance_lockfile_manager, instance_db);
-  Cvd cvd(instance_lockfile_manager, instance_manager);
+  Cvd cvd(instance_manager);
 
   // TODO(b/206893146): Make this decision inside the server.
   if (android::base::Basename(all_args[0]) == "acloud") {


### PR DESCRIPTION
Trying to provide the user enough help to unstick themselves instead of a vague error.