### PR TITLE
Mark cuttlefish 1.1.0 packages stable

### DIFF
--- a/base/debian/changelog
+++ b/base/debian/changelog
@@ -4,7 +4,7 @@ cuttlefish-common (1.2.0) UNRELEASED; urgency=medium
 
  -- Chad Reynolds <chadreynolds@google.com>  Fri, 24 Jan 2025 11:23:42 -0800
 
-cuttlefish-common (1.1.0) unstable; urgency=medium
+cuttlefish-common (1.1.0) stable; urgency=medium
 
   * add cvd cache
   * automatic cache pruning when fetching

--- a/frontend/debian/changelog
+++ b/frontend/debian/changelog
@@ -4,7 +4,7 @@ cuttlefish-frontend (1.2.0) UNRELEASED; urgency=medium
 
  -- Chad Reynolds <chadreynolds@google.com>  Fri, 24 Jan 2025 11:24:30 -0800
 
-cuttlefish-frontend (1.1.0) unstable; urgency=medium
+cuttlefish-frontend (1.1.0) stable; urgency=medium
 
   * the adb bugreport can now be included in the cvd bugreport
   * add --log_file flag


### PR DESCRIPTION
This should trigger this ARM stable host image release process.

Bug: 393146863