### PR TITLE
Copy `logcat_receiver` from AOSP

### DIFF
--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/BUILD.bazel
@@ -1,0 +1,18 @@
+cc_binary(
+    name = "logcat_receiver",
+    deps = [
+        "//cuttlefish/common/libs/fs",
+        "//cuttlefish/host/libs/config",
+        "//libbase",
+        "@gflags",
+    ],
+    srcs = [
+        "main.cpp",
+    ],
+    cxxopts = [
+        "-std=c++17",
+    ],
+    visibility = [
+        "//visibility:public"
+    ],
+)

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
@@ -15,7 +15,7 @@
  */
 
 #include <gflags/gflags.h>
-#include <glog/logging.h>
+#include <android-base/logging.h>
 
 #include "common/libs/fs/shared_fd.h"
 #include "host/libs/config/cuttlefish_config.h"

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
@@ -19,13 +19,14 @@
 
 #include "common/libs/fs/shared_fd.h"
 #include "host/libs/config/cuttlefish_config.h"
+#include "host/libs/config/logging.h"
 
 DEFINE_int32(
     server_fd, -1,
     "File descriptor to an already created vsock server. Must be specified.");
 
 int main(int argc, char** argv) {
-  ::android::base::InitLogging(argv, android::base::StderrLogger);
+  cvd::DefaultSubprocessLogging(argv);
   google::ParseCommandLineFlags(&argc, &argv, true);
 
   auto config = vsoc::CuttlefishConfig::Get();

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
@@ -79,7 +79,7 @@ int main(int argc, char** argv) {
         << ". This is unrecoverable.";
     if (first_iter) {
       first_iter = false;
-      if ((!config->snapshot_path().empty())) {
+      if (cuttlefish::IsRestoring(*config)) {
         cuttlefish::SharedFD restore_pipe = cuttlefish::SharedFD::Open(
             instance.restore_pipe_name().c_str(), O_WRONLY);
         if (!restore_pipe->IsOpen()) {

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
@@ -79,7 +79,7 @@ int main(int argc, char** argv) {
         << ". This is unrecoverable.";
     if (first_iter) {
       first_iter = false;
-      if ((!config->snapshot_path().empty()) && instance.run_as_daemon()) {
+      if ((!config->snapshot_path().empty())) {
         cuttlefish::SharedFD restore_pipe = cuttlefish::SharedFD::Open(
             instance.restore_pipe_name().c_str(), O_WRONLY);
         if (!restore_pipe->IsOpen()) {
@@ -87,10 +87,20 @@ int main(int argc, char** argv) {
                      << restore_pipe->StrError();
           return 2;
         }
+        cuttlefish::SharedFD restore_adbd_pipe = cuttlefish::SharedFD::Open(
+            instance.restore_adbd_pipe_name().c_str(), O_WRONLY);
+        if (!restore_adbd_pipe->IsOpen()) {
+          LOG(ERROR) << "Error opening restore pipe: "
+                     << restore_adbd_pipe->StrError();
+          return 2;
+        }
 
         CHECK(cuttlefish::WriteAll(restore_pipe, "1") == 1)
             << "Error writing to restore pipe: " << restore_pipe->StrError()
             << ". This is unrecoverable.";
+        CHECK(cuttlefish::WriteAll(restore_adbd_pipe, "2") == 1)
+            << "Error writing to adbd restore pipe: "
+            << restore_adbd_pipe->StrError() << ". This is unrecoverable.";
       }
     }
   }

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
@@ -64,7 +64,6 @@ int main(int argc, char** argv) {
   auto logcat_file =
       cuttlefish::SharedFD::Open(path.c_str(), O_CREAT | O_APPEND | O_WRONLY, 0666);
 
-  bool first_iter = true;
   // Server loop
   while (true) {
     char buff[1024];
@@ -74,35 +73,9 @@ int main(int argc, char** argv) {
       break;
     }
     auto written = cuttlefish::WriteAll(logcat_file, buff, read);
-    CHECK(written == read)
-        << "Error writing to log file: " << logcat_file->StrError()
-        << ". This is unrecoverable.";
-    if (first_iter) {
-      first_iter = false;
-      if (cuttlefish::IsRestoring(*config)) {
-        cuttlefish::SharedFD restore_pipe = cuttlefish::SharedFD::Open(
-            instance.restore_pipe_name().c_str(), O_WRONLY);
-        if (!restore_pipe->IsOpen()) {
-          LOG(ERROR) << "Error opening restore pipe: "
-                     << restore_pipe->StrError();
-          return 2;
-        }
-        cuttlefish::SharedFD restore_adbd_pipe = cuttlefish::SharedFD::Open(
-            instance.restore_adbd_pipe_name().c_str(), O_WRONLY);
-        if (!restore_adbd_pipe->IsOpen()) {
-          LOG(ERROR) << "Error opening restore pipe: "
-                     << restore_adbd_pipe->StrError();
-          return 2;
-        }
-
-        CHECK(cuttlefish::WriteAll(restore_pipe, "1") == 1)
-            << "Error writing to restore pipe: " << restore_pipe->StrError()
-            << ". This is unrecoverable.";
-        CHECK(cuttlefish::WriteAll(restore_adbd_pipe, "2") == 1)
-            << "Error writing to adbd restore pipe: "
-            << restore_adbd_pipe->StrError() << ". This is unrecoverable.";
-      }
-    }
+    CHECK(written == read) << "Error writing to log file: "
+                           << logcat_file->StrError()
+                           << ". This is unrecoverable.";
   }
 
   logcat_file->Close();

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
@@ -22,8 +22,7 @@
 
 DEFINE_int32(
     server_fd, -1,
-    "File descriptor to an already created vsock server. If negative a new "
-    "server will be created at the port specified on the config file");
+    "File descriptor to an already created vsock server. Must be specified.");
 
 int main(int argc, char** argv) {
   ::android::base::InitLogging(argv, android::base::StderrLogger);
@@ -37,14 +36,8 @@ int main(int argc, char** argv) {
   CHECK(logcat_file->IsOpen())
       << "Unable to open logcat file: " << logcat_file->StrError();
 
-  cvd::SharedFD server_fd;
-  if (FLAGS_server_fd < 0) {
-    unsigned int port = config->logcat_vsock_port();
-    server_fd = cvd::SharedFD::VsockServer(port, SOCK_STREAM);
-  } else {
-    server_fd = cvd::SharedFD::Dup(FLAGS_server_fd);
-    close(FLAGS_server_fd);
-  }
+  cvd::SharedFD server_fd = cvd::SharedFD::Dup(FLAGS_server_fd);
+  close(FLAGS_server_fd);
 
   CHECK(server_fd->IsOpen()) << "Error creating or inheriting logcat server: "
                              << server_fd->StrError();

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
@@ -30,7 +30,8 @@ int main(int argc, char** argv) {
 
   auto config = vsoc::CuttlefishConfig::Get();
 
-  auto path = config->logcat_path();
+  auto instance = config->ForDefaultInstance();
+  auto path = instance.logcat_path();
   auto logcat_file =
       cvd::SharedFD::Open(path.c_str(), O_CREAT | O_APPEND | O_WRONLY, 0666);
   CHECK(logcat_file->IsOpen())

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
@@ -50,8 +50,7 @@ int main(int argc, char** argv) {
     auto log_name = instance.logcat_pipe_name();
     pipe = cuttlefish::SharedFD::Open(log_name.c_str(), O_RDONLY);
   } else {
-    pipe = cuttlefish::SharedFD::Dup(FLAGS_log_pipe_fd);
-    close(FLAGS_log_pipe_fd);
+    pipe = cuttlefish::SharedFD::DupAndClose(FLAGS_log_pipe_fd);
   }
 
   if (!pipe->IsOpen()) {

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
@@ -14,54 +14,70 @@
  * limitations under the License.
  */
 
+#include <signal.h>
+
 #include <gflags/gflags.h>
 #include <android-base/logging.h>
 
+#include "common/libs/fs/shared_buf.h"
 #include "common/libs/fs/shared_fd.h"
 #include "host/libs/config/cuttlefish_config.h"
+#include "host/libs/config/logging.h"
 
-DEFINE_int32(
-    server_fd, -1,
-    "File descriptor to an already created vsock server. Must be specified.");
+DEFINE_int32(log_pipe_fd, -1,
+             "A file descriptor representing a (UNIX) socket from which to "
+             "read the logs. If -1 is given the socket is created according to "
+             "the instance configuration");
 
 int main(int argc, char** argv) {
-  ::android::base::InitLogging(argv, android::base::StderrLogger);
+  cuttlefish::DefaultSubprocessLogging(argv);
   google::ParseCommandLineFlags(&argc, &argv, true);
 
-  auto config = vsoc::CuttlefishConfig::Get();
+  auto config = cuttlefish::CuttlefishConfig::Get();
+
+  CHECK(config) << "Could not open cuttlefish config";
 
   auto instance = config->ForDefaultInstance();
+
+  // Disable default handling of SIGPIPE
+  struct sigaction new_action {
+  }, old_action{};
+  new_action.sa_handler = SIG_IGN;
+  sigaction(SIGPIPE, &new_action, &old_action);
+
+  cuttlefish::SharedFD pipe;
+  if (FLAGS_log_pipe_fd < 0) {
+    auto log_name = instance.logcat_pipe_name();
+    pipe = cuttlefish::SharedFD::Open(log_name.c_str(), O_RDONLY);
+  } else {
+    pipe = cuttlefish::SharedFD::Dup(FLAGS_log_pipe_fd);
+    close(FLAGS_log_pipe_fd);
+  }
+
+  if (!pipe->IsOpen()) {
+    LOG(ERROR) << "Error opening log pipe: " << pipe->StrError();
+    return 2;
+  }
+
   auto path = instance.logcat_path();
   auto logcat_file =
-      cvd::SharedFD::Open(path.c_str(), O_CREAT | O_APPEND | O_WRONLY, 0666);
-  CHECK(logcat_file->IsOpen())
-      << "Unable to open logcat file: " << logcat_file->StrError();
-
-  cvd::SharedFD server_fd = cvd::SharedFD::Dup(FLAGS_server_fd);
-  close(FLAGS_server_fd);
-
-  CHECK(server_fd->IsOpen()) << "Error creating or inheriting logcat server: "
-                             << server_fd->StrError();
+      cuttlefish::SharedFD::Open(path.c_str(), O_CREAT | O_APPEND | O_WRONLY, 0666);
 
   // Server loop
   while (true) {
-    auto conn = cvd::SharedFD::Accept(*server_fd);
-
-    while (true) {
-      char buff[1024];
-      auto read = conn->Read(buff, sizeof(buff));
-      if (read <= 0) {
-        // Close here to ensure the other side gets reset if it's still
-        // connected
-        conn->Close();
-        LOG(WARNING) << "Detected close from the other side";
-        break;
-      }
-      auto written = logcat_file->Write(buff, read);
-      CHECK(written == read)
-          << "Error writing to log file: " << logcat_file->StrError()
-          << ". This is unrecoverable.";
+    char buff[1024];
+    auto read = pipe->Read(buff, sizeof(buff));
+    if (read < 0) {
+      LOG(ERROR) << "Could not read logcat: " << pipe->StrError();
+      break;
     }
+    auto written = cuttlefish::WriteAll(logcat_file, buff, read);
+    CHECK(written == read)
+        << "Error writing to log file: " << logcat_file->StrError()
+        << ". This is unrecoverable.";
   }
+
+  logcat_file->Close();
+  pipe->Close();
   return 0;
 }

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
@@ -50,7 +50,8 @@ int main(int argc, char** argv) {
     auto log_name = instance.logcat_pipe_name();
     pipe = cuttlefish::SharedFD::Open(log_name.c_str(), O_RDONLY);
   } else {
-    pipe = cuttlefish::SharedFD::DupAndClose(FLAGS_log_pipe_fd);
+    pipe = cuttlefish::SharedFD::Dup(FLAGS_log_pipe_fd);
+    close(FLAGS_log_pipe_fd);
   }
 
   if (!pipe->IsOpen()) {

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
@@ -14,70 +14,54 @@
  * limitations under the License.
  */
 
-#include <signal.h>
-
 #include <gflags/gflags.h>
 #include <android-base/logging.h>
 
-#include "common/libs/fs/shared_buf.h"
 #include "common/libs/fs/shared_fd.h"
 #include "host/libs/config/cuttlefish_config.h"
-#include "host/libs/config/logging.h"
 
-DEFINE_int32(log_pipe_fd, -1,
-             "A file descriptor representing a (UNIX) socket from which to "
-             "read the logs. If -1 is given the socket is created according to "
-             "the instance configuration");
+DEFINE_int32(
+    server_fd, -1,
+    "File descriptor to an already created vsock server. Must be specified.");
 
 int main(int argc, char** argv) {
-  cuttlefish::DefaultSubprocessLogging(argv);
+  ::android::base::InitLogging(argv, android::base::StderrLogger);
   google::ParseCommandLineFlags(&argc, &argv, true);
 
-  auto config = cuttlefish::CuttlefishConfig::Get();
-
-  CHECK(config) << "Could not open cuttlefish config";
+  auto config = vsoc::CuttlefishConfig::Get();
 
   auto instance = config->ForDefaultInstance();
-
-  // Disable default handling of SIGPIPE
-  struct sigaction new_action {
-  }, old_action{};
-  new_action.sa_handler = SIG_IGN;
-  sigaction(SIGPIPE, &new_action, &old_action);
-
-  cuttlefish::SharedFD pipe;
-  if (FLAGS_log_pipe_fd < 0) {
-    auto log_name = instance.logcat_pipe_name();
-    pipe = cuttlefish::SharedFD::Open(log_name.c_str(), O_RDONLY);
-  } else {
-    pipe = cuttlefish::SharedFD::Dup(FLAGS_log_pipe_fd);
-    close(FLAGS_log_pipe_fd);
-  }
-
-  if (!pipe->IsOpen()) {
-    LOG(ERROR) << "Error opening log pipe: " << pipe->StrError();
-    return 2;
-  }
-
   auto path = instance.logcat_path();
   auto logcat_file =
-      cuttlefish::SharedFD::Open(path.c_str(), O_CREAT | O_APPEND | O_WRONLY, 0666);
+      cvd::SharedFD::Open(path.c_str(), O_CREAT | O_APPEND | O_WRONLY, 0666);
+  CHECK(logcat_file->IsOpen())
+      << "Unable to open logcat file: " << logcat_file->StrError();
+
+  cvd::SharedFD server_fd = cvd::SharedFD::Dup(FLAGS_server_fd);
+  close(FLAGS_server_fd);
+
+  CHECK(server_fd->IsOpen()) << "Error creating or inheriting logcat server: "
+                             << server_fd->StrError();
 
   // Server loop
   while (true) {
-    char buff[1024];
-    auto read = pipe->Read(buff, sizeof(buff));
-    if (read < 0) {
-      LOG(ERROR) << "Could not read logcat: " << pipe->StrError();
-      break;
-    }
-    auto written = cuttlefish::WriteAll(logcat_file, buff, read);
-    CHECK(written == read)
-        << "Error writing to log file: " << logcat_file->StrError()
-        << ". This is unrecoverable.";
-  }
+    auto conn = cvd::SharedFD::Accept(*server_fd);
 
-  logcat_file->Close();
-  pipe->Close();
+    while (true) {
+      char buff[1024];
+      auto read = conn->Read(buff, sizeof(buff));
+      if (read <= 0) {
+        // Close here to ensure the other side gets reset if it's still
+        // connected
+        conn->Close();
+        LOG(WARNING) << "Detected close from the other side";
+        break;
+      }
+      auto written = logcat_file->Write(buff, read);
+      CHECK(written == read)
+          << "Error writing to log file: " << logcat_file->StrError()
+          << ". This is unrecoverable.";
+    }
+  }
   return 0;
 }

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
@@ -79,7 +79,7 @@ int main(int argc, char** argv) {
         << ". This is unrecoverable.";
     if (first_iter) {
       first_iter = false;
-      if (cuttlefish::IsRestoring(*config)) {
+      if ((!config->snapshot_path().empty()) && instance.run_as_daemon()) {
         cuttlefish::SharedFD restore_pipe = cuttlefish::SharedFD::Open(
             instance.restore_pipe_name().c_str(), O_WRONLY);
         if (!restore_pipe->IsOpen()) {
@@ -87,20 +87,10 @@ int main(int argc, char** argv) {
                      << restore_pipe->StrError();
           return 2;
         }
-        cuttlefish::SharedFD restore_adbd_pipe = cuttlefish::SharedFD::Open(
-            instance.restore_adbd_pipe_name().c_str(), O_WRONLY);
-        if (!restore_adbd_pipe->IsOpen()) {
-          LOG(ERROR) << "Error opening restore pipe: "
-                     << restore_adbd_pipe->StrError();
-          return 2;
-        }
 
         CHECK(cuttlefish::WriteAll(restore_pipe, "1") == 1)
             << "Error writing to restore pipe: " << restore_pipe->StrError()
             << ". This is unrecoverable.";
-        CHECK(cuttlefish::WriteAll(restore_adbd_pipe, "2") == 1)
-            << "Error writing to adbd restore pipe: "
-            << restore_adbd_pipe->StrError() << ". This is unrecoverable.";
       }
     }
   }

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
@@ -64,6 +64,7 @@ int main(int argc, char** argv) {
   auto logcat_file =
       cuttlefish::SharedFD::Open(path.c_str(), O_CREAT | O_APPEND | O_WRONLY, 0666);
 
+  bool first_iter = true;
   // Server loop
   while (true) {
     char buff[1024];
@@ -73,9 +74,35 @@ int main(int argc, char** argv) {
       break;
     }
     auto written = cuttlefish::WriteAll(logcat_file, buff, read);
-    CHECK(written == read) << "Error writing to log file: "
-                           << logcat_file->StrError()
-                           << ". This is unrecoverable.";
+    CHECK(written == read)
+        << "Error writing to log file: " << logcat_file->StrError()
+        << ". This is unrecoverable.";
+    if (first_iter) {
+      first_iter = false;
+      if (cuttlefish::IsRestoring(*config)) {
+        cuttlefish::SharedFD restore_pipe = cuttlefish::SharedFD::Open(
+            instance.restore_pipe_name().c_str(), O_WRONLY);
+        if (!restore_pipe->IsOpen()) {
+          LOG(ERROR) << "Error opening restore pipe: "
+                     << restore_pipe->StrError();
+          return 2;
+        }
+        cuttlefish::SharedFD restore_adbd_pipe = cuttlefish::SharedFD::Open(
+            instance.restore_adbd_pipe_name().c_str(), O_WRONLY);
+        if (!restore_adbd_pipe->IsOpen()) {
+          LOG(ERROR) << "Error opening restore pipe: "
+                     << restore_adbd_pipe->StrError();
+          return 2;
+        }
+
+        CHECK(cuttlefish::WriteAll(restore_pipe, "1") == 1)
+            << "Error writing to restore pipe: " << restore_pipe->StrError()
+            << ". This is unrecoverable.";
+        CHECK(cuttlefish::WriteAll(restore_adbd_pipe, "2") == 1)
+            << "Error writing to adbd restore pipe: "
+            << restore_adbd_pipe->StrError() << ". This is unrecoverable.";
+      }
+    }
   }
 
   logcat_file->Close();

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
@@ -64,6 +64,7 @@ int main(int argc, char** argv) {
   auto logcat_file =
       cuttlefish::SharedFD::Open(path.c_str(), O_CREAT | O_APPEND | O_WRONLY, 0666);
 
+  bool first_iter = true;
   // Server loop
   while (true) {
     char buff[1024];
@@ -73,9 +74,25 @@ int main(int argc, char** argv) {
       break;
     }
     auto written = cuttlefish::WriteAll(logcat_file, buff, read);
-    CHECK(written == read) << "Error writing to log file: "
-                           << logcat_file->StrError()
-                           << ". This is unrecoverable.";
+    CHECK(written == read)
+        << "Error writing to log file: " << logcat_file->StrError()
+        << ". This is unrecoverable.";
+    if (first_iter) {
+      first_iter = false;
+      if ((!config->snapshot_path().empty()) && instance.run_as_daemon()) {
+        cuttlefish::SharedFD restore_pipe = cuttlefish::SharedFD::Open(
+            instance.restore_pipe_name().c_str(), O_WRONLY);
+        if (!restore_pipe->IsOpen()) {
+          LOG(ERROR) << "Error opening restore pipe: "
+                     << restore_pipe->StrError();
+          return 2;
+        }
+
+        CHECK(cuttlefish::WriteAll(restore_pipe, "1") == 1)
+            << "Error writing to restore pipe: " << restore_pipe->StrError()
+            << ". This is unrecoverable.";
+      }
+    }
   }
 
   logcat_file->Close();

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
@@ -64,6 +64,7 @@ int main(int argc, char** argv) {
   auto logcat_file =
       cuttlefish::SharedFD::Open(path.c_str(), O_CREAT | O_APPEND | O_WRONLY, 0666);
 
+  bool first_iter = true;
   // Server loop
   while (true) {
     char buff[1024];
@@ -73,9 +74,35 @@ int main(int argc, char** argv) {
       break;
     }
     auto written = cuttlefish::WriteAll(logcat_file, buff, read);
-    CHECK(written == read) << "Error writing to log file: "
-                           << logcat_file->StrError()
-                           << ". This is unrecoverable.";
+    CHECK(written == read)
+        << "Error writing to log file: " << logcat_file->StrError()
+        << ". This is unrecoverable.";
+    if (first_iter) {
+      first_iter = false;
+      if ((!config->snapshot_path().empty())) {
+        cuttlefish::SharedFD restore_pipe = cuttlefish::SharedFD::Open(
+            instance.restore_pipe_name().c_str(), O_WRONLY);
+        if (!restore_pipe->IsOpen()) {
+          LOG(ERROR) << "Error opening restore pipe: "
+                     << restore_pipe->StrError();
+          return 2;
+        }
+        cuttlefish::SharedFD restore_adbd_pipe = cuttlefish::SharedFD::Open(
+            instance.restore_adbd_pipe_name().c_str(), O_WRONLY);
+        if (!restore_adbd_pipe->IsOpen()) {
+          LOG(ERROR) << "Error opening restore pipe: "
+                     << restore_adbd_pipe->StrError();
+          return 2;
+        }
+
+        CHECK(cuttlefish::WriteAll(restore_pipe, "1") == 1)
+            << "Error writing to restore pipe: " << restore_pipe->StrError()
+            << ". This is unrecoverable.";
+        CHECK(cuttlefish::WriteAll(restore_adbd_pipe, "2") == 1)
+            << "Error writing to adbd restore pipe: "
+            << restore_adbd_pipe->StrError() << ". This is unrecoverable.";
+      }
+    }
   }
 
   logcat_file->Close();

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
@@ -14,70 +14,55 @@
  * limitations under the License.
  */
 
-#include <signal.h>
-
 #include <gflags/gflags.h>
 #include <android-base/logging.h>
 
-#include "common/libs/fs/shared_buf.h"
 #include "common/libs/fs/shared_fd.h"
 #include "host/libs/config/cuttlefish_config.h"
 #include "host/libs/config/logging.h"
 
-DEFINE_int32(log_pipe_fd, -1,
-             "A file descriptor representing a (UNIX) socket from which to "
-             "read the logs. If -1 is given the socket is created according to "
-             "the instance configuration");
+DEFINE_int32(
+    server_fd, -1,
+    "File descriptor to an already created vsock server. Must be specified.");
 
 int main(int argc, char** argv) {
-  cuttlefish::DefaultSubprocessLogging(argv);
+  cvd::DefaultSubprocessLogging(argv);
   google::ParseCommandLineFlags(&argc, &argv, true);
 
-  auto config = cuttlefish::CuttlefishConfig::Get();
-
-  CHECK(config) << "Could not open cuttlefish config";
+  auto config = vsoc::CuttlefishConfig::Get();
 
   auto instance = config->ForDefaultInstance();
-
-  // Disable default handling of SIGPIPE
-  struct sigaction new_action {
-  }, old_action{};
-  new_action.sa_handler = SIG_IGN;
-  sigaction(SIGPIPE, &new_action, &old_action);
-
-  cuttlefish::SharedFD pipe;
-  if (FLAGS_log_pipe_fd < 0) {
-    auto log_name = instance.logcat_pipe_name();
-    pipe = cuttlefish::SharedFD::Open(log_name.c_str(), O_RDONLY);
-  } else {
-    pipe = cuttlefish::SharedFD::Dup(FLAGS_log_pipe_fd);
-    close(FLAGS_log_pipe_fd);
-  }
-
-  if (!pipe->IsOpen()) {
-    LOG(ERROR) << "Error opening log pipe: " << pipe->StrError();
-    return 2;
-  }
-
   auto path = instance.logcat_path();
   auto logcat_file =
-      cuttlefish::SharedFD::Open(path.c_str(), O_CREAT | O_APPEND | O_WRONLY, 0666);
+      cvd::SharedFD::Open(path.c_str(), O_CREAT | O_APPEND | O_WRONLY, 0666);
+  CHECK(logcat_file->IsOpen())
+      << "Unable to open logcat file: " << logcat_file->StrError();
+
+  cvd::SharedFD server_fd = cvd::SharedFD::Dup(FLAGS_server_fd);
+  close(FLAGS_server_fd);
+
+  CHECK(server_fd->IsOpen()) << "Error creating or inheriting logcat server: "
+                             << server_fd->StrError();
 
   // Server loop
   while (true) {
-    char buff[1024];
-    auto read = pipe->Read(buff, sizeof(buff));
-    if (read < 0) {
-      LOG(ERROR) << "Could not read logcat: " << pipe->StrError();
-      break;
-    }
-    auto written = cuttlefish::WriteAll(logcat_file, buff, read);
-    CHECK(written == read)
-        << "Error writing to log file: " << logcat_file->StrError()
-        << ". This is unrecoverable.";
-  }
+    auto conn = cvd::SharedFD::Accept(*server_fd);
 
-  logcat_file->Close();
-  pipe->Close();
+    while (true) {
+      char buff[1024];
+      auto read = conn->Read(buff, sizeof(buff));
+      if (read <= 0) {
+        // Close here to ensure the other side gets reset if it's still
+        // connected
+        conn->Close();
+        LOG(WARNING) << "Detected close from the other side";
+        break;
+      }
+      auto written = logcat_file->Write(buff, read);
+      CHECK(written == read)
+          << "Error writing to log file: " << logcat_file->StrError()
+          << ". This is unrecoverable.";
+    }
+  }
   return 0;
 }

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
@@ -14,70 +14,60 @@
  * limitations under the License.
  */
 
-#include <signal.h>
-
-#include <android-base/logging.h>
 #include <gflags/gflags.h>
+#include <glog/logging.h>
 
-#include "common/libs/fs/shared_buf.h"
 #include "common/libs/fs/shared_fd.h"
 #include "host/libs/config/cuttlefish_config.h"
-#include "host/libs/config/logging.h"
 
-DEFINE_int32(log_pipe_fd, -1,
-             "A file descriptor representing a (UNIX) socket from which to "
-             "read the logs. If -1 is given the socket is created according to "
-             "the instance configuration");
+DEFINE_int32(
+    server_fd, -1,
+    "File descriptor to an already created vsock server. If negative a new "
+    "server will be created at the port specified on the config file");
 
 int main(int argc, char** argv) {
-  cuttlefish::DefaultSubprocessLogging(argv);
+  ::android::base::InitLogging(argv, android::base::StderrLogger);
   google::ParseCommandLineFlags(&argc, &argv, true);
 
-  auto config = cuttlefish::CuttlefishConfig::Get();
+  auto config = vsoc::CuttlefishConfig::Get();
 
-  CHECK(config) << "Could not open cuttlefish config";
+  auto path = config->logcat_path();
+  auto logcat_file =
+      cvd::SharedFD::Open(path.c_str(), O_CREAT | O_APPEND | O_WRONLY, 0666);
+  CHECK(logcat_file->IsOpen())
+      << "Unable to open logcat file: " << logcat_file->StrError();
 
-  auto instance = config->ForDefaultInstance();
-
-  // Disable default handling of SIGPIPE
-  struct sigaction new_action{}, old_action{};
-  new_action.sa_handler = SIG_IGN;
-  sigaction(SIGPIPE, &new_action, &old_action);
-
-  cuttlefish::SharedFD pipe;
-
-  if (FLAGS_log_pipe_fd < 0) {
-    auto log_name = instance.logcat_pipe_name();
-    pipe = cuttlefish::SharedFD::Open(log_name.c_str(), O_RDONLY);
+  cvd::SharedFD server_fd;
+  if (FLAGS_server_fd < 0) {
+    unsigned int port = config->logcat_vsock_port();
+    server_fd = cvd::SharedFD::VsockServer(port, SOCK_STREAM);
   } else {
-    pipe = cuttlefish::SharedFD::Dup(FLAGS_log_pipe_fd);
-    close(FLAGS_log_pipe_fd);
+    server_fd = cvd::SharedFD::Dup(FLAGS_server_fd);
+    close(FLAGS_server_fd);
   }
 
-  if (!pipe->IsOpen()) {
-    LOG(ERROR) << "Error opening log pipe: " << pipe->StrError();
-    return 2;
-  }
-
-  auto path = instance.logcat_path();
-  auto logcat_file = cuttlefish::SharedFD::Open(
-      path.c_str(), O_CREAT | O_APPEND | O_WRONLY, 0666);
+  CHECK(server_fd->IsOpen()) << "Error creating or inheriting logcat server: "
+                             << server_fd->StrError();
 
   // Server loop
   while (true) {
-    char buff[1024];
-    auto read = pipe->Read(buff, sizeof(buff));
-    if (read < 0) {
-      LOG(ERROR) << "Could not read logcat: " << pipe->StrError();
-      break;
-    }
-    auto written = cuttlefish::WriteAll(logcat_file, buff, read);
-    CHECK(written == read) << "Error writing to log file: "
-                           << logcat_file->StrError()
-                           << ". This is unrecoverable.";
-  }
+    auto conn = cvd::SharedFD::Accept(*server_fd);
 
-  logcat_file->Close();
-  pipe->Close();
+    while (true) {
+      char buff[1024];
+      auto read = conn->Read(buff, sizeof(buff));
+      if (read <= 0) {
+        // Close here to ensure the other side gets reset if it's still
+        // connected
+        conn->Close();
+        LOG(WARNING) << "Detected close from the other side";
+        break;
+      }
+      auto written = logcat_file->Write(buff, read);
+      CHECK(written == read)
+          << "Error writing to log file: " << logcat_file->StrError()
+          << ". This is unrecoverable.";
+    }
+  }
   return 0;
 }

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
@@ -26,7 +26,7 @@ DEFINE_int32(
     "File descriptor to an already created vsock server. Must be specified.");
 
 int main(int argc, char** argv) {
-  cvd::DefaultSubprocessLogging(argv);
+  cuttlefish::DefaultSubprocessLogging(argv);
   google::ParseCommandLineFlags(&argc, &argv, true);
 
   auto config = vsoc::CuttlefishConfig::Get();
@@ -34,11 +34,11 @@ int main(int argc, char** argv) {
   auto instance = config->ForDefaultInstance();
   auto path = instance.logcat_path();
   auto logcat_file =
-      cvd::SharedFD::Open(path.c_str(), O_CREAT | O_APPEND | O_WRONLY, 0666);
+      cuttlefish::SharedFD::Open(path.c_str(), O_CREAT | O_APPEND | O_WRONLY, 0666);
   CHECK(logcat_file->IsOpen())
       << "Unable to open logcat file: " << logcat_file->StrError();
 
-  cvd::SharedFD server_fd = cvd::SharedFD::Dup(FLAGS_server_fd);
+  cuttlefish::SharedFD server_fd = cuttlefish::SharedFD::Dup(FLAGS_server_fd);
   close(FLAGS_server_fd);
 
   CHECK(server_fd->IsOpen()) << "Error creating or inheriting logcat server: "
@@ -46,7 +46,7 @@ int main(int argc, char** argv) {
 
   // Server loop
   while (true) {
-    auto conn = cvd::SharedFD::Accept(*server_fd);
+    auto conn = cuttlefish::SharedFD::Accept(*server_fd);
 
     while (true) {
       char buff[1024];

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char** argv) {
   cuttlefish::DefaultSubprocessLogging(argv);
   google::ParseCommandLineFlags(&argc, &argv, true);
 
-  auto config = cuttlefish::CuttlefishConfig::Get();
+  auto config = vsoc::CuttlefishConfig::Get();
 
   auto instance = config->ForDefaultInstance();
   auto path = instance.logcat_path();

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char** argv) {
   cuttlefish::DefaultSubprocessLogging(argv);
   google::ParseCommandLineFlags(&argc, &argv, true);
 
-  auto config = vsoc::CuttlefishConfig::Get();
+  auto config = cuttlefish::CuttlefishConfig::Get();
 
   auto instance = config->ForDefaultInstance();
   auto path = instance.logcat_path();

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
@@ -14,55 +14,70 @@
  * limitations under the License.
  */
 
+#include <signal.h>
+
 #include <gflags/gflags.h>
 #include <android-base/logging.h>
 
+#include "common/libs/fs/shared_buf.h"
 #include "common/libs/fs/shared_fd.h"
 #include "host/libs/config/cuttlefish_config.h"
 #include "host/libs/config/logging.h"
 
-DEFINE_int32(
-    server_fd, -1,
-    "File descriptor to an already created vsock server. Must be specified.");
+DEFINE_int32(log_pipe_fd, -1,
+             "A file descriptor representing a (UNIX) socket from which to "
+             "read the logs. If -1 is given the socket is created according to "
+             "the instance configuration");
 
 int main(int argc, char** argv) {
-  cvd::DefaultSubprocessLogging(argv);
+  cuttlefish::DefaultSubprocessLogging(argv);
   google::ParseCommandLineFlags(&argc, &argv, true);
 
-  auto config = vsoc::CuttlefishConfig::Get();
+  auto config = cuttlefish::CuttlefishConfig::Get();
+
+  CHECK(config) << "Could not open cuttlefish config";
 
   auto instance = config->ForDefaultInstance();
+
+  // Disable default handling of SIGPIPE
+  struct sigaction new_action {
+  }, old_action{};
+  new_action.sa_handler = SIG_IGN;
+  sigaction(SIGPIPE, &new_action, &old_action);
+
+  cuttlefish::SharedFD pipe;
+  if (FLAGS_log_pipe_fd < 0) {
+    auto log_name = instance.logcat_pipe_name();
+    pipe = cuttlefish::SharedFD::Open(log_name.c_str(), O_RDONLY);
+  } else {
+    pipe = cuttlefish::SharedFD::Dup(FLAGS_log_pipe_fd);
+    close(FLAGS_log_pipe_fd);
+  }
+
+  if (!pipe->IsOpen()) {
+    LOG(ERROR) << "Error opening log pipe: " << pipe->StrError();
+    return 2;
+  }
+
   auto path = instance.logcat_path();
   auto logcat_file =
-      cvd::SharedFD::Open(path.c_str(), O_CREAT | O_APPEND | O_WRONLY, 0666);
-  CHECK(logcat_file->IsOpen())
-      << "Unable to open logcat file: " << logcat_file->StrError();
-
-  cvd::SharedFD server_fd = cvd::SharedFD::Dup(FLAGS_server_fd);
-  close(FLAGS_server_fd);
-
-  CHECK(server_fd->IsOpen()) << "Error creating or inheriting logcat server: "
-                             << server_fd->StrError();
+      cuttlefish::SharedFD::Open(path.c_str(), O_CREAT | O_APPEND | O_WRONLY, 0666);
 
   // Server loop
   while (true) {
-    auto conn = cvd::SharedFD::Accept(*server_fd);
-
-    while (true) {
-      char buff[1024];
-      auto read = conn->Read(buff, sizeof(buff));
-      if (read <= 0) {
-        // Close here to ensure the other side gets reset if it's still
-        // connected
-        conn->Close();
-        LOG(WARNING) << "Detected close from the other side";
-        break;
-      }
-      auto written = logcat_file->Write(buff, read);
-      CHECK(written == read)
-          << "Error writing to log file: " << logcat_file->StrError()
-          << ". This is unrecoverable.";
+    char buff[1024];
+    auto read = pipe->Read(buff, sizeof(buff));
+    if (read < 0) {
+      LOG(ERROR) << "Could not read logcat: " << pipe->StrError();
+      break;
     }
+    auto written = cuttlefish::WriteAll(logcat_file, buff, read);
+    CHECK(written == read)
+        << "Error writing to log file: " << logcat_file->StrError()
+        << ". This is unrecoverable.";
   }
+
+  logcat_file->Close();
+  pipe->Close();
   return 0;
 }

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/main.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <signal.h>
+
+#include <android-base/logging.h>
+#include <gflags/gflags.h>
+
+#include "common/libs/fs/shared_buf.h"
+#include "common/libs/fs/shared_fd.h"
+#include "host/libs/config/cuttlefish_config.h"
+#include "host/libs/config/logging.h"
+
+DEFINE_int32(log_pipe_fd, -1,
+             "A file descriptor representing a (UNIX) socket from which to "
+             "read the logs. If -1 is given the socket is created according to "
+             "the instance configuration");
+
+int main(int argc, char** argv) {
+  cuttlefish::DefaultSubprocessLogging(argv);
+  google::ParseCommandLineFlags(&argc, &argv, true);
+
+  auto config = cuttlefish::CuttlefishConfig::Get();
+
+  CHECK(config) << "Could not open cuttlefish config";
+
+  auto instance = config->ForDefaultInstance();
+
+  // Disable default handling of SIGPIPE
+  struct sigaction new_action{}, old_action{};
+  new_action.sa_handler = SIG_IGN;
+  sigaction(SIGPIPE, &new_action, &old_action);
+
+  cuttlefish::SharedFD pipe;
+
+  if (FLAGS_log_pipe_fd < 0) {
+    auto log_name = instance.logcat_pipe_name();
+    pipe = cuttlefish::SharedFD::Open(log_name.c_str(), O_RDONLY);
+  } else {
+    pipe = cuttlefish::SharedFD::Dup(FLAGS_log_pipe_fd);
+    close(FLAGS_log_pipe_fd);
+  }
+
+  if (!pipe->IsOpen()) {
+    LOG(ERROR) << "Error opening log pipe: " << pipe->StrError();
+    return 2;
+  }
+
+  auto path = instance.logcat_path();
+  auto logcat_file = cuttlefish::SharedFD::Open(
+      path.c_str(), O_CREAT | O_APPEND | O_WRONLY, 0666);
+
+  // Server loop
+  while (true) {
+    char buff[1024];
+    auto read = pipe->Read(buff, sizeof(buff));
+    if (read < 0) {
+      LOG(ERROR) << "Could not read logcat: " << pipe->StrError();
+      break;
+    }
+    auto written = cuttlefish::WriteAll(logcat_file, buff, read);
+    CHECK(written == read) << "Error writing to log file: "
+                           << logcat_file->StrError()
+                           << ". This is unrecoverable.";
+  }
+
+  logcat_file->Close();
+  pipe->Close();
+  return 0;
+}

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -2,9 +2,13 @@ cc_library(
     name = "config",
     srcs = [
         "config_utils.cpp",
+        "cuttlefish_config.cpp",
+        "cuttlefish_config_environment.cpp",
+        "cuttlefish_config_instance.cpp",
         "fetcher_config.cpp",
         "host_tools_version.cpp",
         "instance_nums.cpp",
+        "logging.cpp",
     ],
     hdrs = [
         "config_constants.h",

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+// TODO: chadreynolds - Remove once AOSP <=> Github file syncing is enabled.
+// avoiding fixing lint errors until fixing it once fixes for all copies
+// NOLINTBEGIN
+
 #include "host/libs/config/cuttlefish_config.h"
 
 #include <algorithm>
@@ -34,9 +38,6 @@
 
 #include "common/libs/utils/environment.h"
 #include "common/libs/utils/files.h"
-#include "host/libs/vm_manager/crosvm_manager.h"
-#include "host/libs/vm_manager/gem5_manager.h"
-#include "host/libs/vm_manager/qemu_manager.h"
 
 namespace cuttlefish {
 namespace {
@@ -808,3 +809,5 @@ std::vector<std::string> CuttlefishConfig::environment_dirs() const {
 }
 
 }  // namespace cuttlefish
+
+// NOLINTEND

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_environment.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_environment.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+// TODO: chadreynolds - Remove once AOSP <=> Github file syncing is enabled.
+// avoiding fixing lint errors until fixing it once fixes for all copies
+// NOLINTBEGIN
+
 #include "host/libs/config/cuttlefish_config.h"
 
 #include "common/libs/utils/files.h"
@@ -141,3 +145,5 @@ int CuttlefishConfig::EnvironmentSpecific::wmediumd_mac_prefix() const {
 }
 
 }  // namespace cuttlefish
+
+// NOLINTEND

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+// TODO: chadreynolds - Remove once AOSP <=> Github file syncing is enabled.
+// avoiding fixing lint errors until fixing it once fixes for all copies
+// NOLINTBEGIN
+
 #include "cuttlefish_config.h"
 #include "host/libs/config/cuttlefish_config.h"
 
@@ -25,8 +29,6 @@
 
 #include "common/libs/utils/files.h"
 #include "common/libs/utils/flags_validator.h"
-#include "host/libs/vm_manager/crosvm_manager.h"
-#include "host/libs/vm_manager/gem5_manager.h"
 
 namespace cuttlefish {
 namespace {
@@ -1894,3 +1896,5 @@ std::string CuttlefishConfig::InstanceSpecific::instance_name() const {
 std::string CuttlefishConfig::InstanceSpecific::id() const { return id_; }
 
 }  // namespace cuttlefish
+
+// NOLINTEND


### PR DESCRIPTION
From AOSP - https://cs.android.com/android/platform/superproject/main/+/main:device/google/cuttlefish/host/commands/logcat_receiver/main.cpp;drc=b601a7aeaf2790b0ecf9444ecbd10caa6fad2b8d

The added `.../logcat_receiver/main.cpp` file is not for review in
this repository.  The intention is to verify it against changes made in
Github for now, in preparation for eventually moving more of our host
tools.

History brought over from AOSP via the minimerge tool.

Test: bazel build
//cuttlefish/host_tools/host/commands/logcat_receiver:logcat_receiver