### PR TITLE
Fix wifi and vhost_device_vsock invocation flows

### DIFF
--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd.cpp
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd.cpp
@@ -711,11 +711,6 @@ SharedFD SharedFD::SocketLocalServer(const std::string& name, bool abstract,
 SharedFD SharedFD::VsockServer(
     unsigned int port, int type,
     std::optional<int> vhost_user_vsock_listening_cid, unsigned int cid) {
-#ifndef CUTTLEFISH_HOST
-  CHECK(!vhost_user_vsock_listening_cid)
-      << "vhost_user_vsock_listening_cid is supposed to be nullopt in the "
-         "guest";
-#endif
   if (vhost_user_vsock_listening_cid) {
     return SharedFD::SocketLocalServer(
         GetVhostUserVsockServerAddr(port, *vhost_user_vsock_listening_cid),
@@ -766,9 +761,6 @@ std::string SharedFD::GetVhostUserVsockClientAddr(int cid) {
 
 SharedFD SharedFD::VsockClient(unsigned int cid, unsigned int port, int type,
                                bool vhost_user) {
-#ifndef CUTTLEFISH_HOST
-  CHECK(!vhost_user) << "vhost_user is supposed to be false in the guest";
-#endif
   if (vhost_user) {
     // TODO(b/277909042): better path than /tmp/vsock_{}/vm.vsock
     auto client = SharedFD::SocketLocalClient(GetVhostUserVsockClientAddr(cid),

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -1185,11 +1185,8 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
   tmp_config_obj.set_enable_metrics(FLAGS_report_anonymous_usage_stats);
   // TODO(moelsherif): Handle this flag (set_metrics_binary) in the future
 
-#ifdef ENFORCE_MAC80211_HWSIM
+  // TODO: schuffelen - make this a device-specific android-info.txt setting
   tmp_config_obj.set_virtio_mac80211_hwsim(true);
-#else
-  tmp_config_obj.set_virtio_mac80211_hwsim(false);
-#endif
 
   if ((FLAGS_ap_rootfs_image.empty()) != (FLAGS_ap_kernel_image.empty())) {
     LOG(FATAL) << "Either both ap_rootfs_image and ap_kernel_image should be "


### PR DESCRIPTION
Wifi was broken because a missing preprocessor declaration caused the host wifi flow to not run.

vhost_device_vsock was broken because a missing preprocessor declaration caused an assertion intended for the guest to run on the host.

Bug: b/408245136
Test: /usr/bin/bazel run //cuttlefish/package:cvd -- create --host_substitutions=all --vhost_user_vsock=true
Test: /usr/bin/bazel run //cuttlefish/package:cvd -- create --host_substitutions=all && check wifi