### PR TITLE
Fix 100% CPU uage in webRTC process

### DIFF
--- a/base/cvd/cuttlefish/host/frontend/webrtc/display_handler.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/display_handler.cpp
@@ -262,6 +262,7 @@ void DisplayHandler::RepeatFramesPeriodically() {
     SendBuffers(buffers);
     {
       std::lock_guard last_buffers_lock(last_buffers_mutex_);
+      next_send = std::chrono::system_clock::now() + kRepeatingInterval;
       for (const auto& [_, buffer_info] : display_last_buffers_) {
         next_send = std::min(
             next_send, buffer_info->last_sent_time_stamp + kRepeatingInterval);


### PR DESCRIPTION
The next_send variable is initialized to now() plus an offset and is only subsequently set in the loop over display_last_buffers_. Because the latter assignment uses std::min to compare against the existing value of next_send the value never changes because the value it was initialized to will always be earlier. As a result the wait_until() call in the next iteration of the loop returns immediately and we busy loop. Fix the issue by setting next_send to a reasonable maximum before looping over display_last_buffers_.

Original change: https://android-review.git.corp.google.com/c/device/google/cuttlefish/+/3561563