### PR TITLE
Disable android10-gsi boot test for now.

### DIFF
--- a/e2etests/cvd/BUILD.bazel
+++ b/e2etests/cvd/BUILD.bazel
@@ -31,11 +31,11 @@ launch_cvd_boot_test(
     target = "aosp_cf_x86_64_phone-userdebug",
 )
 
-launch_cvd_boot_test(
-    name = "fetch_and_launch_aosp_android10_phone",
-    branch = "aosp-android10-gsi",
-    target = "aosp_cf_x86_64_phone-userdebug",
-)
+# launch_cvd_boot_test(
+#     name = "fetch_and_launch_aosp_android10_phone",
+#     branch = "aosp-android10-gsi",
+#     target = "aosp_cf_x86_64_phone-userdebug",
+# )
 
 # cvd load tests
 cvd_load_boot_test(


### PR DESCRIPTION
The most recent android10-gsi build has been archived. Disable the test while we figure out if we can get another build.

Bug: b/409672836