### PR TITLE
Split `//cuttlefish/host/libs/config` and enforce `misc-include-cleaner`

### DIFF
--- a/base/cvd/BUILD.bazel
+++ b/base/cvd/BUILD.bazel
@@ -40,6 +40,7 @@ filegroup(
         "//cuttlefish/host/commands/kernel_log_monitor:.clang-tidy",
         "//cuttlefish/host/commands/mkenvimage_slim:.clang-tidy",
         "//cuttlefish/host/commands/run_cvd/launch:.clang-tidy",
+        "//cuttlefish/host/libs/config:.clang-tidy",
         "//cuttlefish/host/libs/web:.clang-tidy",
     ],
 )

--- a/base/cvd/cuttlefish/host/libs/config/.clang-tidy
+++ b/base/cvd/cuttlefish/host/libs/config/.clang-tidy
@@ -1,0 +1,29 @@
+# "clang-diagnostic-pragma-once-outside-header" has a bad interaction with the
+# `parse_headers` bazel feature.
+
+Checks: &checks >-
+  clang-analyzer-*,
+  clang-diagnostic-*,
+  -clang-diagnostic-pragma-once-outside-header,
+  misc-definitions-in-headers,
+  misc-include-cleaner,
+  misc-unused-alias-decls,
+  readability-avoid-const-params-in-decls,
+  readability-const-return-type,
+  readability-container-size-empty,
+  readability-inconsistent-declaration-parameter-name,
+  readability-misleading-indentation,
+  readability-redundant-control-flow,
+  readability-string-compare,
+
+# Using the bazel clang-tidy helper, warnings are not shown from files that
+# don't have any errors.  "*" here treats everything from `Checks` as an error,
+# and from there some exclusions are added.
+WarningsAsErrors: >
+  *,
+  -clang-analyzer-core.uninitialized.Assign,
+  -clang-analyzer-core.UndefinedBinaryOperatorResult,
+  -clang-diagnostic-builtin-macro-redefined,
+  -clang-diagnostic-pragma-once-outside-header,
+  -clang-diagnostic-unused-const-variable,
+  -clang-diagnostic-unused-variable,

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -17,7 +17,6 @@ cc_library(
         "instance_nums.cpp",
         "kernel_args.cpp",
         "known_paths.cpp",
-        "logging.cpp",
         "openwrt_args.cpp",
     ],
     # Intentionally repeats headers from other targets so other targets can
