### PR TITLE
Extract //cuttlefish/common/libs/utils:proto

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
@@ -6,6 +6,24 @@ package(
 )
 
 cc_library(
+    name = "proto",
+    hdrs = ["proto.h"],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+    deps = [
+        "@fmt",
+        "@protobuf",
+        "@protobuf//:json_util",
+    ],
+)
+
+clang_tidy_test(
+    name = "proto_clang_tidy",
+    srcs = [":proto"],
+    tags = ["clang_tidy", "clang-tidy"],
+)
+
+cc_library(
     name = "result",
     srcs = [
         "result.cpp",
@@ -111,7 +129,6 @@ cc_library(
         "json.h",
         "network.h",
         "proc_file_utils.h",
-        "proto.h",
         "shared_fd_flag.h",
         "signals.h",
         "size_utils.h",
@@ -136,8 +153,6 @@ cc_library(
         "@fmt",
         "@gflags",
         "@jsoncpp",
-        "@protobuf",
-        "@protobuf//:json_util",
     ],
 )
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
@@ -592,6 +592,7 @@ cc_library(
     deps = [
         "//:libbuildversion",
         "//cuttlefish/common/libs/utils",
+        "//cuttlefish/common/libs/utils:proto",
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
         "//cuttlefish/host/commands/cvd/cli:command_request",

--- a/base/cvd/cuttlefish/host/commands/cvd/legacy/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/legacy/BUILD.bazel
@@ -30,6 +30,7 @@ cc_library(
         ":cvd_server_cc_proto",
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils",
+        "//cuttlefish/common/libs/utils:proto",
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/commands/cvd/metrics",


### PR DESCRIPTION
This header file requires a `@protobuf` dependency, which was blocking most of the cuttlefish code behind building the proto compiler. Extracting this one target allows a significant amount of targets, including some of the long serial lint targets, to run concurrently with building the proto compiler.

Related to https://bazel.build/docs/bazel-and-cpp

Bug: b/407763557