### PR TITLE
Apply c++ compiler flag to zero-initialize stack variables for parity with Android

### DIFF
--- a/base/cvd/build_variables.bzl
+++ b/base/cvd/build_variables.bzl
@@ -1,3 +1,5 @@
 COPTS = [
-    "-std=c++20"
-    ]
+    "-std=c++20",
+    # https://cs.android.com/android/platform/superproject/main/+/main:build/soong/cc/config/global.go;l=428;drc=27f57506c28cc8e4f6a0c0b8ac22c85aa9140688
+    "-ftrivial-auto-var-init=zero",
+]


### PR DESCRIPTION
https://cs.android.com/android/platform/superproject/main/+/main:build/soong/cc/config/global.go;l=428;drc=27f57506c28cc8e4f6a0c0b8ac22c85aa9140688

This hopefully avoids more surprises like https://github.com/google/android-cuttlefish/pull/964 .