### PR TITLE
Suppress all interaction during upgrade step

### DIFF
--- a/.kokoro/presubmit.sh
+++ b/.kokoro/presubmit.sh
@@ -3,7 +3,8 @@
 set -e -x
 
 sudo apt update
-sudo apt upgrade -y
+# environment variable and options to force answer prompts
+sudo DEBIAN_FRONTEND=noninteractive apt -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade -y
 
 # realpath .kokoro/..
 REPO_DIR="$(realpath "$(dirname "$0")"/..)"


### PR DESCRIPTION
By forcing answers to prompts during installation.  `noninteractive` should force default answers, `--force-confdef` should force default selection if a conffile has been modified, and `--force-confold` should select the old version of the conffile if there is no default option.

References:
DEBIAN_FRONTEND - https://manpages.debian.org/jessie/debconf-doc/debconf.7.en.html#Frontends --option options - https://man7.org/linux/man-pages/man1/dpkg.1.html