### PR TITLE
Move powerbtn logic to cvd.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_record.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_record.cpp
@@ -107,6 +107,8 @@ Result<void> LocalInstance::PressPowerBtn() {
   }
 
   std::unique_ptr<const CuttlefishConfig> config = CuttlefishConfig::GetFromFile(instance_dir() + "/cuttlefish_config.json");
+  CF_EXPECT_EQ(config->vm_manager(), VmmMode::kCrosvm,
+               "powerbtn not supported in vm manager " << config->vm_manager());
   auto instance = config->ForInstance(id());
 
   Command command(instance.crosvm_binary());

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_record.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_record.h
@@ -62,6 +62,7 @@ class LocalInstance {
       std::chrono::seconds timeout = std::chrono::seconds(5));
 
   Result<void> PressPowerBtn();
+  Result<void> PressPowerBtnLegacy();
   Result<void> Restart(std::chrono::seconds launcher_timeout,
                        std::chrono::seconds boot_timeout);
   Result<void> PowerWash(std::chrono::seconds launcher_timeout,

--- a/e2etests/orchestration/common/common.go
+++ b/e2etests/orchestration/common/common.go
@@ -183,6 +183,11 @@ func (h *DockerHelper) RemoveContainer(id string) error {
 	return nil
 }
 
+func (h *DockerHelper) RemoveHostTool(id, filename string) error {
+	_, err := h.exec(id, []string{"rm", filename})
+	return err
+}
+
 func (h *DockerHelper) StartADBServer(id, adbBin string) error {
 	_, err := h.exec(id, []string{adbBin, "start-server"})
 	return err

--- a/e2etests/orchestration/powerbtn_test/BUILD.bazel
+++ b/e2etests/orchestration/powerbtn_test/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
     ],
     deps = [
         "//orchestration/common",
+        "@com_github_google_android_cuttlefish_frontend_src_host_orchestrator//api/v1:api",
         "@com_github_google_android_cuttlefish_frontend_src_libhoclient//:libhoclient",
         "@com_github_google_go_cmp//cmp",
     ],


### PR DESCRIPTION
- Move logic of powerbtn host tool from AOSP (https://cs.android.com/android/platform/superproject/main/+/main:device/google/cuttlefish/host/commands/powerbtn_cvd/powerbtn_cvd.cc;drc=e6f58fd389c91e6968988ab6d63ca861e74a1f5e)