### PR TITLE
Fix version tagging and version helper type

### DIFF
--- a/base/cvd/BUILD.bazel
+++ b/base/cvd/BUILD.bazel
@@ -13,7 +13,8 @@ genrule(
     name = "build_version_header",
     srcs = ["build_version.h.in"],
     outs = ["build/version.h"],
-    cmd = "sed -e \"s|@VCS_TAG@|`git describe`|\" $< > $@",
+    cmd = "sed -e \"s|@VCS_TAG@|`cat bazel-out/*-status.txt | grep \"STABLE_HEAD_COMMIT\" | cut -f 2 -d ' '`|\" $< > $@",
+    stamp = 1,
 )
 
 filegroup(

--- a/base/cvd/build_version.h.in
+++ b/base/cvd/build_version.h.in
@@ -17,14 +17,13 @@
 #ifndef BUILD_VERSION_H
 #define BUILD_VERSION_H
 
-#include <string_view>
+#include <string>
 
 namespace android {
 namespace build {
 
-inline std::string_view GetBuildNumber() {
-  static constexpr char kBuildNumber[] = "@VCS_TAG@";
-  return kBuildNumber;
+std::string GetBuildNumber() {
+  return "@VCS_TAG@";
 }
 
 } // namespace build

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/version.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/version.cpp
@@ -48,7 +48,7 @@ class CvdVersionHandler : public CvdCommandHandler {
     fmt::print(std::cout, "major: {}\n", cvd::kVersionMajor);
     fmt::print(std::cout, "minor: {}\n", cvd::kVersionMinor);
 
-    std::string_view build = android::build::GetBuildNumber();
+    const std::string build = android::build::GetBuildNumber();
     if (!build.empty()) {
       fmt::print(std::cout, "build: {}\n", build);
     }

--- a/base/debian/rules
+++ b/base/debian/rules
@@ -20,7 +20,8 @@ override_dh_installinit:
 	dh_installinit --name=cuttlefish-host-resources
 	dh_installinit
 
+# the `--workspace_status_command` flag path depends on the current working directory of base/cvd
 override_dh_auto_build:
-	cd cvd && bazel build --linkopt="-Wl,--build-id=sha1" cuttlefish/host/commands/cvd:cvd --spawn_strategy=local
+	cd cvd && bazel build --linkopt="-Wl,--build-id=sha1" cuttlefish/host/commands/cvd:cvd --spawn_strategy=local --workspace_status_command=../../tools/buildutils/stamp_helper.sh
 	dh_auto_build
 

--- a/tools/buildutils/stamp_helper.sh
+++ b/tools/buildutils/stamp_helper.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# https://bazel.build/docs/user-manual#workspace-status
+#
+# append `--workspace_status_command=path/to/stamp_helper.sh` to build command
+# to "stamp" this output to `bazel-out/stable_status.txt``
+# 
+# NOTES: 
+# - output must be a "key value" format on a single line
+# - output key must begin with "STABLE_" or the key and value end up in
+#   `volatile_status.txt`
+# - changes to `stable_status.txt` values triggers a re-run of the affected
+#   actions
+
+echo STABLE_HEAD_COMMIT `git rev-parse HEAD`
+


### PR DESCRIPTION
[Update the return type of the version helper](https://github.com/google/android-cuttlefish/commit/4242056b1d5a56741a4953fb8197c539ef8c0f59) 

Also update the callsite, so there are no problems with scope of
objects.

Bug: 393455992

[Fix the genrule for cvd version output](https://github.com/google/android-cuttlefish/commit/877c318b4f166ff420b8b442329ae3dbc923b382) 

The build runs in a sandbox and not in the working directory the `bazel`
command is executed in, so the previous version never had an output to
populate the `cvd version` field.  Also, `git describe` was returning an
old tag.  I updated to return the latest HEAD commit hash instead.

If the
`--working_status_command=path/to/tools/buildutils/stamp_helper.sh` flag
is added to a build, the output goes into a file intended for embedding
outside information for use inside the build sandbox.

The commit hash should not change "often" (like a timestamp would be
different every single build), so we mark it as a stable key.  Then, if
the value changes, every affected action (marked `stamp = 1`) is
triggered.  Volatile keys do not trigger actions when they change.