### PR TITLE
Handle invocations like cvd -h or cvd --help

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/flag_parser.h
+++ b/base/cvd/cuttlefish/common/libs/utils/flag_parser.h
@@ -190,4 +190,7 @@ Flag GflagsCompatFlag(const std::string& name, std::vector<std::string>& value);
 Flag GflagsCompatFlag(const std::string& name, std::vector<bool>& value,
                       bool default_value);
 
+// e.g. cvd start --help, cvd stop -help, cvd fleet -h
+Result<bool> HasHelpFlag(const std::vector<std::string>& args);
+
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/BUILD.bazel
@@ -16,7 +16,6 @@ cc_library(
         "//cuttlefish/host/commands/cvd/cli:command_request",
         "//cuttlefish/host/commands/cvd/cli:frontline_parser",
         "//cuttlefish/host/commands/cvd/cli:nesting_commands",
-        "//cuttlefish/host/commands/cvd/cli:utils",
         "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/commands/cvd/legacy:cvd_server_cc_proto",
         "//cuttlefish/host/commands/cvd/utils",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
@@ -74,7 +74,6 @@ cc_library(
         "//cuttlefish/host/commands/cvd/cli/parser",
         "//cuttlefish/host/commands/cvd/cli/selector:parser",
         "//cuttlefish/host/commands/cvd/cli:types",
-        "//cuttlefish/host/commands/cvd/cli:utils",
         "//cuttlefish/host/commands/cvd/fetch",
         "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/commands/cvd/instances:cvd_persistent_data",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/command_request.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/command_request.cpp
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "common/libs/utils/files.h"
+#include "common/libs/utils/flag_parser.h"
 #include "common/libs/utils/result.h"
 #include "host/commands/cvd/cli/command_request.h"
 #include "host/commands/cvd/cli/selector/selector_common_parser.h"
@@ -43,6 +44,12 @@ CommandRequest::CommandRequest(cvd_common::Args args, cvd_common::Envs env,
   } else {
     subcommand_ = subcommand_arguments_[0];
     subcommand_arguments_.erase(subcommand_arguments_.begin());
+  }
+
+  //  transform `cvd -h` or `cvd --help` requests into `cvd help`
+  Result<bool> is_top_level_help_flag = HasHelpFlag({subcommand_});
+  if (is_top_level_help_flag.ok() && *is_top_level_help_flag) {
+    subcommand_ = "help";
   }
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/bugreport.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/bugreport.cpp
@@ -25,6 +25,7 @@
 #include <android-base/scopeguard.h>
 
 #include "common/libs/utils/files.h"
+#include "common/libs/utils/flag_parser.h"
 #include "common/libs/utils/result.h"
 #include "common/libs/utils/subprocess.h"
 #include "common/libs/utils/users.h"
@@ -73,7 +74,7 @@ Result<void> CvdBugreportCommandHandler::Handle(const CommandRequest& request) {
 
   std::string android_host_out;
   std::string home = CF_EXPECT(SystemWideUserHome());
-  if (!CF_EXPECT(IsHelpSubcmd(cmd_args))) {
+  if (!CF_EXPECT(HasHelpFlag(cmd_args))) {
     bool has_instance_groups = CF_EXPECT(instance_manager_.HasInstanceGroups());
     CF_EXPECTF(!!has_instance_groups, "{}", NoGroupMessage(request));
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/clear.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/clear.cpp
@@ -22,11 +22,11 @@
 #include <android-base/parseint.h>
 #include <android-base/scopeguard.h>
 
+#include "common/libs/utils/flag_parser.h"
 #include "common/libs/utils/result.h"
 #include "cuttlefish/host/commands/cvd/legacy/cvd_server.pb.h"
 #include "host/commands/cvd/cli/commands/command_handler.h"
 #include "host/commands/cvd/cli/types.h"
-#include "host/commands/cvd/cli/utils.h"
 #include "host/commands/cvd/instances/instance_manager.h"
 
 namespace cuttlefish {
@@ -59,7 +59,8 @@ Result<void> CvdClearCommandHandler::Handle(const CommandRequest& request) {
 
   std::vector<std::string> cmd_args = request.SubcommandArguments();
 
-  if (CF_EXPECT(IsHelpSubcmd(cmd_args))) {
+  // TODO: chadreynolds - check if this can be removed
+  if (CF_EXPECT(HasHelpFlag(cmd_args))) {
     std::cout << kSummaryHelpText << std::endl;
     return {};
   }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/clear.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/clear.cpp
@@ -22,7 +22,6 @@
 #include <android-base/parseint.h>
 #include <android-base/scopeguard.h>
 
-#include "common/libs/utils/flag_parser.h"
 #include "common/libs/utils/result.h"
 #include "cuttlefish/host/commands/cvd/legacy/cvd_server.pb.h"
 #include "host/commands/cvd/cli/commands/command_handler.h"
@@ -43,7 +42,7 @@ class CvdClearCommandHandler : public CvdCommandHandler {
   Result<void> Handle(const CommandRequest& request) override;
   cvd_common::Args CmdList() const override { return {kClearCmd}; }
   Result<std::string> SummaryHelp() const override { return kSummaryHelpText; }
-  bool ShouldInterceptHelp() const override { return false; }
+  bool ShouldInterceptHelp() const override { return true; }
   Result<std::string> DetailedHelp(std::vector<std::string>&) const override;
 
  private:
@@ -56,16 +55,7 @@ CvdClearCommandHandler::CvdClearCommandHandler(
 
 Result<void> CvdClearCommandHandler::Handle(const CommandRequest& request) {
   CF_EXPECT(CanHandle(request));
-
-  std::vector<std::string> cmd_args = request.SubcommandArguments();
-
-  // TODO: chadreynolds - check if this can be removed
-  if (CF_EXPECT(HasHelpFlag(cmd_args))) {
-    std::cout << kSummaryHelpText << std::endl;
-    return {};
-  }
   CF_EXPECT_EQ(instance_manager_.CvdClear(request).code(), cvd::Status::OK);
-
   return {};
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
@@ -39,7 +39,6 @@
 #include "host/commands/cvd/cli/commands/host_tool_target.h"
 #include "host/commands/cvd/cli/selector/creation_analyzer.h"
 #include "host/commands/cvd/cli/types.h"
-#include "host/commands/cvd/cli/utils.h"
 #include "host/commands/cvd/instances/instance_database_types.h"
 #include "host/commands/cvd/instances/instance_group_record.h"
 #include "host/commands/cvd/utils/common.h"
@@ -343,7 +342,7 @@ Result<void> CvdCreateCommandHandler::CreateSymlinks(
 Result<void> CvdCreateCommandHandler::Handle(const CommandRequest& request) {
   CF_EXPECT(CanHandle(request));
   std::vector<std::string> subcmd_args = request.SubcommandArguments();
-  bool is_help = CF_EXPECT(IsHelpSubcmd(subcmd_args));
+  bool is_help = CF_EXPECT(HasHelpFlag(subcmd_args));
   CF_EXPECT(!is_help);
 
   cvd_common::Envs envs = CF_EXPECT(GetEnvs(request));

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/display.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/display.cpp
@@ -152,7 +152,7 @@ class CvdDisplayCommandHandler : public CvdCommandHandler {
 
   Result<bool> IsHelp(const cvd_common::Args& cmd_args) const {
     // cvd display --help, --helpxml, etc or simply cvd display
-    if (cmd_args.empty() || CF_EXPECT(IsHelpSubcmd(cmd_args))) {
+    if (cmd_args.empty() || CF_EXPECT(HasHelpFlag(cmd_args))) {
       return true;
     }
     // cvd display help <subcommand> format

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/env.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/env.cpp
@@ -57,7 +57,7 @@ class CvdEnvCommandHandler : public CvdCommandHandler {
     /*
      * cvd_env --help only. Not --helpxml, etc.
      *
-     * Otherwise, IsHelpSubcmd() should be used here instead.
+     * Otherwise, HasHelpFlag() should be used here instead.
      */
     bool help = false;
     Flag help_flag = GflagsCompatFlag("help", help);

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/power_btn.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/power_btn.cpp
@@ -22,11 +22,11 @@
 #include <android-base/strings.h>
 #include <fmt/format.h>
 
+#include "common/libs/utils/flag_parser.h"
 #include "common/libs/utils/result.h"
 #include "host/commands/cvd/cli/commands/command_handler.h"
 #include "host/commands/cvd/cli/selector/selector.h"
 #include "host/commands/cvd/cli/types.h"
-#include "host/commands/cvd/cli/utils.h"
 #include "host/commands/cvd/instances/instance_manager.h"
 
 namespace cuttlefish {
@@ -44,7 +44,8 @@ class CvdDevicePowerBtnCommandHandler : public CvdCommandHandler {
   Result<void> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
 
-    if (CF_EXPECT(IsHelpSubcmd(request.SubcommandArguments()))) {
+    // TODO: chadreynolds - check if this can be removed
+    if (CF_EXPECT(HasHelpFlag(request.SubcommandArguments()))) {
       std::cout << kSummaryHelpText << std::endl;
       return {};
     }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/power_btn.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/power_btn.cpp
@@ -22,7 +22,6 @@
 #include <android-base/strings.h>
 #include <fmt/format.h>
 
-#include "common/libs/utils/flag_parser.h"
 #include "common/libs/utils/result.h"
 #include "host/commands/cvd/cli/commands/command_handler.h"
 #include "host/commands/cvd/cli/selector/selector.h"
@@ -43,13 +42,6 @@ class CvdDevicePowerBtnCommandHandler : public CvdCommandHandler {
 
   Result<void> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
-
-    // TODO: chadreynolds - check if this can be removed
-    if (CF_EXPECT(HasHelpFlag(request.SubcommandArguments()))) {
-      std::cout << kSummaryHelpText << std::endl;
-      return {};
-    }
-
     auto [instance, _] =
         CF_EXPECT(selector::SelectInstance(instance_manager_, request),
                   "Unable to select an instance");

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/powerwash.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/powerwash.cpp
@@ -27,7 +27,6 @@
 #include "host/commands/cvd/cli/commands/command_handler.h"
 #include "host/commands/cvd/cli/selector/selector.h"
 #include "host/commands/cvd/cli/types.h"
-#include "host/commands/cvd/cli/utils.h"
 #include "host/commands/cvd/instances/instance_manager.h"
 
 namespace cuttlefish {
@@ -70,7 +69,8 @@ class CvdDevicePowerwashCommandHandler : public CvdCommandHandler {
 
     std::vector<std::string> subcmd_args = request.SubcommandArguments();
 
-    if (CF_EXPECT(IsHelpSubcmd(subcmd_args))) {
+    // TODO: chadreynolds - check if this can be removed
+    if (CF_EXPECT(HasHelpFlag(subcmd_args))) {
       std::cout << kDetailedHelpText << std::endl;
       return {};
     }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/powerwash.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/powerwash.cpp
@@ -67,21 +67,13 @@ class CvdDevicePowerwashCommandHandler : public CvdCommandHandler {
   Result<void> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
 
+    PowerwashOptions options;
     std::vector<std::string> subcmd_args = request.SubcommandArguments();
-
-    // TODO: chadreynolds - check if this can be removed
-    if (CF_EXPECT(HasHelpFlag(subcmd_args))) {
-      std::cout << kDetailedHelpText << std::endl;
-      return {};
-    }
+    CF_EXPECT(ConsumeFlags(options.Flags(), subcmd_args));
 
     auto [instance, unused] =
         CF_EXPECT(selector::SelectInstance(instance_manager_, request),
                   "Unable to select an instance");
-
-    PowerwashOptions options;
-    CF_EXPECT(ConsumeFlags(options.Flags(), subcmd_args));
-
     CF_EXPECT(instance.PowerWash(
         std::chrono::seconds(options.wait_for_launcher_seconds),
         std::chrono::seconds(options.boot_timeout_seconds)));

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/remove.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/remove.cpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 
+#include "common/libs/utils/flag_parser.h"
 #include "common/libs/utils/result.h"
 #include "host/commands/cvd/cli/commands/command_handler.h"
 #include "host/commands/cvd/cli/selector/selector.h"
@@ -55,7 +56,8 @@ class RemoveCvdCommandHandler : public CvdCommandHandler {
     CF_EXPECT(CanHandle(request));
     std::vector<std::string> subcmd_args = request.SubcommandArguments();
 
-    if (CF_EXPECT(IsHelpSubcmd(subcmd_args))) {
+    // TODO: chadreynolds - check if this can be removed
+    if (CF_EXPECT(HasHelpFlag(subcmd_args))) {
       std::vector<std::string> unused;
       std::cout << CF_EXPECT(DetailedHelp(unused));
       return {};

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/remove.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/remove.cpp
@@ -20,7 +20,6 @@
 #include <string>
 #include <vector>
 
-#include "common/libs/utils/flag_parser.h"
 #include "common/libs/utils/result.h"
 #include "host/commands/cvd/cli/commands/command_handler.h"
 #include "host/commands/cvd/cli/selector/selector.h"
@@ -50,18 +49,11 @@ class RemoveCvdCommandHandler : public CvdCommandHandler {
            "cvd itself)";
   }
 
-  bool ShouldInterceptHelp() const override { return false; }
+  bool ShouldInterceptHelp() const override { return true; }
 
   Result<void> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
     std::vector<std::string> subcmd_args = request.SubcommandArguments();
-
-    // TODO: chadreynolds - check if this can be removed
-    if (CF_EXPECT(HasHelpFlag(subcmd_args))) {
-      std::vector<std::string> unused;
-      std::cout << CF_EXPECT(DetailedHelp(unused));
-      return {};
-    }
 
     if (!CF_EXPECT(instance_manager_.HasInstanceGroups())) {
       return CF_ERR(NoGroupMessage(request));

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/restart.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/restart.cpp
@@ -66,20 +66,13 @@ class CvdDeviceRestartCommandHandler : public CvdCommandHandler {
   Result<void> Handle(const CommandRequest& request) override {
     CF_EXPECT(CanHandle(request));
 
+    RestartOptions options;
     std::vector<std::string> subcmd_args = request.SubcommandArguments();
-
-    // TODO: chadreynolds - check if this can be removed
-    if (CF_EXPECT(HasHelpFlag(subcmd_args))) {
-      std::cout << kDetailedHelpText << std::endl;
-      return {};
-    }
+    CF_EXPECT(ConsumeFlags(options.Flags(), subcmd_args));
 
     auto [instance, unused] =
         CF_EXPECT(selector::SelectInstance(instance_manager_, request),
                   "Unable to select an instance");
-
-    RestartOptions options;
-    CF_EXPECT(ConsumeFlags(options.Flags(), subcmd_args));
 
     CF_EXPECT(instance.Restart(
         std::chrono::seconds(options.wait_for_launcher_seconds),

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/restart.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/restart.cpp
@@ -27,7 +27,6 @@
 #include "host/commands/cvd/cli/commands/command_handler.h"
 #include "host/commands/cvd/cli/selector/selector.h"
 #include "host/commands/cvd/cli/types.h"
-#include "host/commands/cvd/cli/utils.h"
 #include "host/commands/cvd/instances/instance_manager.h"
 
 namespace cuttlefish {
@@ -69,7 +68,8 @@ class CvdDeviceRestartCommandHandler : public CvdCommandHandler {
 
     std::vector<std::string> subcmd_args = request.SubcommandArguments();
 
-    if (CF_EXPECT(IsHelpSubcmd(subcmd_args))) {
+    // TODO: chadreynolds - check if this can be removed
+    if (CF_EXPECT(HasHelpFlag(subcmd_args))) {
       std::cout << kDetailedHelpText << std::endl;
       return {};
     }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -511,7 +511,7 @@ Result<void> CvdStartCommandHandler::Handle(const CommandRequest& request) {
   }
   // update DB if not help
   // collect group creation infos
-  const bool is_help = CF_EXPECT(IsHelpSubcmd(subcmd_args));
+  const bool is_help = CF_EXPECT(HasHelpFlag(subcmd_args));
 
   if (is_help) {
     auto android_host_out = CF_EXPECT(AndroidHostPath(envs));

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/stop.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/stop.cpp
@@ -25,6 +25,7 @@
 #include <android-base/scopeguard.h>
 
 #include "common/libs/utils/files.h"
+#include "common/libs/utils/flag_parser.h"
 #include "common/libs/utils/result.h"
 #include "common/libs/utils/subprocess.h"
 #include "common/libs/utils/users.h"
@@ -101,7 +102,7 @@ Result<void> CvdStopCommandHandler::Handle(const CommandRequest& request) {
   CF_EXPECT(CanHandle(request));
   std::vector<std::string> cmd_args = request.SubcommandArguments();
 
-  if (CF_EXPECT(IsHelpSubcmd(cmd_args))) {
+  if (CF_EXPECT(HasHelpFlag(cmd_args))) {
     CF_EXPECT(HandleHelpCmd(request));
     return {};
   }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
@@ -21,7 +21,6 @@
 #include "common/libs/fs/shared_fd.h"
 #include "common/libs/utils/contains.h"
 #include "common/libs/utils/files.h"
-#include "common/libs/utils/flag_parser.h"
 #include "host/commands/cvd/instances/instance_database_utils.h"
 #include "host/commands/cvd/utils/common.h"
 #include "host/libs/config/config_constants.h"
@@ -131,35 +130,6 @@ Result<Command> ConstructCvdGenericNonHelpCommand(
       .command_name = request_form.bin_file
   };
   return CF_EXPECT(ConstructCommand(construct_cmd_param));
-}
-
-/*
- * From external/gflags/src, commit:
- *  061f68cd158fa658ec0b9b2b989ed55764870047
- *
- */
-constexpr static std::array help_bool_opts{
-    "help", "helpfull", "helpshort", "helppackage", "helpxml", "version", "h"};
-constexpr static std::array help_str_opts{
-    "helpon",
-    "helpmatch",
-};
-
-Result<bool> IsHelpSubcmd(const std::vector<std::string>& args) {
-  std::vector<std::string> copied_args(args);
-  std::vector<Flag> flags;
-  flags.reserve(help_bool_opts.size() + help_str_opts.size());
-  bool bool_value_placeholder = false;
-  std::string str_value_placeholder;
-  for (const auto bool_opt : help_bool_opts) {
-    flags.emplace_back(GflagsCompatFlag(bool_opt, bool_value_placeholder));
-  }
-  for (const auto str_opt : help_str_opts) {
-    flags.emplace_back(GflagsCompatFlag(str_opt, str_value_placeholder));
-  }
-  CF_EXPECT(ConsumeFlags(flags, copied_args));
-  // if there was any match, some in copied_args were consumed.
-  return (args.size() != copied_args.size());
 }
 
 static constexpr char kTerminalBoldRed[] = "\033[0;1;31m";

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
@@ -16,11 +16,21 @@
 
 #include "host/commands/cvd/cli/utils.h"
 
-#include <fmt/core.h>
+#include <signal.h>
+
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
 
 #include "common/libs/fs/shared_fd.h"
 #include "common/libs/utils/contains.h"
 #include "common/libs/utils/files.h"
+#include "common/libs/utils/result.h"
 #include "host/commands/cvd/instances/instance_database_utils.h"
 #include "host/commands/cvd/utils/common.h"
 #include "host/libs/config/config_constants.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
@@ -59,9 +59,6 @@ struct ConstructNonHelpForm {
 Result<Command> ConstructCvdGenericNonHelpCommand(
     const ConstructNonHelpForm& request_form, const CommandRequest& request);
 
-// e.g. cvd start --help, cvd stop --help
-Result<bool> IsHelpSubcmd(const std::vector<std::string>& args);
-
 // Call this when there is no instance group is running
 // The function does not verify that.
 std::string NoGroupMessage(const CommandRequest& request);

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <sys/types.h>
+#include <signal.h>
 
 #include <string>
 #include <string_view>

--- a/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
@@ -25,12 +25,12 @@
 #include <android-base/logging.h>
 
 #include "common/libs/utils/environment.h"
+#include "common/libs/utils/flag_parser.h"
 #include "common/libs/utils/result.h"
 #include "cuttlefish/host/commands/cvd/legacy/cvd_server.pb.h"
 #include "host/commands/cvd/cli/command_request.h"
 #include "host/commands/cvd/cli/frontline_parser.h"
 #include "host/commands/cvd/cli/request_context.h"
-#include "host/commands/cvd/cli/utils.h"
 #include "host/commands/cvd/instances/instance_manager.h"
 
 namespace cuttlefish {
@@ -73,7 +73,7 @@ Result<void> Cvd::HandleCommand(
   auto handler = CF_EXPECT(context.Handler(request));
   if (handler->ShouldInterceptHelp()) {
     std::vector<std::string> invocation_args = request.SubcommandArguments();
-    if (CF_EXPECT(IsHelpSubcmd(invocation_args))) {
+    if (CF_EXPECT(HasHelpFlag(invocation_args))) {
       std::cout << CF_EXPECT(handler->DetailedHelp(invocation_args))
                 << std::endl;
       return {};


### PR DESCRIPTION
Treating it as `cvd help` uses existing logic, rather than trying to
force the handling into selectors parsing or handle it as a "driver"
flag (how `--verbosity` is handled in `main`).

The selector flags are already processed by this point and do not
interfere.

Necessary helper refactor and additional cleanup in the first few commits

Bug: 387539609
Test: cvd -h
Test: cvd --help
Test: cvd -help fetch
Test: cvd --instance_name=test -h
Test: cvd --selector_typo=test -h
