### PR TITLE
Fix chown commands to silence some warnings

### DIFF
--- a/base/debian/cuttlefish-base.cuttlefish-host-resources.init
+++ b/base/debian/cuttlefish-base.cuttlefish-host-resources.init
@@ -293,9 +293,9 @@ start() {
     # When running inside a privileged container, set the ownership and access
     # of these device nodes.
     if test -f /.dockerenv; then
-        chown root.kvm /dev/kvm
-        chown root.cvdnetwork /dev/vhost-net
-        chown root.cvdnetwork /dev/vhost-vsock
+        chown root:kvm /dev/kvm
+        chown root:cvdnetwork /dev/vhost-net
+        chown root:cvdnetwork /dev/vhost-vsock
         chmod ug+rw /dev/kvm
         chmod ug+rw /dev/vhost-net
         chmod ug+rw /dev/vhost-vsock


### PR DESCRIPTION
Fix `chown` commands to silence the following warnings:

```
chown: warning: '.' should be ':': 'root.kvm'
chown: warning: '.' should be ':': 'root.cvdnetwork'
chown: warning: '.' should be ':': 'root.cvdnetwork'
```