### PR TITLE
Add `run_cvd` to the debian binary list

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/BUILD.bazel
@@ -55,6 +55,7 @@ cc_library(
         "//cuttlefish/host/commands/process_restarter",
         "//cuttlefish/host/commands/record_cvd",
         "//cuttlefish/host/commands/restart_cvd",
+        "//cuttlefish/host/commands/run_cvd",
         "//cuttlefish/host/commands/snapshot_util_cvd",
         "//cuttlefish/host/commands/start:cvd_internal_start",
         "//cuttlefish/host/commands/status:cvd_internal_status",

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_builder.h
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_builder.h
@@ -77,8 +77,8 @@ class CrosvmBuilder {
 
  private:
   Command command_;
-  int hvc_num_;
-  int serial_num_;
+  int hvc_num_ = 0;
+  int serial_num_ = 0;
 };
 
 }  // namespace cuttlefish


### PR DESCRIPTION
To enable local fetch substitution testing.

Initialize two variables that were causing errors trying to run the substituted `run_cvd`.  Apparently the Android build system was consistently defaulting them to 0, but that was no longer occurring and causing failures.