### PR TITLE
Add options to control virtio-media

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags_defaults.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags_defaults.h
@@ -67,6 +67,8 @@
 #define CF_DEFAULTS_SECCOMP_POLICY_DIR cuttlefish::GetSeccompPolicyDir()
 #define CF_DEFAULTS_ENABLE_SANDBOX false
 #define CF_DEFAULTS_ENABLE_VIRTIOFS false
+#define CF_DEFAULTS_SIMPLE_MEDIA_DEVICE false
+#define CF_DEFAULTS_V4L2_PROXY ""
 
 // Qemu default parameters
 #define CF_DEFAULTS_QEMU_BINARY_DIR cuttlefish::DefaultQemuBinaryDir()

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_vm_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_vm_configs.cpp
@@ -100,6 +100,18 @@ static bool EnableSandbox(const Instance& instance) {
   return crosvm.has_enable_sandbox() ? crosvm.enable_sandbox() : default_val;
 }
 
+static bool SimpleMediaDevice(const Instance& instance) {
+  const auto& crosvm = instance.vm().crosvm();
+  const auto& default_val = CF_DEFAULTS_SIMPLE_MEDIA_DEVICE;
+  return crosvm.has_simple_media_device() ? crosvm.simple_media_device() : default_val;
+}
+
+static Result<std::string> V4l2Proxy(const Instance& instance) {
+  const auto& crosvm = instance.vm().crosvm();
+  const auto& default_val = CF_DEFAULTS_V4L2_PROXY;
+  return crosvm.has_v4l2_proxy() ? crosvm.v4l2_proxy() : default_val;
+}
+
 static Result<std::string> CustomConfigsFlagValue(const Instance& instance) {
   if (instance.vm().custom_actions().empty()) {
     return "unset";

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_config.proto
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_config.proto
@@ -127,6 +127,8 @@ message Vm {
 
 message Crosvm {
   optional bool enable_sandbox = 1;
+  optional bool simple_media_device = 2;
+  optional string v4l2_proxy = 3;
 }
 
 message Gem5 {}


### PR DESCRIPTION
Implement two options to control two crosvm's command line options below:

* --simple-media-device
* --v4l2-proxy=<device name>