### PR TITLE
Update e2e-tests-orchestration to larger runner

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -105,7 +105,7 @@ jobs:
         name: testlogs
         path: bazel-testlogs
   e2e-tests-orchestration:
-    runs-on: ubuntu-22.04 
+    runs-on: ubuntu-22.04-4core
     steps:
       # Do not reuse bazel cache among `e2e-tests-orchestration` runs.
       #


### PR DESCRIPTION
as https://github.com/google/android-cuttlefish/pull/974 and https://github.com/google/android-cuttlefish/pull/983 show out of disk errors.