### PR TITLE
Disable auto updating CF debian packages at the runtime of Docker image

### DIFF
--- a/docker/guest/run_services.sh
+++ b/docker/guest/run_services.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 
-apt update
-apt --only-upgrade -y --no-install-recommends install \
-  cuttlefish-base \
-  cuttlefish-user \
-  cuttlefish-orchestration
-
 service nginx start
 service cuttlefish-host-resources start
 service cuttlefish-operator start


### PR DESCRIPTION
(Bug: b/408156615)

After building docker image with `docker/image-builder.sh`, users can select whether to perform auto update of CF debian packages or not.

```
docker run --privileged -e AUTO_UPDATE_CF_DEBIAN_PACKAGES=true cuttlefish-orchestration // Enable auto update
```

```
docker run --privileged -e AUTO_UPDATE_CF_DEBIAN_PACKAGES=false cuttlefish-orchestration // Disable auto update
```

```
docker run --privileged cuttlefish-orchestration // Default is for disabling auto update
```