### PR TITLE
Allow separate substitution of `cvd_internal_start` and its subtools, fix `cvd start --help` exception failure

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/subprocess.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/subprocess.cpp
@@ -39,6 +39,8 @@
 #include <string>
 #include <thread>
 #include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -46,6 +48,7 @@
 #include <android-base/strings.h>
 
 #include "common/libs/fs/shared_buf.h"
+#include "common/libs/utils/contains.h"
 #include "common/libs/utils/files.h"
 
 extern char** environ;
@@ -483,6 +486,18 @@ Subprocess Command::Start(SubprocessOptions options) const {
 }
 
 std::ostream& operator<<(std::ostream& out, const Command& command) {
+  std::unordered_set<std::string> to_show{"HOME",
+                                          "ANDROID_HOST_OUT",
+                                          "ANDROID_SOONG_HOST_OUT",
+                                          "ANDROID_PRODUCT_OUT",
+                                          "CUTTLEFISH_CONFIG_FILE",
+                                          "CUTTLEFISH_INSTANCE"};
+  for (const std::string& env_var : command.env_) {
+    std::vector<std::string> env_split = android::base::Split(env_var, "=");
+    if (!env_split.empty() && Contains(to_show, env_split.front())) {
+      out << env_var << " ";
+    }
+  }
   return out << android::base::Join(command.command_, " ");
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
@@ -378,9 +378,16 @@ Result<void> CvdCreateCommandHandler::Handle(const CommandRequest& request) {
   }
 
   // Validate the host artifacts path before proceeding
-  (void)CF_EXPECT(HostToolTarget(flags.host_path).GetStartBinName(),
-                  "\nMaybe try `cvd fetch` or running `lunch "
-                  "<target>; m` to enable starting a CF device?");
+  (void)CF_EXPECT(
+      HostToolTarget(flags.host_path).GetStartBinName(),
+      "\nCould not find the required host tools to launch a device.\n\n"
+      "If you already have the host tools and devices images downloaded use "
+      "the `--host_path` and `--product_path` flags.\nSee `cvd help create` "
+      "for more details.\n\n"
+      "If you need to download host tools or system images try using `cvd "
+      "fetch`.\nFor example: `cvd fetch --default_build=<branch>/<target>`\n\n"
+      "If you are building Android from source, try running `lunch <target>; "
+      "m` to set up your environment and build the images.");
   // CreationAnalyzer needs these to be set in the environment
   envs[kAndroidHostOut] = AbsolutePath(flags.host_path);
   envs[kAndroidProductOut] = AbsolutePath(flags.product_path);

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -511,7 +511,10 @@ Result<void> CvdStartCommandHandler::Handle(const CommandRequest& request) {
   const bool is_help = CF_EXPECT(HasHelpFlag(subcmd_args));
 
   if (is_help) {
-    auto android_host_out = CF_EXPECT(AndroidHostPath(envs));
+    auto android_host_out =
+        CF_EXPECT(AndroidHostPath(envs),
+                  "\nTry running this command from the same directory as the "
+                  "downloaded or fetched host tools.");
     const auto bin = CF_EXPECT(FindStartBin(android_host_out));
 
     Command command =

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -520,7 +520,8 @@ Result<void> CvdStartCommandHandler::Handle(const CommandRequest& request) {
 
     siginfo_t infop;  // NOLINT(misc-include-cleaner)
     command.Start().Wait(&infop, WEXITED);
-    CF_EXPECT(CheckProcessExitedNormally(infop));
+    // gflags (and flag_parser for compatibility) exit with 1 after help output
+    CF_EXPECT(CheckProcessExitedNormally(infop, 1));
     return {};
   }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -421,25 +421,6 @@ Result<Command> CvdStartCommandHandler::ConstructCvdNonHelpCommand(
   return non_help_command;
 }
 
-static void ShowLaunchCommand(const Command& command,
-                              const cvd_common::Envs& envs) {
-  std::stringstream ss;
-  std::vector<std::string> interesting_env_names{"HOME",
-                                                 kAndroidHostOut,
-                                                 kAndroidSoongHostOut,
-                                                 "ANDROID_PRODUCT_OUT",
-                                                 kCuttlefishInstanceEnvVarName,
-                                                 kCuttlefishConfigEnvVarName};
-  for (const auto& interesting_env_name : interesting_env_names) {
-    if (Contains(envs, interesting_env_name)) {
-      ss << interesting_env_name << "=\"" << envs.at(interesting_env_name)
-         << "\" ";
-    }
-  }
-  ss << " " << command;
-  LOG(INFO) << "launcher command: " << ss.str();
-}
-
 Result<std::string> CvdStartCommandHandler::FindStartBin(
     const std::string& android_host_out) {
   return CF_EXPECT(HostToolTarget(android_host_out).GetStartBinName());
@@ -535,7 +516,7 @@ Result<void> CvdStartCommandHandler::Handle(const CommandRequest& request) {
 
     Command command =
         CF_EXPECT(ConstructCvdHelpCommand(bin, envs, subcmd_args, request));
-    ShowLaunchCommand(command, envs);
+    LOG(INFO) << "help command: " << command;
 
     siginfo_t infop;  // NOLINT(misc-include-cleaner)
     command.Start().Wait(&infop, WEXITED);
@@ -638,7 +619,7 @@ Result<void> CvdStartCommandHandler::LaunchDevice(
                   "information won't show in the UI: "
                << conn_res.error().FormatForEnv();
   }
-  ShowLaunchCommand(launch_command, envs);
+  LOG(INFO) << "launch command: " << launch_command;
 
   CF_EXPECT(subprocess_waiter_.Setup(launch_command));
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
@@ -35,8 +35,9 @@
 
 namespace cuttlefish {
 
-Result<void> CheckProcessExitedNormally(siginfo_t infop) {
-  if (infop.si_code == CLD_EXITED && infop.si_status == 0) {
+Result<void> CheckProcessExitedNormally(siginfo_t infop,
+                                        const int expected_exit_code) {
+  if (infop.si_code == CLD_EXITED && infop.si_status == expected_exit_code) {
     return {};
   }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
@@ -84,13 +84,12 @@ Result<Command> ConstructCvdHelpCommand(
     const std::string& bin_file, cvd_common::Envs envs,
     const std::vector<std::string>& subcmd_args,
     const CommandRequest& request) {
-  const auto host_artifacts_path = envs.at("ANDROID_HOST_OUT");
-  const auto bin_path = host_artifacts_path + "/bin/" + bin_file;
   auto client_pwd = CurrentDirectory();
   const auto home = (Contains(envs, "HOME") ? envs.at("HOME") : client_pwd);
   cvd_common::Envs envs_copy{envs};
   envs_copy["HOME"] = AbsolutePath(home);
   auto android_host_out = CF_EXPECT(AndroidHostPath(envs));
+  const auto bin_path = android_host_out + "/bin/" + bin_file;
   envs_copy[kAndroidHostOut] = android_host_out;
   envs_copy[kAndroidSoongHostOut] = android_host_out;
   ConstructCommandParam construct_cmd_param{.bin_path = bin_path,

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
@@ -90,8 +90,8 @@ Result<Command> ConstructCvdHelpCommand(
   cvd_common::Envs envs_copy{envs};
   envs_copy["HOME"] = AbsolutePath(home);
   auto android_host_out = CF_EXPECT(AndroidHostPath(envs));
-  envs[kAndroidHostOut] = android_host_out;
-  envs[kAndroidSoongHostOut] = android_host_out;
+  envs_copy[kAndroidHostOut] = android_host_out;
+  envs_copy[kAndroidSoongHostOut] = android_host_out;
   ConstructCommandParam construct_cmd_param{.bin_path = bin_path,
                                             .home = home,
                                             .args = subcmd_args,

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
@@ -29,7 +29,8 @@
 
 namespace cuttlefish {
 
-Result<void> CheckProcessExitedNormally(siginfo_t infop);
+Result<void> CheckProcessExitedNormally(siginfo_t infop,
+                                        const int expected_exit_code = 0);
 
 struct ConstructCommandParam {
   const std::string& bin_path;

--- a/base/cvd/cuttlefish/host/commands/cvd/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/utils/BUILD.bazel
@@ -24,6 +24,7 @@ cc_library(
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/common/libs/utils",
         "//cuttlefish/host/commands/cvd/cli:types",
+        "//cuttlefish/host/libs/config:config_utils",
         "//libbase",
         "@tinyxml2",
     ],

--- a/base/cvd/cuttlefish/host/commands/cvd/utils/common.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/utils/common.cpp
@@ -26,17 +26,9 @@
 #include "cuttlefish/common/libs/utils/contains.h"
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/libs/config/config_utils.h"
 
 namespace cuttlefish {
-
-namespace {
-
-bool IsValidAndroidHostOutPath(const std::string& path) {
-  std::string start_bin_path = path + "/bin/cvd_internal_start";
-  return FileExists(start_bin_path);
-}
-
-}  // namespace
 
 /*
  * Most branches read the kAndroidHostOut environment variable, but a few read
@@ -61,7 +53,8 @@ Result<std::string> AndroidHostPath(const cvd_common::Envs& envs) {
     return it->second;
   }
   auto current_dir = CurrentDirectory();
-  CF_EXPECT(IsValidAndroidHostOutPath(current_dir));
+  CF_EXPECT(IsValidAndroidHostOutPath(current_dir),
+            "Unable to find a valid host tool directory.");
   return current_dir;
 }
 

--- a/base/cvd/cuttlefish/host/libs/config/config_utils.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/config_utils.cpp
@@ -27,6 +27,7 @@
 #include "common/libs/utils/architecture.h"
 #include "common/libs/utils/contains.h"
 #include "common/libs/utils/environment.h"
+#include "common/libs/utils/files.h"
 #include "common/libs/utils/in_sandbox.h"
 #include "common/libs/utils/subprocess.h"
 #include "host/libs/config/config_constants.h"
@@ -158,6 +159,11 @@ std::string DefaultEnvironmentPath(const std::string& environment_key,
                                    const std::string& default_value,
                                    const std::string& subpath) {
   return StringFromEnv(environment_key, default_value) + "/" + subpath;
+}
+
+bool IsValidAndroidHostOutPath(const std::string& path) {
+  std::string start_bin_path = path + "/bin/cvd_internal_start";
+  return FileExists(start_bin_path);
 }
 
 // In practice this is mostly validating that the `cuttlefish-base` debian

--- a/base/cvd/cuttlefish/host/libs/config/config_utils.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/config_utils.cpp
@@ -154,6 +154,12 @@ std::string DefaultGuestImagePath(const std::string& file_name) {
          file_name;
 }
 
+std::string DefaultEnvironmentPath(const std::string& environment_key,
+                                   const std::string& default_value,
+                                   const std::string& subpath) {
+  return StringFromEnv(environment_key, default_value) + "/" + subpath;
+}
+
 // In practice this is mostly validating that the `cuttlefish-base` debian
 // package is installed, which implies that more things are present like the
 // predefined network setup.

--- a/base/cvd/cuttlefish/host/libs/config/config_utils.h
+++ b/base/cvd/cuttlefish/host/libs/config/config_utils.h
@@ -55,6 +55,7 @@ std::string DefaultGuestImagePath(const std::string& file);
 std::string DefaultEnvironmentPath(const std::string& environment_key,
                                    const std::string& default_value,
                                    const std::string& subpath);
+bool IsValidAndroidHostOutPath(const std::string& path);
 
 // Whether the host supports qemu
 bool HostSupportsQemuCli();

--- a/base/cvd/cuttlefish/host/libs/config/config_utils.h
+++ b/base/cvd/cuttlefish/host/libs/config/config_utils.h
@@ -52,9 +52,9 @@ std::string HostBinaryPath(const std::string& binary_name);
 std::string HostUsrSharePath(const std::string& file);
 std::string HostQemuBiosPath();
 std::string DefaultGuestImagePath(const std::string& file);
-std::string DefaultEnvironmentPath(const char* environment_key,
-                                   const char* default_value,
-                                   const char* path);
+std::string DefaultEnvironmentPath(const std::string& environment_key,
+                                   const std::string& default_value,
+                                   const std::string& subpath);
 
 // Whether the host supports qemu
 bool HostSupportsQemuCli();

--- a/base/cvd/cuttlefish/host/libs/config/config_utils.h
+++ b/base/cvd/cuttlefish/host/libs/config/config_utils.h
@@ -63,4 +63,5 @@ bool HostSupportsQemuCli();
 bool UseQemuPrebuilt();
 
 std::string GetSeccompPolicyDir();
-}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.cpp
@@ -42,12 +42,6 @@ const char* kInstances = "instances";
 
 }  // namespace
 
-std::string DefaultEnvironmentPath(const char* environment_key,
-                                   const char* default_value,
-                                   const char* subpath) {
-  return StringFromEnv(environment_key, default_value) + "/" + subpath;
-}
-
 bool IsRestoring(const CuttlefishConfig& config) {
   return FileExists(config.AssemblyPath("restore"));
 }


### PR DESCRIPTION
Along with some error message improvements and other small cleanups related to the above.


Copied from the major commit messages:

- [Remove same directory requirement for subtools](https://github.com/google/android-cuttlefish/commit/12a7a8b038636e87af0045bec41ddcfa49b39ba7) 

Previously, `assemble_cvd` and `run_cvd` must be run from the same
directory as `cvd_internal_start`.  With our current substitution
strategy, this meant that substituting `cvd_internal_start` also forced
substitution of the others.

This version CAN (via environment variable or CWD) substitute only
`cvd_internal_start`.  `cvd create` and `cvd start` always set
`ANDROID_HOST_OUT`, for instance.



- [Fix cvd start --help in some cases](https://github.com/google/android-cuttlefish/commit/2a239d399248a446c62b94846a70f1b9a1e32d16) 

It expected `ANDROID_HOST_OUT` to be set, and looked it up in a way that
would throw an exception if it did not exist.  This version,
specifically for `start` help invocations, allows falling back to
different locations to find the host tools for the user's convenience.

That value needs to be propogated through to the subtool `Command`
invocations because of requirements on `etc/` files for outputting
flags.

Test: `cvd start --help` in a non-HOME directory with fetched host tools
and `ANDROID_HOST_OUT` unset.