### PR TITLE
Define toolchain options to use a host clang executable

### DIFF
--- a/base/cvd/MODULE.bazel
+++ b/base/cvd/MODULE.bazel
@@ -43,7 +43,6 @@ git_override(
     remote = "https://github.com/mikael-s-persson/bazel-compile-commands-extractor",
 )
 
-# Configure and register the toolchain.
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
 llvm.toolchain(
    llvm_version = "18.1.8",
@@ -51,7 +50,44 @@ llvm.toolchain(
 
 use_repo(llvm, "llvm_toolchain")
 
-register_toolchains("@llvm_toolchain//:all")
+file_detector = use_repo_rule("//toolchain:file_detector.bzl", "file_detector")
+
+file_detector(
+    name = "clang_detector",
+    files = {
+        "/usr/bin/clang-11": "clang_11",
+        "/usr/bin/clang-12": "clang_12",
+        "/usr/bin/clang-13": "clang_13",
+        "/usr/bin/clang-14": "clang_14",
+        "/usr/bin/clang-15": "clang_15",
+        "/usr/bin/clang-16": "clang_16",
+        "/usr/bin/clang-17": "clang_17",
+        "/usr/bin/clang-18": "clang_18",
+        "/usr/bin/clang-19": "clang_19",
+    },
+)
+
+# The first toolchain that satisfies platform constraints is chosen.
+# Alternatively, a specific toolchain can be chosen with the
+# `--extra_toolchains` flag, e.g.
+# ```
+# bazel build //cuttlefish/package:cvd \
+#   --extra_toolchains=//toolchain:linux_local_clang_19
+# ```
+#
+# For more information, see https://bazel.build/extending/toolchains
+register_toolchains(
+    "@llvm_toolchain//:all",  # TODO: b/407854179 - demote after testing others
+    "//toolchain:linux_local_clang_19",
+    "//toolchain:linux_local_clang_18",
+    "//toolchain:linux_local_clang_17",
+    "//toolchain:linux_local_clang_16",
+    "//toolchain:linux_local_clang_15",
+    "//toolchain:linux_local_clang_14",
+    "//toolchain:linux_local_clang_13",
+    "//toolchain:linux_local_clang_12",
+    "//toolchain:linux_local_clang_11",
+)
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(

--- a/base/cvd/cuttlefish/common/libs/utils/architecture.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/architecture.cpp
@@ -16,6 +16,7 @@
 
 #include "common/libs/utils/architecture.h"
 
+#include <string.h>
 #include <sys/utsname.h>
 
 #include <cstdlib>

--- a/base/cvd/cuttlefish/common/libs/utils/socket2socket_proxy.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/socket2socket_proxy.cpp
@@ -20,6 +20,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 
+#include <atomic>
 #include <cstring>
 #include <functional>
 #include <list>

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <optional>
 #include <regex>

--- a/base/cvd/cuttlefish/host/commands/console_forwarder/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/console_forwarder/main.cpp
@@ -19,6 +19,7 @@
 #include <signal.h>
 #include <unistd.h>
 
+#include <condition_variable>
 #include <deque>
 #include <mutex>
 #include <thread>

--- a/base/cvd/cuttlefish/host/commands/metrics/host_receiver.h
+++ b/base/cvd/cuttlefish/host/commands/metrics/host_receiver.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <string>
 #include <thread>
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/host/libs/image_aggregator/image_aggregator.h
+++ b/base/cvd/cuttlefish/host/libs/image_aggregator/image_aggregator.h
@@ -19,6 +19,8 @@
  * Functions for manipulating disk files given to crosvm or QEMU.
  */
 
+#include <stdint.h>
+
 #include <string>
 #include <vector>
 

--- a/base/cvd/toolchain/BUILD.bazel
+++ b/base/cvd/toolchain/BUILD.bazel
@@ -1,0 +1,86 @@
+package(default_visibility = ["//visibility:public"])
+
+load(":cc_toolchain_macro.bzl", "linux_local_clang")
+
+filegroup(name = "empty")
+
+linux_local_clang(
+    name = "linux_local_clang_19",
+    exec_compatible_with = [
+        "@clang_detector//:clang_19_present",
+        "@platforms//os:linux",
+    ],
+    version = 19,
+)
+
+linux_local_clang(
+    name = "linux_local_clang_18",
+    exec_compatible_with = [
+        "@clang_detector//:clang_18_present",
+        "@platforms//os:linux",
+    ],
+    version = 18,
+)
+
+linux_local_clang(
+    name = "linux_local_clang_17",
+    exec_compatible_with = [
+        "@clang_detector//:clang_17_present",
+        "@platforms//os:linux",
+    ],
+    version = 17,
+)
+
+linux_local_clang(
+    name = "linux_local_clang_16",
+    exec_compatible_with = [
+        "@clang_detector//:clang_16_present",
+        "@platforms//os:linux",
+    ],
+    version = 16,
+)
+
+linux_local_clang(
+    name = "linux_local_clang_15",
+    exec_compatible_with = [
+        "@clang_detector//:clang_15_present",
+        "@platforms//os:linux",
+    ],
+    version = 15,
+)
+
+linux_local_clang(
+    name = "linux_local_clang_14",
+    exec_compatible_with = [
+        "@clang_detector//:clang_14_present",
+        "@platforms//os:linux",
+    ],
+    version = 14,
+)
+
+linux_local_clang(
+    name = "linux_local_clang_13",
+    exec_compatible_with = [
+        "@clang_detector//:clang_13_present",
+        "@platforms//os:linux",
+    ],
+    version = 13,
+)
+
+linux_local_clang(
+    name = "linux_local_clang_12",
+    exec_compatible_with = [
+        "@clang_detector//:clang_12_present",
+        "@platforms//os:linux",
+    ],
+    version = 12,
+)
+
+linux_local_clang(
+    name = "linux_local_clang_11",
+    exec_compatible_with = [
+        "@clang_detector//:clang_11_present",
+        "@platforms//os:linux",
+    ],
+    version = 11,
+)

--- a/base/cvd/toolchain/cc_toolchain_config.bzl
+++ b/base/cvd/toolchain/cc_toolchain_config.bzl
@@ -1,0 +1,113 @@
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+load(
+    "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+    "feature",
+    "flag_group",
+    "flag_set",
+    "tool_path",
+)
+
+all_link_actions = [
+    ACTION_NAMES.cpp_link_executable,
+    ACTION_NAMES.cpp_link_dynamic_library,
+    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+]
+
+# Relevant documentation:
+# - https://bazel.build/rules/lib/providers/CcToolchainInfo
+# - https://bazel.build/rules/lib/toplevel/cc_common#create_cc_toolchain_config_info
+# - https://bazel.build/tutorials/ccp-toolchain-config
+def _impl(ctx):
+    tool_paths = [
+        tool_path(
+            name = "gcc",
+            path = "/usr/bin/clang-%d" % ctx.attr.version,
+        ),
+        tool_path(
+            name = "ld",
+            path = "/usr/bin/ld",
+        ),
+        tool_path(
+            name = "ar",
+            path = "/usr/bin/ar",
+        ),
+        tool_path(
+            name = "cpp",
+            path = "/bin/false",
+        ),
+        tool_path(
+            name = "gcov",
+            path = "/bin/false",
+        ),
+        tool_path(
+            name = "nm",
+            path = "/bin/false",
+        ),
+        tool_path(
+            name = "objdump",
+            path = "/bin/false",
+        ),
+        tool_path(
+            name = "strip",
+            path = "/bin/false",
+        ),
+    ]
+
+    features = [
+        feature(
+            name = "default_linker_flags",
+            enabled = True,
+            flag_sets = [
+                flag_set(
+                    actions = [ACTION_NAMES.cpp_compile],
+                    flag_groups = ([
+                        flag_group(
+                            flags = [
+                                "-fPIC",
+                            ],
+                        ),
+                    ]),
+                ),
+                flag_set(
+                    actions = all_link_actions,
+                    flag_groups = ([
+                        flag_group(
+                            flags = [
+                                "-lm",
+                                "-lstdc++",
+                            ],
+                        ),
+                    ]),
+                ),
+            ],
+        ),
+    ]
+
+    return cc_common.create_cc_toolchain_config_info(
+        ctx = ctx,
+        features = features,
+        cxx_builtin_include_directories = [
+            "/usr/lib/llvm-%d/lib/clang/" % ctx.attr.version,
+            "/usr/include",
+        ],
+        toolchain_identifier = "local",
+        host_system_name = "local",
+        target_system_name = "local",
+        target_cpu = "k8",
+        target_libc = "unknown",
+        compiler = "clang",
+        abi_version = "unknown",
+        abi_libc_version = "unknown",
+        tool_paths = tool_paths,
+    )
+
+# Relevant documentation:
+# - https://bazel.build/rules/lib/globals/bzl.html#rule
+# - https://bazel.build/rules/lib/toplevel/attr.html#int
+linux_local_clang_toolchain_config = rule(
+    implementation = _impl,
+    attrs = {
+        "version": attr.int(mandatory = True),
+    },
+    provides = [CcToolchainConfigInfo],
+)

--- a/base/cvd/toolchain/cc_toolchain_macro.bzl
+++ b/base/cvd/toolchain/cc_toolchain_macro.bzl
@@ -1,0 +1,49 @@
+load(":cc_toolchain_config.bzl", "linux_local_clang_toolchain_config")
+
+# Relevant documentation:
+# - https://bazel.build/extending/macros
+# - https://bazel.build/extending/toolchains
+# - https://bazel.build/reference/be/platforms-and-toolchains#toolchain
+# - https://bazel.build/tutorials/ccp-toolchain-config
+def _linux_local_clang_impl(name, visibility, exec_compatible_with, version, **kwargs):
+    linux_local_clang_toolchain_config(
+        name = name + "_config",
+        visibility = ["//visibility:private"],
+        version = version,
+    )
+    native.cc_toolchain(
+        name = name + "_cc_toolchain",
+        visibility = ["//visibility:private"],
+        toolchain_identifier = name,
+        toolchain_config = ":" + name + "_config",
+        all_files = ":empty",
+        compiler_files = ":empty",
+        dwp_files = ":empty",
+        linker_files = ":empty",
+        objcopy_files = ":empty",
+        strip_files = ":empty",
+        supports_param_files = 0,
+    )
+    native.toolchain(
+        name = name,
+        visibility = visibility,
+        toolchain = ":" + name + "_cc_toolchain",
+        toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+        exec_compatible_with = exec_compatible_with,
+        target_compatible_with = ["@platforms//os:linux"],
+        **kwargs,
+    )
+
+# Defines a compiler toolchain that calls /usr/bin/clang-{version} to compile and link c++.
+#
+# Relevant documentation:
+# - https://bazel.build/rules/lib/globals/bzl.html#macro
+# - https://bazel.build/rules/lib/toplevel/attr#int
+# - https://bazel.build/rules/lib/toplevel/attr#label_list
+linux_local_clang = macro(
+    attrs = {
+        "exec_compatible_with": attr.label_list(configurable = False),
+        "version": attr.int(configurable = False, mandatory = True),
+    },
+    implementation = _linux_local_clang_impl,
+)

--- a/base/cvd/toolchain/file_detector.bzl
+++ b/base/cvd/toolchain/file_detector.bzl
@@ -1,0 +1,86 @@
+# Relevant documentation:
+# - https://bazel.build/reference/be/platforms-and-toolchains
+# - https://bazel.build/rules/lib/builtins/path.html
+# - https://bazel.build/rules/lib/builtins/repository_ctx
+# - https://bazel.build/rules/lib/globals/bzl.html#repository_rule
+def _file_detector_impl(repository_ctx):
+    root_build_file = 'package(default_visibility = ["//visibility:public"])\n\n'
+    for (filename, constraint_setting) in repository_ctx.attr.files.items():
+        file_path = repository_ctx.path(filename)
+        repository_ctx.watch(file_path)
+        if file_path.exists:
+            exists_str = "present"
+        else:
+            exists_str = "absent"
+        build_fragment = """
+constraint_setting(
+    name = "{0}",
+    default_constraint_value = ":{0}_{1}"
+)
+constraint_value(
+    name = "{0}_present",
+    constraint_setting = ":{0}",
+)
+constraint_value(
+    name = "{0}_absent",
+    constraint_setting = ":{0}",
+)
+        """.strip().format(constraint_setting, exists_str)
+        root_build_file += "\n" + build_fragment + "\n"
+    build_file = repository_ctx.path("BUILD.bazel")
+    repository_ctx.file(build_file, root_build_file, False)
+
+# Creates a repository that defines `constraint_setting`s and
+# `constraint_value`s based on the existence of some files on the host.
+#
+# Example usage:
+# ```
+# file_detector = use_repo_rule("//toolchain:file_detector.bzl", "file_detector")
+#
+# file_detector(
+#     name = "clang_detector",
+#     files = {
+#         "/usr/bin/clang-11": "clang_11",
+#     },
+# ),
+# ```
+# This expands to a repository `@clang_detector` defining the following
+# targets:
+# ```
+# constraint_setting(
+#     name = "clang_11",
+#     default_constraint_value = ":clang_11_present",
+# )
+# constraint_value(
+#     name = "clang_11_present",
+#     constraint_setting = ":clang_11",
+# )
+# constraint_value(
+#     name = "clang_11_absent",
+#     constraint_setting = ":clang_11",
+# )
+# ```
+# The default constraint value of the "@clang_detector//:clang_11" setting is
+# set to either "@clang_detector//:clang_11_present" or
+# "@clang_detector//:clang_11_absent" depending on whether the file
+# /usr/bin/clang-11 is present on the host.
+#
+# This is helpful for toolchain resolution. A toolchain relying on host
+# executables can reference these constraints in its `exec_compatible_with`
+# list, which is used to report availability.
+#
+# Relevant documentation:
+# - https://bazel.build/extending/toolchains
+# - https://bazel.build/reference/be/platforms-and-toolchains
+# - https://bazel.build/rules/lib/globals/bzl.html#repository_rule
+# - https://bazel.build/rules/lib/toplevel/attr#string_dict
+file_detector = repository_rule(
+    implementation = _file_detector_impl,
+    attrs = {
+        "files": attr.string_dict(
+            allow_empty = False,
+            configurable = False,
+            mandatory = True,
+        ),
+    },
+)


### PR DESCRIPTION
These toolchains are registered with lower priority than the downloaded prebuilt LLVM/clang, but can be selected using the `--extra-toolchains` flag, e.g.

```
bazel build //cuttlefish/package:cvd \
  --extra_toolchains=//toolchain:linux_local_clang_19
```

Note that if the clang executable for the requested version is missing, the toolchain will silently be excluded from toolchain resolution, so requesting `//toolchain:linux_local_clang_11` on a system without /usr/bin/clang-11 will fall through to the next supported toolchain following the normal resolution order.

See https://bazel.build/extending/toolchains#toolchain-resolution

Bug: b/407854179