### PR TITLE
Add option to disable checking if link_name exists

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/host_pkg_migration.proto
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/host_pkg_migration.proto
@@ -23,4 +23,7 @@ message HostPkgMigrationConfig {
 message Symlink {
   string target = 1;
   string link_name = 2;
+  // If true, disables checking that `link_name` exists. Useful for targets
+  // which conditionally exist such as host arch specific files.
+  bool ignore_link_name_presence_check = 3;
 }


### PR DESCRIPTION
The host lavapipe/swiftshader vulkan libraries and ICD manifest json files historically exist in a nested aarch64-linux-gnu or x86_64-linux-gnu subdirectory depending on the host arch.

Instead of adding more complex logic to have a link_name per host arch, let's just add to option to skip the check and then debian_substituion_marker can be updated with:

```
symlinks: {
  target: "/usr/lib/cuttlefish-common/bin/libvk_swiftshader.so"
  link_name: "bin/aarch64-linux-gnu/vulkan.pastel.so"
}
symlinks: {
  target: "/usr/lib/cuttlefish-common/bin/libvk_swiftshader.so"
  link_name: "bin/x86_64-linux-gnu/vulkan.pastel.so"
}
```

to create 2 links (one of which would never be used).

After the host migration is fully rolled out and stable, crosvm_manager.cpp can be to reference the new vulkan libraries and vulkan manfiest files directly.

Bug: b/410874401