### PR TITLE
Add visibility declaration

### DIFF
--- a/base/cvd/cuttlefish/host/frontend/webrtc/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/BUILD.bazel
@@ -1,6 +1,10 @@
 load("//:build_variables.bzl", "COPTS")
 # load("//tools/lint:linters.bzl", "clang_tidy_test")
 
+package(
+    default_visibility = ["//:android_cuttlefish"],
+)
+
 proto_library(
     name = "webrtc_commands_proto",
     srcs = ["webrtc_commands.proto"],


### PR DESCRIPTION
Otherwise there is a visibility error trying to include it.

```
ERROR: run_cvd/BUILD.bazel:26:11: in cc_library rule //cuttlefish/host/commands/run_cvd:librun_cvd: Visibility error:
target '//cuttlefish/host/frontend/webrtc:libcuttlefish_webrtc_command_channel' is not visible from
target '//cuttlefish/host/commands/run_cvd:librun_cvd'
Recommendation: modify the visibility declaration if you think the dependency is legitimate. For more info see https://bazel.build/concepts/visibility
```

Test: bazel build
//cuttlefish/host/frontend/webrtc:libcuttlefish_webrtc_commands_proto