### PR TITLE
buildutils: Adds preserve-env switch to make debuild work behind proxy

### DIFF
--- a/tools/buildutils/build_packages.sh
+++ b/tools/buildutils/build_packages.sh
@@ -18,7 +18,7 @@ function build_package() {
   echo "Installing package dependencies"
   sudo mk-build-deps -i -t 'apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y'
   echo "Building packages"
-  debuild --prepend-path /usr/local/bin -i -uc -us -b
+  debuild --preserve-env --prepend-path /usr/local/bin -i -uc -us -b
   popd
 }
 


### PR DESCRIPTION
The environment variables for proxy settings (http_proxy, https_proxy) must be preserved to make the bazel build work in networks with a proxy server.