### PR TITLE
Add a missing include

### DIFF
--- a/base/cvd/cuttlefish/host/commands/sensors_simulator/sensors_simulator.h
+++ b/base/cvd/cuttlefish/host/commands/sensors_simulator/sensors_simulator.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <chrono>
+#include <mutex>
 #include <string>
 
 #include <Eigen/Dense>


### PR DESCRIPTION
Was causing builds to fail when using the Clang 19 toolchain.

Test: bazel build //cuttlefish/package:cvd --extratoolchains=//toolchain:linux_local_clang_19