### PR TITLE
Runners updated to `ubuntu-latest`.

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -10,7 +10,7 @@ on:
       - main
 jobs:
   export-debs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container:
       image: debian@sha256:4cb3f4198e4af2d03dffe6bfa4f3686773596494ef298f3882553d52e885634b # debian:bullseye-20240110
     steps:
@@ -33,7 +33,7 @@ jobs:
         path: debs.tar
   export-gce-image:
     needs: export-debs 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Free space 
       run: rm -rf /opt/hostedtoolcache
@@ -53,7 +53,7 @@ jobs:
         name: image_gce_debian11_amd64
         path: image.tar.gz
   export-docker-image-x86_64:
-    runs-on: ubuntu-22.04
+    runs-on: uubuntu-latest
     steps:
     - name: Checkout repository
       uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
@@ -72,7 +72,7 @@ jobs:
         name: docker-image-x86_64
         path: ${{ env.x86_64_image_path }}
   export-docker-image-arm64:
-    runs-on: arm-ubuntu-arm-22.04-4core
+    runs-on: arm-ubuntu-arm-latest-4core
     steps:
     - name: Checkout repository
       uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2

--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -72,7 +72,7 @@ jobs:
         name: docker-image-x86_64
         path: ${{ env.x86_64_image_path }}
   export-docker-image-arm64:
-    runs-on: arm-ubuntu-arm-latest-4core
+    runs-on: ubuntu-24.04-arm-4core
     steps:
     - name: Checkout repository
       uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Vet Test Build
       run: cd frontend/src/host_orchestrator && go vet ./... && go test ./... && go build ./...
   build-debian-package:
-    runs-on: ubuntu-20.04-4core
+    runs-on: ubuntu-latest-4core
     if: ${{ always() && needs.build-orchestrator.result == 'success' }}
     needs: [build-orchestrator]
     container:
@@ -105,7 +105,7 @@ jobs:
         name: testlogs
         path: bazel-testlogs
   e2e-tests-orchestration:
-    runs-on: ubuntu-22.04 
+    runs-on: ubuntu-latest
     steps:
       # Do not reuse bazel cache among `e2e-tests-orchestration` runs.
       #


### PR DESCRIPTION
There were some more occurrences and `latest` means the current default version. In case that `arm-ubuntu-arm-22.04-4core` ? image also can be found, sticking with `latest` might be a more proper approach than what #986 provides.