### PR TITLE
Enforce misc-include-cleaner on mkenvimage_slim

### DIFF
--- a/base/cvd/BUILD.bazel
+++ b/base/cvd/BUILD.bazel
@@ -38,6 +38,7 @@ filegroup(
         ".clang-tidy",
         "//cuttlefish/host/commands/cvd/cli/commands:.clang-tidy",
         "//cuttlefish/host/commands/kernel_log_monitor:.clang-tidy",
+        "//cuttlefish/host/commands/mkenvimage_slim:.clang-tidy",
         "//cuttlefish/host/commands/run_cvd/launch:.clang-tidy",
     ],
 )

--- a/base/cvd/cuttlefish/host/commands/mkenvimage_slim/.clang-tidy
+++ b/base/cvd/cuttlefish/host/commands/mkenvimage_slim/.clang-tidy
@@ -1,0 +1,29 @@
+# "clang-diagnostic-pragma-once-outside-header" has a bad interaction with the
+# `parse_headers` bazel feature.
+
+Checks: &checks >-
+  clang-analyzer-*,
+  clang-diagnostic-*,
+  -clang-diagnostic-pragma-once-outside-header,
+  misc-definitions-in-headers,
+  misc-include-cleaner,
+  misc-unused-alias-decls,
+  readability-avoid-const-params-in-decls,
+  readability-const-return-type,
+  readability-container-size-empty,
+  readability-inconsistent-declaration-parameter-name,
+  readability-misleading-indentation,
+  readability-redundant-control-flow,
+  readability-string-compare,
+
+# Using the bazel clang-tidy helper, warnings are not shown from files that
+# don't have any errors.  "*" here treats everything from `Checks` as an error,
+# and from there some exclusions are added.
+WarningsAsErrors: >
+  *,
+  -clang-analyzer-core.uninitialized.Assign,
+  -clang-analyzer-core.UndefinedBinaryOperatorResult,
+  -clang-diagnostic-builtin-macro-redefined,
+  -clang-diagnostic-pragma-once-outside-header,
+  -clang-diagnostic-unused-const-variable,
+  -clang-diagnostic-unused-variable,

--- a/base/cvd/cuttlefish/host/commands/mkenvimage_slim/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/mkenvimage_slim/BUILD.bazel
@@ -5,6 +5,8 @@ package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
+exports_files([".clang-tidy"])
+
 cc_binary(
     name = "mkenvimage_slim",
     srcs = [

--- a/base/cvd/cuttlefish/host/commands/mkenvimage_slim/mkenvimage_slim.cc
+++ b/base/cvd/cuttlefish/host/commands/mkenvimage_slim/mkenvimage_slim.cc
@@ -17,16 +17,21 @@
 // https://github.com/u-boot/u-boot/blob/master/tools/mkenvimage.c The bare
 // minimum amount of functionality for our application is replicated.
 
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include <zlib.h>
 
+#include <vector>
+
 #include <android-base/logging.h>
-#include <android-base/strings.h>
 #include <gflags/gflags.h>
 
-#include "common/libs/fs/shared_buf.h"
-#include "common/libs/fs/shared_fd.h"
-#include "common/libs/utils/files.h"
-#include "common/libs/utils/result.h"
+#include "cuttlefish/common/libs/fs/shared_buf.h"
+#include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/common/libs/utils/result.h"
 
 #define PAD_VALUE (0xff)
 #define CRC_SIZE (sizeof(uint32_t))
@@ -68,7 +73,7 @@ Result<int> MkenvimageSlimMain(int argc, char** argv) {
   uint32_t crc = crc32(0, env_ptr, FLAGS_env_size - CRC_SIZE);
   memcpy(env_buffer.data(), &crc, sizeof(uint32_t));
 
-  auto output_fd =
+  auto output_fd =  // NOLINTNEXTLINE(misc-include-cleaner)
       SharedFD::Creat(FLAGS_output_path, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
   if (!output_fd->IsOpen()) {
     return CF_ERR("Couldn't open the output file " + FLAGS_output_path);


### PR DESCRIPTION
Also use include paths relative to the workspace root for files under //cuttlefish.