### PR TITLE
Make `flags_defaults.h` dependencies explicit

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -91,6 +91,7 @@ cc_library(
         "//cuttlefish/host/libs/avb",
         "//cuttlefish/host/libs/command_util",
         "//cuttlefish/host/libs/config",
+        "//cuttlefish/host/libs/config:config_utils",
         "//cuttlefish/host/libs/config/adb",
         "//cuttlefish/host/libs/config/fastboot",
         "//cuttlefish/host/libs/image_aggregator",

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -96,6 +96,7 @@ cc_library(
         "//cuttlefish/host/libs/avb",
         "//cuttlefish/host/libs/command_util",
         "//cuttlefish/host/libs/config",
+        "//cuttlefish/host/libs/config:config_constants",
         "//cuttlefish/host/libs/config:config_utils",
         "//cuttlefish/host/libs/config/adb",
         "//cuttlefish/host/libs/config/fastboot",

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -12,6 +12,11 @@ cc_library(
     ],
     copts = COPTS + [ "-Werror=sign-compare" ],
     strip_include_prefix = "//cuttlefish",
+    deps = [
+        "//cuttlefish/common/libs/utils:environment",
+        "//cuttlefish/host/libs/config:config_constants",
+        "//cuttlefish/host/libs/config:config_utils",
+    ],
 )
 
 clang_tidy_test(

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/bootconfig_args.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/bootconfig_args.cpp
@@ -26,6 +26,7 @@
 #include "common/libs/utils/environment.h"
 #include "common/libs/utils/files.h"
 #include "common/libs/utils/json.h"
+#include "host/libs/config/config_constants.h"
 #include "host/libs/config/cuttlefish_config.h"
 #include "host/libs/config/known_paths.h"
 #include "host/libs/vm_manager/crosvm_manager.h"

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -60,6 +60,7 @@
 #include "host/commands/assemble_cvd/misc_info.h"
 #include "host/commands/assemble_cvd/network_flags.h"
 #include "host/commands/assemble_cvd/touchpad.h"
+#include "host/libs/config/config_constants.h"
 #include "host/libs/config/config_flag.h"
 #include "host/libs/config/cuttlefish_config.h"
 #include "host/libs/config/display.h"

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -74,16 +74,6 @@
 #include "host/libs/vm_manager/qemu_manager.h"
 #include "host/libs/vm_manager/vm_manager.h"
 
-using cuttlefish::DefaultHostArtifactsPath;
-using cuttlefish::HostBinaryPath;
-using cuttlefish::TempDir;
-using cuttlefish::vm_manager::CrosvmManager;
-using google::FlagSettingMode::SET_FLAGS_DEFAULT;
-using google::FlagSettingMode::SET_FLAGS_VALUE;
-
-// https://cs.android.com/android/platform/superproject/main/+/main:device/google/cuttlefish/Android.bp;l=122;drc=6f7d6a4db58efcc2ddd09eda07e009c6329414cd
-#define USERDATA_FILE_SYSTEM_TYPE "f2fs"
-
 #define DEFINE_vec DEFINE_string
 #define DEFINE_proto DEFINE_string
 #define GET_FLAG_STR_VALUE(name) GetFlagStrValueForInstances(FLAGS_ ##name, instances_size, #name, name_to_default_value)
@@ -550,7 +540,7 @@ DEFINE_vec(
 DEFINE_vec(vhost_user_block, CF_DEFAULTS_VHOST_USER_BLOCK ? "true" : "false",
            "(experimental) use crosvm vhost-user block device implementation ");
 
-DEFINE_string(early_tmp_dir, TempDir(),
+DEFINE_string(early_tmp_dir, cuttlefish::TempDir(),
               "Parent directory to use for temporary files in early startup");
 
 DEFINE_vec(enable_tap_devices, "true",
@@ -2152,13 +2142,13 @@ Result<void> SetDefaultFlagsForQemu(
   // This is the 1st place to set "start_webrtc" flag value
   // for now, we don't set non-default options for QEMU
   SetCommandLineOptionWithMode("start_webrtc", default_start_webrtc.c_str(),
-                               SET_FLAGS_DEFAULT);
+                               google::FlagSettingMode::SET_FLAGS_DEFAULT);
 
   SetCommandLineOptionWithMode("bootloader", default_bootloader.c_str(),
-                               SET_FLAGS_DEFAULT);
+                               google::FlagSettingMode::SET_FLAGS_DEFAULT);
   SetCommandLineOptionWithMode("android_efi_loader",
                                default_android_efi_loader.c_str(),
-                               SET_FLAGS_DEFAULT);
+                               google::FlagSettingMode::SET_FLAGS_DEFAULT);
   return {};
 }
 
@@ -2233,27 +2223,30 @@ Result<void> SetDefaultFlagsForCrosvm(
     }
   }
   SetCommandLineOptionWithMode("bootloader", default_bootloader.c_str(),
-                               SET_FLAGS_DEFAULT);
+                               google::FlagSettingMode::SET_FLAGS_DEFAULT);
   SetCommandLineOptionWithMode("android_efi_loader",
                                default_android_efi_loader.c_str(),
-                               SET_FLAGS_DEFAULT);
+                               google::FlagSettingMode::SET_FLAGS_DEFAULT);
   // This is the 1st place to set "start_webrtc" flag value
   SetCommandLineOptionWithMode("start_webrtc", default_start_webrtc.c_str(),
-                               SET_FLAGS_DEFAULT);
+                               google::FlagSettingMode::SET_FLAGS_DEFAULT);
   // This is the 1st place to set "enable_sandbox" flag value