@@ -59,6 +58,7 @@ cc_library(
         "//cuttlefish/host/libs/config:config_utils",
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:feature",
+        "//cuttlefish/host/libs/config:logging",
         "//cuttlefish/host/libs/config:secure_hals",
         "//cuttlefish/host/libs/config:touchpad",
         "//libbase",
@@ -193,6 +193,25 @@ cc_library(
 clang_tidy_test(
     name = "feature_clang_tidy",
     srcs = [":feature"],
+    tags = ["clang-tidy", "clang_tidy"],
+)
+
+cc_library(
+    name = "logging",
+    srcs = ["logging.cpp"],
+    hdrs = ["logging.h"],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+    deps = [
+        "//cuttlefish/common/libs/utils",
+        "//cuttlefish/host/libs/config:cuttlefish_config",
+        "//libbase",
+    ],
+)
+
+clang_tidy_test(
+    name = "logging_clang_tidy",
+    srcs = [":logging"],
     tags = ["clang-tidy", "clang_tidy"],
 )
 

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -8,7 +8,6 @@ package(
 cc_library(
     name = "config",
     srcs = [
-        "data_image.cpp",
         "fetcher_config.cpp",
     ],
     # Intentionally repeats headers from other targets so other targets can
@@ -50,6 +49,7 @@ cc_library(
         "//cuttlefish/host/libs/config:config_utils",
         "//cuttlefish/host/libs/config:custom_actions",
         "//cuttlefish/host/libs/config:cuttlefish_config",
+        "//cuttlefish/host/libs/config:data_image",
         "//cuttlefish/host/libs/config:display",
         "//cuttlefish/host/libs/config:esp",
         "//cuttlefish/host/libs/config:feature",
@@ -200,6 +200,30 @@ clang_tidy_test(
     name = "cuttlefish_config_clang_tidy",
     srcs = [":cuttlefish_config"],
     tags = ["clang-tidy", "clang_tidy"],
+)
+
+cc_library(
+    name = "data_image",
+    srcs = ["data_image.cpp"],
+    hdrs = ["data_image.h"],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+    deps = [
+        "//cuttlefish/common/libs/fs",
+        "//cuttlefish/common/libs/utils",
+        "//cuttlefish/common/libs/utils:result",
+        "//cuttlefish/host/libs/config:cuttlefish_config",
+        "//cuttlefish/host/libs/config:esp",
+        "//cuttlefish/host/libs/config:mbr",
+        "//cuttlefish/host/libs/config:openwrt_args",
+        "//libbase",
+    ],
+)
+
+clang_tidy_test(
+    name = "data_image_clang_tidy",
+    srcs = [":data_image"],
+    tags = ["clang_tidy", "clang-tidy"],
 )
 
 cc_library(

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -13,7 +13,6 @@ cc_library(
         "esp.cpp",
         "fetcher_config.cpp",
         "host_tools_version.cpp",
-        "instance_nums.cpp",
     ],
     # Intentionally repeats headers from other targets so other targets can
     # continue to depend on `:config` for everything.
@@ -55,6 +54,7 @@ cc_library(
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:display",
         "//cuttlefish/host/libs/config:feature",
+        "//cuttlefish/host/libs/config:instance_nums",
         "//cuttlefish/host/libs/config:kernel_args",
         "//cuttlefish/host/libs/config:known_paths",
         "//cuttlefish/host/libs/config:logging",
@@ -215,6 +215,27 @@ clang_tidy_test(
     name = "feature_clang_tidy",
     srcs = [":feature"],
     tags = ["clang-tidy", "clang_tidy"],
+)
+
+cc_library(
+    name = "instance_nums",
+    srcs = ["instance_nums.cpp"],
+    hdrs = ["instance_nums.h"],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+    deps = [
+        "//cuttlefish/common/libs/utils",
+        "//cuttlefish/common/libs/utils:result",
+        "//cuttlefish/host/libs/config:config_utils",
+        "//libbase",
+        "@gflags",
+    ],
+)
+
+clang_tidy_test(
+    name = "instance_nums_clang_tidy",
+    srcs = [":instance_nums"],
+    tags = ["clang_tidy", "clang-tidy"],
 )
 
 cc_library(

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -8,7 +8,6 @@ package(
 cc_library(
     name = "config",
     srcs = [
-        "config_flag.cpp",
         "custom_actions.cpp",
         "data_image.cpp",
         "display.cpp",
@@ -56,6 +55,7 @@ cc_library(
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/commands/assemble_cvd:libassemble_cvd",
         "//cuttlefish/host/libs/config:config_constants",
+        "//cuttlefish/host/libs/config:config_flag",
         "//cuttlefish/host/libs/config:config_fragment",
         "//cuttlefish/host/libs/config:config_utils",
         "//cuttlefish/host/libs/config:cuttlefish_config",
@@ -87,6 +87,29 @@ clang_tidy_test(
     name = "config_constants_clang_tidy",
     srcs = [":config_constants"],
     tags = ["clang_tidy", "clang-tidy"],
+)
+
+cc_library(
+    name = "config_flag",
+    srcs = ["config_flag.cpp"],
+    hdrs = ["config_flag.h"],
+    deps = [
+        "//cuttlefish/common/libs/utils",
+        "//cuttlefish/common/libs/utils:result",
+        "//cuttlefish/host/libs/config:cuttlefish_config",
+        "//cuttlefish/host/libs/config:feature",
+        "//cuttlefish/host/commands/assemble_cvd:libassemble_cvd",
+        "//libbase",
+        "@fruit",
+        "@gflags",
+        "@jsoncpp",
+    ],
+)
+
+clang_tidy_test(
+    name = "config_flag_clang_tidy",
+    srcs = [":config_flag"],
+    tags = ["clang-tidy", "clang_tidy"],
 )
 
 cc_library(

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -19,7 +19,6 @@ cc_library(
         "known_paths.cpp",
         "logging.cpp",
         "openwrt_args.cpp",
-        "touchpad.cpp",
     ],
     # Intentionally repeats headers from other targets so other targets can
     # continue to depend on `:config` for everything.
@@ -61,6 +60,7 @@ cc_library(
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:feature",
         "//cuttlefish/host/libs/config:secure_hals",
+        "//cuttlefish/host/libs/config:touchpad",
         "//libbase",
         "@fmt",
         "@fruit",
@@ -211,5 +211,25 @@ cc_library(
 clang_tidy_test(
     name = "secure_hals_clang_tidy",
     srcs = [":secure_hals"],
+    tags = ["clang_tidy", "clang-tidy"],
+)
+
+cc_library(
+    name = "touchpad",
+    srcs = ["touchpad.cpp"],
+    hdrs = ["touchpad.h"],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+    deps = [
+        "//cuttlefish/common/libs/utils",
+        "//cuttlefish/common/libs/utils:result",
+        "//cuttlefish/host/libs/config:cuttlefish_config",
+        "//libbase",
+    ],
+)
+
+clang_tidy_test(
+    name = "touchpad_clang_tidy",
+    srcs = [":touchpad"],
     tags = ["clang_tidy", "clang-tidy"],
 )

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -15,7 +15,6 @@ cc_library(
         "fetcher_config.cpp",
         "host_tools_version.cpp",
         "instance_nums.cpp",
-        "kernel_args.cpp",
     ],
     # Intentionally repeats headers from other targets so other targets can
     # continue to depend on `:config` for everything.
@@ -56,6 +55,7 @@ cc_library(
         "//cuttlefish/host/libs/config:config_utils",
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:feature",
+        "//cuttlefish/host/libs/config:kernel_args",
         "//cuttlefish/host/libs/config:known_paths",
         "//cuttlefish/host/libs/config:logging",
         "//cuttlefish/host/libs/config:openwrt_args",
@@ -195,6 +195,22 @@ clang_tidy_test(
     srcs = [":feature"],
     tags = ["clang-tidy", "clang_tidy"],
 )
+
+cc_library(
+    name = "kernel_args",
+    srcs = ["kernel_args.cpp"],
+    hdrs = ["kernel_args.h"],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+    deps = ["//cuttlefish/host/libs/config:cuttlefish_config"],
+)
+
+clang_tidy_test(
+    name = "kernel_args_clang_tidy",
+    srcs = ["kernel_args"],
+    tags = ["clang_tidy", "clang-tidy"],
+)
+
 
 cc_library(
     name = "known_paths",

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -10,9 +10,6 @@ cc_library(
     srcs = [
         "config_flag.cpp",
         "custom_actions.cpp",
-        "cuttlefish_config.cpp",
-        "cuttlefish_config_instance.cpp",
-        "cuttlefish_config_environment.cpp",
         "data_image.cpp",
         "display.cpp",
         "esp.cpp",
@@ -24,9 +21,10 @@ cc_library(
         "known_paths.cpp",
         "logging.cpp",
         "openwrt_args.cpp",
-        "secure_hals.cpp",
         "touchpad.cpp",
     ],
+    # Intentionally repeats headers from other targets so other targets can
+    # continue to depend on `:config` for everything.
     hdrs = [
         "command_source.h",
         "config_flag.h",
@@ -61,6 +59,8 @@ cc_library(
         "//cuttlefish/host/libs/config:config_constants",
         "//cuttlefish/host/libs/config:config_fragment",
         "//cuttlefish/host/libs/config:config_utils",
+        "//cuttlefish/host/libs/config:cuttlefish_config",
+        "//cuttlefish/host/libs/config:secure_hals",
         "//libbase",
         "@fmt",
         "@fruit",
@@ -120,5 +120,53 @@ cc_library(
 clang_tidy_test(
     name = "config_utils_clang_tidy",
     srcs = [":config_utils"],
+    tags = ["clang_tidy", "clang-tidy"],
+)
+
+cc_library(
+    name = "cuttlefish_config",
+    srcs = [
+        "cuttlefish_config.cpp",
+        "cuttlefish_config_environment.cpp",
+        "cuttlefish_config_instance.cpp",
+    ],
+    hdrs = ["cuttlefish_config.h"],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+    deps = [
+        "//cuttlefish/common/libs/utils",
+        "//cuttlefish/common/libs/utils:environment",
+        "//cuttlefish/common/libs/utils:result",
+        "//cuttlefish/host/libs/config:config_constants",
+        "//cuttlefish/host/libs/config:config_fragment",
+        "//cuttlefish/host/libs/config:config_utils",
+        "//cuttlefish/host/libs/config:secure_hals",
+        "//libbase",
+        "@fmt",
+        "@jsoncpp",
+    ],
+)
+
+clang_tidy_test(
+    name = "cuttlefish_config_clang_tidy",
+    srcs = [":cuttlefish_config"],
+    tags = ["clang-tidy", "clang_tidy"],
+)
+
+cc_library(
+    name = "secure_hals",
+    srcs = ["secure_hals.cpp"],
+    hdrs = ["secure_hals.h"],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+    deps = [
+        "//cuttlefish/common/libs/utils:result",
+        "//libbase",
+    ]
+)
+
+clang_tidy_test(
+    name = "secure_hals_clang_tidy",
+    srcs = [":secure_hals"],
     tags = ["clang_tidy", "clang-tidy"],
 )

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -5,6 +5,8 @@ package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
+exports_files([".clang-tidy"])
+
 cc_library(
     name = "config",
     # Intentionally repeats headers from other targets so outside targets can
@@ -84,10 +86,12 @@ cc_library(
     deps = [
         "//cuttlefish/common/libs/utils",
         "//cuttlefish/common/libs/utils:result",
+        "//cuttlefish/host/commands/assemble_cvd:libassemble_cvd",
+        "//cuttlefish/host/libs/config:config_utils",
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:feature",
-        "//cuttlefish/host/commands/assemble_cvd:libassemble_cvd",
         "//libbase",
+        "@fmt",
         "@fruit",
         "@gflags",
         "@jsoncpp",
@@ -145,6 +149,7 @@ cc_library(
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/libs/config:config_flag",
         "//cuttlefish/host/libs/config:config_fragment",
+        "//cuttlefish/host/libs/config:config_utils",
         "//cuttlefish/host/libs/config:feature",
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//libbase",
@@ -199,6 +204,7 @@ cc_library(
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils",
         "//cuttlefish/common/libs/utils:result",
+        "//cuttlefish/host/libs/config:config_utils",
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:esp",
         "//cuttlefish/host/libs/config:mbr",
@@ -243,7 +249,8 @@ cc_library(
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils",
-        "//cuttlefish/host/libs/config:cuttlefish_config",
+        "//cuttlefish/host/libs/config:config_utils",
+        "//libbase",
     ],
 )
 
@@ -303,6 +310,7 @@ cc_library(
     deps = [
         "//cuttlefish/common/libs/utils",
         "//cuttlefish/host/libs/config:config_utils",
+        "//libbase",
         "@zlib",
     ],
 )
@@ -340,7 +348,10 @@ cc_library(
     hdrs = ["kernel_args.h"],
     copts = COPTS,
     strip_include_prefix = "//cuttlefish",
-    deps = ["//cuttlefish/host/libs/config:cuttlefish_config"],
+    deps = [
+        "//cuttlefish/common/libs/utils",
+        "//cuttlefish/host/libs/config:cuttlefish_config",
+    ],
 )
 
 clang_tidy_test(

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -13,7 +13,6 @@ cc_library(
         "data_image.cpp",
         "display.cpp",
         "esp.cpp",
-        "feature.cpp",
         "fetcher_config.cpp",
         "host_tools_version.cpp",
         "instance_nums.cpp",
@@ -60,6 +59,7 @@ cc_library(
         "//cuttlefish/host/libs/config:config_fragment",
         "//cuttlefish/host/libs/config:config_utils",
         "//cuttlefish/host/libs/config:cuttlefish_config",
+        "//cuttlefish/host/libs/config:feature",
         "//cuttlefish/host/libs/config:secure_hals",
         "//libbase",
         "@fmt",
@@ -150,6 +150,26 @@ cc_library(
 clang_tidy_test(
     name = "cuttlefish_config_clang_tidy",
     srcs = [":cuttlefish_config"],
+    tags = ["clang-tidy", "clang_tidy"],
+)
+
+cc_library(
+    name = "feature",
+    srcs = ["feature.cpp"],
+    hdrs = ["feature.h"],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+    deps = [
+        "//cuttlefish/common/libs/utils",
+        "//cuttlefish/common/libs/utils:result",
+        "//libbase",
+        "@fruit",
+    ],
+)
+
+clang_tidy_test(
+    name = "feature_clang_tidy",
+    srcs = [":feature"],
     tags = ["clang-tidy", "clang_tidy"],
 )
 

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -16,7 +16,6 @@ cc_library(
         "host_tools_version.cpp",
         "instance_nums.cpp",
         "kernel_args.cpp",
-        "known_paths.cpp",
         "openwrt_args.cpp",
     ],
     # Intentionally repeats headers from other targets so other targets can
@@ -58,6 +57,7 @@ cc_library(
         "//cuttlefish/host/libs/config:config_utils",
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:feature",
+        "//cuttlefish/host/libs/config:known_paths",
         "//cuttlefish/host/libs/config:logging",
         "//cuttlefish/host/libs/config:secure_hals",
         "//cuttlefish/host/libs/config:touchpad",
@@ -193,6 +193,21 @@ cc_library(
 clang_tidy_test(
     name = "feature_clang_tidy",
     srcs = [":feature"],
+    tags = ["clang-tidy", "clang_tidy"],
+)
+
+cc_library(
+    name = "known_paths",
+    srcs = ["known_paths.cpp"],
+    hdrs = ["known_paths.h"],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+    deps = ["//cuttlefish/host/libs/config:config_utils"],
+)
+
+clang_tidy_test(
+    name = "known_paths_clang_tidy",
+    srcs = [":known_paths"],
     tags = ["clang-tidy", "clang_tidy"],
 )
 

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -16,7 +16,6 @@ cc_library(
         "host_tools_version.cpp",
         "instance_nums.cpp",
         "kernel_args.cpp",
-        "openwrt_args.cpp",
     ],
     # Intentionally repeats headers from other targets so other targets can
     # continue to depend on `:config` for everything.
@@ -59,6 +58,7 @@ cc_library(
         "//cuttlefish/host/libs/config:feature",
         "//cuttlefish/host/libs/config:known_paths",
         "//cuttlefish/host/libs/config:logging",
+        "//cuttlefish/host/libs/config:openwrt_args",
         "//cuttlefish/host/libs/config:secure_hals",
         "//cuttlefish/host/libs/config:touchpad",
         "//libbase",
@@ -228,6 +228,24 @@ clang_tidy_test(
     name = "logging_clang_tidy",
     srcs = [":logging"],
     tags = ["clang-tidy", "clang_tidy"],
+)
+
+cc_library(
+    name = "openwrt_args",
+    srcs = ["openwrt_args.cpp"],
+    hdrs = ["openwrt_args.h"],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+    deps = [
+        "//cuttlefish/host/libs/config:cuttlefish_config",
+        "//libbase",
+    ],
+)
+
+clang_tidy_test(
+    name = "openwrt_args_clang_tidy",
+    srcs = [":openwrt_args"],
+    tags = ["clang_tidy", "clang-tidy"],
 )
 
 cc_library(

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -8,9 +8,7 @@ package(
 cc_library(
     name = "config",
     srcs = [
-        "custom_actions.cpp",
         "data_image.cpp",
-        "esp.cpp",
         "fetcher_config.cpp",
         "host_tools_version.cpp",
     ],
@@ -51,8 +49,10 @@ cc_library(
         "//cuttlefish/host/libs/config:config_flag",
         "//cuttlefish/host/libs/config:config_fragment",
         "//cuttlefish/host/libs/config:config_utils",
+        "//cuttlefish/host/libs/config:custom_actions",
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:display",
+        "//cuttlefish/host/libs/config:esp",
         "//cuttlefish/host/libs/config:feature",
         "//cuttlefish/host/libs/config:instance_nums",
         "//cuttlefish/host/libs/config:kernel_args",
@@ -147,6 +147,31 @@ clang_tidy_test(
 )
 
 cc_library(
+    name = "custom_actions",
+    srcs = ["custom_actions.cpp"],
+    hdrs = ["custom_actions.h"],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+    deps = [
+        "//cuttlefish/common/libs/utils",
+        "//cuttlefish/common/libs/utils:result",
+        "//cuttlefish/host/libs/config:config_flag",
+        "//cuttlefish/host/libs/config:config_fragment",
+        "//cuttlefish/host/libs/config:feature",
+        "//cuttlefish/host/libs/config:cuttlefish_config",
+        "//libbase",
+        "@fruit",
+        "@jsoncpp",
+    ],
+)
+
+clang_tidy_test(
+    name = "custom_actions_clang_tidy",
+    srcs = [":custom_actions"],
+    tags = ["clang_tidy", "clang-tidy"],
+)
+
+cc_library(
     name = "cuttlefish_config",
     srcs = [
         "cuttlefish_config.cpp",
@@ -194,6 +219,25 @@ cc_library(
 clang_tidy_test(
     name = "display_clang_tidy",
     srcs = [":display"],
+    tags = ["clang_tidy", "clang-tidy"],
+)
+
+cc_library(
+    name = "esp",
+    srcs = ["esp.cpp"],
+    hdrs = ["esp.h"],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+    deps = [
+        "//cuttlefish/common/libs/fs",
+        "//cuttlefish/common/libs/utils",
+        "//cuttlefish/host/libs/config:cuttlefish_config",
+    ],
+)
+
+clang_tidy_test(
+    name = "esp_clang_tidy",
+    srcs = [":esp"],
     tags = ["clang_tidy", "clang-tidy"],
 )
 

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -7,11 +7,8 @@ package(
 
 cc_library(
     name = "config",
-    srcs = [
-        "fetcher_config.cpp",
-    ],
-    # Intentionally repeats headers from other targets so other targets can
-    # continue to depend on `:config` for everything.
+    # Intentionally repeats headers from other targets so outside targets can
+    # continue to depend on :config for everything. See go/cpp-build#splitting
     hdrs = [
         "command_source.h",
         "config_flag.h",
@@ -38,36 +35,26 @@ cc_library(
     copts = COPTS,
     strip_include_prefix = "//cuttlefish",
     deps = [
-        "//cuttlefish/common/libs/fs",
-        "//cuttlefish/common/libs/utils",
-        "//cuttlefish/common/libs/utils:environment",
-        "//cuttlefish/common/libs/utils:result",
-        "//cuttlefish/host/commands/assemble_cvd:libassemble_cvd",
-        "//cuttlefish/host/libs/config:config_constants",
-        "//cuttlefish/host/libs/config:config_flag",
-        "//cuttlefish/host/libs/config:config_fragment",
-        "//cuttlefish/host/libs/config:config_utils",
-        "//cuttlefish/host/libs/config:custom_actions",
-        "//cuttlefish/host/libs/config:cuttlefish_config",
-        "//cuttlefish/host/libs/config:data_image",
-        "//cuttlefish/host/libs/config:display",
-        "//cuttlefish/host/libs/config:esp",
-        "//cuttlefish/host/libs/config:feature",
-        "//cuttlefish/host/libs/config:host_tools_version",
-        "//cuttlefish/host/libs/config:instance_nums",
-        "//cuttlefish/host/libs/config:kernel_args",
-        "//cuttlefish/host/libs/config:known_paths",
-        "//cuttlefish/host/libs/config:logging",
-        "//cuttlefish/host/libs/config:mbr",
-        "//cuttlefish/host/libs/config:openwrt_args",
-        "//cuttlefish/host/libs/config:secure_hals",
-        "//cuttlefish/host/libs/config:touchpad",
-        "//libbase",
-        "@fmt",
-        "@fruit",
-        "@gflags",
-        "@jsoncpp",
-        "@zlib",
+        ":config_constants",
+        ":config_flag",
+        ":config_fragment",
+        ":config_utils",
+        ":custom_actions",
+        ":cuttlefish_config",
+        ":data_image",
+        ":display",
+        ":esp",
+        ":feature",
+        ":fetcher_config",
+        ":host_tools_version",
+        ":instance_nums",
+        ":kernel_args",
+        ":known_paths",
+        ":logging",
+        ":mbr",
+        ":openwrt_args",
+        ":secure_hals",
+        ":touchpad",
     ],
 )
 
@@ -284,6 +271,27 @@ clang_tidy_test(
     name = "feature_clang_tidy",
     srcs = [":feature"],
     tags = ["clang-tidy", "clang_tidy"],
+)
+
+cc_library(
+    name = "fetcher_config",
+    srcs = ["fetcher_config.cpp"],
+    hdrs = ["fetcher_config.h"],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+    deps = [
+        "//cuttlefish/common/libs/utils",
+        "//cuttlefish/common/libs/utils:result",
+        "//libbase",
+        "@gflags",
+        "@jsoncpp",
+    ],
+)
+
+clang_tidy_test(
+    name = "fetcher_config_clang_tidy",
+    srcs = [":fetcher_config"],
+    tags = ["clang_tidy", "clang-tidy"],
 )
 
 cc_library(

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -10,7 +10,6 @@ cc_library(
     srcs = [
         "custom_actions.cpp",
         "data_image.cpp",
-        "display.cpp",
         "esp.cpp",
         "fetcher_config.cpp",
         "host_tools_version.cpp",
@@ -54,6 +53,7 @@ cc_library(
         "//cuttlefish/host/libs/config:config_fragment",
         "//cuttlefish/host/libs/config:config_utils",
         "//cuttlefish/host/libs/config:cuttlefish_config",
+        "//cuttlefish/host/libs/config:display",
         "//cuttlefish/host/libs/config:feature",
         "//cuttlefish/host/libs/config:kernel_args",
         "//cuttlefish/host/libs/config:known_paths",
@@ -174,6 +174,27 @@ clang_tidy_test(
     name = "cuttlefish_config_clang_tidy",
     srcs = [":cuttlefish_config"],
     tags = ["clang-tidy", "clang_tidy"],
+)
+
+cc_library(
+    name = "display",
+    srcs = ["display.cpp"],
+    hdrs = ["display.h"],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+    deps = [
+        "//cuttlefish/common/libs/utils",
+        "//cuttlefish/common/libs/utils:result",
+        "//cuttlefish/host/commands/assemble_cvd:libassemble_cvd",
+        "//cuttlefish/host/libs/config:cuttlefish_config",
+        "//libbase",
+    ],
+)
+
+clang_tidy_test(
+    name = "display_clang_tidy",
+    srcs = [":display"],
+    tags = ["clang_tidy", "clang-tidy"],
 )
 
 cc_library(

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -58,6 +58,7 @@ cc_library(
         "//cuttlefish/host/libs/config:kernel_args",
         "//cuttlefish/host/libs/config:known_paths",
         "//cuttlefish/host/libs/config:logging",
+        "//cuttlefish/host/libs/config:mbr",
         "//cuttlefish/host/libs/config:openwrt_args",
         "//cuttlefish/host/libs/config:secure_hals",
         "//cuttlefish/host/libs/config:touchpad",
@@ -349,6 +350,19 @@ clang_tidy_test(
     name = "logging_clang_tidy",
     srcs = [":logging"],
     tags = ["clang-tidy", "clang_tidy"],
+)
+
+cc_library(
+    name = "mbr",
+    hdrs = ["mbr.h"],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+)
+
+clang_tidy_test(
+    name = "mbr_clang_tidy",
+    srcs = [":mbr"],
+    tags = ["clang_tidy", "clang-tidy"],
 )
 
 cc_library(

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -10,7 +10,6 @@ cc_library(
     srcs = [
         "data_image.cpp",
         "fetcher_config.cpp",
-        "host_tools_version.cpp",
     ],
     # Intentionally repeats headers from other targets so other targets can
     # continue to depend on `:config` for everything.
@@ -54,6 +53,7 @@ cc_library(
         "//cuttlefish/host/libs/config:display",
         "//cuttlefish/host/libs/config:esp",
         "//cuttlefish/host/libs/config:feature",
+        "//cuttlefish/host/libs/config:host_tools_version",
         "//cuttlefish/host/libs/config:instance_nums",
         "//cuttlefish/host/libs/config:kernel_args",
         "//cuttlefish/host/libs/config:known_paths",
@@ -259,6 +259,25 @@ clang_tidy_test(
     name = "feature_clang_tidy",
     srcs = [":feature"],
     tags = ["clang-tidy", "clang_tidy"],
+)
+
+cc_library(
+    name = "host_tools_version",
+    srcs = ["host_tools_version.cpp"],
+    hdrs = ["host_tools_version.h"],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+    deps = [
+        "//cuttlefish/common/libs/utils",
+        "//cuttlefish/host/libs/config:config_utils",
+        "@zlib",
+    ],
+)
+
+clang_tidy_test(
+    name = "host_tools_version_clang_tidy",
+    srcs = [":host_tools_version"],
+    tags = ["clang_tidy", "clang-tidy"],
 )
 
 cc_library(

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -53,13 +53,14 @@ cc_library(
     copts = COPTS,
     strip_include_prefix = "//cuttlefish",
     deps = [
-        ":config_constants",
-        ":config_utils",
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils",
         "//cuttlefish/common/libs/utils:environment",
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/commands/assemble_cvd:libassemble_cvd",
+        "//cuttlefish/host/libs/config:config_constants",
+        "//cuttlefish/host/libs/config:config_fragment",
+        "//cuttlefish/host/libs/config:config_utils",
         "//libbase",
         "@fmt",
         "@fruit",
@@ -77,9 +78,7 @@ clang_tidy_test(
 
 cc_library(
     name = "config_constants",
-    hdrs = [
-        "config_constants.h",
-    ],
+    hdrs = ["config_constants.h"],
     copts = COPTS,
     strip_include_prefix = "//cuttlefish",
 )
@@ -91,19 +90,29 @@ clang_tidy_test(
 )
 
 cc_library(
+    name = "config_fragment",
+    hdrs = ["config_fragment.h"],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+    deps = ["@jsoncpp"],
+)
+
+clang_tidy_test(
+    name = "config_fragment_clang_tidy",
+    srcs = [":config_fragment"],
+    tags = ["clang_tidy", "clang-tidy"],
+)
+
+cc_library(
     name = "config_utils",
-    srcs = [
-        "config_utils.cpp",
-    ],
-    hdrs = [
-        "config_utils.h",
-    ],
+    srcs = ["config_utils.cpp"],
+    hdrs = ["config_utils.h"],
     copts = COPTS,
     strip_include_prefix = "//cuttlefish",
     deps = [
-        ":config_constants",
         "//cuttlefish/common/libs/utils",
         "//cuttlefish/common/libs/utils:environment",
+        "//cuttlefish/host/libs/config:config_constants",
         "//libbase",
     ],
 )

--- a/base/cvd/cuttlefish/host/libs/config/adb/adb.h
+++ b/base/cvd/cuttlefish/host/libs/config/adb/adb.h
@@ -18,12 +18,11 @@
 #include <fruit/fruit.h>
 #include <set>
 
-#include "host/libs/config/command_source.h"
-#include "host/libs/config/config_flag.h"
-#include "host/libs/config/config_fragment.h"
-#include "host/libs/config/cuttlefish_config.h"
-#include "host/libs/config/feature.h"
-#include "host/libs/config/kernel_log_pipe_provider.h"
+#include "cuttlefish/host/libs/config/config_flag.h"
+#include "cuttlefish/host/libs/config/config_fragment.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/feature.h"
+#include "cuttlefish/host/libs/config/kernel_log_pipe_provider.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/adb/config.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/adb/config.cpp
@@ -13,13 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "host/libs/config/adb/adb.h"
+#include "cuttlefish/host/libs/config/adb/adb.h"
+
+#include <set>
+#include <string>
+#include <utility>
 
 #include <android-base/logging.h>
-#include <fruit/fruit.h>
-#include <json/json.h>
+#include <fruit/component.h>
+#include <fruit/fruit_forward_decls.h>
+#include <fruit/macro.h>
+#include <json/value.h>
 
-#include "host/libs/config/config_fragment.h"
+#include "cuttlefish/host/libs/config/config_fragment.h"
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/host/libs/config/adb/data.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/adb/data.cpp
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "host/libs/config/adb/adb.h"
+#include "cuttlefish/host/libs/config/adb/adb.h"
 
-#include <fruit/fruit.h>
 #include <set>
+#include <utility>
+
+#include <fruit/component.h>
+#include <fruit/macro.h>
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/host/libs/config/adb/flags.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/adb/flags.cpp
@@ -13,14 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "host/libs/config/adb/adb.h"
+#include "cuttlefish/host/libs/config/adb/adb.h"
 
+#include <ostream>
+#include <set>
+#include <sstream>
+#include <unordered_set>
+#include <vector>
+
+#include <android-base/logging.h>
 #include <android-base/strings.h>
+#include <fruit/component.h>
+#include <fruit/fruit_forward_decls.h>
+#include <fruit/macro.h>
 
-#include "common/libs/utils/container.h"
-#include "common/libs/utils/flag_parser.h"
-#include "host/libs/config/config_flag.h"
-#include "host/libs/config/feature.h"
+#include "cuttlefish/common/libs/utils/container.h"
+#include "cuttlefish/common/libs/utils/flag_parser.h"
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/libs/config/config_flag.h"
+#include "cuttlefish/host/libs/config/feature.h"
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/host/libs/config/adb/launch.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/adb/launch.cpp
@@ -13,21 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "host/libs/config/adb/adb.h"
+#include "cuttlefish/host/libs/config/adb/adb.h"
 
+#include <set>
 #include <string>
 #include <unordered_set>
 #include <utility>
 #include <vector>
 
-#include <fruit/fruit.h>
-#include <gflags/gflags.h>
+#include <fruit/component.h>
+#include <fruit/fruit_forward_decls.h>
+#include <fruit/macro.h>
 
-#include "common/libs/utils/result.h"
-#include "host/commands/kernel_log_monitor/utils.h"
-#include "host/libs/config/command_source.h"
-#include "host/libs/config/cuttlefish_config.h"
-#include "host/libs/config/known_paths.h"
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/common/libs/utils/subprocess.h"
+#include "cuttlefish/host/commands/kernel_log_monitor/kernel_log_server.h"
+#include "cuttlefish/host/libs/config/command_source.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/feature.h"
+#include "cuttlefish/host/libs/config/kernel_log_pipe_provider.h"
+#include "cuttlefish/host/libs/config/known_paths.h"
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/host/libs/config/adb/strings.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/adb/strings.cpp
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "host/libs/config/adb/adb.h"
+#include "cuttlefish/host/libs/config/adb/adb.h"
 
 #include <algorithm>
+#include <cctype>
 #include <string>
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/host/libs/config/adb/test.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/adb/test.cpp
@@ -14,13 +14,19 @@
  * limitations under the License.
  */
 
-#include <fruit/fruit.h>
-#include <gtest/gtest.h>
-#include <host/libs/config/adb/adb.h>
+#include "cuttlefish/host/libs/config/adb/adb.h"
 
+#include <set>
 #include <string>
+#include <vector>
 
-#include "host/libs/config/feature.h"
+#include <fruit/component.h>
+#include <fruit/macro.h>
+#include <fruit/injector.h>
+#include <gtest/gtest.h>
+
+#include "cuttlefish/host/libs/config/config_flag.h"
+#include "cuttlefish/host/libs/config/feature.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/command_source.h
+++ b/base/cvd/cuttlefish/host/libs/config/command_source.h
@@ -21,9 +21,9 @@
 #include <android-base/logging.h>
 #include <fruit/fruit.h>
 
-#include "common/libs/utils/result.h"
-#include "common/libs/utils/subprocess.h"
-#include "host/libs/config/feature.h"
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/common/libs/utils/subprocess.h"
+#include "cuttlefish/host/libs/config/feature.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/config_flag.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/config_flag.cpp
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-#include "host/libs/config/config_flag.h"
+#include "cuttlefish/host/libs/config/config_flag.h"
+
+#include <set>
+#include <string>
 
 #include <android-base/file.h>
 #include <android-base/logging.h>
 #include <android-base/strings.h>
 #include <gflags/gflags.h>
 #include <json/json.h>
-#include <fstream>
-#include <set>
-#include <string>
 
-#include "common/libs/utils/files.h"
-#include "common/libs/utils/flag_parser.h"
-#include "common/libs/utils/json.h"
-#include "host/commands/assemble_cvd/flags_defaults.h"
-#include "host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/common/libs/utils/flag_parser.h"
+#include "cuttlefish/common/libs/utils/json.h"
+#include "cuttlefish/host/commands/assemble_cvd/flags_defaults.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 // To support other files that use this from gflags.
 // TODO: Add a description to this flag

--- a/base/cvd/cuttlefish/host/libs/config/config_flag.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/config_flag.cpp
@@ -16,20 +16,32 @@
 
 #include "cuttlefish/host/libs/config/config_flag.h"
 
+#include <optional>
+#include <ostream>
 #include <set>
 #include <string>
+#include <string_view>
+#include <unordered_set>
+#include <vector>
 
 #include <android-base/file.h>
 #include <android-base/logging.h>
 #include <android-base/strings.h>
+#include <fmt/format.h>
+#include <fruit/component.h>
+#include <fruit/macro.h>
 #include <gflags/gflags.h>
-#include <json/json.h>
+#include <json/value.h>
+#include <json/writer.h>
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/flag_parser.h"
 #include "cuttlefish/common/libs/utils/json.h"
+#include "cuttlefish/common/libs/utils/result.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags_defaults.h"
+#include "cuttlefish/host/libs/config/config_utils.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/feature.h"
 
 // To support other files that use this from gflags.
 // TODO: Add a description to this flag

--- a/base/cvd/cuttlefish/host/libs/config/config_flag.h
+++ b/base/cvd/cuttlefish/host/libs/config/config_flag.h
@@ -15,10 +15,11 @@
  */
 #pragma once
 
-#include <fruit/fruit.h>
 #include <string>
 
-#include "host/libs/config/feature.h"
+#include <fruit/fruit.h>
+
+#include "cuttlefish/host/libs/config/feature.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/config_fragment.h
+++ b/base/cvd/cuttlefish/host/libs/config/config_fragment.h
@@ -15,9 +15,9 @@
  */
 #pragma once
 
-#include <json/json.h>
-#include <memory>
 #include <string>
+
+#include <json/json.h>
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/config_utils.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/config_utils.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "host/libs/config/config_utils.h"
+#include "cuttlefish/host/libs/config/config_utils.h"
 
 #include <string.h>
 
@@ -24,13 +24,13 @@
 #include <android-base/logging.h>
 #include <android-base/strings.h>
 
-#include "common/libs/utils/architecture.h"
-#include "common/libs/utils/contains.h"
-#include "common/libs/utils/environment.h"
-#include "common/libs/utils/files.h"
-#include "common/libs/utils/in_sandbox.h"
-#include "common/libs/utils/subprocess.h"
-#include "host/libs/config/config_constants.h"
+#include "cuttlefish/common/libs/utils/architecture.h"
+#include "cuttlefish/common/libs/utils/contains.h"
+#include "cuttlefish/common/libs/utils/environment.h"
+#include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/common/libs/utils/in_sandbox.h"
+#include "cuttlefish/common/libs/utils/subprocess.h"
+#include "cuttlefish/host/libs/config/config_constants.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/config_utils.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/config_utils.cpp
@@ -17,9 +17,12 @@
 #include "cuttlefish/host/libs/config/config_utils.h"
 
 #include <string.h>
+#include <time.h>
 
+#include <cstdlib>
 #include <iomanip>
 #include <sstream>
+#include <string>
 
 #include <android-base/logging.h>
 #include <android-base/strings.h>

--- a/base/cvd/cuttlefish/host/libs/config/custom_actions.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/custom_actions.cpp
@@ -16,19 +16,29 @@
 #include "cuttlefish/host/libs/config/custom_actions.h"
 
 #include <optional>
+#include <ostream>
 #include <string>
+#include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include <android-base/file.h>
 #include <android-base/logging.h>
-#include <android-base/parseint.h>
 #include <android-base/strings.h>
-#include <json/json.h>
+#include <fruit/component.h>
+#include <fruit/fruit_forward_decls.h>
+#include <fruit/macro.h>
+#include <json/value.h>
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/flag_parser.h"
 #include "cuttlefish/common/libs/utils/json.h"
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/libs/config/config_flag.h"
+#include "cuttlefish/host/libs/config/config_fragment.h"
+#include "cuttlefish/host/libs/config/config_utils.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/feature.h"
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/host/libs/config/custom_actions.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/custom_actions.cpp
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "host/libs/config/custom_actions.h"
+#include "cuttlefish/host/libs/config/custom_actions.h"
+
+#include <optional>
+#include <string>
+#include <vector>
 
 #include <android-base/file.h>
 #include <android-base/logging.h>
@@ -21,15 +25,10 @@
 #include <android-base/strings.h>
 #include <json/json.h>
 
-#include <fstream>
-#include <optional>
-#include <string>
-#include <vector>
-
-#include "common/libs/utils/files.h"
-#include "common/libs/utils/flag_parser.h"
-#include "common/libs/utils/json.h"
-#include "host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/common/libs/utils/flag_parser.h"
+#include "cuttlefish/common/libs/utils/json.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/host/libs/config/custom_actions.h
+++ b/base/cvd/cuttlefish/host/libs/config/custom_actions.h
@@ -15,14 +15,15 @@
  */
 #pragma once
 
-#include <fruit/fruit.h>
 #include <optional>
 #include <string>
 #include <vector>
 
-#include "host/libs/config/config_flag.h"
-#include "host/libs/config/config_fragment.h"
-#include "host/libs/config/feature.h"
+#include <fruit/fruit.h>
+
+#include "cuttlefish/host/libs/config/config_flag.h"
+#include "cuttlefish/host/libs/config/config_fragment.h"
+#include "cuttlefish/host/libs/config/feature.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.cpp
@@ -14,26 +14,20 @@
  * limitations under the License.
  */
 
-#include "host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
-#include <algorithm>
-#include <climits>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
-#include <iomanip>
-#include <iterator>
-#include <sstream>
 #include <string>
-#include <time.h>
 
 #include <android-base/strings.h>
 #include <android-base/logging.h>
 #include <json/json.h>
 
-#include "common/libs/utils/environment.h"
-#include "common/libs/utils/files.h"
+#include "cuttlefish/common/libs/utils/environment.h"
+#include "cuttlefish/common/libs/utils/files.h"
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.cpp
@@ -20,14 +20,25 @@
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <map>
+#include <memory>
+#include <set>
 #include <string>
+#include <vector>
 
 #include <android-base/strings.h>
 #include <android-base/logging.h>
-#include <json/json.h>
+#include <fmt/core.h>
+#include <json/reader.h>
+#include <json/value.h>
 
 #include "cuttlefish/common/libs/utils/environment.h"
 #include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/libs/config/config_fragment.h"
+#include "cuttlefish/host/libs/config/config_constants.h"
+#include "cuttlefish/host/libs/config/config_utils.h"
+#include "cuttlefish/host/libs/config/secure_hals.h"
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <sys/types.h>
+
 #include <array>
 #include <cstdint>
 #include <map>
@@ -28,13 +29,13 @@
 
 #include <fmt/ostream.h>
 
-#include "common/libs/utils/architecture.h"
-#include "common/libs/utils/device_type.h"
-#include "common/libs/utils/result.h"
-#include "host/libs/config/config_constants.h"
-#include "host/libs/config/config_fragment.h"
-#include "host/libs/config/config_utils.h"
-#include "host/libs/config/secure_hals.h"
+#include "cuttlefish/common/libs/utils/architecture.h"
+#include "cuttlefish/common/libs/utils/device_type.h"
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/libs/config/config_constants.h"
+#include "cuttlefish/host/libs/config/config_fragment.h"
+#include "cuttlefish/host/libs/config/config_utils.h"
+#include "cuttlefish/host/libs/config/secure_hals.h"
 
 namespace Json {
 class Value;

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_environment.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_environment.cpp
@@ -16,7 +16,10 @@
 
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
+#include <string>
+
 #include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/host/libs/config/config_constants.h"
 
 const char* kEnvironments = "environments";
 

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_environment.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_environment.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include "host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
-#include "common/libs/utils/files.h"
+#include "cuttlefish/common/libs/utils/files.h"
 
 const char* kEnvironments = "environments";
 

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#include "cuttlefish_config.h"
-#include "host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 #include <fstream>
 #include <string>
@@ -25,8 +24,8 @@
 #include <android-base/strings.h>
 #include <json/json.h>
 
-#include "common/libs/utils/files.h"
-#include "common/libs/utils/flags_validator.h"
+#include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/common/libs/utils/flags_validator.h"
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
@@ -16,16 +16,32 @@
 
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
+#include <stdint.h>
+
+#include <algorithm>
+#include <cctype>
 #include <fstream>
+#include <optional>
+#include <ostream>
+#include <sstream>
 #include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 #include <android-base/logging.h>
 #include <android-base/strings.h>
-#include <json/json.h>
+#include <fmt/core.h>
+#include <json/config.h>
+#include <json/reader.h>
+#include <json/value.h>
 
+#include "cuttlefish/common/libs/utils/architecture.h"
+#include "cuttlefish/common/libs/utils/device_type.h"
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/flags_validator.h"
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/libs/config/config_constants.h"
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/host/libs/config/data_image.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/data_image.cpp
@@ -13,19 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "host/libs/config/data_image.h"
+#include "cuttlefish/host/libs/config/data_image.h"
 
 #include <android-base/logging.h>
 #include <android-base/result.h>
 
-#include "common/libs/fs/shared_buf.h"
-#include "common/libs/utils/files.h"
-#include "common/libs/utils/result.h"
-#include "common/libs/utils/subprocess.h"
-#include "host/libs/config/cuttlefish_config.h"
-#include "host/libs/config/esp.h"
-#include "host/libs/config/mbr.h"
-#include "host/libs/config/openwrt_args.h"
+#include "cuttlefish/common/libs/fs/shared_buf.h"
+#include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/common/libs/utils/subprocess.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/esp.h"
+#include "cuttlefish/host/libs/config/mbr.h"
+#include "cuttlefish/host/libs/config/openwrt_args.h"
 
 // https://cs.android.com/android/platform/superproject/main/+/main:device/google/cuttlefish/Android.bp;l=127;drc=6f7d6a4db58efcc2ddd09eda07e009c6329414cd
 #define F2FS_BLOCKSIZE "4096"

--- a/base/cvd/cuttlefish/host/libs/config/data_image.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/data_image.cpp
@@ -15,13 +15,24 @@
  */
 #include "cuttlefish/host/libs/config/data_image.h"
 
+#include <fcntl.h>
+#include <sys/types.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <utility>
+
 #include <android-base/logging.h>
-#include <android-base/result.h>
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
+#include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/common/libs/utils/architecture.h"
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/result.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"
+#include "cuttlefish/host/libs/config/config_utils.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 #include "cuttlefish/host/libs/config/esp.h"
 #include "cuttlefish/host/libs/config/mbr.h"

--- a/base/cvd/cuttlefish/host/libs/config/data_image.h
+++ b/base/cvd/cuttlefish/host/libs/config/data_image.h
@@ -17,8 +17,8 @@
 
 #include <string>
 
-#include "common/libs/utils/result.h"
-#include "host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/display.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/display.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "host/libs/config/display.h"
+#include "cuttlefish/host/libs/config/display.h"
 
 #include <unordered_map>
 #include <vector>
@@ -23,9 +23,9 @@
 #include <android-base/parseint.h>
 #include <android-base/strings.h>
 
-#include "common/libs/utils/contains.h"
-#include "common/libs/utils/flag_parser.h"
-#include "host/commands/assemble_cvd/flags_defaults.h"
+#include "cuttlefish/common/libs/utils/contains.h"
+#include "cuttlefish/common/libs/utils/flag_parser.h"
+#include "cuttlefish/host/commands/assemble_cvd/flags_defaults.h"
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/host/libs/config/display.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/display.cpp
@@ -16,16 +16,19 @@
 
 #include "cuttlefish/host/libs/config/display.h"
 
+#include <optional>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
-#include <android-base/logging.h>
 #include <android-base/parseint.h>
 #include <android-base/strings.h>
 
 #include "cuttlefish/common/libs/utils/contains.h"
 #include "cuttlefish/common/libs/utils/flag_parser.h"
+#include "cuttlefish/common/libs/utils/result.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags_defaults.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/host/libs/config/display.h
+++ b/base/cvd/cuttlefish/host/libs/config/display.h
@@ -17,8 +17,8 @@
 #include <optional>
 #include <string>
 
-#include "common/libs/utils/result.h"
-#include "host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/esp.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/esp.cpp
@@ -15,18 +15,25 @@
 
 #include "cuttlefish/host/libs/config/esp.h"
 
+#include <sys/types.h>
+
 #include <algorithm>
 #include <array>
+#include <iterator>
+#include <ostream>
 #include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include <android-base/logging.h>
+
 #include "cuttlefish/common/libs/fs/shared_buf.h"
+#include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/architecture.h"
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"
-#include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/config_utils.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/esp.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/esp.cpp
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "cuttlefish/host/libs/config/esp.h"
+
 #include <algorithm>
 #include <array>
 #include <sstream>
@@ -20,12 +22,11 @@
 #include <utility>
 #include <vector>
 
-#include "common/libs/fs/shared_buf.h"
-#include "common/libs/utils/architecture.h"
-#include "common/libs/utils/files.h"
-#include "common/libs/utils/subprocess.h"
-#include "host/libs/config/cuttlefish_config.h"
-#include "host/libs/config/esp.h"
+#include "cuttlefish/common/libs/fs/shared_buf.h"
+#include "cuttlefish/common/libs/utils/architecture.h"
+#include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/common/libs/utils/subprocess.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/esp.h
+++ b/base/cvd/cuttlefish/host/libs/config/esp.h
@@ -20,7 +20,7 @@
 #include <utility>
 #include <vector>
 
-#include "common/libs/utils/architecture.h"
+#include "cuttlefish/common/libs/utils/architecture.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/fastboot/config.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/fastboot/config.cpp
@@ -13,12 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "host/libs/config/fastboot/fastboot.h"
+#include "cuttlefish/host/libs/config/fastboot/fastboot.h"
+
+#include <string>
 
 #include <android-base/logging.h>
-#include <json/json.h>
+#include <fruit/component.h>
+#include <fruit/fruit_forward_decls.h>
+#include <fruit/macro.h>
+#include <json/value.h>
 
-#include "host/libs/config/config_fragment.h"
+#include "cuttlefish/host/libs/config/config_fragment.h"
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/host/libs/config/fastboot/data.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/fastboot/data.cpp
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "host/libs/config/fastboot/fastboot.h"
+#include "cuttlefish/host/libs/config/fastboot/fastboot.h"
+
+#include <fruit/component.h>
+#include <fruit/macro.h>
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/host/libs/config/fastboot/fastboot.h
+++ b/base/cvd/cuttlefish/host/libs/config/fastboot/fastboot.h
@@ -17,11 +17,11 @@
 
 #include <fruit/fruit.h>
 
-#include "host/libs/config/config_flag.h"
-#include "host/libs/config/config_fragment.h"
-#include "host/libs/config/cuttlefish_config.h"
-#include "host/libs/config/feature.h"
-#include "host/libs/config/kernel_log_pipe_provider.h"
+#include "cuttlefish/host/libs/config/config_flag.h"
+#include "cuttlefish/host/libs/config/config_fragment.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/feature.h"
+#include "cuttlefish/host/libs/config/kernel_log_pipe_provider.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/fastboot/flags.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/fastboot/flags.cpp
@@ -13,11 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "host/libs/config/fastboot/fastboot.h"
+#include "cuttlefish/host/libs/config/fastboot/fastboot.h"
 
-#include "common/libs/utils/flag_parser.h"
-#include "host/libs/config/config_flag.h"
-#include "host/libs/config/feature.h"
+#include <ostream>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <fruit/component.h>
+#include <fruit/fruit_forward_decls.h>
+#include <fruit/macro.h>
+
+#include "cuttlefish/common/libs/utils/flag_parser.h"
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/libs/config/config_flag.h"
+#include "cuttlefish/host/libs/config/feature.h"
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/host/libs/config/fastboot/launch.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/fastboot/launch.cpp
@@ -13,16 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "host/libs/config/fastboot/fastboot.h"
+#include "cuttlefish/host/libs/config/fastboot/fastboot.h"
 
+#include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
-#include "common/libs/utils/result.h"
-#include "host/commands/kernel_log_monitor/utils.h"
-#include "host/libs/config/command_source.h"
-#include "host/libs/config/cuttlefish_config.h"
-#include "host/libs/config/known_paths.h"
+#include <fruit/component.h>
+#include <fruit/fruit_forward_decls.h>
+#include <fruit/macro.h>
+
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/common/libs/utils/subprocess.h"
+#include "cuttlefish/host/commands/kernel_log_monitor/kernel_log_server.h"
+#include "cuttlefish/host/libs/config/command_source.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/feature.h"
+#include "cuttlefish/host/libs/config/kernel_log_pipe_provider.h"
+#include "cuttlefish/host/libs/config/known_paths.h"
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/host/libs/config/feature.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/feature.cpp
@@ -16,9 +16,12 @@
 
 #include "cuttlefish/host/libs/config/feature.h"
 
+#include <ostream>
+#include <string>
 #include <unordered_set>
+#include <vector>
 
-#include <android-base/strings.h>
+#include <android-base/logging.h>
 
 #include "cuttlefish/common/libs/utils/result.h"
 

--- a/base/cvd/cuttlefish/host/libs/config/feature.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/feature.cpp
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-#include "host/libs/config/feature.h"
+#include "cuttlefish/host/libs/config/feature.h"
 
 #include <unordered_set>
 
 #include <android-base/strings.h>
 
-#include "common/libs/utils/result.h"
+#include "cuttlefish/common/libs/utils/result.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/feature.h
+++ b/base/cvd/cuttlefish/host/libs/config/feature.h
@@ -25,8 +25,8 @@
 #include <android-base/logging.h>
 #include <fruit/fruit.h>
 
-#include "common/libs/utils/result.h"
-#include "common/libs/utils/type_name.h"
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/common/libs/utils/type_name.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/fetcher_config.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/fetcher_config.cpp
@@ -16,16 +16,21 @@
 
 #include "cuttlefish/host/libs/config/fetcher_config.h"
 
+#include <cctype>
 #include <fstream>
 #include <map>
+#include <ostream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <android-base/file.h>
 #include <android-base/logging.h>
 #include <android-base/strings.h>
 #include <gflags/gflags.h>
-#include <json/json.h>
+#include <json/reader.h>
+#include <json/value.h>
+#include <json/writer.h>
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/result.h"

--- a/base/cvd/cuttlefish/host/libs/config/fetcher_config.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/fetcher_config.cpp
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
-#include "host/libs/config/fetcher_config.h"
+#include "cuttlefish/host/libs/config/fetcher_config.h"
 
 #include <fstream>
 #include <map>
 #include <string>
 #include <vector>
 
-#include "android-base/file.h"
-#include "android-base/logging.h"
-#include "android-base/strings.h"
-#include "gflags/gflags.h"
-#include "json/json.h"
+#include <android-base/file.h>
+#include <android-base/logging.h>
+#include <android-base/strings.h>
+#include <gflags/gflags.h>
+#include <json/json.h>
 
-#include "common/libs/utils/files.h"
-#include "common/libs/utils/result.h"
+#include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/common/libs/utils/result.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/fetcher_config.h
+++ b/base/cvd/cuttlefish/host/libs/config/fetcher_config.h
@@ -20,7 +20,7 @@
 #include <ostream>
 #include <string>
 
-#include "common/libs/utils/result.h"
+#include "cuttlefish/common/libs/utils/result.h"
 
 namespace Json {
 class Value;

--- a/base/cvd/cuttlefish/host/libs/config/host_tools_version.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/host_tools_version.cpp
@@ -13,17 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "host/libs/config/host_tools_version.h"
+#include "cuttlefish/host/libs/config/host_tools_version.h"
 
-#include <algorithm>
+#include <zlib.h>
+
 #include <fstream>
 #include <future>
 #include <vector>
 
-#include <zlib.h>
-
-#include "common/libs/utils/files.h"
-#include "host/libs/config/config_utils.h"
+#include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/host/libs/config/config_utils.h"
 
 using std::uint32_t;
 

--- a/base/cvd/cuttlefish/host/libs/config/host_tools_version.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/host_tools_version.cpp
@@ -15,11 +15,18 @@
 
 #include "cuttlefish/host/libs/config/host_tools_version.h"
 
+#include <stdint.h>
 #include <zlib.h>
 
+#include <cstdint>
 #include <fstream>
 #include <future>
+#include <map>
+#include <string>
+#include <utility>
 #include <vector>
+
+#include <android-base/logging.h>
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/libs/config/config_utils.h"

--- a/base/cvd/cuttlefish/host/libs/config/inject.h
+++ b/base/cvd/cuttlefish/host/libs/config/inject.h
@@ -16,11 +16,9 @@
 
 #pragma once
 
-#include <type_traits>
-
 #include <fruit/fruit.h>
 
-#include "common/libs/utils/result.h"
+#include "cuttlefish/common/libs/utils/result.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/instance_nums.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/instance_nums.cpp
@@ -13,15 +13,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "host/libs/config/instance_nums.h"
+#include "cuttlefish/host/libs/config/instance_nums.h"
+
+#include <optional>
+#include <set>
+#include <string>
 
 #include <android-base/parseint.h>
 #include <android-base/strings.h>
 #include <gflags/gflags.h>
 
-#include "common/libs/utils/contains.h"
-#include "common/libs/utils/flag_parser.h"
-#include "host/libs/config/config_utils.h"
+#include "cuttlefish/common/libs/utils/contains.h"
+#include "cuttlefish/common/libs/utils/flag_parser.h"
+#include "cuttlefish/host/libs/config/config_utils.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/instance_nums.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/instance_nums.cpp
@@ -15,9 +15,13 @@
 
 #include "cuttlefish/host/libs/config/instance_nums.h"
 
+#include <cstdint>
+#include <cstdlib>
 #include <optional>
 #include <set>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include <android-base/parseint.h>
 #include <android-base/strings.h>
@@ -25,6 +29,7 @@
 
 #include "cuttlefish/common/libs/utils/contains.h"
 #include "cuttlefish/common/libs/utils/flag_parser.h"
+#include "cuttlefish/common/libs/utils/result.h"
 #include "cuttlefish/host/libs/config/config_utils.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/host/libs/config/instance_nums.h
+++ b/base/cvd/cuttlefish/host/libs/config/instance_nums.h
@@ -17,10 +17,10 @@
 
 #include <cstdint>
 #include <optional>
-#include <set>
 #include <string>
+#include <vector>
 
-#include "common/libs/utils/result.h"
+#include "cuttlefish/common/libs/utils/result.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/kernel_args.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/kernel_args.cpp
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-#include "host/libs/config/kernel_args.h"
+#include "cuttlefish/host/libs/config/kernel_args.h"
 
-#include <array>
-#include <sstream>
 #include <string>
 #include <vector>
 
-#include "common/libs/utils/environment.h"
-#include "host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/host/libs/config/kernel_args.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/kernel_args.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 
+#include "cuttlefish/common/libs/utils/architecture.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/host/libs/config/kernel_args.h
+++ b/base/cvd/cuttlefish/host/libs/config/kernel_args.h
@@ -19,7 +19,7 @@
 #include <string>
 #include <vector>
 
-#include "host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/kernel_log_pipe_provider.h
+++ b/base/cvd/cuttlefish/host/libs/config/kernel_log_pipe_provider.h
@@ -16,10 +16,9 @@
 #pragma once
 
 #include <fruit/fruit.h>
-#include <vector>
 
-#include "common/libs/fs/shared_fd.h"
-#include "host/libs/config/feature.h"
+#include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/host/libs/config/feature.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/known_paths.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/known_paths.cpp
@@ -16,6 +16,8 @@
 
 #include "cuttlefish/host/libs/config/known_paths.h"
 
+#include <string>
+
 #include "cuttlefish/host/libs/config/config_utils.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/host/libs/config/known_paths.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/known_paths.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include "host/libs/config/known_paths.h"
+#include "cuttlefish/host/libs/config/known_paths.h"
 
-#include "host/libs/config/config_utils.h"
+#include "cuttlefish/host/libs/config/config_utils.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/logging.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/logging.cpp
@@ -13,11 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "logging.h"
+#include "cuttlefish/host/libs/config/logging.h"
 
 #include <android-base/logging.h>
 
-#include "host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 using android::base::SetLogger;
 

--- a/base/cvd/cuttlefish/host/libs/config/logging.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/logging.cpp
@@ -15,8 +15,11 @@
 
 #include "cuttlefish/host/libs/config/logging.h"
 
+#include <string>
+
 #include <android-base/logging.h>
 
+#include "cuttlefish/common/libs/utils/tee_logging.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 using android::base::SetLogger;

--- a/base/cvd/cuttlefish/host/libs/config/logging.h
+++ b/base/cvd/cuttlefish/host/libs/config/logging.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include "common/libs/utils/tee_logging.h"
+#include "cuttlefish/common/libs/utils/tee_logging.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/openwrt_args.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/openwrt_args.cpp
@@ -16,7 +16,12 @@
 
 #include "cuttlefish/host/libs/config/openwrt_args.h"
 
+#include <string>
+#include <unordered_map>
+
 #include <android-base/parseint.h>
+
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/openwrt_args.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/openwrt_args.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <android-base/parseint.h>
+#include "cuttlefish/host/libs/config/openwrt_args.h"
 
-#include "host/libs/config/openwrt_args.h"
+#include <android-base/parseint.h>
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/openwrt_args.h
+++ b/base/cvd/cuttlefish/host/libs/config/openwrt_args.h
@@ -19,7 +19,7 @@
 #include <string>
 #include <unordered_map>
 
-#include "host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/secure_hals.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/secure_hals.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "host/libs/config/secure_hals.h"
+#include "cuttlefish/host/libs/config/secure_hals.h"
 
 #include <cctype>
 #include <set>
@@ -23,7 +23,7 @@
 #include <android-base/no_destructor.h>
 #include <android-base/strings.h>
 
-#include "common/libs/utils/result.h"
+#include "cuttlefish/common/libs/utils/result.h"
 
 using android::base::NoDestructor;
 using android::base::Tokenize;

--- a/base/cvd/cuttlefish/host/libs/config/secure_hals.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/secure_hals.cpp
@@ -18,6 +18,7 @@
 #include <cctype>
 #include <set>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 
 #include <android-base/no_destructor.h>

--- a/base/cvd/cuttlefish/host/libs/config/secure_hals.h
+++ b/base/cvd/cuttlefish/host/libs/config/secure_hals.h
@@ -18,7 +18,7 @@
 #include <set>
 #include <string>
 
-#include "common/libs/utils/result.h"
+#include "cuttlefish/common/libs/utils/result.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/touchpad.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/touchpad.cpp
@@ -16,16 +16,17 @@
 
 #include "cuttlefish/host/libs/config/touchpad.h"
 
+#include <string>
 #include <unordered_map>
 #include <vector>
 
-#include <android-base/logging.h>
 #include <android-base/parseint.h>
 #include <android-base/strings.h>
 
 #include "cuttlefish/common/libs/utils/contains.h"
 #include "cuttlefish/common/libs/utils/flag_parser.h"
 #include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/touchpad.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/touchpad.cpp
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-#include "host/libs/config/touchpad.h"
+#include "cuttlefish/host/libs/config/touchpad.h"
 
-#include <algorithm>
 #include <unordered_map>
 #include <vector>
 
@@ -24,9 +23,9 @@
 #include <android-base/parseint.h>
 #include <android-base/strings.h>
 
-#include "common/libs/utils/contains.h"
-#include "common/libs/utils/flag_parser.h"
-#include "host/commands/assemble_cvd/flags_defaults.h"
+#include "cuttlefish/common/libs/utils/contains.h"
+#include "cuttlefish/common/libs/utils/flag_parser.h"
+#include "cuttlefish/common/libs/utils/result.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/touchpad.h
+++ b/base/cvd/cuttlefish/host/libs/config/touchpad.h
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#pragma once
 
-#include <optional>
 #include <string>
+#include <vector>
 
-#include "common/libs/utils/result.h"
-#include "host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 namespace cuttlefish {
 


### PR DESCRIPTION
The original `:config` target is preserved for its many dependencies in other directories.

This target would take 3 minutes to lint before. Additional incremental build gains are possible by depending on the inner targets rather than on `:config`, but that is left for a later change.

Bug: b/410080567