### PR TITLE
Update e2etests so device logs are stored as test artifacts

### DIFF
--- a/.kokoro/presubmit.cfg
+++ b/.kokoro/presubmit.cfg
@@ -4,7 +4,7 @@ action {
   define_artifacts {
     regex: "*/*sponge_log.xml" # Actually a glob, not a regex
     regex: "*/*sponge_log.log"
-    regex: "*/device_logs/*"
+    regex: "*/device_logs/**" # match all files regardless of directory depth
     regex: "github/android-cuttlefish/*.deb"
   }
 }

--- a/e2etests/cvd/cvd_load_boot_test.sh
+++ b/e2etests/cvd/cvd_load_boot_test.sh
@@ -37,7 +37,7 @@ function collect_logs_and_cleanup() {
     cp "${CMD_OUT}" "${TEST_UNDECLARED_OUTPUTS_DIR}"
     cp "${CMD_ERR}" "${TEST_UNDECLARED_OUTPUTS_DIR}"
     # TODO(b/324650975): cvd doesn't print very useful information yet so file locations must be extracted this way
-    home_dir="$(grep -o -E 'HOME="/tmp/cvd/[0-9a-zA-Z/_]+"' "${CMD_ERR}" | cut -d= -f2 | grep -o -E '[^"]*')"
+    home_dir="$(grep -o -E -m1 HOME="/tmp/cvd/[0-9a-zA-Z/_]+" "${CMD_ERR}" | cut -d= -f2)"
     artifacts_dir="$(grep -o -E '\-\-target_directory=/tmp/cvd/[0-9a-zA-Z/_]+' "${CMD_ERR}" | cut -d= -f2 | grep -o -E '[^"]*')"
 
     cp "${artifacts_dir}/fetch.log" "${TEST_UNDECLARED_OUTPUTS_DIR}"

--- a/e2etests/cvd/cvd_load_boot_test.sh
+++ b/e2etests/cvd/cvd_load_boot_test.sh
@@ -36,18 +36,28 @@ function collect_logs_and_cleanup() {
     cp "${ENV_FILE}" "${TEST_UNDECLARED_OUTPUTS_DIR}/environment.json"
     cp "${CMD_OUT}" "${TEST_UNDECLARED_OUTPUTS_DIR}"
     cp "${CMD_ERR}" "${TEST_UNDECLARED_OUTPUTS_DIR}"
+
     # TODO(b/324650975): cvd doesn't print very useful information yet so file locations must be extracted this way
     home_dir="$(grep -o -E -m1 HOME="/tmp/cvd/[0-9a-zA-Z/_]+" "${CMD_ERR}" | cut -d= -f2)"
     artifacts_dir="$(grep -o -E '\-\-target_directory=/tmp/cvd/[0-9a-zA-Z/_]+' "${CMD_ERR}" | cut -d= -f2 | grep -o -E '[^"]*')"
 
     cp "${artifacts_dir}/fetch.log" "${TEST_UNDECLARED_OUTPUTS_DIR}"
+
     for instance_dir in "${home_dir}"/cuttlefish/instances/*; do
-      instance="$(basename "${instance_dir}")"
-      for log_file in "${instance_dir}"/logs/*; do
-        base_name="$(basename "${log_file}")"
-        cp "${log_file}" "${TEST_UNDECLARED_OUTPUTS_DIR}/${instance}_${base_name}"
-      done
-      cp "${instance_dir}"/cuttlefish_config.json "${TEST_UNDECLARED_OUTPUTS_DIR}/${instance}_cuttlefish_config.json"
+      if [[ -d "${instance_dir}" ]]; then
+        instance="$(basename "${instance_dir}")"
+        for log_file in "${instance_dir}"/logs/*; do
+          if [[ -f "${log_file}" ]]; then
+            base_name="$(basename "${log_file}")"
+            cp "${log_file}" "${TEST_UNDECLARED_OUTPUTS_DIR}/${instance}_${base_name}"
+          fi
+        done
+        if [[ -f "${instance_dir}/cuttlefish_config.json" ]]; then
+          cp "${instance_dir}"/cuttlefish_config.json "${TEST_UNDECLARED_OUTPUTS_DIR}/${instance}_cuttlefish_config.json"
+        else
+          echo "No cuttlefish_config.json found for instance ${instance}"
+        fi
+      fi
     done
   fi
 

--- a/tools/testutils/runcvde2etests.sh
+++ b/tools/testutils/runcvde2etests.sh
@@ -26,5 +26,7 @@ cd "${REPO_DIR}/e2etests"
 # Gather test results regardless of status, but still return the exit code from
 # those tests
 trap gather_test_results EXIT
-bazel test cvd/...
 
+# --zip_undeclared_test_outputs triggers the creation of the outputs.zip file
+# everything written to $TEST_UNDECLARED_OUTPUTS_DIR is put into this zip
+bazel test --zip_undeclared_test_outputs cvd/...


### PR DESCRIPTION
The `outputs.zip` now needs a flag to be created, even though this behavior used to be triggered automatically when files were written to `$TEST_UNDECLARED_OUTPUTS_DIR`.

Other minor fixes noted in commits.

Bug: 412696459