-  SetCommandLineOptionWithMode(
-      "enable_sandbox", default_enable_sandbox_str.c_str(), SET_FLAGS_DEFAULT);
-  SetCommandLineOptionWithMode(
-      "enable_virtiofs", default_enable_sandbox_str.c_str(), SET_FLAGS_DEFAULT);
+  SetCommandLineOptionWithMode("enable_sandbox",
+                               default_enable_sandbox_str.c_str(),
+                               google::FlagSettingMode::SET_FLAGS_DEFAULT);
+  SetCommandLineOptionWithMode("enable_virtiofs",
+                               default_enable_sandbox_str.c_str(),
+                               google::FlagSettingMode::SET_FLAGS_DEFAULT);
   return {};
 }
 
 void SetDefaultFlagsForGem5() {
   // TODO: Add support for gem5 gpu models
   SetCommandLineOptionWithMode("gpu_mode", kGpuModeGuestSwiftshader,
-                               SET_FLAGS_DEFAULT);
+                               google::FlagSettingMode::SET_FLAGS_DEFAULT);
 
-  SetCommandLineOptionWithMode("cpus", "1", SET_FLAGS_DEFAULT);
+  SetCommandLineOptionWithMode("cpus", "1",
+                               google::FlagSettingMode::SET_FLAGS_DEFAULT);
 }
 
 void SetDefaultFlagsForMcu() {
@@ -2261,7 +2254,8 @@ void SetDefaultFlagsForMcu() {
   if (!CanAccess(path, R_OK)) {
     return;
   }
-  SetCommandLineOptionWithMode("mcu_config_path", path.c_str(), SET_FLAGS_DEFAULT);
+  SetCommandLineOptionWithMode("mcu_config_path", path.c_str(),
+                               google::FlagSettingMode::SET_FLAGS_DEFAULT);
 }
 
 void SetDefaultFlagsForOpenwrt(Arch target_arch) {
@@ -2270,23 +2264,23 @@ void SetDefaultFlagsForOpenwrt(Arch target_arch) {
         "ap_kernel_image",
         DefaultHostArtifactsPath("etc/openwrt/images/openwrt_kernel_x86_64")
             .c_str(),
-        SET_FLAGS_DEFAULT);
+        google::FlagSettingMode::SET_FLAGS_DEFAULT);
     SetCommandLineOptionWithMode(
         "ap_rootfs_image",
         DefaultHostArtifactsPath("etc/openwrt/images/openwrt_rootfs_x86_64")
             .c_str(),
-        SET_FLAGS_DEFAULT);
+        google::FlagSettingMode::SET_FLAGS_DEFAULT);
   } else if (target_arch == Arch::Arm64) {
     SetCommandLineOptionWithMode(
         "ap_kernel_image",
         DefaultHostArtifactsPath("etc/openwrt/images/openwrt_kernel_aarch64")
             .c_str(),
-        SET_FLAGS_DEFAULT);
+        google::FlagSettingMode::SET_FLAGS_DEFAULT);
     SetCommandLineOptionWithMode(
         "ap_rootfs_image",
         DefaultHostArtifactsPath("etc/openwrt/images/openwrt_rootfs_aarch64")
             .c_str(),
-        SET_FLAGS_DEFAULT);
+        google::FlagSettingMode::SET_FLAGS_DEFAULT);
   }
 }
 
