### PR TITLE
Remove BEGIN END blocks from logs.

### DIFF
--- a/frontend/src/host_orchestrator/orchestrator/cvd/cvd.go
+++ b/frontend/src/host_orchestrator/orchestrator/cvd/cvd.go
@@ -146,14 +146,6 @@ func (cli *CLI) runCmd(cmd *exec.Cmd) ([]byte, error) {
 // Runs the given command returning the stdout output as a byte array.
 // Both stdout and stderr output also written to the logs.
 func (cli *CLI) exec(bin string, args ...string) ([]byte, error) {
-	const begin = "############################################\n" +
-		"## BEGIN \n" +
-		"############################################"
-	const end = "############################################\n" +
-		"## END \n" +
-		"############################################"
-	log.Println(begin)
-	defer log.Println(end)
 	return cli.runCmd(cli.buildCmd(bin, args...))
 }
 


### PR DESCRIPTION
- The blocks are no longer necessary given the existence of sudo session blocks

May 01 22:53:22 0800f2480989 sudo[356]: _cutf-operator : PWD=/usr/share/cuttlefish-common/operator ; USER=_cvd-executor ; COMMAND=/usr/bin/cvd fleet
May 01 22:53:22 0800f2480989 sudo[356]: pam_unix(sudo:session): session opened for user _cvd-executor(uid=102) by (uid=101)
May 01 22:53:22 0800f2480989 cuttlefish-host_orchestrator[343]: {
May 01 22:53:22 0800f2480989 cuttlefish-host_orchestrator[343]:         "groups" : []
May 01 22:53:22 0800f2480989 cuttlefish-host_orchestrator[343]: }
May 01 22:53:22 0800f2480989 sudo[356]: pam_unix(sudo:session): session closed for user _cvd-executor