### PR TITLE
Fix race in interruption around process starting

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -521,7 +521,7 @@ Result<void> CvdStartCommandHandler::Handle(const CommandRequest& request) {
         CF_EXPECT(ConstructCvdHelpCommand(bin, envs, subcmd_args, request));
     ShowLaunchCommand(command, envs);
 
-    CF_EXPECT(subprocess_waiter_.Setup(command.Start()));
+    CF_EXPECT(subprocess_waiter_.Setup(command));
     siginfo_t infop = CF_EXPECT(subprocess_waiter_.Wait());
     CF_EXPECT(CheckProcessExitedNormally(infop));
     return {};
@@ -614,7 +614,7 @@ Result<void> CvdStartCommandHandler::LaunchDevice(
   }
   ShowLaunchCommand(launch_command, envs);
 
-  CF_EXPECT(subprocess_waiter_.Setup(launch_command.Start()));
+  CF_EXPECT(subprocess_waiter_.Setup(launch_command));
 
   auto acloud_compat_action_result = AcloudCompatActions(group, envs, request);
   if (!acloud_compat_action_result.ok()) {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -521,8 +521,8 @@ Result<void> CvdStartCommandHandler::Handle(const CommandRequest& request) {
         CF_EXPECT(ConstructCvdHelpCommand(bin, envs, subcmd_args, request));
     ShowLaunchCommand(command, envs);
 
-    CF_EXPECT(subprocess_waiter_.Setup(command));
-    siginfo_t infop = CF_EXPECT(subprocess_waiter_.Wait());
+    siginfo_t infop;
+    command.Start().Wait(&infop, WEXITED);
     CF_EXPECT(CheckProcessExitedNormally(infop));
     return {};
   }

--- a/base/cvd/cuttlefish/host/commands/cvd/utils/subprocess_waiter.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/utils/subprocess_waiter.cpp
@@ -18,12 +18,12 @@
 
 namespace cuttlefish {
 
-Result<void> SubprocessWaiter::Setup(Subprocess subprocess) {
+Result<void> SubprocessWaiter::Setup(Command& command) {
   std::unique_lock interrupt_lock(interruptible_);
   CF_EXPECT(!interrupted_, "Interrupted");
   CF_EXPECT(!subprocess_, "Already running");
 
-  subprocess_ = std::move(subprocess);
+  subprocess_ = command.Start();
   return {};
 }
 
@@ -68,6 +68,7 @@ Result<void> SubprocessWaiter::Interrupt() {
         return CF_ERR("Unknown stop result: " << (uint64_t)stop_result);
     }
   }
+  interrupted_ = true;
   return {};
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/utils/subprocess_waiter.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/utils/subprocess_waiter.h
@@ -28,7 +28,7 @@ class SubprocessWaiter {
  public:
   SubprocessWaiter() {}
 
-  Result<void> Setup(Subprocess subprocess);
+  Result<void> Setup(Command&);
   Result<siginfo_t> Wait();
   Result<void> Interrupt();
 


### PR DESCRIPTION
It's possible for there to be a race between the interrupt handler
waiting on the process and the process being created, and also possible
to interrupt the subprocess before the fact that the subprocess is
launched was recorded.

Developed together with jemoreira@.

Bug: b/393657553
Test: bazel test '//...'