### PR TITLE
Check for reboot completion and rebalance threads

### DIFF
--- a/base/cvd/cuttlefish/host/commands/run_cvd/boot_state_machine.cc
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/boot_state_machine.cc
@@ -511,6 +511,15 @@ class CvdBootStateMachine : public SetupFeature, public KernelLogPipeConsumer {
         if (!read_result.ok()) {
           return;
         }
+        if ((*read_result)->event == monitor::Event::BootCompleted) {
+          LOG(INFO) << "Virtual device rebooted successfully";
+          if (!instance_.vcpu_config_path().empty()) {
+            auto res = WattsonRebalanceThreads(instance_.id());
+            if (!res.ok()) {
+              LOG(ERROR) << res.error().FormatForEnv();
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Rebalance needs to occur after crosvm restarts and after "adb reboot" occurs in the guest. Check for another BootCompleted event in the monitoring thread and rebalance the threads.

Bug: b/408290580
Test: m && adb reboot and saw that the threads migrated