### PR TITLE
Encapsulate cvd command construction

### DIFF
--- a/frontend/src/host_orchestrator/orchestrator/BUILD.bazel
+++ b/frontend/src/host_orchestrator/orchestrator/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//orchestrator/artifacts",
         "//orchestrator/cvd",
         "//orchestrator/debug",
+        "//orchestrator/exec",
         "@com_github_google_android_cuttlefish_frontend_src_liboperator//operator",
         "@com_github_google_uuid//:uuid",
         "@com_github_gorilla_mux//:mux",
@@ -43,6 +44,7 @@ go_test(
     deps = [
         "//api/v1:api",
         "//orchestrator/debug",
+        "//orchestrator/exec",
         "//orchestrator/testing",
         "@com_github_google_android_cuttlefish_frontend_src_liboperator//operator",
         "@com_github_google_go_cmp//cmp",

--- a/frontend/src/host_orchestrator/orchestrator/controller.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/artifacts"
 	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/cvd"
 	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/debug"
+	hoexec "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/exec"
 	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
 
 	"github.com/google/uuid"
@@ -177,7 +178,7 @@ func (h *fetchArtifactsHandler) Handle(r *http.Request) (interface{}, error) {
 	buildAPI := artifacts.NewAndroidCIBuildAPIWithOpts(
 		http.DefaultClient, h.Config.AndroidBuildServiceURL, buildAPIOpts)
 	artifactsFetcher := newBuildAPIArtifactsFetcher(buildAPI)
-	execCtx := newCVDExecContext(exec.CommandContext, h.Config.CVDUser)
+	execCtx := hoexec.NewAsUserExecContext(exec.CommandContext, h.Config.CVDUser)
 	cvdBundleFetcher := newFetchCVDCommandArtifactsFetcher(execCtx, buildAPICredentials)
 	opts := FetchArtifactsActionOpts{
 		Request:          &req,
@@ -220,7 +221,7 @@ func (h *createCVDHandler) Handle(r *http.Request) (interface{}, error) {
 	buildAPI := artifacts.NewAndroidCIBuildAPIWithOpts(
 		http.DefaultClient, h.Config.AndroidBuildServiceURL, buildAPIOpts)
 	artifactsFetcher := newBuildAPIArtifactsFetcher(buildAPI)
-	execCtx := newCVDExecContext(exec.CommandContext, h.Config.CVDUser)
+	execCtx := hoexec.NewAsUserExecContext(exec.CommandContext, h.Config.CVDUser)
 	cvdBundleFetcher := newFetchCVDCommandArtifactsFetcher(execCtx, buildAPICredentials)
 	opts := CreateCVDActionOpts{
 		Request:                  req,
@@ -344,7 +345,7 @@ func (h *getCVDLogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	group := vars["group"]
 	name := vars["name"]
-	ctx := newCVDExecContext(exec.CommandContext, h.Config.CVDUser)
+	ctx := hoexec.NewAsUserExecContext(exec.CommandContext, h.Config.CVDUser)
 	logsDir, err := CVDLogsDir(ctx, group, name)
 	if err != nil {
 		log.Printf("request %q failed with error: %v", r.Method+" "+r.URL.Path, err)
@@ -467,7 +468,7 @@ func (h *createCVDBugReportHandler) Handle(r *http.Request) (interface{}, error)
 		IncludeADBBugreport: includeADBBugreport,
 		Paths:               h.Config.Paths,
 		OperationManager:    h.OM,
-		ExecContext:         newCVDExecContext(exec.CommandContext, h.Config.CVDUser),
+		ExecContext:         hoexec.NewAsUserExecContext(exec.CommandContext, h.Config.CVDUser),
 		UUIDGen:             func() string { return uuid.New().String() },
 	}
 	return NewCreateCVDBugReportAction(opts).Run()

--- a/frontend/src/host_orchestrator/orchestrator/createcvdaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/createcvdaction.go
@@ -27,6 +27,7 @@ import (
 	apiv1 "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
 	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/artifacts"
 	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/cvd"
+	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/exec"
 	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
 
 	"github.com/hashicorp/go-multierror"
@@ -46,7 +47,7 @@ type CreateCVDActionOpts struct {
 	HostValidator            Validator
 	Paths                    IMPaths
 	OperationManager         OperationManager
-	ExecContext              ExecContext
+	ExecContext              exec.ExecContext
 	BuildAPI                 artifacts.BuildAPI
 	ArtifactsFetcher         artifacts.Fetcher
 	CVDBundleFetcher         artifacts.CVDBundleFetcher
@@ -61,7 +62,7 @@ type CreateCVDAction struct {
 	hostValidator            Validator
 	paths                    IMPaths
 	om                       OperationManager
-	execContext              cvd.CVDExecContext
+	execContext              exec.ExecContext
 	cvdCLI                   *cvd.CLI
 	buildAPI                 artifacts.BuildAPI
 	artifactsFetcher         artifacts.Fetcher
@@ -75,7 +76,7 @@ type CreateCVDAction struct {
 }
 
 func NewCreateCVDAction(opts CreateCVDActionOpts) *CreateCVDAction {
-	execCtx := newCVDExecContext(opts.ExecContext, opts.CVDUser)
+	execCtx := exec.NewAsUserExecContext(opts.ExecContext, opts.CVDUser)
 	return &CreateCVDAction{
 		req:                      opts.Request,
 		hostValidator:            opts.HostValidator,

--- a/frontend/src/host_orchestrator/orchestrator/createcvdaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/createcvdaction.go
@@ -21,10 +21,8 @@ import (
 	"log"
 	"os"
 	"os/user"
-	"strconv"
 	"sync"
 	"sync/atomic"
-	"syscall"
 
 	apiv1 "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
 	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/artifacts"
@@ -64,6 +62,7 @@ type CreateCVDAction struct {
 	paths                    IMPaths
 	om                       OperationManager
 	execContext              cvd.CVDExecContext
+	cvdCLI                   *cvd.CLI
 	buildAPI                 artifacts.BuildAPI
 	artifactsFetcher         artifacts.Fetcher
 	cvdBundleFetcher         artifacts.CVDBundleFetcher
@@ -76,6 +75,7 @@ type CreateCVDAction struct {
 }
 
 func NewCreateCVDAction(opts CreateCVDActionOpts) *CreateCVDAction {
+	execCtx := newCVDExecContext(opts.ExecContext, opts.CVDUser)
 	return &CreateCVDAction{
 		req:                      opts.Request,
 		hostValidator:            opts.HostValidator,
@@ -92,7 +92,8 @@ func NewCreateCVDAction(opts CreateCVDActionOpts) *CreateCVDAction {
 			opts.Paths.ArtifactsRootDir,
 			opts.UUIDGen,
 		),
-		execContext: newCVDExecContext(opts.ExecContext, opts.CVDUser),
+		execContext: execCtx,
+		cvdCLI:      cvd.NewCLI(execCtx),
 	}
 }
 
@@ -135,50 +136,34 @@ func (a *CreateCVDAction) launchWithCanonicalConfig(op apiv1.Operation) (*apiv1.
 	if err != nil {
 		return nil, err
 	}
-	args := []string{"load", configFile.Name()}
-	if a.buildAPICredentials.AccessToken != "" {
-		filename, err := createCredsFile(a.execContext)
-		if err != nil {
-			return nil, err
-		}
-		if err := writeCredsFile(a.execContext, filename, []byte(a.buildAPICredentials.AccessToken)); err != nil {
-			return nil, err
-		}
-		defer func() {
-			if err := removeCredsFile(a.execContext, filename); err != nil {
-				log.Println("failed to remove credentials file: ", err)
-			}
-		}()
-		args = append(args, "--credential_source="+filename)
 
-		if a.buildAPICredentials.UserProjectID != "" {
-			args = append(args, "--project_id="+a.buildAPICredentials.UserProjectID)
+	var creds cvd.FetchCredentials
+	if a.buildAPICredentials.AccessToken != "" {
+		creds = &cvd.FetchTokenFileCredentials{
+			AccessToken: a.buildAPICredentials.AccessToken,
+			ProjectId:   a.buildAPICredentials.UserProjectID,
 		}
 	} else if isRunningOnGCE() {
 		if ok, err := hasServiceAccountAccessToken(); err != nil {
 			log.Printf("service account token check failed: %s", err)
 		} else if ok {
-			args = append(args, "--credential_source=gce")
+			creds = &cvd.FetchGceCredentials{}
 		}
 	}
-	cmd := cvd.NewCommand(a.execContext, args, cvd.CommandOpts{})
-	if err := cmd.Run(); err != nil {
+	group, err := a.cvdCLI.Load(configFile.Name(), creds)
+	if err != nil {
 		return nil, operator.NewInternalError(ErrMsgLaunchCVDFailed, err)
 	}
-	group, err := cvdFleetFirstGroup(a.execContext)
-	if err != nil {
-		return nil, err
-	}
-	return &apiv1.CreateCVDResponse{CVDs: group.toAPIObject()}, nil
+	return &apiv1.CreateCVDResponse{CVDs: CvdGroupToAPIObject(group)}, nil
 }
 
 func (a *CreateCVDAction) launchCVDResult(op apiv1.Operation) *OperationResult {
 	instancesCount := 1 + a.req.AdditionalInstancesNum
-	var instanceNumbers []uint32
+	var group *cvd.Group
 	var err error
 	switch {
 	case a.req.CVD.BuildSource.AndroidCIBuildSource != nil:
-		instanceNumbers, err = a.launchFromAndroidCI(a.req.CVD.BuildSource.AndroidCIBuildSource, instancesCount, op)
+		group, err = a.launchFromAndroidCI(a.req.CVD.BuildSource.AndroidCIBuildSource, instancesCount, op)
 	default:
 		return &OperationResult{
 			Error: operator.NewBadRequestError(
@@ -188,29 +173,14 @@ func (a *CreateCVDAction) launchCVDResult(op apiv1.Operation) *OperationResult {
 	if err != nil {
 		return &OperationResult{Error: operator.NewInternalError(ErrMsgLaunchCVDFailed, err)}
 	}
-	group, err := cvdFleetFirstGroup(a.execContext)
-	if err != nil {
-		return &OperationResult{Error: operator.NewInternalError(ErrMsgLaunchCVDFailed, err)}
-	}
-	relevant := []*cvdInstance{}
-	for _, item := range group.Instances {
-		n, err := strconv.Atoi(item.InstanceName)
-		if err != nil {
-			return &OperationResult{Error: operator.NewInternalError(ErrMsgLaunchCVDFailed, err)}
-		}
-		if contains(instanceNumbers, uint32(n)) {
-			relevant = append(relevant, item)
-		}
-	}
-	group.Instances = relevant
-	res := &apiv1.CreateCVDResponse{CVDs: group.toAPIObject()}
+	res := &apiv1.CreateCVDResponse{CVDs: CvdGroupToAPIObject(group)}
 	return &OperationResult{Value: res}
 }
 
 const ErrMsgLaunchCVDFailed = "failed to launch cvd"
 
 func (a *CreateCVDAction) launchFromAndroidCI(
-	buildSource *apiv1.AndroidCIBuildSource, instancesCount uint32, op apiv1.Operation) ([]uint32, error) {
+	buildSource *apiv1.AndroidCIBuildSource, instancesCount uint32, op apiv1.Operation) (*cvd.Group, error) {
 	var mainBuild *apiv1.AndroidCIBuild = defaultMainBuild()
 	var kernelBuild *apiv1.AndroidCIBuild
 	var bootloaderBuild *apiv1.AndroidCIBuild
@@ -282,14 +252,15 @@ func (a *CreateCVDAction) launchFromAndroidCI(
 		KernelDir:        kernelBuildDir,
 		BootloaderDir:    bootloaderBuildDir,
 	}
-	if err := CreateCVD(a.execContext, startParams); err != nil {
+	group, err := CreateCVD(a.execContext, startParams)
+	if err != nil {
 		return nil, err
 	}
 	// TODO: Remove once `acloud CLI` gets deprecated.
 	if contains(startParams.InstanceNumbers, 1) {
 		go runAcloudSetup(a.execContext, a.paths.ArtifactsRootDir, mainBuildDir)
 	}
-	return startParams.InstanceNumbers, nil
+	return group, nil
 }
 
 func (a *CreateCVDAction) newInstanceNumbers(n uint32) []uint32 {
@@ -334,81 +305,4 @@ func createTempFile(pattern string, data []byte, mode os.FileMode) (*os.File, er
 		return nil, err
 	}
 	return file, nil
-}
-
-// Create the credential file so it's owned by the configured `cvd user`, e.g: `_cvd-executor`.
-func createCredsFile(ctx cvd.CVDExecContext) (string, error) {
-	name, err := tempFilename("cvdload*.creds")
-	if err != nil {
-		return "", err
-	}
-	if _, err := cvd.Exec(ctx, "touch", name); err != nil {
-		return "", err
-	}
-	if _, err := cvd.Exec(ctx, "chmod", "0600", name); err != nil {
-		return "", err
-	}
-	return name, nil
-}
-
-// Write into credential files by granting temporary write permission to `cvdnetwork` group.
-func writeCredsFile(ctx cvd.CVDExecContext, name string, data []byte) error {
-	info, err := os.Stat(name)
-	if err != nil {
-		return err
-	}
-	infoSys := info.Sys()
-	var gid uint32
-	if stat, ok := infoSys.(*syscall.Stat_t); ok {
-		gid = stat.Gid
-	} else {
-		panic("unexpected stat syscall type")
-	}
-	defer func() {
-		// Reverts the write permission.
-		if _, err := cvd.Exec(ctx, "chgrp", strconv.Itoa(int(gid)), name); err != nil {
-			log.Println(err)
-		}
-		if _, err := cvd.Exec(ctx, "chmod", "0600", name); err != nil {
-			log.Println(err)
-		}
-	}()
-	// Grants temporal write permission to `cvdnetwork`, so this process can write the file.
-	if _, err := cvd.Exec(ctx, "chgrp", "cvdnetwork", name); err != nil {
-		return err
-	}
-	if _, err := cvd.Exec(ctx, "chmod", "0620", name); err != nil {
-		return err
-	}
-	file, err := os.OpenFile(name, os.O_WRONLY, 0)
-	if err != nil {
-		return err
-	}
-	_, err = file.Write(data)
-	if closeErr := file.Close(); closeErr != nil && err == nil {
-		err = closeErr
-	}
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func removeCredsFile(ctx cvd.CVDExecContext, name string) error {
-	_, err := cvd.Exec(ctx, "rm", name)
-	return err
-}
-
-// Returns a random name for a file in the /tmp directory given a pattern.
-// See https://pkg.go.dev/io/ioutil@go1.13.15#TempFile
-func tempFilename(pattern string) (string, error) {
-	file, err := ioutil.TempFile("", pattern)
-	if err != nil {
-		return "", err
-	}
-	name := file.Name()
-	if err := os.Remove(name); err != nil {
-		return "", err
-	}
-	return name, nil
 }

--- a/frontend/src/host_orchestrator/orchestrator/createcvdbugreportaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/createcvdbugreportaction.go
@@ -37,7 +37,7 @@ type CreateCVDBugReportAction struct {
 	includeADBBugreport bool
 	paths               IMPaths
 	om                  OperationManager
-	execContext         cvd.CVDExecContext
+	cvdCLI              *cvd.CLI
 	uuidgen             func() string
 }
 
@@ -47,7 +47,7 @@ func NewCreateCVDBugReportAction(opts CreateCVDBugReportActionOpts) *CreateCVDBu
 		includeADBBugreport: opts.IncludeADBBugreport,
 		paths:               opts.Paths,
 		om:                  opts.OperationManager,
-		execContext:         opts.ExecContext,
+		cvdCLI:              cvd.NewCLI(opts.ExecContext),
 		uuidgen:             opts.UUIDGen,
 	}
 }
@@ -69,7 +69,7 @@ func (a *CreateCVDBugReportAction) Run() (apiv1.Operation, error) {
 	go func(uuid string, op apiv1.Operation) {
 		dst := filepath.Join(a.paths.CVDBugReportsDir, uuid, BugReportZipFileName)
 		result := &OperationResult{}
-		if err := execBugReportCommand(a.execContext, a.group, a.includeADBBugreport, dst); err != nil {
+		if err := a.cvdCLI.BugReport(cvd.Selector{Group: a.group}, a.includeADBBugreport, dst); err != nil {
 			result.Error = operator.NewInternalError("`cvd host_bugreport` failed: ", err)
 		} else {
 			result.Value = uuid
@@ -79,15 +79,4 @@ func (a *CreateCVDBugReportAction) Run() (apiv1.Operation, error) {
 		}
 	}(uuid, op)
 	return op, nil
-}
-
-func execBugReportCommand(exec cvd.CVDExecContext, group string, includeADBBugReport bool, dst string) error {
-	sel := &CVDSelector{Group: group}
-	args := sel.ToCVDCLI()
-	args = append(args, []string{"host_bugreport", "--output=" + dst}...)
-	if includeADBBugReport {
-		args = append(args, []string{"--include_adb_bugreport=true"}...)
-	}
-	cmd := cvd.NewCommand(exec, args, cvd.CommandOpts{})
-	return cmd.Run()
 }

--- a/frontend/src/host_orchestrator/orchestrator/createcvdbugreportaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/createcvdbugreportaction.go
@@ -20,6 +20,7 @@ import (
 
 	apiv1 "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
 	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/cvd"
+	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/exec"
 	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
 )
 
@@ -28,7 +29,7 @@ type CreateCVDBugReportActionOpts struct {
 	IncludeADBBugreport bool
 	Paths               IMPaths
 	OperationManager    OperationManager
-	ExecContext         cvd.CVDExecContext
+	ExecContext         exec.ExecContext
 	UUIDGen             func() string
 }
 

--- a/frontend/src/host_orchestrator/orchestrator/createsnapshotaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/createsnapshotaction.go
@@ -21,6 +21,7 @@ import (
 
 	apiv1 "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
 	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/cvd"
+	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/exec"
 	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
 )
 
@@ -28,7 +29,7 @@ type CreateSnapshotActionOpts struct {
 	Selector         cvd.Selector
 	Paths            IMPaths
 	OperationManager OperationManager
-	ExecContext      ExecContext
+	ExecContext      exec.ExecContext
 	CVDUser          *user.User
 }
 
@@ -44,7 +45,7 @@ func NewCreateSnapshotAction(opts CreateSnapshotActionOpts) *CreateSnapshotActio
 		selector: opts.Selector,
 		paths:    opts.Paths,
 		om:       opts.OperationManager,
-		cvdCLI:   cvd.NewCLI(newCVDExecContext(opts.ExecContext, opts.CVDUser)),
+		cvdCLI:   cvd.NewCLI(exec.NewAsUserExecContext(opts.ExecContext, opts.CVDUser)),
 	}
 }
 

--- a/frontend/src/host_orchestrator/orchestrator/cvd/BUILD.bazel
+++ b/frontend/src/host_orchestrator/orchestrator/cvd/BUILD.bazel
@@ -1,8 +1,19 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "cvd",
     srcs = ["cvd.go"],
     importpath = "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/cvd",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "cvd_test",
+    srcs = [
+        "cvd_test.go",
+    ],
+    embed = [":cvd"],
+    deps = [
+        "@com_github_google_go_cmp//cmp",
+    ],
 )

--- a/frontend/src/host_orchestrator/orchestrator/cvd/BUILD.bazel
+++ b/frontend/src/host_orchestrator/orchestrator/cvd/BUILD.bazel
@@ -5,6 +5,9 @@ go_library(
     srcs = ["cvd.go"],
     importpath = "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/cvd",
     visibility = ["//visibility:public"],
+    deps = [
+        "//orchestrator/exec",
+    ]
 )
 
 go_test(
@@ -15,5 +18,6 @@ go_test(
     embed = [":cvd"],
     deps = [
         "@com_github_google_go_cmp//cmp",
+        "//orchestrator/exec",
     ],
 )

--- a/frontend/src/host_orchestrator/orchestrator/cvd/cvd.go
+++ b/frontend/src/host_orchestrator/orchestrator/cvd/cvd.go
@@ -17,114 +17,391 @@ package cvd
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
-type CVDExecContext = func(ctx context.Context, env []string, name string, arg ...string) *exec.Cmd
+type CVDExecContext = func(ctx context.Context, name string, arg ...string) *exec.Cmd
 
 const (
 	CVDBin      = "/usr/bin/cvd"
 	FetchCVDBin = "/usr/bin/fetch_cvd"
 )
 
-const (
-	envVarAndroidHostOut = "ANDROID_HOST_OUT"
-)
-
-type CommandOpts struct {
-	AndroidHostOut string
-	Home           string
-	Stdout         io.Writer
-}
-
-type Command struct {
-	execContext CVDExecContext
-	cvdBin      string
-	args        []string
-	opts        CommandOpts
-}
-
-func NewCommand(execContext CVDExecContext, args []string, opts CommandOpts) *Command {
-	return &Command{
-		execContext: execContext,
-		cvdBin:      CVDBin,
-		args:        args,
-		opts:        opts,
-	}
-}
-
-type CommandExecErr struct {
+type commandExecErr struct {
 	args   []string
 	stderr string
 	err    error
 }
 
-func (e *CommandExecErr) Error() string {
+func (e *commandExecErr) Error() string {
 	return fmt.Sprintf("cvd execution with args %q failed with stderr:\n%s",
 		strings.Join(e.args, " "),
 		e.stderr)
 }
 
-func (e *CommandExecErr) Unwrap() error { return e.err }
-
-func (c *Command) Run() error {
-	cmd := c.execContext(context.TODO(), cvdEnv(c.opts.AndroidHostOut), c.cvdBin, c.args...)
-	stderrBuff := &bytes.Buffer{}
-	stderrMw := io.MultiWriter(stderrBuff, log.Writer())
-	cmd.Stdout = c.opts.Stdout
-	cmd.Stderr = stderrMw
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-	if err := cmd.Wait(); err != nil {
-		return &CommandExecErr{c.args, stderrBuff.String(), err}
-	}
-	return nil
-}
-
-func cvdEnv(androidHostOut string) []string {
-	if androidHostOut == "" {
-		return nil
-	}
-	// Make sure the current process' environment is inherited by cvd, some cvd subcommands, like
-	// start, expect the PATH environment variable to be defined.
-	return append(os.Environ(), envVarAndroidHostOut+"="+androidHostOut)
-}
-
-func OutputLogMessage(output string) string {
-	const format = "############################################\n" +
-		"## BEGIN \n" +
-		"############################################\n" +
-		"\n%s\n\n" +
-		"############################################\n" +
-		"## END \n" +
-		"############################################\n"
-	return fmt.Sprintf(format, string(output))
-}
-
-func LogStderr(cmd *exec.Cmd, val string) {
-	msg := "`%s`, stderr:\n%s"
-	log.Printf(msg, strings.Join(cmd.Args, " "), OutputLogMessage(val))
-}
-
-func LogCombinedStdoutStderr(cmd *exec.Cmd, val string) {
-	msg := "`%s`, combined stdout and stderr :\n%s"
-	log.Printf(msg, strings.Join(cmd.Args, " "), OutputLogMessage(val))
-}
+func (e *commandExecErr) Unwrap() error { return e.err }
 
 func Exec(ctx CVDExecContext, name string, args ...string) (string, error) {
-	cmd := ctx(context.TODO(), nil, name, args...)
+	cmd := ctx(context.TODO(), name, args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil {
-		return "", &CommandExecErr{args, stderr.String(), err}
+		return "", &commandExecErr{args, stderr.String(), err}
 	}
 	return stdout.String(), nil
+}
+
+// A CVD instance group
+type Group struct {
+	Name      string      `json:"group_name"`
+	Instances []*Instance `json:"instances"`
+}
+
+// A CVD instance
+type Instance struct {
+	InstanceName   string   `json:"instance_name"`
+	Status         string   `json:"status"`
+	Displays       []string `json:"displays"`
+	InstanceDir    string   `json:"instance_dir"`
+	WebRTCDeviceID string   `json:"webrtc_device_id"`
+	ADBSerial      string   `json:"adb_serial"`
+}
+
+// The output of the cvd fleet command
+type Fleet struct {
+	Groups []*Group `json:"groups"`
+}
+
+// Credentials to be passed to cvd fetch or cvd load.
+// cvd supports multiple strategies to obtain these credentials, with
+// different command line flags used for each of them.
+type FetchCredentials interface {
+	// Adds command line flags and other setup like inheriting file descriptors
+	AddToCmd(cmd *exec.Cmd) error
+}
+
+// Build api credentials from a file (OAUTH2.0 access token).
+// Optionally includes the project id associated with the client
+type FetchTokenFileCredentials struct {
+	AccessToken string
+	ProjectId   string // optional
+}
+
+func (c *FetchTokenFileCredentials) AddToCmd(cmd *exec.Cmd) error {
+	file, err := createCredentialsFile(c.AccessToken)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	// This is necessary for the subprocess to inherit the file.
+	cmd.ExtraFiles = append(cmd.ExtraFiles, file)
+	// The actual fd number is not retained, the lowest available number is used instead.
+	fd := 3 + len(cmd.ExtraFiles) - 1
+	// TODO(b/401592023) Use --credential_filepath when cvd load supports it
+	cmd.Args = append(cmd.Args, fmt.Sprintf("--credential_source=/proc/self/fd/%d", fd))
+	return nil
+}
+
+// Build api credentials from the GCE instance's service account
+type FetchGceCredentials struct{}
+
+func (c *FetchGceCredentials) AddToCmd(cmd *exec.Cmd) error {
+	// TODO(b/401592023) Use --use_gce_metadata when cvd load supports them
+	_ = append(cmd.Args, "--credential_source=gce")
+	return nil
+}
+
+// A filter allowing to select instances or groups by name.
+type Selector struct {
+	Group    string
+	Instance string
+}
+
+func (s *Selector) asArgs() []string {
+	res := []string{}
+	if s.Group != "" {
+		res = append(res, "--group_name="+s.Group)
+	}
+	if s.Instance != "" {
+		res = append(res, "--instance_name="+s.Instance)
+	}
+	return res
+}
+
+// Wrapper around the cvd command, exposing the tool's subcommands as functions
+type CLI struct {
+	execContext CVDExecContext
+}
+
+func NewCLI(execCtx CVDExecContext) *CLI {
+	return &CLI{execCtx}
+}
+
+func (cli *CLI) buildCmd(bin string, args ...string) *exec.Cmd {
+	return cli.execContext(context.TODO(), bin, args...)
+}
+
+func (cli *CLI) runCmd(cmd *exec.Cmd) ([]byte, error) {
+	stdoutBuff := &bytes.Buffer{}
+	stdoutMw := io.MultiWriter(stdoutBuff, log.Writer())
+	cmd.Stdout = stdoutMw
+	stderrBuff := &bytes.Buffer{}
+	stderrMw := io.MultiWriter(stderrBuff, log.Writer())
+	cmd.Stderr = stderrMw
+	if err := cmd.Start(); err != nil {
+		return stdoutBuff.Bytes(), err
+	}
+	if err := cmd.Wait(); err != nil {
+		return stdoutBuff.Bytes(), &commandExecErr{cmd.Args, stderrBuff.String(), err}
+	}
+	return stdoutBuff.Bytes(), nil
+}
+
+// Runs the given command returning the stdout output as a byte array.
+// Both stdout and stderr output also written to the logs.
+func (cli *CLI) exec(bin string, args ...string) ([]byte, error) {
+	const begin = "############################################\n" +
+		"## BEGIN \n" +
+		"############################################"
+	const end = "############################################\n" +
+		"## END \n" +
+		"############################################"
+	log.Println(begin)
+	defer log.Println(end)
+	return cli.runCmd(cli.buildCmd(bin, args...))
+}
+
+func (cli *CLI) Load(configPath string, creds FetchCredentials) (*Group, error) {
+	cmd := cli.buildCmd(CVDBin, "load", configPath)
+	if creds != nil {
+		creds.AddToCmd(cmd)
+	}
+
+	out, err := cli.runCmd(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("failed execution of `cvd load`: %w", err)
+	}
+	var group Group
+	if err := json.Unmarshal(out, &group); err != nil {
+		return nil, fmt.Errorf("failed parsing `cvd load` output: %w", err)
+	}
+	return &group, nil
+}
+
+type CreateOptions struct {
+	HostPath     string
+	ProductPath  string
+	InstanceNums []uint32
+}
+
+func (o *CreateOptions) toArgs() []string {
+	args := []string{}
+	if o.HostPath != "" {
+		args = append(args, "--host_path", o.HostPath)
+	}
+	if o.ProductPath != "" {
+		args = append(args, "--product_path", o.ProductPath)
+	}
+	if len(o.InstanceNums) > 0 {
+		args = append(args, "--instance_nums", strings.Join(sliceItoa(o.InstanceNums), ","))
+		args = append(args, "--num_instances", fmt.Sprintf("%d", len(o.InstanceNums)))
+	}
+	return args
+}
+
+func (cli *CLI) Create(selector Selector, createOpts CreateOptions, startOpts StartOptions) (*Group, error) {
+	args := selector.asArgs()
+	args = append(args, "create")
+	args = append(args, createOpts.toArgs()...)
+	args = append(args, startOpts.toArgs()...)
+	out, err := cli.exec(CVDBin, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed execution of `cvd %s`: %w", strings.Join(args, " "), err)
+	}
+	var group Group
+	if err := json.Unmarshal(out, &group); err != nil {
+		return nil, fmt.Errorf("failed parsing `cvd create` output: %w", err)
+	}
+	return &group, nil
+}
+
+type StartOptions struct {
+	SnapshotPath     string
+	KernelImage      string
+	InitramfsImage   string
+	BootloaderRom    string
+	ReportUsageStats bool
+}
+
+func (o *StartOptions) toArgs() []string {
+	args := []string{}
+	if o.SnapshotPath != "" {
+		args = append(args, "--snapshot_path", o.SnapshotPath)
+	}
+	if o.KernelImage != "" {
+		args = append(args, "--kernel_path", o.KernelImage)
+	}
+	if o.InitramfsImage != "" {
+		args = append(args, "--initramfs_path", o.InitramfsImage)
+	}
+	if o.BootloaderRom != "" {
+		args = append(args, "--bootloader", o.BootloaderRom)
+	}
+	if o.ReportUsageStats {
+		args = append(args, "--report_anonymous_usage_stats=y")
+	} else {
+		args = append(args, "--report_anonymous_usage_stats=n")
+	}
+	return args
+}
+
+func (cli *CLI) Start(selector Selector, opts StartOptions) error {
+	args := selector.asArgs()
+	args = append(args, "start", "--report_anonymous_usage_stats=y")
+	args = append(args, opts.toArgs()...)
+	_, err := cli.exec(CVDBin, args...)
+	return err
+}
+
+func (cli *CLI) Stop(selector Selector) error {
+	args := selector.asArgs()
+	args = append(args, "stop")
+	_, err := cli.exec(CVDBin, args...)
+	return err
+}
+
+func (cli *CLI) Remove(selector Selector) error {
+	args := selector.asArgs()
+	args = append(args, "remove")
+	_, err := cli.exec(CVDBin, args...)
+	return err
+}
+
+func (cli *CLI) Fleet() (*Fleet, error) {
+	out, err := cli.exec(CVDBin, "fleet")
+	if err != nil {
+		return nil, fmt.Errorf("failed execution of `cvd fleet`: %w", err)
+	}
+	fleet := &Fleet{}
+	if err := json.Unmarshal(out, fleet); err != nil {
+		return nil, fmt.Errorf("error parsing `cvd fleet` output: %w", err)
+	}
+	return fleet, nil
+}
+
+func (cli *CLI) BugReport(selector Selector, includeADBBugReport bool, dst string) error {
+	args := selector.asArgs()
+	args = append(args, []string{"host_bugreport", "--output=" + dst}...)
+	if includeADBBugReport {
+		args = append(args, []string{"--include_adb_bugreport=true"}...)
+	}
+	_, err := cli.exec(CVDBin, args...)
+	return err
+}
+
+func (cli *CLI) Suspend(selector Selector) error {
+	args := selector.asArgs()
+	args = append(args, "suspend")
+	_, err := cli.exec(CVDBin, args...)
+	return err
+}
+
+func (cli *CLI) Resume(selector Selector) error {
+	args := selector.asArgs()
+	args = append(args, "resume")
+	_, err := cli.exec(CVDBin, args...)
+	return err
+}
+
+func (cli *CLI) TakeSnapshot(selector Selector, dir string) error {
+	args := selector.asArgs()
+	args = append(args, "snapshot_take", "--snapshot_path", dir)
+	_, err := cli.exec(CVDBin, args...)
+	return err
+}
+
+func (cli *CLI) PowerWash(selector Selector) error {
+	args := selector.asArgs()
+	args = append(args, "powerwash")
+	_, err := cli.exec(CVDBin, args...)
+	return err
+}
+
+func (cli *CLI) PowerBtn(selector Selector) error {
+	args := selector.asArgs()
+	args = append(args, "powerbtn")
+	_, err := cli.exec(CVDBin, args...)
+	return err
+}
+
+type FetchOpts struct {
+	DefaultBuildID         string
+	DefaultBuildTarget     string
+	SystemImageBuildID     string
+	SystemImageBuildTarget string
+}
+
+func (cli *CLI) Fetch(opts FetchOpts, creds FetchCredentials, targetDir string) error {
+	if opts.DefaultBuildID == "" {
+		return fmt.Errorf("default build id is required")
+	}
+	if opts.DefaultBuildTarget == "" {
+		return fmt.Errorf("default build target is required")
+	}
+	args := []string{
+		fmt.Sprintf("--directory=%s", targetDir),
+		fmt.Sprintf("--default_build=%s/%s", opts.DefaultBuildID, opts.DefaultBuildTarget),
+	}
+	if opts.SystemImageBuildID != "" || opts.SystemImageBuildTarget != "" {
+		if opts.SystemImageBuildID == "" || opts.SystemImageBuildTarget == "" {
+			return fmt.Errorf(
+				"either system image build and target are set or neither: build=%q, target=%q",
+				opts.SystemImageBuildID, opts.SystemImageBuildTarget)
+		}
+		args = append(args, fmt.Sprintf("--system_build=%s/%s", opts.SystemImageBuildID, opts.SystemImageBuildTarget))
+	}
+	cmd := cli.buildCmd(FetchCVDBin, args...)
+	if creds != nil {
+		creds.AddToCmd(cmd)
+	}
+	if _, err := cli.runCmd(cmd); err != nil {
+		return fmt.Errorf("`fetch_cvd` failed: %w", err)
+	}
+	// TODO(b/286466643): Remove this hack once cuttlefish is capable of booting from read-only artifacts again.
+	if _, err := cli.exec("chmod", "-R", "g+rw", targetDir); err != nil {
+		return err
+	}
+	return nil
+}
+
+func sliceItoa(s []uint32) []string {
+	result := make([]string, len(s))
+	for i, v := range s {
+		result[i] = strconv.Itoa(int(v))
+	}
+	return result
+}
+
+func createCredentialsFile(content string) (*os.File, error) {
+	p1, p2, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pipe for credentials: %w", err)
+	}
+	go func(f *os.File) {
+		defer f.Close()
+		if _, err := f.Write([]byte(content)); err != nil {
+			log.Printf("Failed to write credentials to file: %v\n", err)
+			// Can't return this error without risking a deadlock when the pipe buffer fills up.
+		}
+	}(p2)
+	return p1, nil
 }

--- a/frontend/src/host_orchestrator/orchestrator/cvd/cvd_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/cvd/cvd_test.go
@@ -12,32 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package orchestrator
+package cvd
 
 import (
-	"context"
-	"os/exec"
+	"testing"
 
-	apiv1 "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
+	"github.com/google/go-cmp/cmp"
 )
 
-type AlwaysSucceedsValidator struct{}
-
-func (AlwaysSucceedsValidator) Validate() error {
-	return nil
-}
-
-func execCtxAlwaysSucceeds(ctx context.Context, name string, args ...string) *exec.Cmd {
-	return exec.Command("true")
-}
-
-func androidCISource(buildID, target string) *apiv1.BuildSource {
-	return &apiv1.BuildSource{
-		AndroidCIBuildSource: &apiv1.AndroidCIBuildSource{
-			MainBuild: &apiv1.AndroidCIBuild{
-				BuildID: buildID,
-				Target:  target,
-			},
+func TestSliceItoa(t *testing.T) {
+	tests := []struct {
+		in  []uint32
+		out []string
+	}{
+		{
+			in:  []uint32{},
+			out: []string{},
+		},
+		{
+			in:  []uint32{79, 83, 89, 97},
+			out: []string{"79", "83", "89", "97"},
 		},
 	}
+	for _, tc := range tests {
+
+		res := sliceItoa(tc.in)
+
+		if diff := cmp.Diff(tc.out, res); diff != "" {
+			t.Errorf("result mismatch (-want +got):\n%s", diff)
+		}
+	}
+
 }

--- a/frontend/src/host_orchestrator/orchestrator/exec/BUILD.bazel
+++ b/frontend/src/host_orchestrator/orchestrator/exec/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "exec",
+    srcs = ["exec.go"],
+    importpath = "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/exec",
+    visibility = ["//visibility:public"],
+)
+

--- a/frontend/src/host_orchestrator/orchestrator/exec/exec.go
+++ b/frontend/src/host_orchestrator/orchestrator/exec/exec.go
@@ -1,0 +1,55 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exec
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"os/user"
+	"strings"
+)
+
+type ExecContext = func(ctx context.Context, name string, args ...string) *exec.Cmd
+
+// Creates an execution context from another execution context.
+// If a non-nil user is provided the returned execution context executes commands as that user.
+func NewAsUserExecContext(execContext ExecContext, usr *user.User) ExecContext {
+	if usr != nil {
+		return func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+			newArgs := []string{"-u", usr.Username}
+			newArgs = append(newArgs, name)
+			newArgs = append(newArgs, arg...)
+			return execContext(ctx, "sudo", newArgs...)
+		}
+	}
+	return execContext
+}
+
+// Executes a command with an execution context and return it standard output.
+// Standard error is included in the error message if it fails.
+func Exec(ctx ExecContext, name string, args ...string) (string, error) {
+	cmd := ctx(context.TODO(), name, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return stdout.String(),
+			fmt.Errorf("execution of command %q with args %q failed: %w", name, strings.Join(args, " "), err)
+	}
+	return stdout.String(), nil
+}

--- a/frontend/src/host_orchestrator/orchestrator/execcvdcommandaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/execcvdcommandaction.go
@@ -20,12 +20,45 @@ import (
 
 	apiv1 "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
 	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/cvd"
-	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
 )
 
+type execCvdCommand interface {
+	exec(cvd *cvd.CLI, sel cvd.Selector) error
+}
+
+type startCvdCommand struct{}
+
+func (a *startCvdCommand) exec(cvdCLI *cvd.CLI, sel cvd.Selector) error {
+	return cvdCLI.Start(sel, cvd.StartOptions{})
+}
+
+type stopCvdCommand struct{}
+
+func (a *stopCvdCommand) exec(cvd *cvd.CLI, sel cvd.Selector) error {
+	return cvd.Stop(sel)
+}
+
+type removeCvdCommand struct{}
+
+func (a *removeCvdCommand) exec(cvd *cvd.CLI, sel cvd.Selector) error {
+	return cvd.Remove(sel)
+}
+
+type powerwashCvdCommand struct{}
+
+func (a *powerwashCvdCommand) exec(cvd *cvd.CLI, sel cvd.Selector) error {
+	return cvd.PowerWash(sel)
+}
+
+type powerbtnCvdCommand struct{}
+
+func (a *powerbtnCvdCommand) exec(cvd *cvd.CLI, sel cvd.Selector) error {
+	return cvd.PowerBtn(sel)
+}
+
 type ExecCVDCommandActionOpts struct {
-	Command          string
-	Selector         CVDSelector
+	Command          execCvdCommand
+	Selector         cvd.Selector
 	Paths            IMPaths
 	OperationManager OperationManager
 	ExecContext      ExecContext
@@ -33,20 +66,20 @@ type ExecCVDCommandActionOpts struct {
 }
 
 type ExecCVDCommandAction struct {
-	command     string
-	selector    CVDSelector
-	paths       IMPaths
-	om          OperationManager
-	execContext cvd.CVDExecContext
+	command  execCvdCommand
+	selector cvd.Selector
+	paths    IMPaths
+	om       OperationManager
+	cvdCLI   *cvd.CLI
 }
 
 func NewExecCVDCommandAction(opts ExecCVDCommandActionOpts) *ExecCVDCommandAction {
 	return &ExecCVDCommandAction{
-		command:     opts.Command,
-		selector:    opts.Selector,
-		paths:       opts.Paths,
-		om:          opts.OperationManager,
-		execContext: newCVDExecContext(opts.ExecContext, opts.CVDUser),
+		command:  opts.Command,
+		selector: opts.Selector,
+		paths:    opts.Paths,
+		om:       opts.OperationManager,
+		cvdCLI:   cvd.NewCLI(newCVDExecContext(opts.ExecContext, opts.CVDUser)),
 	}
 }
 
@@ -54,20 +87,11 @@ func (a *ExecCVDCommandAction) Run() (apiv1.Operation, error) {
 	op := a.om.New()
 	go func(op apiv1.Operation) {
 		result := &OperationResult{}
-		result.Value, result.Error = a.exec(op)
+		result.Value = &apiv1.EmptyResponse{}
+		result.Error = a.command.exec(a.cvdCLI, a.selector)
 		if err := a.om.Complete(op.Name, result); err != nil {
 			log.Printf("error completing operation %q: %v\n", op.Name, err)
 		}
 	}(op)
 	return op, nil
-}
-
-func (a *ExecCVDCommandAction) exec(op apiv1.Operation) (*apiv1.EmptyResponse, error) {
-	args := a.selector.ToCVDCLI()
-	args = append(args, a.command)
-	cmd := cvd.NewCommand(a.execContext, args, cvd.CommandOpts{})
-	if err := cmd.Run(); err != nil {
-		return nil, operator.NewInternalError("cvd "+a.command+" failed", err)
-	}
-	return &apiv1.EmptyResponse{}, nil
 }

--- a/frontend/src/host_orchestrator/orchestrator/execcvdcommandaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/execcvdcommandaction.go
@@ -20,6 +20,7 @@ import (
 
 	apiv1 "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
 	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/cvd"
+	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/exec"
 )
 
 type execCvdCommand interface {
@@ -61,7 +62,7 @@ type ExecCVDCommandActionOpts struct {
 	Selector         cvd.Selector
 	Paths            IMPaths
 	OperationManager OperationManager
-	ExecContext      ExecContext
+	ExecContext      exec.ExecContext
 	CVDUser          *user.User
 }
 
@@ -79,7 +80,7 @@ func NewExecCVDCommandAction(opts ExecCVDCommandActionOpts) *ExecCVDCommandActio
 		selector: opts.Selector,
 		paths:    opts.Paths,
 		om:       opts.OperationManager,
-		cvdCLI:   cvd.NewCLI(newCVDExecContext(opts.ExecContext, opts.CVDUser)),
+		cvdCLI:   cvd.NewCLI(exec.NewAsUserExecContext(opts.ExecContext, opts.CVDUser)),
 	}
 }
 

--- a/frontend/src/host_orchestrator/orchestrator/listcvdsaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/listcvdsaction.go
@@ -20,13 +20,14 @@ import (
 
 	apiv1 "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
 	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/cvd"
+	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/exec"
 	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
 )
 
 type ListCVDsActionOpts struct {
 	Group       string
 	Paths       IMPaths
-	ExecContext ExecContext
+	ExecContext exec.ExecContext
 	CVDUser     *user.User
 }
 
@@ -40,7 +41,7 @@ func NewListCVDsAction(opts ListCVDsActionOpts) *ListCVDsAction {
 	return &ListCVDsAction{
 		group:  opts.Group,
 		paths:  opts.Paths,
-		cvdCLI: cvd.NewCLI(newCVDExecContext(opts.ExecContext, opts.CVDUser)),
+		cvdCLI: cvd.NewCLI(exec.NewAsUserExecContext(opts.ExecContext, opts.CVDUser)),
 	}
 }
 

--- a/frontend/src/host_orchestrator/orchestrator/listcvdsaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/listcvdsaction.go
@@ -31,35 +31,35 @@ type ListCVDsActionOpts struct {
 }
 
 type ListCVDsAction struct {
-	group       string
-	paths       IMPaths
-	execContext cvd.CVDExecContext
+	group  string
+	paths  IMPaths
+	cvdCLI *cvd.CLI
 }
 
 func NewListCVDsAction(opts ListCVDsActionOpts) *ListCVDsAction {
 	return &ListCVDsAction{
-		group:       opts.Group,
-		paths:       opts.Paths,
-		execContext: newCVDExecContext(opts.ExecContext, opts.CVDUser),
+		group:  opts.Group,
+		paths:  opts.Paths,
+		cvdCLI: cvd.NewCLI(newCVDExecContext(opts.ExecContext, opts.CVDUser)),
 	}
 }
 
 func (a *ListCVDsAction) Run() (*apiv1.ListCVDsResponse, error) {
-	fleet, err := cvdFleet(a.execContext)
+	fleet, err := a.cvdCLI.Fleet()
 	if err != nil {
 		return nil, err
 	}
 	groups := fleet.Groups
 	if a.group != "" {
-		ok, g := fleet.findGroup(a.group)
+		ok, g := findGroup(fleet, a.group)
 		if !ok {
 			return nil, operator.NewNotFoundError(fmt.Sprintf("Group %q not found", a.group), nil)
 		}
-		groups = []*cvdGroup{g}
+		groups = []*cvd.Group{g}
 	}
 	cvds := []*apiv1.CVD{}
 	for _, g := range groups {
-		cvds = append(cvds, g.toAPIObject()...)
+		cvds = append(cvds, CvdGroupToAPIObject(g)...)
 	}
 	return &apiv1.ListCVDsResponse{CVDs: cvds}, nil
 }

--- a/frontend/src/host_orchestrator/orchestrator/startcvdaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/startcvdaction.go
@@ -26,7 +26,7 @@ import (
 
 type StartCVDActionOpts struct {
 	Request          *apiv1.StartCVDRequest
-	Selector         CVDSelector
+	Selector         cvd.Selector
 	Paths            IMPaths
 	OperationManager OperationManager
 	ExecContext      ExecContext
@@ -34,20 +34,20 @@ type StartCVDActionOpts struct {
 }
 
 type StartCVDAction struct {
-	req         *apiv1.StartCVDRequest
-	selector    CVDSelector
-	paths       IMPaths
-	om          OperationManager
-	execContext cvd.CVDExecContext
+	req      *apiv1.StartCVDRequest
+	selector cvd.Selector
+	paths    IMPaths
+	om       OperationManager
+	cvdCLI   *cvd.CLI
 }
 
 func NewStartCVDAction(opts StartCVDActionOpts) *StartCVDAction {
 	return &StartCVDAction{
-		req:         opts.Request,
-		selector:    opts.Selector,
-		paths:       opts.Paths,
-		om:          opts.OperationManager,
-		execContext: newCVDExecContext(opts.ExecContext, opts.CVDUser),
+		req:      opts.Request,
+		selector: opts.Selector,
+		paths:    opts.Paths,
+		om:       opts.OperationManager,
+		cvdCLI:   cvd.NewCLI(newCVDExecContext(opts.ExecContext, opts.CVDUser)),
 	}
 }
 
@@ -64,14 +64,12 @@ func (a *StartCVDAction) Run() (apiv1.Operation, error) {
 }
 
 func (a *StartCVDAction) exec(op apiv1.Operation) (*apiv1.EmptyResponse, error) {
-	args := a.selector.ToCVDCLI()
-	args = append(args, "start")
+	startOpts := cvd.StartOptions{}
 	if a.req.SnapshotID != "" {
 		dir := filepath.Join(a.paths.SnapshotsRootDir, a.req.SnapshotID)
-		args = append(args, "--snapshot_path", dir)
+		startOpts.SnapshotPath = dir
 	}
-	cmd := cvd.NewCommand(a.execContext, args, cvd.CommandOpts{})
-	if err := cmd.Run(); err != nil {
+	if err := a.cvdCLI.Start(a.selector, startOpts); err != nil {
 		return nil, operator.NewInternalError("cvd start failed", err)
 	}
 	return &apiv1.EmptyResponse{}, nil

--- a/frontend/src/host_orchestrator/orchestrator/startcvdaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/startcvdaction.go
@@ -21,6 +21,7 @@ import (
 
 	apiv1 "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
 	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/cvd"
+	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/exec"
 	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
 )
 
@@ -29,7 +30,7 @@ type StartCVDActionOpts struct {
 	Selector         cvd.Selector
 	Paths            IMPaths
 	OperationManager OperationManager
-	ExecContext      ExecContext
+	ExecContext      exec.ExecContext
 	CVDUser          *user.User
 }
 
@@ -47,7 +48,7 @@ func NewStartCVDAction(opts StartCVDActionOpts) *StartCVDAction {
 		selector: opts.Selector,
 		paths:    opts.Paths,
 		om:       opts.OperationManager,
-		cvdCLI:   cvd.NewCLI(newCVDExecContext(opts.ExecContext, opts.CVDUser)),
+		cvdCLI:   cvd.NewCLI(exec.NewAsUserExecContext(opts.ExecContext, opts.CVDUser)),
 	}
 }
 

--- a/frontend/src/host_orchestrator/orchestrator/userartifacts.go
+++ b/frontend/src/host_orchestrator/orchestrator/userartifacts.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 
 	apiv1 "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
-	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/cvd"
+	hoexec "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/exec"
 	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
 )
 
@@ -179,8 +179,8 @@ func (m *UserArtifactsManagerImpl) ExtractArtifact(dir, name string) error {
 }
 
 func Untar(dst string, src string, owner *user.User) error {
-	ctx := newCVDExecContext(exec.CommandContext, owner)
-	_, err := cvd.Exec(ctx, "tar", "-xf", src, "-C", dst)
+	ctx := hoexec.NewAsUserExecContext(exec.CommandContext, owner)
+	_, err := hoexec.Exec(ctx, "tar", "-xf", src, "-C", dst)
 	if err != nil {
 		return err
 	}
@@ -226,27 +226,27 @@ func Unzip(dstDir string, src string, owner *user.User) error {
 }
 
 func createNewUADir(parent string, owner *user.User) (string, error) {
-	ctx := newCVDExecContext(exec.CommandContext, owner)
-	stdout, err := cvd.Exec(ctx, "mktemp", "--directory", "-p", parent)
+	ctx := hoexec.NewAsUserExecContext(exec.CommandContext, owner)
+	stdout, err := hoexec.Exec(ctx, "mktemp", "--directory", "-p", parent)
 	if err != nil {
 		return "", err
 	}
 	name := strings.TrimRight(stdout, "\n")
 	// Sets permission regardless of umask.
-	if _, err := cvd.Exec(ctx, "chmod", "u=rwx,g=rwx,o=r", name); err != nil {
+	if _, err := hoexec.Exec(ctx, "chmod", "u=rwx,g=rwx,o=r", name); err != nil {
 		return "", err
 	}
 	return name, nil
 }
 
 func createUAFile(filename string, owner *user.User) error {
-	ctx := newCVDExecContext(exec.CommandContext, owner)
-	_, err := cvd.Exec(ctx, "touch", filename)
+	ctx := hoexec.NewAsUserExecContext(exec.CommandContext, owner)
+	_, err := hoexec.Exec(ctx, "touch", filename)
 	if err != nil {
 		return err
 	}
 	// Sets permission regardless of umask.
-	if _, err := cvd.Exec(ctx, "chmod", "u=rwx,g=rw,o=r", filename); err != nil {
+	if _, err := hoexec.Exec(ctx, "chmod", "u=rwx,g=rw,o=r", filename); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Encapsulates building the different cvd commands in a single file/struct.

Adds a new exec package to move non-cvd specific funtionality there.