### PR TITLE
Remove `InstanceManager` intermediate for `CreationAnalyzer`

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/BUILD.bazel
@@ -17,6 +17,7 @@ cc_library(
         "//cuttlefish/host/commands/cvd/cli:frontline_parser",
         "//cuttlefish/host/commands/cvd/cli:nesting_commands",
         "//cuttlefish/host/commands/cvd/instances",
+        "//cuttlefish/host/commands/cvd/instances/lock",
         "//cuttlefish/host/commands/cvd/legacy:cvd_server_cc_proto",
         "//cuttlefish/host/commands/cvd/utils",
         "//libbase",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
@@ -76,6 +76,7 @@ cc_library(
         "//cuttlefish/host/commands/cvd/cli:types",
         "//cuttlefish/host/commands/cvd/fetch",
         "//cuttlefish/host/commands/cvd/instances",
+        "//cuttlefish/host/commands/cvd/instances/lock",
         "//cuttlefish/host/commands/cvd/instances:cvd_persistent_data",
         "//cuttlefish/host/commands/cvd/legacy:cvd_server_cc_proto",
         "//cuttlefish/host/commands/cvd/utils",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
@@ -118,6 +118,7 @@ cc_library(
         "//cuttlefish/host/commands/cvd/cli:utils",
         "//cuttlefish/host/commands/cvd/fetch",
         "//cuttlefish/host/commands/cvd/instances",
+        "//cuttlefish/host/commands/cvd/instances/lock",
         "//cuttlefish/host/commands/cvd/instances:cvd_persistent_data",
         "//cuttlefish/host/commands/cvd/instances:instance_database_utils",
         "//cuttlefish/host/commands/cvd/instances:reset_client_utils",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
@@ -41,6 +41,7 @@
 #include "host/commands/cvd/cli/types.h"
 #include "host/commands/cvd/instances/instance_database_types.h"
 #include "host/commands/cvd/instances/instance_group_record.h"
+#include "host/commands/cvd/instances/lock/instance_lock.h"
 #include "host/commands/cvd/utils/common.h"
 
 namespace cuttlefish {
@@ -217,9 +218,11 @@ Result<void> EnsureSymlink(const std::string& target, const std::string link) {
 class CvdCreateCommandHandler : public CvdCommandHandler {
  public:
   CvdCreateCommandHandler(InstanceManager& instance_manager,
-                          CommandSequenceExecutor& command_executor)
+                          CommandSequenceExecutor& command_executor,
+                          InstanceLockFileManager& lock_manager)
       : instance_manager_(instance_manager),
-        command_executor_(command_executor) {}
+        command_executor_(command_executor),
+        lock_manager_(lock_manager) {}
 
   Result<void> Handle(const CommandRequest& request) override;
   std::vector<std::string> CmdList() const override { return {"create"}; }
@@ -241,6 +244,7 @@ class CvdCreateCommandHandler : public CvdCommandHandler {
 
   InstanceManager& instance_manager_;
   CommandSequenceExecutor& command_executor_;
+  InstanceLockFileManager& lock_manager_;
 };
 
 void CvdCreateCommandHandler::MarkLockfiles(
@@ -261,7 +265,8 @@ Result<LocalInstanceGroup> CvdCreateCommandHandler::GetOrCreateGroup(
   CreationAnalyzerParam analyzer_param{
       .cmd_args = subcmd_args, .envs = envs, .selectors = request.Selectors()};
 
-  auto analyzer = CF_EXPECT(instance_manager_.CreationAnalyzer(analyzer_param));
+  auto analyzer = CF_EXPECT(
+      selector::CreationAnalyzer::Create(analyzer_param, lock_manager_));
   auto group_creation_info =
       CF_EXPECT(analyzer.ExtractGroupInfo(acquire_file_locks));
 
@@ -413,9 +418,10 @@ Result<std::string> CvdCreateCommandHandler::DetailedHelp(
 }
 
 std::unique_ptr<CvdCommandHandler> NewCvdCreateCommandHandler(
-    InstanceManager& instance_manager, CommandSequenceExecutor& executor) {
-  return std::unique_ptr<CvdCommandHandler>(
-      new CvdCreateCommandHandler(instance_manager, executor));
+    InstanceManager& instance_manager, CommandSequenceExecutor& executor,
+    InstanceLockFileManager& lock_manager) {
+  return std::make_unique<CvdCreateCommandHandler>(instance_manager, executor,
+                                                   lock_manager);
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.h
@@ -19,13 +19,15 @@
 #include <memory>
 
 #include "host/commands/cvd/cli/command_sequence.h"
-#include "host/commands/cvd/instances/instance_manager.h"
 #include "host/commands/cvd/cli/commands/command_handler.h"
+#include "host/commands/cvd/instances/instance_manager.h"
+#include "host/commands/cvd/instances/lock/instance_lock.h"
 
 namespace cuttlefish {
 
 std::unique_ptr<CvdCommandHandler> NewCvdCreateCommandHandler(
-    InstanceManager& instance_manager, CommandSequenceExecutor& executor);
+    InstanceManager& instance_manager, CommandSequenceExecutor& executor,
+    InstanceLockFileManager& lock_manager);
 
 }  // namespace cuttlefish
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/request_context.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/request_context.cpp
@@ -56,6 +56,7 @@
 #include "host/commands/cvd/cli/commands/try_acloud.h"
 #include "host/commands/cvd/cli/commands/version.h"
 #include "host/commands/cvd/instances/instance_manager.h"
+#include "host/commands/cvd/instances/lock/instance_lock.h"
 
 namespace cuttlefish {
 
@@ -83,43 +84,42 @@ std::vector<std::string> GetPossibleCommands(
 
 }  //  namespace
 
-RequestContext::RequestContext(InstanceManager& instance_manager)
-    : instance_manager_(instance_manager),
-      command_sequence_executor_(this->request_handlers_) {
+RequestContext::RequestContext(InstanceManager& instance_manager,
+                               InstanceLockFileManager& lock_file_manager)
+    : command_sequence_executor_(this->request_handlers_) {
   request_handlers_.emplace_back(NewAcloudCommand(command_sequence_executor_));
   request_handlers_.emplace_back(NewAcloudMixSuperImageCommand());
-  request_handlers_.emplace_back(NewAcloudTranslatorCommand(instance_manager_));
+  request_handlers_.emplace_back(NewAcloudTranslatorCommand(instance_manager));
   request_handlers_.emplace_back(NewCvdCacheCommandHandler());
   request_handlers_.emplace_back(
       NewCvdCmdlistHandler(command_sequence_executor_));
   request_handlers_.emplace_back(NewCvdCreateCommandHandler(
-      instance_manager_, command_sequence_executor_));
-  request_handlers_.emplace_back(
-      NewCvdDisplayCommandHandler(instance_manager_));
-  request_handlers_.emplace_back(NewCvdEnvCommandHandler(instance_manager_));
+      instance_manager, command_sequence_executor_, lock_file_manager));
+  request_handlers_.emplace_back(NewCvdDisplayCommandHandler(instance_manager));
+  request_handlers_.emplace_back(NewCvdEnvCommandHandler(instance_manager));
   request_handlers_.emplace_back(NewCvdFetchCommandHandler());
-  request_handlers_.emplace_back(NewCvdFleetCommandHandler(instance_manager_));
-  request_handlers_.emplace_back(NewCvdClearCommandHandler(instance_manager_));
+  request_handlers_.emplace_back(NewCvdFleetCommandHandler(instance_manager));
+  request_handlers_.emplace_back(NewCvdClearCommandHandler(instance_manager));
   request_handlers_.emplace_back(
-      NewCvdBugreportCommandHandler(instance_manager_));
-  request_handlers_.emplace_back(NewCvdStopCommandHandler(instance_manager_));
+      NewCvdBugreportCommandHandler(instance_manager));
+  request_handlers_.emplace_back(NewCvdStopCommandHandler(instance_manager));
   request_handlers_.emplace_back(NewCvdHelpHandler(this->request_handlers_));
   request_handlers_.emplace_back(NewLintCommand());
   request_handlers_.emplace_back(
-      NewLoadConfigsCommand(command_sequence_executor_, instance_manager_));
+      NewLoadConfigsCommand(command_sequence_executor_, instance_manager));
   request_handlers_.emplace_back(NewLoginCommand());
   request_handlers_.emplace_back(
-      NewCvdDevicePowerBtnCommandHandler(instance_manager_));
+      NewCvdDevicePowerBtnCommandHandler(instance_manager));
   request_handlers_.emplace_back(
-      NewCvdDevicePowerwashCommandHandler(instance_manager_));
+      NewCvdDevicePowerwashCommandHandler(instance_manager));
   request_handlers_.emplace_back(
-      NewCvdDeviceRestartCommandHandler(instance_manager_));
-  request_handlers_.emplace_back(NewRemoveCvdCommandHandler(instance_manager_));
-  request_handlers_.emplace_back(NewCvdResetCommandHandler(instance_manager_));
+      NewCvdDeviceRestartCommandHandler(instance_manager));
+  request_handlers_.emplace_back(NewRemoveCvdCommandHandler(instance_manager));
+  request_handlers_.emplace_back(NewCvdResetCommandHandler(instance_manager));
   request_handlers_.emplace_back(
-      NewCvdSnapshotCommandHandler(instance_manager_));
-  request_handlers_.emplace_back(NewCvdStartCommandHandler(instance_manager_));
-  request_handlers_.emplace_back(NewCvdStatusCommandHandler(instance_manager_));
+      NewCvdSnapshotCommandHandler(instance_manager));
+  request_handlers_.emplace_back(NewCvdStartCommandHandler(instance_manager));
+  request_handlers_.emplace_back(NewCvdStatusCommandHandler(instance_manager));
   request_handlers_.emplace_back(NewTryAcloudCommand());
   request_handlers_.emplace_back(NewCvdVersionHandler());
   request_handlers_.emplace_back(NewCvdNoopHandler());

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/request_context.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/request_context.h
@@ -24,18 +24,18 @@
 #include "host/commands/cvd/cli/command_sequence.h"
 #include "host/commands/cvd/cli/commands/command_handler.h"
 #include "host/commands/cvd/instances/instance_manager.h"
+#include "host/commands/cvd/instances/lock/instance_lock.h"
 
 namespace cuttlefish {
 
 class RequestContext {
  public:
-  RequestContext(InstanceManager& instance_manager);
+  RequestContext(InstanceManager& instance_manager, InstanceLockFileManager&);
 
   Result<CvdCommandHandler*> Handler(const CommandRequest& request);
 
  private:
   std::vector<std::unique_ptr<CvdCommandHandler>> request_handlers_;
-  InstanceManager& instance_manager_;
   CommandSequenceExecutor command_sequence_executor_;
 };
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
@@ -32,6 +32,7 @@
 #include "host/commands/cvd/cli/frontline_parser.h"
 #include "host/commands/cvd/cli/request_context.h"
 #include "host/commands/cvd/instances/instance_manager.h"
+#include "host/commands/cvd/instances/lock/instance_lock.h"
 
 namespace cuttlefish {
 
@@ -56,8 +57,10 @@ namespace {
 
 }  // namespace
 
-Cvd::Cvd(InstanceManager& instance_manager)
-    : instance_manager_(instance_manager) {}
+Cvd::Cvd(InstanceManager& instance_manager,
+         InstanceLockFileManager& lock_file_manager)
+    : instance_manager_(instance_manager),
+      lock_file_manager_(lock_file_manager) {}
 
 Result<void> Cvd::HandleCommand(
     const std::vector<std::string>& cvd_process_args,
@@ -69,7 +72,7 @@ Result<void> Cvd::HandleCommand(
                                          .AddSelectorArguments(selector_args)
                                          .Build());
 
-  RequestContext context(instance_manager_);
+  RequestContext context(instance_manager_, lock_file_manager_);
   auto handler = CF_EXPECT(context.Handler(request));
   if (handler->ShouldInterceptHelp()) {
     std::vector<std::string> invocation_args = request.SubcommandArguments();

--- a/base/cvd/cuttlefish/host/commands/cvd/cvd.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cvd.h
@@ -23,12 +23,13 @@
 #include "common/libs/utils/result.h"
 #include "cuttlefish/host/commands/cvd/legacy/cvd_server.pb.h"
 #include "host/commands/cvd/instances/instance_manager.h"
+#include "host/commands/cvd/instances/lock/instance_lock.h"
 
 namespace cuttlefish {
 
 class Cvd {
  public:
-  Cvd(InstanceManager& instance_manager);
+  Cvd(InstanceManager&, InstanceLockFileManager&);
 
   Result<void> HandleCommand(
       const std::vector<std::string>& cvd_process_args,
@@ -45,6 +46,7 @@ class Cvd {
 
  private:
   InstanceManager& instance_manager_;
+  InstanceLockFileManager& lock_file_manager_;
 };
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_manager.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_manager.cpp
@@ -79,11 +79,6 @@ Result<bool> InstanceManager::GetAcloudTranslatorOptout() const {
   return CF_EXPECT(instance_db_.GetAcloudTranslatorOptout());
 }
 
-Result<selector::CreationAnalyzer> InstanceManager::CreationAnalyzer(
-    const selector::CreationAnalyzer::CreationAnalyzerParam& param) {
-  return selector::CreationAnalyzer::Create(param, lock_manager_);
-}
-
 Result<std::pair<LocalInstance, LocalInstanceGroup>>
 InstanceManager::FindInstanceWithGroup(
     const InstanceDatabase::Filter& filter) const {

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_manager.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_manager.h
@@ -40,10 +40,6 @@ class InstanceManager {
 
   InstanceManager(InstanceLockFileManager&, InstanceDatabase& instance_db);
 
-  // For cvd start
-  Result<selector::CreationAnalyzer> CreationAnalyzer(
-      const selector::CreationAnalyzer::CreationAnalyzerParam& param);
-
   Result<bool> HasInstanceGroups() const;
   Result<LocalInstanceGroup> CreateInstanceGroup(
       const selector::GroupCreationInfo& group_info);

--- a/base/cvd/cuttlefish/host/commands/cvd/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/main.cc
@@ -196,7 +196,7 @@ Result<void> CvdMain(int argc, char** argv, char** envp) {
   InstanceLockFileManager instance_lockfile_manager;
   InstanceDatabase instance_db(InstanceDatabasePath());
   InstanceManager instance_manager(instance_lockfile_manager, instance_db);
-  Cvd cvd(instance_manager);
+  Cvd cvd(instance_manager, instance_lockfile_manager);
 
   // TODO(b/206893146): Make this decision inside the server.
   if (android::base::Basename(all_args[0]) == "acloud") {


### PR DESCRIPTION
Now `cvd/cli/commands/create.cpp` can create `CreationAnalyzer` directly.

Bug: b/392949844
Test: bazel test '//...'