### PR TITLE
Update runners to ubuntu-24.04 from deprecated ubuntu-20.04 label

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Vet Test Build
       run: cd frontend/src/host_orchestrator && go vet ./... && go test ./... && go build ./...
   build-debian-package:
-    runs-on: ubuntu-20.04-4core
+    runs-on: 'ubuntu-24.04-4core'
     if: ${{ always() && needs.build-orchestrator.result == 'success' }}
     needs: [build-orchestrator]
     container:


### PR DESCRIPTION
This is a http://go/LSC run by http://go/ghss to upgrade all self-hosted depreacated ubuntu-20.04 runners to ubuntu-24.04.

On April 1, 2025, GitHub will stop supporting ubuntu-20.04 runners and workflows configured with this label will cease to run.  This PR is an attempt to save you work by doing the upgrade for you.

WARNING: We do not know if the updated label is compatiable with your workflow or not.

If you do not want to merge this PR, feel free to close it and deal with the problem yourselves.

More context and feedback: http://b/406537467
