### PR TITLE
Enable jcardsim simulator for Strongbox via new flag.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/bootconfig_args.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/bootconfig_args.cpp
@@ -210,6 +210,21 @@ Result<std::unordered_map<std::string, std::string>> BootconfigArgsFromConfig(
           ? "com.android.hardware.gatekeeper.nonsecure"
           : "com.android.hardware.gatekeeper.cf_remote";
 
+  // jcardsimulator
+  if (secure_hals.count(SecureHal::kGuestStrongboxInsecure)) {
+    bootconfig_args
+        ["androidboot.vendor.apex.com.android.hardware.secure_element"] =
+            "com.android.hardware.secure_element_jcardsim";
+    bootconfig_args["androidboot.vendor.apex.com.android.hardware.strongbox"] =
+        "com.android.hardware.strongbox";
+  } else {
+    bootconfig_args
+        ["androidboot.vendor.apex.com.android.hardware.secure_element"] =
+            "com.android.hardware.secure_element";
+    bootconfig_args["androidboot.vendor.apex.com.android.hardware.strongbox"] =
+        "none";
+  }
+
   bootconfig_args
       ["androidboot.vendor.apex.com.android.hardware.graphics.composer"] =
           instance.hwcomposer() == kHwComposerDrm

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -480,6 +480,10 @@ DEFINE_vec(enable_audio, fmt::format("{}", CF_DEFAULTS_ENABLE_AUDIO),
 DEFINE_vec(enable_usb, fmt::format("{}", CF_DEFAULTS_ENABLE_USB),
            "Whether to allow USB passthrough on the device");
 
+DEFINE_vec(enable_jcard_simulator,
+           fmt::format("{}", CF_DEFAULTS_ENABLE_JCARD_SIMULATOR),
+           "Whether to allow host jcard simulator on the device");
+
 DEFINE_vec(camera_server_port, std::to_string(CF_DEFAULTS_CAMERA_SERVER_PORT),
               "camera vsock port");
 
@@ -1309,6 +1313,8 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
       CF_EXPECT(GET_FLAG_STR_VALUE(vhost_user_vsock));
   std::vector<std::string> ril_dns_vec =
       CF_EXPECT(GET_FLAG_STR_VALUE(ril_dns));
+  std::vector<bool> enable_jcard_simulator_vec =
+      CF_EXPECT(GET_FLAG_BOOL_VALUE(enable_jcard_simulator));
 
   // At this time, FLAGS_enable_sandbox comes from SetDefaultFlagsForCrosvm
   std::vector<bool> enable_sandbox_vec = CF_EXPECT(GET_FLAG_BOOL_VALUE(
@@ -1585,6 +1591,25 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
 
     instance.set_audio_output_streams_count(
         guest_configs[instance_index].output_audio_streams_count);
+
+    // jcardsim
+    instance.set_enable_jcard_simulator(
+        enable_jcard_simulator_vec[instance_index]);
+
+    if (enable_jcard_simulator_vec[instance_index]) {
+      const auto& secure_hals = CF_EXPECT(tmp_config_obj.secure_hals());
+      if (0 == secure_hals.count(SecureHal::kGuestStrongboxInsecure)) {
+        // When the enable_jcard_simulator flag is enabled, include the keymint
+        // and secure_element hals, which interact with jcard simulator.
+        static constexpr char kDefaultSecure[] =
+            "oemlock,guest_keymint_insecure,guest_gatekeeper_insecure,guest_"
+            "strongbox_insecure";
+
+        auto secure_hals = CF_EXPECT(ParseSecureHals(kDefaultSecure));
+        CF_EXPECT(ValidateSecureHals(secure_hals));
+        tmp_config_obj.set_secure_hals(secure_hals);
+      }
+    }
 
     if (vhost_user_vsock_vec[instance_index] == kVhostUserVsockModeAuto) {
       std::set<Arch> default_on_arch = {Arch::Arm64};

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags_defaults.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags_defaults.h
@@ -218,6 +218,9 @@
 // USB Passhtrough default parameters
 #define CF_DEFAULTS_ENABLE_USB false
 
+// Jcardsim default parameters
+#define CF_DEFAULTS_ENABLE_JCARD_SIMULATOR false
+
 // Streaming default parameters
 #define CF_DEFAULTS_START_WEBRTC false
 #define CF_DEFAULTS_START_WEBRTC_SIG_SERVER true

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
@@ -638,6 +638,7 @@ class CuttlefishConfig {
     bool fail_fast() const;
     bool vhost_user_block() const;
     std::string ti50_emulator() const;
+    bool enable_jcard_simulator() const;
 
     // Kernel and bootloader logging
     bool enable_kernel_log() const;
@@ -876,6 +877,8 @@ class CuttlefishConfig {
     void set_fail_fast(bool fail_fast);
     void set_vhost_user_block(bool qemu_vhost_user_block);
     void set_ti50_emulator(const std::string& ti50_emulator);
+    // jcardsim
+    void set_enable_jcard_simulator(bool enable);
 
     // Kernel and bootloader logging
     void set_enable_kernel_log(bool enable_kernel_log);

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
@@ -1164,6 +1164,16 @@ std::string CuttlefishConfig::InstanceSpecific::ti50_emulator() const {
   return (*Dictionary())[kTi50].asString();
 }
 
+// jcardsim
+static constexpr char kEnableJcardSimulator[] = "enable_jcard_simulator";
+void CuttlefishConfig::MutableInstanceSpecific::set_enable_jcard_simulator(
+    bool enable_jcard_simulator) {
+  (*Dictionary())[kEnableJcardSimulator] = enable_jcard_simulator;
+}
+bool CuttlefishConfig::InstanceSpecific::enable_jcard_simulator() const {
+  return (*Dictionary())[kEnableJcardSimulator].asBool();
+}
+
 static constexpr char kEnableWebRTC[] = "enable_webrtc";
 void CuttlefishConfig::MutableInstanceSpecific::set_enable_webrtc(bool enable_webrtc) {
   (*Dictionary())[kEnableWebRTC] = enable_webrtc;

--- a/base/cvd/cuttlefish/host/libs/config/secure_hals.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/secure_hals.cpp
@@ -51,6 +51,7 @@ NoDestructor<std::unordered_map<std::string_view, SecureHal>> kMapping([] {
       {"oemlock", SecureHal::kHostOemlockSecure},
       {"host_oemlock_secure", SecureHal::kHostOemlockSecure},
       {"host_secure_oemlock", SecureHal::kHostOemlockSecure},
+      {"guest_strongbox_insecure", SecureHal::kGuestStrongboxInsecure},
   };
 }());
 
@@ -115,6 +116,8 @@ std::string ToString(SecureHal hal_in) {
       return "host_oemlock_insecure";
     case SecureHal::kHostOemlockSecure:
       return "host_oemlock_secure";
+    case SecureHal::kGuestStrongboxInsecure:
+      return "guest_strongbox_insecure";
   }
 }
 

--- a/base/cvd/cuttlefish/host/libs/config/secure_hals.h
+++ b/base/cvd/cuttlefish/host/libs/config/secure_hals.h
@@ -26,6 +26,7 @@ enum class SecureHal {
   kGuestGatekeeperInsecure,
   kGuestKeymintInsecure,
   kGuestKeymintTrustyInsecure,
+  kGuestStrongboxInsecure,
   kHostKeymintInsecure,
   kHostKeymintSecure,
   kHostGatekeeperInsecure,

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
@@ -887,6 +887,15 @@ Result<std::vector<MonitorCommand>> CrosvmManager::StartCommands(
     crosvm_cmd.AddHvcSink();
   }
 
+  if (instance.enable_jcard_simulator()) {
+    // /dev/hvc17 = JCardSimulator
+    crosvm_cmd.AddHvcReadWrite(
+        instance.PerInstanceInternalPath("jcardsim_fifo_vm.out"),
+        instance.PerInstanceInternalPath("jcardsim_fifo_vm.in"));
+  } else {
+    crosvm_cmd.AddHvcSink();
+  }
+
   for (auto i = 0; i < VmManager::kMaxDisks - disk_num; i++) {
     crosvm_cmd.AddHvcSink();
   }

--- a/base/cvd/cuttlefish/host/libs/vm_manager/qemu_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/qemu_manager.cpp
@@ -656,6 +656,13 @@ Result<std::vector<MonitorCommand>> QemuManager::StartCommands(
     add_hvc_sink();
   }
 
+  if (instance.enable_jcard_simulator()) {
+    // /dev/hvc17 = keymint (jcardsim implementation)
+    add_hvc(instance.PerInstanceInternalPath("jcardsim_fifo_vm"));
+  } else {
+    add_hvc_sink();
+  }
+
   auto disk_num = instance.virtual_disk_paths().size();
 
   for (auto i = 0; i < VmManager::kMaxDisks - disk_num; i++) {

--- a/base/cvd/cuttlefish/host/libs/vm_manager/vm_manager.h
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/vm_manager.h
@@ -64,7 +64,8 @@ class VmManager {
   // - /dev/hvc14 = MCU control
   // - /dev/hvc15 = MCU UART
   // - /dev/hvc16 = Ti50 TPM FIFO
-  static const int kDefaultNumHvcs = 17;
+  // - /dev/hvc17 = jcardsimulator
+  static const int kDefaultNumHvcs = 18;
 
   // This is the number of virtual disks (block devices) that should be
   // configured by the VmManager. Related to the description above regarding


### PR DESCRIPTION
Introduces the `enable_jcard_simulator` flag. When true, this flag adds Strongbox and Secure Element APEX files to bootconfig arguments. It also passes the flag's value to the `secure_env` binary to enable communication with the jcardsim simulator.

Bug: 363308661
Test: NA