### PR TITLE
Revert "Expose `gpu_mode` parameter in env config."

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_graphics_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_graphics_configs.cpp
@@ -90,19 +90,11 @@ bool RecordScreen(const Instance& instance) {
   }
 }
 
-std::string GpuMode(const Instance& instance) {
-  if (instance.graphics().has_gpu_mode()) {
-    return instance.graphics().gpu_mode();
-  }
-  return CF_DEFAULTS_GPU_MODE;
-}
-
 Result<std::vector<std::string>> GenerateGraphicsFlags(
     const EnvironmentSpecification& cfg) {
   return std::vector<std::string>{
       CF_EXPECT(GenerateDisplayFlag(cfg)),
       GenerateInstanceFlag("record_screen", cfg, RecordScreen),
-      GenerateInstanceFlag("gpu_mode", cfg, GpuMode),
   };
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_config.proto
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_config.proto
@@ -78,7 +78,6 @@ message Vsock {
 message Graphics {
   repeated Display displays = 1;
   optional bool record_screen = 2;
-  optional string gpu_mode = 3;
 }
 
 message Display {


### PR DESCRIPTION
This reverts commit 9a267341274b13f970ad1bcba97cc41dbf78d499.

The reason is a bad interaction with a gpu_mode setting in a legacy config.json file which sets flag defaults in cvd_internal_start at lower priority than an unset gpu_mode value in a canonical configuration.