### PR TITLE
Update runners to ubuntu-24.04 from deprecated ubuntu-20.04 label

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   staticcheck:
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-24.04'
     strategy:
       matrix:
         dir: ["e2etests", "frontend/src/host_orchestrator", "frontend/src/libhoclient", "frontend/src/liboperator", "frontend/src/operator"]
@@ -27,7 +27,7 @@ jobs:
         install-go: false
         working-directory: ${{ matrix.dir }}
   build-orchestrator:
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-24.04'
     steps:
     - name: Checkout repository
       uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
@@ -77,7 +77,7 @@ jobs:
     - name: install user debian package
       run: dpkg -i android-cuttlefish/cuttlefish-user_*_*64.deb || apt-get install -f -y
   build-cvd:
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-24.04'
     container: 
       image: debian@sha256:3b6053ca925336c804e2d3f080af177efcdc9f51198a627569bfc7c7e730ef7e
     steps:


### PR DESCRIPTION
This is a LSC run by http://go/ghss to upgrade all depreacated ubuntu-20.04 runners to ubuntu-24.04.

On April 1, 2025, GitHub will stop supporting ubuntu-20.04 runners and workflows configured with this label will cease to run.  This PR is an attempt to save you work by doing the upgrade for you.

WARNING: We do not know if the updated label is compatiable with your workflow or not.

If you do not want to merge this PR, feel free to close it and deal with the problem yourselves.

More context and feedback: http://b/406537467
