### PR TITLE
Disable e2e orchistration snapshot test

### DIFF
--- a/e2etests/orchestration/snapshot_test/main_test.go
+++ b/e2etests/orchestration/snapshot_test/main_test.go
@@ -30,6 +30,8 @@ import (
 )
 
 func TestSnapshot(t *testing.T) {
+	t.Skip("b/403233780: Skipping snapshot tests due to out of disk issues on standard runners.")
+	
 	ctx, err := common.Setup()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
as an alternative to promoting the runner to a large runner (https://github.com/google/android-cuttlefish/pull/993)