### PR TITLE
Use textproto for package migration config file.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/BUILD.bazel
@@ -5,6 +5,16 @@ package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
+proto_library(
+    name = "host_pkg_migration_proto",
+    srcs = ["host_pkg_migration.proto"],
+)
+
+cc_proto_library(
+    name = "host_pkg_migration_cc_proto",
+    deps = [":host_pkg_migration_proto"],
+)
+
 cc_library(
     name = "fetch",
     srcs = [
@@ -20,6 +30,7 @@ cc_library(
     copts = COPTS + [ "-Werror=sign-compare" ],
     strip_include_prefix = "//cuttlefish",
     deps = [
+        ":host_pkg_migration_cc_proto",
         "//cuttlefish/common/libs/utils",
         "//cuttlefish/common/libs/utils:environment",
         "//cuttlefish/common/libs/utils:result",
@@ -36,6 +47,7 @@ cc_library(
         "@fmt",
         "@gflags",
         "@jsoncpp",
+        "@protobuf",
         "@rules_cc//cc/runfiles",
     ],
     data = [

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/host_pkg_migration.proto
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/host_pkg_migration.proto
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package fetch;
+
+message HostPkgMigrationConfig {
+  repeated Symlink symlinks = 1;
+}
+
+message Symlink {
+  string target = 1;
+  string link_name = 2;
+}


### PR DESCRIPTION
- Use LOCAL_DEBIAN_SUBSTITUTION_MARKER_FILE environment variable for
  local testing.

```
LOCAL_DEBIAN_SUBSTITUTION_MARKER_FILE=/tmp/debian_substitution_marker bazel run //cuttlefish/host/commands/cvd -- fetch --default_build=aosp-main/aosp_cf_x86_64_phone-trunk_staging-userdebug --target_directory=$HOME/dl
```

- Example config

```
symlinks: {
  target: "/usr/lib/cuttlefish-common/bin/logcat_receiver"
  link_name: "bin/logcat_receiver"
}

symlinks: {
  target: "/usr/lib/cuttlefish-common/modem_simulator/files/iccprofile_for_sim0.xml"
  link_name: "etc/modem_simulator/files/iccprofile_for_sim0.xml"
}
```