@@ -2357,11 +2351,11 @@ Result<std::vector<GuestConfig>> GetGuestConfigAndSetDefaults() {
     SetCommandLineOptionWithMode(
         "start_webrtc_sig_server",
         start_webrtc && !host_operator_present ? "true" : "false",
-        SET_FLAGS_DEFAULT);
+        google::FlagSettingMode::SET_FLAGS_DEFAULT);
     SetCommandLineOptionWithMode(
         "webrtc_sig_server_addr",
         host_operator_present ? HOST_OPERATOR_SOCKET_PATH : "0.0.0.0",
-        SET_FLAGS_DEFAULT);
+        google::FlagSettingMode::SET_FLAGS_DEFAULT);
   }
 
   SetDefaultFlagsForOpenwrt(guest_configs[0].target_arch);
@@ -2376,12 +2370,6 @@ Result<std::vector<GuestConfig>> GetGuestConfigAndSetDefaults() {
 
 std::string GetConfigFilePath(const CuttlefishConfig& config) {
   return config.AssemblyPath("cuttlefish_config.json");
-}
-
-std::string GetSeccompPolicyDir() {
-  std::string kSeccompDir =
-      "usr/share/crosvm/" + HostArchStr() + "-linux-gnu/seccomp";
-  return DefaultHostArtifactsPath(kSeccompDir);
 }
 
 } // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.h
@@ -53,6 +53,5 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
     fruit::Injector<>& injector, const FetcherConfig& fetcher_config);
 
 std::string GetConfigFilePath(const CuttlefishConfig& config);
-std::string GetSeccompPolicyDir();
 
 } // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags_defaults.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags_defaults.h
@@ -15,16 +15,24 @@
  */
 #pragma once
 
+#include "common/libs/utils/environment.h"
+#include "host/libs/config/config_constants.h"
+#include "host/libs/config/config_utils.h"
+
 #define CF_DEFAULTS_DYNAMIC_STRING ""
 #define CF_DEFAULTS_DYNAMIC_INT 0
 
-// Common configs paramneters
+// https://cs.android.com/android/platform/superproject/main/+/main:device/google/cuttlefish/Android.bp;l=122;drc=6f7d6a4db58efcc2ddd09eda07e009c6329414cd
+#define USERDATA_FILE_SYSTEM_TYPE "f2fs"
+
+// Common configs parameters
 #define CF_DEFAULTS_NUM_INSTANCES 1
 #define CF_DEFAULTS_INSTANCE_NUMS CF_DEFAULTS_DYNAMIC_STRING
 #define CF_DEFAULTS_BASE_INSTANCE_NUM cuttlefish::GetInstance()
 #define CF_DEFAULTS_ASSEMBLY_DIR \
-  (StringFromEnv("HOME", ".") + "/cuttlefish_assembly")
-#define CF_DEFAULTS_INSTANCE_DIR (StringFromEnv("HOME", ".") + "/cuttlefish")
+  (cuttlefish::StringFromEnv("HOME", ".") + "/cuttlefish_assembly")
+#define CF_DEFAULTS_INSTANCE_DIR \
+  (cuttlefish::StringFromEnv("HOME", ".") + "/cuttlefish")
 
 #define CF_DEFAULTS_SYSTEM_IMAGE_DIR CF_DEFAULTS_DYNAMIC_STRING
 
@@ -59,7 +67,7 @@
 #define CF_DEFAULTS_DEVICE_EXTERNAL_NETWORK "tap"
 
 // crosvm default parameters
-#define CF_DEFAULTS_CROSVM_BINARY HostBinaryPath("crosvm")
+#define CF_DEFAULTS_CROSVM_BINARY cuttlefish::HostBinaryPath("crosvm")
 #define CF_DEFAULTS_SECCOMP_POLICY_DIR cuttlefish::GetSeccompPolicyDir()
 #define CF_DEFAULTS_ENABLE_SANDBOX false
 #define CF_DEFAULTS_ENABLE_VIRTIOFS false
@@ -69,7 +77,7 @@
 #define CF_DEFAULTS_QEMU_BINARY_DIR cuttlefish::DefaultQemuBinaryDir()
 
 // Gem5 default parameters
