### PR TITLE
Implement display composition parser

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_graphics_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_graphics_configs.cpp
@@ -68,6 +68,11 @@ Result<std::string> GenerateDisplayFlag(const EnvironmentSpecification& cfg) {
       } else {
         out_display.set_refresh_rate_hertz(CF_DEFAULTS_DISPLAY_REFRESH_RATE);
       }
+      for (const auto& overlay_entry : in_display.overlays()) {
+        DisplayOverlay* overlay_proto = out_display.add_overlays();
+        overlay_proto->set_vm_index(overlay_entry.vm_index());
+        overlay_proto->set_display_index(overlay_entry.display_index());
+      }
     }
   }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_config.proto
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_config.proto
@@ -86,6 +86,7 @@ message Display {
   optional uint32 height = 2;
   optional uint32 dpi = 3;
   optional uint32 refresh_rate_hertz = 4;
+  repeated DisplayOverlay overlays = 5;
 }
 
 message Disk {
@@ -154,4 +155,9 @@ message DeviceState {
 
 message Metrics {
   optional bool enable = 1;
+}
+
+message DisplayOverlay {
+  int32 vm_index = 1;
+  int32 display_index = 2;
 }


### PR DESCRIPTION
It implements the 'overlays' parser for cvd.  To use the feature, something similair to the following is needed in the canonical config withint the 'displays' stanza:

"overlays": [
  { "vm_index": 0, "display_index":0 }
]