### PR TITLE
Remove `#ifdef CUTTLEFISH_HOST` checks

### DIFF
--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd.cpp
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd.cpp
@@ -89,12 +89,7 @@ void CheckMarked(fd_set* in_out_mask, SharedFDSet* in_out_set) {
 
 int memfd_create_wrapper(const char* name, unsigned int flags) {
 #ifdef __linux__
-#ifdef CUTTLEFISH_HOST
-  // TODO(schuffelen): Use memfd_create with a newer host libc.
-  return syscall(__NR_memfd_create, name, flags);
-#else
   return memfd_create(name, flags);
-#endif
 #else
   (void)flags;
   return shm_open(name, O_RDWR);
@@ -414,7 +409,7 @@ SharedFD SharedFD::Event(int initval, int flags) {
   return std::shared_ptr<FileInstance>(new FileInstance(fd, errno));
 }
 
-#ifdef CUTTLEFISH_HOST
+#if 0  // TODO: schuffelen - Figure out how to apply `-lrt` throughout bazel.
 SharedFD SharedFD::ShmOpen(const std::string& name, int oflag, int mode) {
   errno = 0;
   int fd = shm_open(name.c_str(), oflag, mode);
@@ -422,7 +417,6 @@ SharedFD SharedFD::ShmOpen(const std::string& name, int oflag, int mode) {
   return std::shared_ptr<FileInstance>(new FileInstance(fd, error_num));
 }
 #endif
-
 #endif
 
 SharedFD SharedFD::MemfdCreate(const std::string& name, unsigned int flags) {

--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd.h
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd.h
@@ -152,7 +152,7 @@ class SharedFD {
   static bool Pipe(SharedFD* fd0, SharedFD* fd1);
 #ifdef __linux__
   static SharedFD Event(int initval = 0, int flags = 0);
-#ifdef CUTTLEFISH_HOST
+#if 0  // TODO: schuffelen - Figure out how to apply `-lrt` throughout bazel.
   static SharedFD ShmOpen(const std::string& name, int oflag, int mode);
 #endif
 #endif

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/logcat_receiver.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/logcat_receiver.cpp
@@ -15,11 +15,6 @@
 
 #include "host/commands/run_cvd/launch/launch.h"
 
-#if defined(CUTTLEFISH_HOST) && defined(__linux__)
-#include <sys/prctl.h>
-#include <sys/syscall.h>
-#endif
-
 #include <string>
 
 #include "common/libs/utils/result.h"


### PR DESCRIPTION
The code in this project is intended solely for the cuttlefish host environment.