-#define CF_DEFAULTS_GEM5_BINARY_DIR HostBinaryPath("gem5")
+#define CF_DEFAULTS_GEM5_BINARY_DIR cuttlefish::HostBinaryPath("gem5")
 #define CF_DEFAULTS_GEM5_CHECKPOINT_DIR CF_DEFAULTS_DYNAMIC_STRING
 #define CF_DEFAULTS_GEM5_DEBUG_FILE CF_DEFAULTS_DYNAMIC_STRING
 #define CF_DEFAULTS_GEM5_DEBUG_FLAGS CF_DEFAULTS_DYNAMIC_STRING
@@ -214,9 +222,9 @@
 #define CF_DEFAULTS_WEBRTC_DEVICE_ID "cvd-{num}"
 #define CF_DEFAULTS_VERIFY_SIG_SERVER_CERTIFICATE false
 #define CF_DEFAULTS_WEBRTC_ASSETS_DIR \
-  DefaultHostArtifactsPath("usr/share/webrtc/assets")
+  cuttlefish::DefaultHostArtifactsPath("usr/share/webrtc/assets")
 #define CF_DEFAULTS_WEBRTC_CERTS_DIR \
-  DefaultHostArtifactsPath("usr/share/webrtc/certs")
+  cuttlefish::DefaultHostArtifactsPath("usr/share/webrtc/certs")
 #define CF_DEFAULTS_WEBRTC_SIG_SERVER_ADDR CF_DEFAULTS_DYNAMIC_STRING
 #define CF_DEFAULTS_WEBRTC_SIG_SERVER_PATH "/register_device"
 #define CF_DEFAULTS_WEBRTC_SIG_SERVER_PORT 443

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/graphics_flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/graphics_flags.cc
@@ -27,6 +27,7 @@
 #include "common/libs/utils/files.h"
 #include "common/libs/utils/subprocess.h"
 #include "cuttlefish/host/graphics_detector/graphics_detector.pb.h"
+#include "host/libs/config/config_constants.h"
 #include "host/libs/config/cuttlefish_config.h"
 
 #ifdef __APPLE__

--- a/base/cvd/cuttlefish/host/commands/cvd/acloud/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/acloud/BUILD.bazel
@@ -42,6 +42,7 @@ cc_library(
         "//cuttlefish/host/commands/cvd/instances:instance_database_utils",
         "//cuttlefish/host/commands/cvd/utils",
         "//cuttlefish/host/libs/config",
+        "//cuttlefish/host/libs/config:config_constants",
         "//libbase",
         "@protobuf",
     ],

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
@@ -157,6 +157,7 @@ cc_library(
         "//cuttlefish/host/commands/cvd/instances:instance_database_utils",
         "//cuttlefish/host/commands/cvd/utils",
         "//cuttlefish/host/libs/config",
+        "//cuttlefish/host/libs/config:config_constants",
         "@fmt",
     ],
 )

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
@@ -48,6 +48,7 @@ cc_library(
         "//cuttlefish/host/commands/cvd/cli:command_request",
         "//cuttlefish/host/commands/cvd/cli:types",
         "//cuttlefish/host/libs/config",
+        "//cuttlefish/host/libs/config:config_utils",
         "//libbase",
     ],
 )
@@ -499,6 +500,7 @@ cc_library(
         "//cuttlefish/host/commands/cvd/instances/lock",
         "//cuttlefish/host/commands/cvd/utils",
         "//cuttlefish/host/libs/config",
+        "//cuttlefish/host/libs/config:config_constants",
         "//libbase",
         "@fmt",
     ],
