### PR TITLE
Expose a function rather than a class for `creation_analyzer.h`

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
@@ -47,6 +47,10 @@
 namespace cuttlefish {
 namespace {
 
+using selector::AnalyzeCreation;
+using selector::CreationAnalyzerParam;
+using selector::GroupCreationInfo;
+
 constexpr char kSummaryHelpText[] =
     "Create a Cuttlefish virtual device or environment";
 
@@ -260,15 +264,14 @@ void CvdCreateCommandHandler::MarkLockfiles(
 Result<LocalInstanceGroup> CvdCreateCommandHandler::GetOrCreateGroup(
     const std::vector<std::string>& subcmd_args, const cvd_common::Envs& envs,
     const CommandRequest& request, bool acquire_file_locks) {
-  using CreationAnalyzerParam =
-      selector::CreationAnalyzer::CreationAnalyzerParam;
-  CreationAnalyzerParam analyzer_param{
-      .cmd_args = subcmd_args, .envs = envs, .selectors = request.Selectors()};
-
-  auto analyzer = CF_EXPECT(
-      selector::CreationAnalyzer::Create(analyzer_param, lock_manager_));
-  auto group_creation_info =
-      CF_EXPECT(analyzer.ExtractGroupInfo(acquire_file_locks));
+  GroupCreationInfo group_creation_info = CF_EXPECT(AnalyzeCreation(
+      {
+          .cmd_args = subcmd_args,
+          .envs = envs,
+          .selectors = request.Selectors(),
+          .acquire_file_locks = acquire_file_locks,
+      },
+      lock_manager_));
 
   std::vector<InstanceLockFile> lock_files;
   for (auto& instance : group_creation_info.instances) {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/creation_analyzer.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/creation_analyzer.h
@@ -68,6 +68,13 @@ struct GroupCreationInfo {
   std::vector<PerInstanceInfo> instances;
 };
 
+struct CreationAnalyzerParam {
+  const std::vector<std::string>& cmd_args;
+  const std::unordered_map<std::string, std::string>& envs;
+  const SelectorOptions& selectors;
+  bool acquire_file_locks;
+};
+
 /**
  * Instance IDs:
  *  Use the InstanceNumCalculator's logic
@@ -96,73 +103,8 @@ struct GroupCreationInfo {
  *    instance ids --> per_instance_name
  *
  */
-class CreationAnalyzer {
- public:
-  struct CreationAnalyzerParam {
-    const std::vector<std::string>& cmd_args;
-    const std::unordered_map<std::string, std::string>& envs;
-    const SelectorOptions& selectors;
-  };
-
-  struct GroupInfo {
-    std::string group_name;
-    const bool default_group;
-  };
-
-  static Result<CreationAnalyzer> Create(
-      const CreationAnalyzerParam& param,
-      InstanceLockFileManager& instance_lock_file_manager);
-
-  Result<GroupCreationInfo> ExtractGroupInfo(bool acquire_file_locks);
-
- private:
-  using IdAllocator = UniqueResourceAllocator<unsigned>;
-
-  CreationAnalyzer(const CreationAnalyzerParam& param,
-                   StartSelectorParser&& selector_options_parser,
-                   InstanceLockFileManager& instance_lock_file_manager);
-
-  /**
-   * calculate n_instances_ and instance_ids_
-   */
-  Result<std::vector<PerInstanceInfo>> AnalyzeInstanceIds(
-      bool acquire_file_locks);
-
-  /*
-   * When group name is nil, it is auto-generated using instance ids
-   *
-   * If the instanc group is the default one, the group name is cvd. Otherwise,
-   * for given instance ids, {i}, the group name will be cvd_i.
-   */
-  Result<GroupInfo> ExtractGroup(const std::vector<PerInstanceInfo>&) const;
-
-  /**
-   * Figures out the HOME directory
-   *
-   * The issue is that many times, HOME is anyway implicitly given. Thus, only
-   * if the HOME value is not equal to the HOME directory recognized by the
-   * system, it can be safely regarded as overridden by the user.
-   *
-   * If that is not the case, we use a automatically generated value as HOME.
-   * If the group instance is the default one, we still use the user's system-
-   * widely recognized home. If not, we populate them user /tmp/.cf/<uid>/
-   *
-   */
-  Result<std::string> AnalyzeHome() const;
-
-  Result<std::vector<PerInstanceInfo>> AnalyzeInstanceIdsInternal(
-      bool acquire_file_locks);
-  Result<std::vector<PerInstanceInfo>> AnalyzeInstanceIdsInternal(
-      const std::vector<unsigned>& requested_instance_ids,
-      bool acquire_file_locks);
-
-  // inputs
-  std::unordered_map<std::string, std::string> envs_;
-
-  // internal, temporary
-  StartSelectorParser selector_options_parser_;
-  InstanceLockFileManager& instance_lock_file_manager_;
-};
+Result<GroupCreationInfo> AnalyzeCreation(const CreationAnalyzerParam&,
+                                          InstanceLockFileManager&);
 
 }  // namespace selector
 }  // namespace cuttlefish


### PR DESCRIPTION
The class exists only to call one function, so the public API is changed to something that takes the class creation inputs and returns the function output.

Bug: b/392949844
Test: bazel test '//...'