### PR TITLE
Set the entire team as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,27 +1,4 @@
 # refer to https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
 
 # overall code owners
-* @Databean @jemoreira @rmuthiah @jmacnak @adelva1984
-
-# cvd
-/base/cvd @Databean @rmuthiah @jemoreira @ser-io @google/android-cuttlefish
-
-# github workflows
-/.github/workflows/ @jemoreira @ser-io @Databean @cjreynol
-
-# docker TLs
-/docker/ @jemoreira @ikicha @0405ysj @Databean
-
-# host orchestration TLs
-/frontend/ @jemoreira @ser-io
-
-# WebUI Owners
-/frontend/src/operator/webui/ @jemoreira @ikicha 
-
-# AOSP migration
-/staging @Databean @cjreynol @google/android-cuttlefish
-
-# debian package updates
-
-/base/debian/ @cjreynol @Databean @jemoreira @ser-io
-/frontend/debian/ @cjreynol @Databean @jemoreira @ser-io
+@google/android-cuttlefish


### PR DESCRIPTION
Like our Android OWNERS: https://cs.android.com/search?q=file:device%2Fgoogle%2Fcuttlefish%2F*%2FOWNERS

Though we could always institute the "techleads" portion as well: https://cs.android.com/search?q=(file:device%2Fgoogle%2Fcuttlefish%2Fhost%20OR%20file:device%2Fgoogle%2Fcuttlefish%2Fcommon)%20OWNERS_techleads