@@ -524,6 +526,7 @@ cc_library(
         "//cuttlefish/host/commands/cvd/cli:command_request",
         "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/libs/config",
+        "//cuttlefish/host/libs/config:config_constants",
         "//libbase",
         "@fmt",
         "@jsoncpp",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/BUILD.bazel
@@ -29,7 +29,6 @@ cc_library(
         "//cuttlefish/host/commands/assemble_cvd:libassemble_cvd",
         "//cuttlefish/host/commands/cvd/cli/parser:configs_common",
         "//cuttlefish/host/commands/cvd/cli/parser:load_config_cc_proto",
-        "//cuttlefish/host/libs/config",
         "//libbase",
         "@jsoncpp",
         "@protobuf",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_graphics_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_graphics_configs.cpp
@@ -26,7 +26,6 @@
 #include "cuttlefish/host/commands/assemble_cvd/flags_defaults.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/cf_configs_common.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/load_config.pb.h"
-#include "cuttlefish/host/libs/config/cuttlefish_config.h"  // flags_defaults.h dep
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_security_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_security_configs.cpp
@@ -21,8 +21,6 @@
 #include "cuttlefish/host/commands/assemble_cvd/flags_defaults.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/cf_configs_common.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/load_config.pb.h"
-// Needed by preprocessor constants in flags_defaults.h
-#include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_vm_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_vm_configs.cpp
@@ -27,9 +27,7 @@
 #include "cuttlefish/common/libs/utils/result.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags_defaults.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/cf_configs_common.h"
-// for a function in a flags_defaults.h preprocessor constant
 #include "cuttlefish/host/commands/cvd/cli/parser/load_config.pb.h"
-#include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 #define UI_DEFAULTS_MEMORY_MB 2048
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/BUILD.bazel
@@ -32,6 +32,7 @@ cc_library(
         "//cuttlefish/host/commands/cvd/instances:instance_database_utils",
         "//cuttlefish/host/commands/cvd/utils",
         "//cuttlefish/host/libs/config",
+        "//cuttlefish/host/libs/config:config_constants",
         "//libbase",
     ],
 )
@@ -55,6 +56,7 @@ cc_library(
         "//cuttlefish/host/commands/cvd/cli:utils",
         "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/libs/config",
+        "//cuttlefish/host/libs/config:config_constants",
         "//libbase",
     ],
 )

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/BUILD.bazel
@@ -53,6 +53,8 @@ cc_library(
         "//cuttlefish/host/commands/cvd/legacy:cvd_server_cc_proto",
         "//cuttlefish/host/commands/cvd/utils",
         "//cuttlefish/host/libs/config",
+        "//cuttlefish/host/libs/config:config_constants",
+        "//cuttlefish/host/libs/config:config_utils",
         "//cuttlefish/host/libs/command_util",
         "//libbase",
         "@fmt",

--- a/base/cvd/cuttlefish/host/commands/cvd/unittests/selector/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/unittests/selector/BUILD.bazel
@@ -33,6 +33,7 @@ cc_test(
         "//cuttlefish/host/commands/cvd/cli:types",
         "//cuttlefish/host/commands/cvd/cli/selector:parser",
         "//cuttlefish/host/libs/config",
+        "//cuttlefish/host/libs/config:config_constants",
         "//libbase",
         "@googletest//:gtest",
         "@googletest//:gtest_main",

--- a/base/cvd/cuttlefish/host/commands/kernel_log_monitor/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/kernel_log_monitor/BUILD.bazel
@@ -48,6 +48,7 @@ cc_library(
         "//cuttlefish/common/libs/utils",
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/libs/config",
+        "//cuttlefish/host/libs/config:config_constants",
         "//libbase",
         "@jsoncpp",
     ],

--- a/base/cvd/cuttlefish/host/commands/run_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/BUILD.bazel
@@ -27,8 +27,6 @@ cc_binary(
         "boot_state_machine.cc",
         "boot_state_machine.h",
         "main.cc",
-        "reporting.cpp",
-        "reporting.h",
         "server_loop.cpp",
         "server_loop.h",
         "server_loop_impl.cpp",

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
@@ -549,6 +549,7 @@ cc_library(
         "//cuttlefish/host/commands/run_cvd/launch:vhost_input_devices",
         "//cuttlefish/host/commands/run_cvd/launch:webrtc_controller",
         "//cuttlefish/host/libs/config",
+        "//cuttlefish/host/libs/config:config_constants",
         "//cuttlefish/host/libs/config:config_utils",
         "//libbase",
         "@fruit",

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
@@ -33,6 +33,7 @@ cc_library(
     copts = COPTS,
     deps = [
         "//cuttlefish/host/libs/config",
+        "//cuttlefish/host/libs/config:config_utils",
     ],
 )
 
@@ -225,6 +226,7 @@ cc_library(
         "//cuttlefish/common/libs/utils",
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/libs/config",
+        "//cuttlefish/host/libs/config:config_utils",
         "@fruit",
     ],
 )
@@ -264,6 +266,7 @@ cc_library(
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/commands/run_cvd/launch:log_tee_creator",
         "//cuttlefish/host/libs/config",
+        "//cuttlefish/host/libs/config:config_utils",
         "//cuttlefish/host/libs/vm_manager",
         "//libbase",
         "@fruit",
@@ -324,6 +327,7 @@ cc_library(
         "//cuttlefish/common/libs/utils",
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/libs/config",
+        "//cuttlefish/host/libs/config:config_utils",
         "@fruit",
     ],
 )
@@ -545,6 +549,7 @@ cc_library(
         "//cuttlefish/host/commands/run_cvd/launch:vhost_input_devices",
         "//cuttlefish/host/commands/run_cvd/launch:webrtc_controller",
         "//cuttlefish/host/libs/config",
+        "//cuttlefish/host/libs/config:config_utils",
         "//libbase",
         "@fruit",
         "@fmt",
@@ -611,6 +616,7 @@ cc_library(
         "//cuttlefish/common/libs/utils",
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/libs/config",
+        "//cuttlefish/host/libs/config:config_utils",
     ],
 )
 
@@ -651,6 +657,7 @@ cc_library(
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/commands/run_cvd/launch:log_tee_creator",
         "//cuttlefish/host/libs/config",
+        "//cuttlefish/host/libs/config:config_utils",
         "//cuttlefish/host/libs/vm_manager",
         "//libbase",
         "@fmt",

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/streamer.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/streamer.cpp
@@ -39,6 +39,7 @@
 #include "cuttlefish/host/commands/run_cvd/launch/webrtc_controller.h"
 #include "cuttlefish/host/commands/run_cvd/reporting.h"
 #include "cuttlefish/host/libs/config/command_source.h"
+#include "cuttlefish/host/libs/config/config_constants.h"
 #include "cuttlefish/host/libs/config/config_utils.h"
 #include "cuttlefish/host/libs/config/custom_actions.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"

--- a/base/cvd/cuttlefish/host/frontend/webrtc/main.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/main.cpp
@@ -39,6 +39,7 @@
 #include "host/frontend/webrtc/screenshot_handler.h"
 #include "host/frontend/webrtc/webrtc_command_channel.h"
 #include "host/libs/audio_connector/server.h"
+#include "host/libs/config/config_constants.h"
 #include "host/libs/config/cuttlefish_config.h"
 #include "host/libs/config/logging.h"
 #include "host/libs/config/openwrt_args.h"

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -9,7 +9,6 @@ cc_library(
     name = "config",
     srcs = [
         "config_flag.cpp",
-        "config_utils.cpp",
         "custom_actions.cpp",
         "cuttlefish_config.cpp",
         "cuttlefish_config_instance.cpp",
@@ -30,10 +29,8 @@ cc_library(
     ],
     hdrs = [
         "command_source.h",
-        "config_constants.h",
         "config_flag.h",
         "config_fragment.h",
-        "config_utils.h",
         "custom_actions.h",
         "cuttlefish_config.h",
         "data_image.h",
@@ -56,6 +53,8 @@ cc_library(
     copts = COPTS,
     strip_include_prefix = "//cuttlefish",
     deps = [
+        ":config_constants",
+        ":config_utils",
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils",
         "//cuttlefish/common/libs/utils:environment",
@@ -73,5 +72,44 @@ cc_library(
 clang_tidy_test(
     name = "config_clang_tidy",
     srcs = [":config"],
+    tags = ["clang_tidy", "clang-tidy"],
+)
+
+cc_library(
+    name = "config_constants",
+    hdrs = [
+        "config_constants.h",
+    ],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+)
+
+clang_tidy_test(
+    name = "config_constants_clang_tidy",
+    srcs = [":config_constants"],
+    tags = ["clang_tidy", "clang-tidy"],
+)
+
+cc_library(
+    name = "config_utils",
+    srcs = [
+        "config_utils.cpp",
+    ],
+    hdrs = [
+        "config_utils.h",
+    ],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+    deps = [
+        ":config_constants",
+        "//cuttlefish/common/libs/utils",
+        "//cuttlefish/common/libs/utils:environment",
+        "//libbase",
+    ],
+)
+
+clang_tidy_test(
+    name = "config_utils_clang_tidy",
+    srcs = [":config_utils"],
     tags = ["clang_tidy", "clang-tidy"],
 )

--- a/base/cvd/cuttlefish/host/libs/config/config_constants.h
+++ b/base/cvd/cuttlefish/host/libs/config/config_constants.h
@@ -60,4 +60,28 @@ inline constexpr char kApName[] = "crosvm_openwrt";
 
 inline constexpr int kDefaultInstance = 1;
 
+inline constexpr char kVhostUserVsockModeAuto[] = "auto";
+inline constexpr char kVhostUserVsockModeTrue[] = "true";
+inline constexpr char kVhostUserVsockModeFalse[] = "false";
+
+inline constexpr char kGpuModeAuto[] = "auto";
+inline constexpr char kGpuModeCustom[] = "custom";
+inline constexpr char kGpuModeDrmVirgl[] = "drm_virgl";
+inline constexpr char kGpuModeGfxstream[] = "gfxstream";
+inline constexpr char kGpuModeGfxstreamGuestAngle[] = "gfxstream_guest_angle";
+inline constexpr char kGpuModeGfxstreamGuestAngleHostSwiftShader[] =
+    "gfxstream_guest_angle_host_swiftshader";
+inline constexpr char kGpuModeGfxstreamGuestAngleHostLavapipe[] =
+    "gfxstream_guest_angle_host_lavapipe";
+inline constexpr char kGpuModeGuestSwiftshader[] = "guest_swiftshader";
+inline constexpr char kGpuModeNone[] = "none";
+
+inline constexpr char kGpuVhostUserModeAuto[] = "auto";
+inline constexpr char kGpuVhostUserModeOn[] = "on";
+inline constexpr char kGpuVhostUserModeOff[] = "off";
+
+inline constexpr char kHwComposerAuto[] = "auto";
+inline constexpr char kHwComposerDrm[] = "drm_hwcomposer";
+inline constexpr char kHwComposerRanchu[] = "ranchu";
+inline constexpr char kHwComposerNone[] = "none";
 }

--- a/base/cvd/cuttlefish/host/libs/config/config_utils.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/config_utils.cpp
@@ -171,4 +171,9 @@ bool HostSupportsQemuCli() {
   return supported;
 }
 
+std::string GetSeccompPolicyDir() {
+  std::string kSeccompDir =
+      "usr/share/crosvm/" + HostArchStr() + "-linux-gnu/seccomp";
+  return DefaultHostArtifactsPath(kSeccompDir);
+}
 }

--- a/base/cvd/cuttlefish/host/libs/config/config_utils.h
+++ b/base/cvd/cuttlefish/host/libs/config/config_utils.h
@@ -61,4 +61,6 @@ bool HostSupportsQemuCli();
 
 // Whether to use our local QEMU prebuilt
 bool UseQemuPrebuilt();
+
+std::string GetSeccompPolicyDir();
 }

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.cpp
@@ -42,31 +42,6 @@ const char* kInstances = "instances";
 
 }  // namespace
 
-const char* const kVhostUserVsockModeAuto = "auto";
-const char* const kVhostUserVsockModeTrue = "true";
-const char* const kVhostUserVsockModeFalse = "false";
-
-const char* const kGpuModeAuto = "auto";
-const char* const kGpuModeCustom = "custom";
-const char* const kGpuModeDrmVirgl = "drm_virgl";
-const char* const kGpuModeGfxstream = "gfxstream";
-const char* const kGpuModeGfxstreamGuestAngle = "gfxstream_guest_angle";
-const char* const kGpuModeGfxstreamGuestAngleHostSwiftShader =
-    "gfxstream_guest_angle_host_swiftshader";
-const char* const kGpuModeGfxstreamGuestAngleHostLavapipe =
-    "gfxstream_guest_angle_host_lavapipe";
-const char* const kGpuModeGuestSwiftshader = "guest_swiftshader";
-const char* const kGpuModeNone = "none";
-
-const char* const kGpuVhostUserModeAuto = "auto";
-const char* const kGpuVhostUserModeOn = "on";
-const char* const kGpuVhostUserModeOff = "off";
-
-const char* const kHwComposerAuto = "auto";
-const char* const kHwComposerDrm = "drm_hwcomposer";
-const char* const kHwComposerRanchu = "ranchu";
-const char* const kHwComposerNone = "none";
-
 std::string DefaultEnvironmentPath(const char* environment_key,
                                    const char* default_value,
                                    const char* subpath) {

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
@@ -1093,32 +1093,6 @@ class CuttlefishConfig {
 // device would actually perform a restore instead of their respective actions.
 bool IsRestoring(const CuttlefishConfig&);
 
-// Vhost-user-vsock modes
-extern const char* const kVhostUserVsockModeAuto;
-extern const char* const kVhostUserVsockModeTrue;
-extern const char* const kVhostUserVsockModeFalse;
-
-// GPU modes
-extern const char* const kGpuModeAuto;
-extern const char* const kGpuModeCustom;
-extern const char* const kGpuModeDrmVirgl;
-extern const char* const kGpuModeGfxstream;
-extern const char* const kGpuModeGfxstreamGuestAngle;
-extern const char* const kGpuModeGfxstreamGuestAngleHostSwiftShader;
-extern const char* const kGpuModeGfxstreamGuestAngleHostLavapipe;
-extern const char* const kGpuModeGuestSwiftshader;
-extern const char* const kGpuModeNone;
-
-// GPU vhost user modes
-extern const char* const kGpuVhostUserModeAuto;
-extern const char* const kGpuVhostUserModeOn;
-extern const char* const kGpuVhostUserModeOff;
-
-// HwComposer modes
-extern const char* const kHwComposerAuto;
-extern const char* const kHwComposerDrm;
-extern const char* const kHwComposerRanchu;
-extern const char* const kHwComposerNone;
 }  // namespace cuttlefish
 
 #if FMT_VERSION >= 90000

--- a/base/cvd/cuttlefish/host/libs/image_aggregator/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/image_aggregator/BUILD.bazel
@@ -34,6 +34,7 @@ cc_library(
         "//cuttlefish/common/libs/utils",
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/libs/config",
+        "//cuttlefish/host/libs/config:config_utils",
         "//libbase",
         "//libsparse",
         "@protobuf",

--- a/base/cvd/cuttlefish/host/libs/screen_connector/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/screen_connector/BUILD.bazel
@@ -65,6 +65,7 @@ cc_library(
         "//cuttlefish/common/libs/utils",
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/libs/config",
+        "//cuttlefish/host/libs/config:config_constants",
         "//cuttlefish/host/libs/confui:host_confui",
         "//cuttlefish/host/libs/wayland:cuttlefish_wayland_server",
         "//libbase",

--- a/base/cvd/cuttlefish/host/libs/screen_connector/screen_connector.h
+++ b/base/cvd/cuttlefish/host/libs/screen_connector/screen_connector.h
@@ -34,6 +34,7 @@
 #include "common/libs/fs/shared_fd.h"
 #include "common/libs/utils/contains.h"
 #include "common/libs/utils/size_utils.h"
+#include "host/libs/config/config_constants.h"
 #include "host/libs/config/cuttlefish_config.h"
 #include "host/libs/confui/host_mode_ctrl.h"
 #include "host/libs/confui/host_utils.h"

--- a/base/cvd/cuttlefish/host/libs/vm_manager/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/BUILD.bazel
@@ -39,6 +39,7 @@ cc_library(
         "//cuttlefish/common/libs/utils:environment",
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/libs/config",
+        "//cuttlefish/host/libs/config:config_constants",
         "//cuttlefish/host/libs/command_util",
         "//libbase",
         "@fmt",

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
@@ -42,6 +42,7 @@
 #include "common/libs/utils/result.h"
 #include "common/libs/utils/subprocess.h"
 #include "host/libs/command_util/snapshot_utils.h"
+#include "host/libs/config/config_constants.h"
 #include "host/libs/config/cuttlefish_config.h"
 #include "host/libs/config/known_paths.h"
 #include "host/libs/vm_manager/crosvm_builder.h"

--- a/base/cvd/cuttlefish/host/libs/vm_manager/gem5_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/gem5_manager.cpp
@@ -37,6 +37,7 @@
 #include "common/libs/utils/result.h"
 #include "common/libs/utils/subprocess.h"
 #include "host/libs/config/command_source.h"
+#include "host/libs/config/config_constants.h"
 #include "host/libs/config/cuttlefish_config.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/host/libs/vm_manager/qemu_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/qemu_manager.cpp
@@ -40,6 +40,7 @@
 #include "common/libs/utils/result.h"
 #include "common/libs/utils/subprocess.h"
 #include "host/libs/config/command_source.h"
+#include "host/libs/config/config_constants.h"
 #include "host/libs/config/cuttlefish_config.h"
 #include "host/libs/vm_manager/vhost_user.h"
 


### PR DESCRIPTION
Which required moving some declarations+definitions around and splitting out a couple of `host/libs/config` files into new targets, then dealing with the ripples of that. 
 `flags_defaults.h` was depending on declarations from `cuttlefish_config.h` and `flags.cc`, both in targets that depended on the `libassemble_cvd` target containing `flags_defaults.h`.