### PR TITLE
Separate the cache logic from message formatting

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cache/cache.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cache/cache.h
@@ -25,10 +25,14 @@ namespace cuttlefish {
 
 inline constexpr std::size_t kDefaultCacheSizeGb = 25;
 
-Result<std::string> EmptyCache(const std::string& cache_directory);
-Result<std::string> GetCacheInfo(const std::string& cache_directory,
-                                 bool json_formatted);
-Result<std::string> PruneCache(const std::string& cache_directory,
+struct PruneResult {
+  std::size_t before;
+  std::size_t after;
+};
+
+Result<void> EmptyCache(const std::string& cache_directory);
+Result<std::size_t> GetCacheSize(const std::string& cache_directory);
+Result<PruneResult> PruneCache(const std::string& cache_directory,
                                std::size_t allowed_size_GB);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.cpp
@@ -65,10 +65,16 @@ Result<void> CvdFetchCommandHandler::Handle(const CommandRequest& request) {
   Result<void> result = FetchCvdMain(flags);
   if (flags.build_api_flags.enable_caching) {
     const std::string cache_directory = PerUserCacheDir();
-    LOG(INFO) << CF_EXPECTF(
+    const PruneResult prune_result = CF_EXPECTF(
         PruneCache(cache_directory, flags.build_api_flags.max_cache_size_gb),
         "Error pruning cache at {} to {}GB", cache_directory,
         flags.build_api_flags.max_cache_size_gb);
+    if (prune_result.before > prune_result.after) {
+      LOG(INFO) << fmt::format(
+          "Cache at \"{}\" pruned from ~{}GB to ~{}GB of {}GB max size",
+          cache_directory, prune_result.before, prune_result.after,
+          flags.build_api_flags.max_cache_size_gb);
+    }
   }
   CF_EXPECT(std::move(result));
   return {};


### PR DESCRIPTION
Allows the callsites to decide what to output.  Specifically, the auto prune in fetching can now omit the message if no files are removed.

Test: # populate cache if necessary
Test: cvd fetch --target_directory=/tmp/cvd/fetch_test --default_build=12924704,12924909,12924919
Test: cvd cache info
Test: cvd fetch --target_directory=/tmp/cvd/fetch_test2 --default_build=12924921 --max_cache_size_gb=2
Test: # only prunes when caching is enabled
Test: cvd fetch --target_directory=/tmp/cvd/fetch_test3 --default_build=12924578 --max_cache_size_gb=0 --enable_caching=false Test: cvd cache info
Test: cvd cache empty