### PR TITLE
Downgrade from c++20 to c++17

### DIFF
--- a/base/cvd/build_variables.bzl
+++ b/base/cvd/build_variables.bzl
@@ -1,5 +1,5 @@
 COPTS = [
-    "-std=c++20",
+    "-std=c++17",
     # https://cs.android.com/android/platform/superproject/main/+/main:build/soong/cc/config/global.go;l=428;drc=27f57506c28cc8e4f6a0c0b8ac22c85aa9140688
     "-ftrivial-auto-var-init=zero",
 ]

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd.cc
@@ -193,7 +193,8 @@ Result<void> RestoreHostFiles(const std::string& cuttlefish_root_dir,
       CF_EXPECT(GuestSnapshotDirectories(snapshot_dir_path));
   auto filter_guest_dir =
       [&guest_snapshot_dirs](const std::string& src_dir) -> bool {
-    if (src_dir.ends_with("logs") && Contains(guest_snapshot_dirs, src_dir)) {
+    if (android::base::EndsWith(src_dir, "logs") &&
+        Contains(guest_snapshot_dirs, src_dir)) {
       return false;
     }
     return !Contains(guest_snapshot_dirs, src_dir);

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -2120,7 +2120,7 @@ Result<void> SetDefaultFlagsForQemu(
     // it's presented.
     if (!FileExists(curr_bootloader)) {
       // Fallback to default bootloader
-      curr_bootloader = DefaultHostArtifactsPath(std::format(
+      curr_bootloader = DefaultHostArtifactsPath(fmt::format(
           "etc/bootloader_{}/bootloader.qemu",
           DefaultBootloaderArchDir(guest_configs[instance_index].target_arch)));
     }
@@ -2202,7 +2202,7 @@ Result<void> SetDefaultFlagsForCrosvm(
     // it's presented.
     if (!FileExists(curr_bootloader)) {
       // Fallback to default bootloader
-      curr_bootloader = DefaultHostArtifactsPath(std::format(
+      curr_bootloader = DefaultHostArtifactsPath(fmt::format(
           "etc/bootloader_{}/bootloader.crosvm",
           DefaultBootloaderArchDir(guest_configs[instance_index].target_arch)));
     }

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/vhost_input_devices.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/vhost_input_devices.cpp
@@ -43,8 +43,6 @@
 namespace cuttlefish {
 namespace {
 
-using Subprocess::StdIOChannel::kStdErr;
-
 // Holds all sockets related to a single vhost user input device process.
 struct DeviceSockets {
   // Device end of the connection between device and streamer.
@@ -129,18 +127,20 @@ class VhostInputDevices : public CommandSource,
     std::vector<MonitorCommand> commands;
     Command rotary_cmd =
         NewVhostUserInputCommand(rotary_sockets_, DefaultRotaryDeviceSpec());
-    Command rotary_log_tee = CF_EXPECT(
-        log_tee_.CreateLogTee(rotary_cmd, "vhost_user_rotary", kStdErr),
-        "Failed to create log tee command for rotary device");
+    Command rotary_log_tee =
+        CF_EXPECT(log_tee_.CreateLogTee(rotary_cmd, "vhost_user_rotary",
+                                        Subprocess::StdIOChannel::kStdErr),
+                  "Failed to create log tee command for rotary device");
     commands.emplace_back(std::move(rotary_cmd));
     commands.emplace_back(std::move(rotary_log_tee));
 
     if (instance_.enable_mouse()) {
       Command mouse_cmd =
           NewVhostUserInputCommand(mouse_sockets_, DefaultMouseSpec());
-      Command mouse_log_tee = CF_EXPECT(
-          log_tee_.CreateLogTee(mouse_cmd, "vhost_user_mouse", kStdErr),
-          "Failed to create log tee command for mouse device");
+      Command mouse_log_tee =
+          CF_EXPECT(log_tee_.CreateLogTee(mouse_cmd, "vhost_user_mouse",
+                                          Subprocess::StdIOChannel::kStdErr),
+                    "Failed to create log tee command for mouse device");
       commands.emplace_back(std::move(mouse_cmd));
       commands.emplace_back(std::move(mouse_log_tee));
     }
@@ -149,17 +149,19 @@ class VhostInputDevices : public CommandSource,
         instance_.custom_keyboard_config().value_or(DefaultKeyboardSpec());
     Command keyboard_cmd =
         NewVhostUserInputCommand(keyboard_sockets_, keyboard_spec);
-    Command keyboard_log_tee = CF_EXPECT(
-        log_tee_.CreateLogTee(keyboard_cmd, "vhost_user_keyboard", kStdErr),
-        "Failed to create log tee command for keyboard device");
+    Command keyboard_log_tee =
+        CF_EXPECT(log_tee_.CreateLogTee(keyboard_cmd, "vhost_user_keyboard",
+                                        Subprocess::StdIOChannel::kStdErr),
+                  "Failed to create log tee command for keyboard device");
     commands.emplace_back(std::move(keyboard_cmd));
     commands.emplace_back(std::move(keyboard_log_tee));
 
     Command switches_cmd =
         NewVhostUserInputCommand(switches_sockets_, DefaultSwitchesSpec());
-    Command switches_log_tee = CF_EXPECT(
-        log_tee_.CreateLogTee(switches_cmd, "vhost_user_switches", kStdErr),
-        "Failed to create log tee command for switches device");
+    Command switches_log_tee =
+        CF_EXPECT(log_tee_.CreateLogTee(switches_cmd, "vhost_user_switches",
+                                        Subprocess::StdIOChannel::kStdErr),
+                  "Failed to create log tee command for switches device");
     commands.emplace_back(std::move(switches_cmd));
     commands.emplace_back(std::move(switches_log_tee));
 
@@ -185,11 +187,11 @@ class VhostInputDevices : public CommandSource,
                  "Failed to write touchscreen spec to file: {}", spec_path);
       Command touchscreen_cmd =
           NewVhostUserInputCommand(touchscreen_sockets_[i], spec_path);
-      Command touchscreen_log_tee =
-          CF_EXPECTF(log_tee_.CreateLogTee(
-                         touchscreen_cmd,
-                         fmt::format("vhost_user_touchscreen_{}", i), kStdErr),
-                     "Failed to create log tee for touchscreen device", i);
+      Command touchscreen_log_tee = CF_EXPECTF(
+          log_tee_.CreateLogTee(touchscreen_cmd,
+                                fmt::format("vhost_user_touchscreen_{}", i),
+                                Subprocess::StdIOChannel::kStdErr),
+          "Failed to create log tee for touchscreen device", i);
       commands.emplace_back(std::move(touchscreen_cmd));
       commands.emplace_back(std::move(touchscreen_log_tee));
     }
@@ -212,10 +214,11 @@ class VhostInputDevices : public CommandSource,
                  "Failed to write touchpad spec to file: {}", spec_path);
       Command touchpad_cmd =
           NewVhostUserInputCommand(touchpad_sockets_[i], spec_path);
-      Command touchpad_log_tee = CF_EXPECTF(
-          log_tee_.CreateLogTee(
-              touchpad_cmd, fmt::format("vhost_user_touchpad_{}", i), kStdErr),
-          "Failed to create log tee for touchpad {}", i);
+      Command touchpad_log_tee =
+          CF_EXPECTF(log_tee_.CreateLogTee(
+                         touchpad_cmd, fmt::format("vhost_user_touchpad_{}", i),
+                         Subprocess::StdIOChannel::kStdErr),
+                     "Failed to create log tee for touchpad {}", i);
       commands.emplace_back(std::move(touchpad_cmd));
       commands.emplace_back(std::move(touchpad_log_tee));
     }

--- a/base/cvd/cuttlefish/host/libs/screen_connector/composition_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/screen_connector/composition_manager.cpp
@@ -209,7 +209,7 @@ void CompositionManager::OnFrame(std::uint32_t display_number,
 // layers are updated, the user will see the blended result.
 void CompositionManager::ComposeFrame(
     int display_index, std::shared_ptr<VideoFrameBuffer> buffer) {
-  if (!last_frame_info_map_.contains(display_index)) {
+  if (!last_frame_info_map_.count(display_index)) {
     return;
   }
   LastFrameInfo& last_frame_info = last_frame_info_map_[display_index];

--- a/base/cvd/cuttlefish/host/libs/screen_connector/ring_buffer_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/screen_connector/ring_buffer_manager.cpp
@@ -127,7 +127,7 @@ Result<void> DisplayRingBufferManager::CreateLocalDisplayBuffer(
     int vm_index, int display_index, int display_width, int display_height) {
   auto buffer_key = std::make_pair(vm_index, display_index);
 
-  if (!display_buffer_cache_.contains(buffer_key)) {
+  if (!display_buffer_cache_.count(buffer_key)) {
     std::string shmem_name = MakeLayerName(display_index);
 
     auto shm_buffer = CF_EXPECT(DisplayRingBuffer::Create(
@@ -153,7 +153,7 @@ std::uint8_t* DisplayRingBufferManager::WriteFrame(int vm_index,
                                                    std::uint8_t* frame_data,
                                                    int size) {
   auto buffer_key = std::make_pair(vm_index, display_index);
-  if (display_buffer_cache_.contains(buffer_key)) {
+  if (display_buffer_cache_.count(buffer_key)) {
     return display_buffer_cache_[buffer_key]->WriteNextFrame(frame_data, size);
   }
   // It's possible to request a write to buffer that doesn't yet exist.
@@ -168,7 +168,7 @@ std::uint8_t* DisplayRingBufferManager::ReadFrame(int vm_index,
 
   // If this buffer was read successfully in the past, that valid pointer is
   // returned from the cache
-  if (!display_buffer_cache_.contains(buffer_key)) {
+  if (!display_buffer_cache_.count(buffer_key)) {
     // Since no cache found, next step is to request from OS to map a new IPC
     // buffer. It may not yet exist so we want this method to only cache if it
     // is a non-null pointer, to retrigger this logic continually every request.
@@ -195,7 +195,7 @@ std::string DisplayRingBufferManager::MakeLayerName(int display_index,
   if (vm_index == -1) {
     vm_index = local_group_index_;
   }
-  return std::format("/cf_shmem_display_{}_{}_{}", vm_index, display_index,
+  return fmt::format("/cf_shmem_display_{}_{}_{}", vm_index, display_index,
                      group_uuid_);
 }
 

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_cpu.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_cpu.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include <android-base/strings.h>
+#include <fmt/format.h>
 #include <json/value.h>
 
 #include "common/libs/utils/json.h"
@@ -41,7 +42,7 @@ std::string SerializeFreqDomains(
     freq_domain_arg << "[" << android::base::Join(pair.second, ",") << "]";
   }
 
-  return {std::format("[{}]", freq_domain_arg.str())};
+  return {fmt::format("[{}]", freq_domain_arg.str())};
 }
 
 }  // namespace

--- a/base/cvd/libziparchive/BUILD.bazel
+++ b/base/cvd/libziparchive/BUILD.bazel
@@ -2,8 +2,6 @@ package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
-load("//:build_variables.bzl", "COPTS")
-
 cc_library(
     name = "libziparchive",
     srcs = [
@@ -23,7 +21,10 @@ cc_library(
         "include/ziparchive/zip_archive_stream_entry.h",
         "include/ziparchive/zip_writer.h",
     ],
-    copts = COPTS + [
+    copts = [
+        "-std=c++20",
+        # https://cs.android.com/android/platform/superproject/main/+/main:build/soong/cc/config/global.go;l=428;drc=27f57506c28cc8e4f6a0c0b8ac22c85aa9140688
+        "-ftrivial-auto-var-init=zero",
         "-Wno-vla-cxx-extension",
         "-Wno-c99-designator",
     ],


### PR DESCRIPTION
This makes c++ compiler behavior more consistent with the distro packaged compiler on debian bullseye, which is clang 11. If we want to drop the LLVM prebuilt, we'll have to support that compiler version.

Bug: b/407854179