### PR TITLE
Support older versions of libwebsockets in webRTC

### DIFF
--- a/base/cvd/cuttlefish/host/frontend/webrtc/client_server.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/client_server.h
@@ -35,12 +35,14 @@ class ClientFilesServer {
  private:
   struct Config;
 
-  ClientFilesServer(std::unique_ptr<Config> config, lws_context* context);
+  ClientFilesServer(std::unique_ptr<Config> config, lws_context* context,
+                    lws_vhost* vhost);
 
   void Serve();
 
   std::unique_ptr<Config> config_;
   lws_context* context_;
+  lws_vhost* vhost_;
   std::atomic<bool> running_;
   std::thread server_thread_;
 };


### PR DESCRIPTION
Older versions don't provide a way to get the default created vhost from the context structure, so one must be manually created to access it.