### PR TITLE
Revert "Begin development on unreleased version 1.2.0"

### DIFF
--- a/base/debian/changelog
+++ b/base/debian/changelog
@@ -1,9 +1,3 @@
-cuttlefish-common (1.2.0) UNRELEASED; urgency=medium
-
-  * 
-
- -- Chad Reynolds <chadreynolds@google.com>  Fri, 24 Jan 2025 11:23:42 -0800
-
 cuttlefish-common (1.1.0) unstable; urgency=medium
 
   * add cvd cache

--- a/frontend/debian/changelog
+++ b/frontend/debian/changelog
@@ -1,9 +1,3 @@
-cuttlefish-frontend (1.2.0) UNRELEASED; urgency=medium
-
-  * 
-
- -- Chad Reynolds <chadreynolds@google.com>  Fri, 24 Jan 2025 11:24:30 -0800
-
 cuttlefish-frontend (1.1.0) unstable; urgency=medium
 
   * the adb bugreport can now be included in the cvd bugreport


### PR DESCRIPTION
This reverts commit 6079a237c346c5a5348c5fc4a4cc5ce54c33e9c1.

The new "version-dev" branch and unstable release need to happen BEFORE this change, or the version number for the release is incorrect.

Bug: 392924284