### PR TITLE
Simplify base64.cpp and fix 0 byte ending issue

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
@@ -135,6 +135,7 @@ clang_tidy_test(
 cc_test(
     name = "utils_test",
     srcs = [
+        "base64_test.cpp",
         "files_test.cpp",
         "files_test_helper.cpp",
         "files_test_helper.h",
@@ -155,6 +156,7 @@ cc_test(
         ":utils",
         "//cuttlefish/common/libs/fs",
         "//libbase",
+        "@boringssl//:crypto",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
         "@libxml2//:libxml2",

--- a/base/cvd/cuttlefish/common/libs/utils/base64_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/base64_test.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "common/libs/utils/base64.h"
+
+namespace cuttlefish {
+
+TEST(Base64Test, EncodeMult3) {
+  std::string in = "foobar";
+  std::string expected("Zm9vYmFy");
+  std::string out;
+  ASSERT_TRUE(EncodeBase64(in.c_str(), in.size(), &out));
+  ASSERT_EQ(out.size(), expected.size());
+  ASSERT_EQ(out, expected);
+}
+
+TEST(Base64Test, EncodeNonMult3) {
+  std::string in = "foobar1";
+  std::string expected("Zm9vYmFyMQ==");
+  std::string out;
+  ASSERT_TRUE(EncodeBase64(in.c_str(), in.size(), &out));
+   ASSERT_EQ(out.size(), expected.size());
+  ASSERT_EQ(out, expected);
+}
+
+TEST(Base64Test, DecodeMult3) {
+  std::string in = "Zm9vYmFy";
+  std::vector<uint8_t> expected{'f','o','o','b','a','r'};
+  std::vector<uint8_t> out;
+  ASSERT_TRUE(DecodeBase64(in, &out));
+  ASSERT_EQ(out.size(), expected.size());
+  ASSERT_EQ(out, expected);
+}
+
+TEST(Base64Test, DecodeNonMult3) {
+  std::string in = "Zm9vYmFyMQ==";
+  std::vector<uint8_t> expected{'f','o','o','b','a','r','1'};
+  std::vector<uint8_t> out;
+  ASSERT_TRUE(DecodeBase64(in, &out));
+  ASSERT_EQ(out.size(), expected.size());
+  ASSERT_EQ(out, expected);
+}
+
+TEST(Base64Test, EncodeOneZero) {
+  std::vector<uint8_t> in = {0};
+  std::string string_encoding;
+
+  ASSERT_TRUE(EncodeBase64(in.data(), in.size(), &string_encoding));
+
+  std::vector<uint8_t> out;
+  ASSERT_TRUE(DecodeBase64(string_encoding, &out));
+
+  ASSERT_EQ(in, out);
+}
+
+TEST(Base64Test, EncodeTwoZeroes) {
+  std::vector<uint8_t> in = {0, 0};
+  std::string string_encoding;
+
+  ASSERT_TRUE(EncodeBase64(in.data(), in.size(), &string_encoding));
+
+  std::vector<uint8_t> out;
+  ASSERT_TRUE(DecodeBase64(string_encoding, &out));
+
+  ASSERT_EQ(in, out);
+}
+
+TEST(Base64Test, EncodeThreeZeroes) {
+  std::vector<uint8_t> in = {0, 0, 0};
+  std::string string_encoding;
+
+  ASSERT_TRUE(EncodeBase64(in.data(), in.size(), &string_encoding));
+
+  std::vector<uint8_t> out;
+  ASSERT_TRUE(DecodeBase64(string_encoding, &out));
+
+  ASSERT_EQ(in, out);
+}
+}


### PR DESCRIPTION
Uses `EVP_EncodedLength` to avoid a local implementation, and uses `EVP_DecodeBase64` to handle a corner case around null bytes at the end of input data for base64 encoding.

Counterpart to https://android-review.googlesource.com/c/device/google/cuttlefish/+/3481535

Bug: b/395180112
Test: bazel test :utils_test