### PR TITLE
Move `architecture.{cpp,h}` from `utils:environment` to `utils:utils`.

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
@@ -51,12 +51,10 @@ clang_tidy_test(
 cc_library(
     name = "environment",
     srcs = [
-        "architecture.cpp",
         "environment.cpp",
         "known_paths.cpp",
     ],
     hdrs = [
-        "architecture.h",
         "environment.h",
         "known_paths.h",
     ],
@@ -76,6 +74,7 @@ clang_tidy_test(
 cc_library(
     name = "utils",
     srcs = [
+        "architecture.cpp",
         "archive.cpp",
         "base64.cpp",
         "files.cpp",
@@ -92,6 +91,7 @@ cc_library(
         "users.cpp",
     ],
     hdrs = [
+        "architecture.h",
         "archive.h",
         "base64.h",
         "contains.h",


### PR DESCRIPTION
This more accurately represents the Android build targets: https://cs.android.com/android/platform/superproject/main/+/main:device/google/cuttlefish/common/libs/utils/Android.bp;l=23;drc=f024a7eb6f23c6715775fa3f98e5d17c2f82e758