### PR TITLE
Build and package simg2img

### DIFF
--- a/base/cvd/cuttlefish/host/libs/config/known_paths.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/known_paths.cpp
@@ -119,6 +119,10 @@ std::string SensorsSimulatorBinary() {
   return HostBinaryPath("sensors_simulator");
 }
 
+std::string Simg2ImgBinary() {
+  return HostBinaryPath("simg2img");
+}
+
 std::string SocketVsockProxyBinary() {
   return HostBinaryPath("socket_vsock_proxy");
 }

--- a/base/cvd/cuttlefish/host/libs/config/known_paths.h
+++ b/base/cvd/cuttlefish/host/libs/config/known_paths.h
@@ -48,6 +48,7 @@ std::string RootCanalBinary();
 std::string ScreenRecordingServerBinary();
 std::string SecureEnvBinary();
 std::string SensorsSimulatorBinary();
+std::string Simg2ImgBinary();
 std::string SocketVsockProxyBinary();
 std::string StopCvdBinary();
 std::string TcpConnectorBinary();

--- a/base/cvd/cuttlefish/host/libs/image_aggregator/sparse_image_utils.cc
+++ b/base/cvd/cuttlefish/host/libs/image_aggregator/sparse_image_utils.cc
@@ -30,6 +30,7 @@
 #include "common/libs/utils/subprocess.h"
 #include "host/libs/config/config_utils.h"
 #include "host/libs/config/cuttlefish_config.h"
+#include "host/libs/config/known_paths.h"
 
 namespace cuttlefish {
 namespace {
@@ -71,7 +72,7 @@ Result<void> ForceRawImage(const std::string& image_path) {
   std::string tmp_raw_image_path = image_path + ".raw";
   // Use simg2img to convert sparse image to raw images.
   int simg2img_status =
-      Execute({HostBinaryPath("simg2img"), image_path, tmp_raw_image_path});
+      Execute({Simg2ImgBinary(), image_path, tmp_raw_image_path});
 
   CF_EXPECT_EQ(simg2img_status, 0,
                "Unable to convert Android sparse image '"

--- a/base/cvd/cuttlefish/package/BUILD.bazel
+++ b/base/cvd/cuttlefish/package/BUILD.bazel
@@ -46,6 +46,7 @@ package_files(
         "cuttlefish-common/bin/run_cvd": "//cuttlefish/host/commands/run_cvd",
         "cuttlefish-common/bin/screen_recording_server": "//cuttlefish/host/commands/screen_recording_server",
         "cuttlefish-common/bin/sensors_simulator": "//cuttlefish/host/commands/sensors_simulator",
+        "cuttlefish-common/bin/simg2img": "//libsparse:simg2img",
         "cuttlefish-common/bin/snapshot_util_cvd": "//cuttlefish/host/commands/snapshot_util_cvd",
         "cuttlefish-common/bin/socket_vsock_proxy": "//cuttlefish/common/frontend/socket_vsock_proxy",
         "cuttlefish-common/bin/tcp_connector": "//cuttlefish/host/commands/tcp_connector",

--- a/base/cvd/libsparse/BUILD.bazel
+++ b/base/cvd/libsparse/BUILD.bazel
@@ -6,21 +6,21 @@ cc_library(
     name = "libsparse",
     srcs = [
         "backed_block.cpp",
+        "backed_block.h",
+        "defs.h",
         "output_file.cpp",
+        "output_file.h",
         "sparse.cpp",
         "sparse_crc32.cpp",
+        "sparse_crc32.h",
+        "sparse_defs.h",
         "sparse_err.cpp",
+        "sparse_file.h",
+        "sparse_format.h",
         "sparse_read.cpp",
     ],
     hdrs = [
-        "backed_block.h",
-        "defs.h",
         "include/sparse/sparse.h",
-        "output_file.h",
-        "sparse_crc32.h",
-        "sparse_defs.h",
-        "sparse_file.h",
-        "sparse_format.h",
     ],
     copts = [
         "-Wno-vla-cxx-extension",
@@ -31,4 +31,10 @@ cc_library(
         "//libbase",
         "@zlib",
     ],
+)
+
+cc_binary(
+    name = "simg2img",
+    srcs = ["simg2img.cpp"],
+    deps = [":libsparse"],
 )


### PR DESCRIPTION
Migrated simg2img to known_paths at the same time, and cleaned up the unnecessary exported hdrs in the libsparse module.