### PR TITLE
Fix includes for environment.h

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/environment.h
+++ b/base/cvd/cuttlefish/common/libs/utils/environment.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <optional>
 #include <string>
 
 namespace cuttlefish {


### PR DESCRIPTION
`std::optional` is used but not included directly in environment.h.