### PR TITLE
Restore gpu_mode flag and propagate gpu_mode presence from cvd canonical configs

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_graphics_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_graphics_configs.cpp
@@ -91,10 +91,15 @@ bool RecordScreen(const Instance& instance) {
 }
 
 std::string GpuMode(const Instance& instance) {
-  if (instance.graphics().has_gpu_mode()) {
+  if (instance.graphics().has_gpu_mode() &&
+      instance.graphics().gpu_mode() != "") {
     return instance.graphics().gpu_mode();
+  } else {
+    // Use the instance default
+    // https://github.com/google/android-cuttlefish/blob/c4f1643479f98bdc7310d281e81751188595233b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc#L948
+    // See also b/406464352#comment7
+    return "unset";
   }
-  return CF_DEFAULTS_GPU_MODE;
 }
 
 Result<std::vector<std::string>> GenerateGraphicsFlags(

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_graphics_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_graphics_configs.cpp
@@ -90,11 +90,19 @@ bool RecordScreen(const Instance& instance) {
   }
 }
 
+std::string GpuMode(const Instance& instance) {
+  if (instance.graphics().has_gpu_mode()) {
+    return instance.graphics().gpu_mode();
+  }
+  return CF_DEFAULTS_GPU_MODE;
+}
+
 Result<std::vector<std::string>> GenerateGraphicsFlags(
     const EnvironmentSpecification& cfg) {
   return std::vector<std::string>{
       CF_EXPECT(GenerateDisplayFlag(cfg)),
       GenerateInstanceFlag("record_screen", cfg, RecordScreen),
+      GenerateInstanceFlag("gpu_mode", cfg, GpuMode),
   };
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_config.proto
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_config.proto
@@ -78,6 +78,7 @@ message Vsock {
 message Graphics {
   repeated Display displays = 1;
   optional bool record_screen = 2;
+  optional string gpu_mode = 3;
 }
 
 message Display {


### PR DESCRIPTION
This uses the "unset" keyword to let the layer below decide what default to apply, which can be influenced by legacy config.json values. This is load-bearing for some tests in CI.

Bug: b/408472915