### PR TITLE
Enforce include-cleaner validation on kernel_log_monitor.

### DIFF
--- a/base/cvd/BUILD.bazel
+++ b/base/cvd/BUILD.bazel
@@ -34,7 +34,10 @@ cc_library(
 
 filegroup(
     name = "clang_tidy_config",
-    srcs = [".clang-tidy"],
+    srcs = [
+        ".clang-tidy",
+        "//cuttlefish/host/commands/kernel_log_monitor:.clang-tidy",
+    ],
 )
 
 cc_library(

--- a/base/cvd/cuttlefish/host/commands/kernel_log_monitor/.clang-tidy
+++ b/base/cvd/cuttlefish/host/commands/kernel_log_monitor/.clang-tidy
@@ -6,6 +6,7 @@ Checks: &checks >-
   clang-diagnostic-*,
   -clang-diagnostic-pragma-once-outside-header,
   misc-definitions-in-headers,
+  misc-include-cleaner,
   misc-unused-alias-decls,
   readability-avoid-const-params-in-decls,
   readability-const-return-type,

--- a/base/cvd/cuttlefish/host/commands/kernel_log_monitor/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/kernel_log_monitor/BUILD.bazel
@@ -5,6 +5,8 @@ package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
+exports_files([".clang-tidy"])
+
 cc_binary(
     name = "kernel_log_monitor",
     srcs = [

--- a/base/cvd/cuttlefish/host/commands/kernel_log_monitor/kernel_log_server.cc
+++ b/base/cvd/cuttlefish/host/commands/kernel_log_monitor/kernel_log_server.cc
@@ -14,17 +14,24 @@
  * limitations under the License.
  */
 
-#include "host/commands/kernel_log_monitor/kernel_log_server.h"
+#include "cuttlefish/host/commands/kernel_log_monitor/kernel_log_server.h"
 
+#include <fcntl.h>
+#include <sys/types.h>
+
+#include <cstddef>
 #include <string>
-#include <tuple>
+#include <string_view>
 #include <utility>
+#include <vector>
 
 #include <android-base/logging.h>
 #include <android-base/strings.h>
-#include <netinet/in.h>
-#include "common/libs/fs/shared_select.h"
-#include "host/libs/config/cuttlefish_config.h"
+
+#include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/common/libs/fs/shared_select.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/config_constants.h"
 
 namespace cuttlefish::monitor {
 namespace {

--- a/base/cvd/cuttlefish/host/commands/kernel_log_monitor/kernel_log_server.h
+++ b/base/cvd/cuttlefish/host/commands/kernel_log_monitor/kernel_log_server.h
@@ -23,8 +23,8 @@
 
 #include <json/json.h>
 
-#include "common/libs/fs/shared_fd.h"
-#include "common/libs/fs/shared_select.h"
+#include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/common/libs/fs/shared_select.h"
 
 namespace cuttlefish::monitor {
 

--- a/base/cvd/cuttlefish/host/commands/kernel_log_monitor/main.cc
+++ b/base/cvd/cuttlefish/host/commands/kernel_log_monitor/main.cc
@@ -14,23 +14,26 @@
  * limitations under the License.
  */
 
+#include <errno.h>
+#include <fcntl.h>
 #include <signal.h>
 #include <unistd.h>
 
+#include <cstdlib>
 #include <string>
 #include <vector>
 
 #include <android-base/logging.h>
 #include <android-base/strings.h>
 #include <gflags/gflags.h>
-#include <json/json.h>
+#include <json/value.h>
 
-#include <common/libs/fs/shared_fd.h>
-#include <common/libs/fs/shared_select.h>
-#include <host/libs/config/cuttlefish_config.h>
-#include <host/libs/config/logging.h>
-#include "host/commands/kernel_log_monitor/kernel_log_server.h"
-#include "host/commands/kernel_log_monitor/utils.h"
+#include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/common/libs/fs/shared_select.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/logging.h"
+#include "cuttlefish/host/commands/kernel_log_monitor/kernel_log_server.h"
+#include "cuttlefish/host/commands/kernel_log_monitor/utils.h"
 
 DEFINE_int32(log_pipe_fd, -1,
              "A file descriptor representing a (UNIX) socket from which to "

--- a/base/cvd/cuttlefish/host/commands/kernel_log_monitor/utils.cc
+++ b/base/cvd/cuttlefish/host/commands/kernel_log_monitor/utils.cc
@@ -14,13 +14,23 @@
  * limitations under the License.
  */
 
-#include "host/commands/kernel_log_monitor/utils.h"
+#include "cuttlefish/host/commands/kernel_log_monitor/utils.h"
+
+#include <stddef.h>
+#include <sys/types.h>
+
+#include <optional>
+#include <string>
 
 #include <android-base/logging.h>
+#include <json/value.h>
+#include <json/writer.h>
 
-#include "common/libs/fs/shared_buf.h"
-#include "common/libs/utils/json.h"
-#include "common/libs/utils/result.h"
+#include "cuttlefish/common/libs/fs/shared_buf.h"
+#include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/common/libs/utils/json.h"
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/commands/kernel_log_monitor/kernel_log_server.h"
 
 namespace cuttlefish::monitor {
 

--- a/base/cvd/cuttlefish/host/commands/kernel_log_monitor/utils.h
+++ b/base/cvd/cuttlefish/host/commands/kernel_log_monitor/utils.h
@@ -18,9 +18,9 @@
 #include <json/json.h>
 #include <optional>
 
-#include "common/libs/fs/shared_fd.h"
-#include "common/libs/utils/result.h"
-#include "host/commands/kernel_log_monitor/kernel_log_server.h"
+#include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/commands/kernel_log_monitor/kernel_log_server.h"
 
 namespace cuttlefish::monitor {
 

--- a/base/cvd/tools/lint/linters.bzl
+++ b/base/cvd/tools/lint/linters.bzl
@@ -3,7 +3,7 @@ load("@aspect_rules_lint//lint:lint_test.bzl", "lint_test")
 
 clang_tidy = lint_clang_tidy_aspect(
     binary = "@@//tools/lint:clang_tidy",
-    configs = ["@@//:.clang-tidy"],
+    configs = ["@@//:clang_tidy_config"],
 )
 
 clang_tidy_test = lint_test(aspect = clang_tidy)


### PR DESCRIPTION
Also makes `cuttlefish/` includes relative to the bazel workspace, lifting the requirement to use strip_include_prefix on dependencies.