### PR TITLE
Include staging/ directory in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 * @Databean @jemoreira @rmuthiah @jmacnak @adelva1984
 
 # cvd
-/base/cvd @Databean @rmuthiah @jemoreira @ser-io
+/base/cvd @Databean @rmuthiah @jemoreira @ser-io @google/android-cuttlefish
 
 # github workflows
 /.github/workflows/ @jemoreira @ser-io @Databean @cjreynol
@@ -17,3 +17,6 @@
 
 # WebUI Owners
 /frontend/src/operator/webui/ @jemoreira @ikicha 
+
+# AOSP migration
+/staging @Databean @cjreynol @google/android-cuttlefish


### PR DESCRIPTION
Also expand CODEOWNERS for base/cvd as we plan to expand the contents by a lot.

Note that having CODEOWNERS doesn't help with being a PR author, unlike gerrit's OWNERS files.

https://github.com/orgs/community/discussions/14866

Uses the newly created GitHub team: https://github.com/orgs/google/teams/android-cuttlefish/members