### PR TITLE
Introduce HO API PUT /v1/userartifacts/{checksum}

### DIFF
--- a/frontend/src/host_orchestrator/go.mod
+++ b/frontend/src/host_orchestrator/go.mod
@@ -22,3 +22,5 @@ require (
 	google.golang.org/grpc v1.40.0 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
 )
+
+replace github.com/google/android-cuttlefish/frontend/src/liboperator => ../liboperator

--- a/frontend/src/host_orchestrator/go.sum
+++ b/frontend/src/host_orchestrator/go.sum
@@ -31,8 +31,6 @@ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QD
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
-github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20240822182916-7bea0dafdbde h1:laMjSvqBHvDZ9DB+YaM6I4y5t0a7zYQRorYLM1VJsyM=
-github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20240822182916-7bea0dafdbde/go.mod h1:iA3V13fYW7It3n+LqvgOkXAOhw56XAjS1vH43+kU/4o=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=

--- a/frontend/src/host_orchestrator/main.go
+++ b/frontend/src/host_orchestrator/main.go
@@ -117,9 +117,14 @@ func main() {
 
 	om := orchestrator.NewMapOM()
 	uamOpts := orchestrator.UserArtifactsManagerOpts{
-		RootDir: filepath.Join(*imRootDir, "user_artifacts"),
+		LegacyRootDir: filepath.Join(*imRootDir, "user_artifacts"),
+		RootDir:       filepath.Join(*imRootDir, "userartifacts"),
 	}
-	uam := orchestrator.NewUserArtifactsManagerImpl(uamOpts)
+	uam, err := orchestrator.NewUserArtifactsManagerImpl(uamOpts)
+	if err != nil {
+		log.Fatalf("Unable to prepare UserArtifactsManager: %v", err)
+	}
+	defer os.RemoveAll(uam.UuidWorkDir)
 	debugStaticVars := debug.StaticVariables{}
 	debugVarsManager := debug.NewVariablesManager(debugStaticVars)
 	imController := orchestrator.Controller{

--- a/frontend/src/host_orchestrator/orchestrator/controller.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller.go
@@ -556,48 +556,35 @@ func (h *createUpdateUserArtifactHandler) Handle(r *http.Request) (interface{}, 
 		return nil, err
 	}
 	chunkOffsetBytesRaw := r.FormValue("chunk_offset_bytes")
+	var chunkOffsetBytes int64
 	if chunkOffsetBytesRaw != "" {
-		chunkOffsetBytes, err := strconv.ParseInt(chunkOffsetBytesRaw, 10, 64)
+		chunkOffsetBytes, err = strconv.ParseInt(chunkOffsetBytesRaw, 10, 64)
 		if err != nil {
 			return nil, operator.NewBadRequestError(
 				fmt.Sprintf("Invalid chunk_offset_bytes form field value: %q", chunkOffsetBytesRaw), err)
 		}
-		chunk := UserArtifactChunk{
-			Name:             fheader.Filename,
-			File:             f,
-			UseChunkOffset:   true,
-			ChunkOffsetBytes: chunkOffsetBytes,
-		}
-		return nil, h.m.UpdateArtifactWithDir(dir, chunk)
 	} else {
-		// Deprecated: clients should use `chunk_offset_bytes` only
+		log.Println("deprecated: use `chunk_offset_bytes`")
 		chunkNumberRaw := r.FormValue("chunk_number")
-		chunkTotalRaw := r.FormValue("chunk_total")
 		chunkSizeBytesRaw := r.FormValue("chunk_size_bytes")
 		chunkNumber, err := strconv.Atoi(chunkNumberRaw)
 		if err != nil {
 			return nil, operator.NewBadRequestError(
 				fmt.Sprintf("Invalid chunk_number value: %q", chunkNumberRaw), err)
 		}
-		chunkTotal, err := strconv.Atoi(chunkTotalRaw)
-		if err != nil {
-			return nil, operator.NewBadRequestError(
-				fmt.Sprintf("Invalid chunk_total form field value: %q", chunkTotalRaw), err)
-		}
 		chunkSizeBytes, err := strconv.ParseInt(chunkSizeBytesRaw, 10, 64)
 		if err != nil {
 			return nil, operator.NewBadRequestError(
 				fmt.Sprintf("Invalid chunk_size_bytes form field value: %q", chunkSizeBytesRaw), err)
 		}
-		chunk := UserArtifactChunk{
-			Name:           fheader.Filename,
-			ChunkNumber:    chunkNumber,
-			ChunkTotal:     chunkTotal,
-			ChunkSizeBytes: chunkSizeBytes,
-			File:           f,
-		}
-		return nil, h.m.UpdateArtifactWithDir(dir, chunk)
+		chunkOffsetBytes = int64(chunkNumber-1) * chunkSizeBytes
 	}
+	chunk := UserArtifactChunk{
+		Name:        fheader.Filename,
+		File:        f,
+		OffsetBytes: chunkOffsetBytes,
+	}
+	return nil, h.m.UpdateArtifactWithDir(dir, chunk)
 }
 
 type extractUserArtifactHandler struct {

--- a/frontend/src/host_orchestrator/orchestrator/controller_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller_test.go
@@ -201,7 +201,11 @@ func (testUAM) UpdateArtifactWithDir(dir string, chunk UserArtifactChunk) error 
 	return nil
 }
 
-func (testUAM) GetDirPath(string) string {
+func (testUAM) UpdateArtifact(checksum string, chunk UserArtifactChunk) error {
+	return nil
+}
+
+func (testUAM) GetDirPath(string, bool) string {
 	return ""
 }
 

--- a/frontend/src/host_orchestrator/orchestrator/createcvdaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/createcvdaction.go
@@ -116,7 +116,7 @@ func (a *CreateCVDAction) launchWithCanonicalConfig(op apiv1.Operation) (*apiv1.
 	log.Printf("environment config:\n%s", string(data))
 	data = bytes.ReplaceAll(data,
 		[]byte(apiv1.EnvConfigUserArtifactsVar+"/"),
-		[]byte(a.userArtifactsDirResolver.GetDirPath("")))
+		[]byte(a.userArtifactsDirResolver.GetDirPath("", true)+"/"))
 	configFile, err := createTempFile("cvdload*.json", data, 0640)
 	if err != nil {
 		return nil, err

--- a/frontend/src/host_orchestrator/orchestrator/userartifacts.go
+++ b/frontend/src/host_orchestrator/orchestrator/userartifacts.go
@@ -37,14 +37,9 @@ type UserArtifactsDirResolver interface {
 }
 
 type UserArtifactChunk struct {
-	Name             string
-	File             io.Reader
-	UseChunkOffset   bool
-	ChunkOffsetBytes int64
-
-	ChunkNumber    int   // Deprecated: use `ChunkOffsetBytes`
-	ChunkTotal     int   // Deprecated: use `OffsetBytes`
-	ChunkSizeBytes int64 // Deprecated: use `OffsetBytes`
+	Name        string
+	File        io.Reader
+	OffsetBytes int64
 }
 
 // Abstraction for managing user artifacts for launching CVDs.
@@ -142,12 +137,7 @@ func writeChunk(filename string, chunk UserArtifactChunk) error {
 		return err
 	}
 	defer f.Close()
-	offset := chunk.ChunkOffsetBytes
-	if !chunk.UseChunkOffset {
-		log.Println("deprecated: use `ChunkOffsetBytes`")
-		offset = int64(chunk.ChunkNumber-1) * chunk.ChunkSizeBytes
-	}
-	if _, err := f.Seek(offset, 0); err != nil {
+	if _, err := f.Seek(chunk.OffsetBytes, 0); err != nil {
 		return err
 	}
 	if _, err = io.Copy(f, chunk.File); err != nil {

--- a/frontend/src/host_orchestrator/orchestrator/userartifacts.go
+++ b/frontend/src/host_orchestrator/orchestrator/userartifacts.go
@@ -16,6 +16,7 @@ package orchestrator
 
 import (
 	"archive/zip"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -24,32 +25,42 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	apiv1 "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
 	hoexec "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/exec"
 	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
+	"github.com/google/uuid"
 )
 
 // Resolves the user artifacts full directory.
 type UserArtifactsDirResolver interface {
 	// Given a directory name returns its full path.
-	GetDirPath(name string) string
+	GetDirPath(name string, isLegacy bool) string
 }
 
 type UserArtifactChunk struct {
-	Name        string
-	File        io.Reader
-	OffsetBytes int64
+	Name          string
+	File          io.Reader
+	OffsetBytes   int64
+	SizeBytes     int64
+	FileSizeBytes int64
 }
 
 // Abstraction for managing user artifacts for launching CVDs.
 type UserArtifactsManager interface {
+	// Update artifact with the passed chunk
+	UpdateArtifact(checksum string, chunk UserArtifactChunk) error
+
 	UserArtifactsDirResolver
 	// Creates a new directory for uploading user artifacts in the future.
+	// Deprecated: use `UpdateArtifact` instead
 	NewDir() (*apiv1.UploadDirectory, error)
 	// List existing directories
+	// Deprecated: use `UpdateArtifact` instead
 	ListDirs() (*apiv1.ListUploadDirectoriesResponse, error)
-	// Update artifact with the passed chunk.
+	// Update artifact with the passed chunk
+	// Deprecated: use `UpdateArtifact` instead
 	UpdateArtifactWithDir(dir string, chunk UserArtifactChunk) error
 	// Extract artifact
 	ExtractArtifactWithDir(dir, name string) error
@@ -57,27 +68,43 @@ type UserArtifactsManager interface {
 
 // Options for creating instances of UserArtifactsManager implementations.
 type UserArtifactsManagerOpts struct {
-	// The root directory where to store the artifacts.
+	// Root directory for legacy APIs treating user artifacts.
+	LegacyRootDir string
+	// Root directory for storing user artifacts. After Host Orchestrator moves user artifacts from
+	// the working directory into here, it becomes immutable unless introducing any replacement
+	// algorithm(e.g. LRU) on RootDir to manage the storage.
 	RootDir string
 }
 
 // An implementation of the UserArtifactsManager interface.
 type UserArtifactsManagerImpl struct {
 	UserArtifactsManagerOpts
+	// The root directory where to store artifacts with legacy API calls.
+	commonWorkDir string
+	UuidWorkDir   string
+	mutexes       sync.Map
+	chunkStates   sync.Map
 }
 
 // Creates a new instance of UserArtifactsManagerImpl.
-func NewUserArtifactsManagerImpl(opts UserArtifactsManagerOpts) *UserArtifactsManagerImpl {
+func NewUserArtifactsManagerImpl(opts UserArtifactsManagerOpts) (*UserArtifactsManagerImpl, error) {
+	commonWorkDir := filepath.Join(opts.RootDir, "working")
+	UuidWorkDir := filepath.Join(commonWorkDir, uuid.New().String())
+	if err := os.RemoveAll(UuidWorkDir); err != nil {
+		return nil, err
+	}
 	return &UserArtifactsManagerImpl{
 		UserArtifactsManagerOpts: opts,
-	}
+		commonWorkDir:            commonWorkDir,
+		UuidWorkDir:              UuidWorkDir,
+	}, nil
 }
 
 func (m *UserArtifactsManagerImpl) NewDir() (*apiv1.UploadDirectory, error) {
-	if err := createDir(m.RootDir); err != nil {
+	if err := createDir(m.LegacyRootDir); err != nil {
 		return nil, err
 	}
-	dir, err := createNewUADir(m.RootDir)
+	dir, err := createNewUADir(m.LegacyRootDir)
 	if err != nil {
 		return nil, err
 	}
@@ -86,14 +113,14 @@ func (m *UserArtifactsManagerImpl) NewDir() (*apiv1.UploadDirectory, error) {
 }
 
 func (m *UserArtifactsManagerImpl) ListDirs() (*apiv1.ListUploadDirectoriesResponse, error) {
-	exist, err := fileExist(m.RootDir)
+	exist, err := fileExist(m.LegacyRootDir)
 	if err != nil {
 		return nil, err
 	}
 	if !exist {
 		return &apiv1.ListUploadDirectoriesResponse{Items: make([]*apiv1.UploadDirectory, 0)}, nil
 	}
-	entries, err := ioutil.ReadDir(m.RootDir)
+	entries, err := ioutil.ReadDir(m.LegacyRootDir)
 	if err != nil {
 		return nil, err
 	}
@@ -106,16 +133,45 @@ func (m *UserArtifactsManagerImpl) ListDirs() (*apiv1.ListUploadDirectoriesRespo
 	return &apiv1.ListUploadDirectoriesResponse{Items: dirs}, nil
 }
 
-func (m *UserArtifactsManagerImpl) GetDirPath(name string) string {
-	return m.RootDir + "/" + name
+func (m *UserArtifactsManagerImpl) GetDirPath(name string, isLegacy bool) string {
+	if isLegacy {
+		return filepath.Join(m.LegacyRootDir, name)
+	} else {
+		return filepath.Join(m.RootDir, name)
+	}
 }
 
 func (m *UserArtifactsManagerImpl) GetFilePath(dir, filename string) string {
-	return m.RootDir + "/" + dir + "/" + filename
+	return filepath.Join(m.LegacyRootDir, dir, filename)
+}
+
+func (m *UserArtifactsManagerImpl) UpdateArtifact(checksum string, chunk UserArtifactChunk) error {
+	if chunk.OffsetBytes < 0 {
+		return operator.NewBadRequestError(fmt.Sprintf("invalid value (chunk_offset:%d)", chunk.OffsetBytes), nil)
+	}
+	if chunk.SizeBytes < 0 {
+		return fmt.Errorf("invalid value (chunk_size:%d)", chunk.SizeBytes)
+	}
+	if chunk.FileSizeBytes < 0 {
+		return operator.NewBadRequestError(fmt.Sprintf("invalid value (file_size:%d)", chunk.FileSizeBytes), nil)
+	}
+	if chunk.OffsetBytes+chunk.SizeBytes > chunk.FileSizeBytes {
+		return operator.NewBadRequestError(fmt.Sprintf("invalid value pair (chunk_offset:%d, chunk_size:%d, file_size:%d)", chunk.OffsetBytes, chunk.SizeBytes, chunk.FileSizeBytes), nil)
+	}
+	mayMoveArtifact, err := m.writeChunkAndUpdateState(checksum, chunk)
+	if err != nil {
+		return fmt.Errorf("failed to update chunk: %w", err)
+	}
+	if mayMoveArtifact {
+		if err := m.moveArtifactIfNeeds(checksum, chunk); err != nil {
+			return fmt.Errorf("failed to move the user artifact from working directory: %w", err)
+		}
+	}
+	return nil
 }
 
 func (m *UserArtifactsManagerImpl) UpdateArtifactWithDir(dir string, chunk UserArtifactChunk) error {
-	dir = m.RootDir + "/" + dir
+	dir = filepath.Join(m.LegacyRootDir, dir)
 	if ok, err := fileExist(dir); err != nil {
 		return err
 	} else if !ok {
@@ -131,23 +187,126 @@ func (m *UserArtifactsManagerImpl) UpdateArtifactWithDir(dir string, chunk UserA
 	return nil
 }
 
+func (m *UserArtifactsManagerImpl) getRWMutex(checksum string) *sync.RWMutex {
+	mu, _ := m.mutexes.LoadOrStore(checksum, &sync.RWMutex{})
+	return mu.(*sync.RWMutex)
+}
+
+func (m *UserArtifactsManagerImpl) getChunkState(checksum string, fileSize int64) *ChunkState {
+	cs, _ := m.chunkStates.LoadOrStore(checksum, NewChunkState(fileSize))
+	return cs.(*ChunkState)
+}
+
+func dirExists(dir string) (bool, error) {
+	if info, err := os.Stat(dir); os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	} else {
+		return info.IsDir(), nil
+	}
+}
+
 func writeChunk(filename string, chunk UserArtifactChunk) error {
-	f, err := os.OpenFile(filename, os.O_WRONLY, 0664)
+	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE, 0664)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to open or create working file: %w", err)
 	}
 	defer f.Close()
-	if _, err := f.Seek(chunk.OffsetBytes, 0); err != nil {
-		return err
+	if _, err := f.Seek(chunk.OffsetBytes, io.SeekStart); err != nil {
+		return fmt.Errorf("failed to seek offset of working file: %w", err)
 	}
-	if _, err = io.Copy(f, chunk.File); err != nil {
-		return err
+	if _, err := io.Copy(f, chunk.File); err != nil {
+		return fmt.Errorf("failed to copy chunk into working file: %w", err)
 	}
 	return nil
 }
 
+// Calculating the checksum of the user artifact is a heavy task. Instead, it records the state
+// of updated chunks to know whether it's ready to calculate checksum and move the user artifact or
+// not. This function returns the boolean value as true if it needs to calculate checksum afterwards.
+func (m *UserArtifactsManagerImpl) writeChunkAndUpdateState(checksum string, chunk UserArtifactChunk) (bool, error) {
+	mu := m.getRWMutex(checksum)
+	// Reason for acquiring read lock is to allow updating multiple chunks concurrently, but to
+	// restrict validating checksum or moving artifact into different directory when one or more
+	// chunks are being updated.
+	mu.RLock()
+	defer mu.RUnlock()
+	if exists, err := dirExists(filepath.Join(m.RootDir, checksum)); err != nil {
+		return false, fmt.Errorf("failed to check existence of directory: %w", err)
+	} else if exists {
+		return false, operator.NewConflictError(fmt.Sprintf("user artifact(checksum:%q) already exists", checksum), nil)
+	}
+	if err := createDir(m.RootDir); err != nil {
+		return false, fmt.Errorf("failed to create root directory for storing user artifacts: %w", err)
+	}
+	if err := createDir(m.commonWorkDir); err != nil {
+		return false, fmt.Errorf("failed to create working directory for all Host Orchestrators: %w", err)
+	}
+	if err := createDir(m.UuidWorkDir); err != nil {
+		return false, fmt.Errorf("failed to create working directory for this Host Orchestrator: %w", err)
+	}
+	workDir := filepath.Join(m.UuidWorkDir, checksum)
+	if err := createDir(workDir); err != nil {
+		return false, fmt.Errorf("failed to create working directory: %w", err)
+	}
+	workFile := filepath.Join(workDir, chunk.Name)
+	if err := writeChunk(workFile, chunk); err != nil {
+		return false, err
+	}
+	cs := m.getChunkState(checksum, chunk.FileSizeBytes)
+	cs.Update(chunk.OffsetBytes, chunk.OffsetBytes+chunk.SizeBytes)
+	return cs.IsCompleted(), nil
+}
+
+func (m *UserArtifactsManagerImpl) validateChecksum(checksum string, chunk UserArtifactChunk) (bool, error) {
+	workFile := filepath.Join(m.UuidWorkDir, checksum, chunk.Name)
+	f, err := os.Open(workFile)
+	if err != nil {
+		return false, fmt.Errorf("failed to open working file: %w", err)
+	}
+	defer f.Close()
+	if info, err := f.Stat(); err != nil {
+		return false, err
+	} else if chunk.FileSizeBytes != info.Size() {
+		return false, nil
+	}
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return false, err
+	}
+	return checksum == fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+func (m *UserArtifactsManagerImpl) moveArtifactIfNeeds(checksum string, chunk UserArtifactChunk) error {
+	mu := m.getRWMutex(checksum)
+	// Reason for acquiring write lock is to restrict writing new chunks while validating checksum
+	// or moving artifact.
+	mu.Lock()
+	defer mu.Unlock()
+	dir := filepath.Join(m.RootDir, checksum)
+	if exists, err := dirExists(dir); err != nil {
+		return fmt.Errorf("failed to check existence of directory: %w", err)
+	} else if exists {
+		return nil
+	}
+	if matches, err := m.validateChecksum(checksum, chunk); err != nil {
+		return fmt.Errorf("failed to validate checksum of the user artifact: %w", err)
+	} else if !matches {
+		// Only if the checksum matches, it's ready to move the user artifact from working
+		// directory.
+		return nil
+	}
+	workDir := filepath.Join(m.UuidWorkDir, checksum)
+	if err := os.Rename(workDir, dir); err != nil {
+		return fmt.Errorf("failed to move the user artifact: %w", err)
+	}
+	m.chunkStates.Delete(checksum)
+	return nil
+}
+
 func (m *UserArtifactsManagerImpl) ExtractArtifactWithDir(dir, name string) error {
-	dir = filepath.Join(m.RootDir, dir)
+	dir = filepath.Join(m.LegacyRootDir, dir)
 	if ok, err := fileExist(dir); err != nil {
 		return err
 	} else if !ok {

--- a/frontend/src/host_orchestrator/orchestrator/userartifacts_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/userartifacts_test.go
@@ -92,8 +92,7 @@ func TestCreateArtifactDirectoryDoesNotExist(t *testing.T) {
 	am := NewUserArtifactsManagerImpl(opts)
 	chunk := UserArtifactChunk{
 		Name:        "xyzz",
-		ChunkNumber: 1,
-		ChunkTotal:  11,
+		OffsetBytes: 0,
 		File:        strings.NewReader("lorem ipsum"),
 	}
 
@@ -101,55 +100,6 @@ func TestCreateArtifactDirectoryDoesNotExist(t *testing.T) {
 
 	if err == nil {
 		t.Error("expected error")
-	}
-}
-
-func TestCreateArtifactsLegacySucceeds(t *testing.T) {
-	wg := sync.WaitGroup{}
-	root := orchtesting.TempDir(t)
-	defer orchtesting.RemoveDir(t, root)
-	opts := UserArtifactsManagerOpts{RootDir: root}
-	am := NewUserArtifactsManagerImpl(opts)
-	upDir, err := am.NewDir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	chunk1 := UserArtifactChunk{
-		Name:           "xyzz",
-		ChunkNumber:    1,
-		ChunkTotal:     3,
-		ChunkSizeBytes: 4,
-		File:           strings.NewReader("lore"),
-	}
-	chunk2 := UserArtifactChunk{
-		Name:           "xyzz",
-		ChunkNumber:    2,
-		ChunkTotal:     3,
-		ChunkSizeBytes: 4,
-		File:           strings.NewReader("m ip"),
-	}
-	chunk3 := UserArtifactChunk{
-		Name:           "xyzz",
-		ChunkNumber:    3,
-		ChunkTotal:     3,
-		ChunkSizeBytes: 4,
-		File:           strings.NewReader("sum"),
-	}
-	chunks := [3]UserArtifactChunk{chunk1, chunk2, chunk3}
-	wg.Add(3)
-
-	for i := 0; i < len(chunks); i++ {
-		go func(i int) {
-			defer wg.Done()
-			am.UpdateArtifactWithDir(upDir.Name, chunks[i])
-		}(i)
-
-	}
-
-	wg.Wait()
-	b, _ := ioutil.ReadFile(am.GetFilePath(upDir.Name, "xyzz"))
-	if diff := cmp.Diff("lorem ipsum", string(b)); diff != "" {
-		t.Errorf("aritfact content mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -164,22 +114,19 @@ func TestCreateArtifactsSucceeds(t *testing.T) {
 		t.Fatal(err)
 	}
 	chunk1 := UserArtifactChunk{
-		Name:             "xyzz",
-		File:             strings.NewReader("lore"),
-		UseChunkOffset:   true,
-		ChunkOffsetBytes: 0,
+		Name:        "xyzz",
+		File:        strings.NewReader("lore"),
+		OffsetBytes: 0,
 	}
 	chunk2 := UserArtifactChunk{
-		Name:             "xyzz",
-		File:             strings.NewReader("m ip"),
-		UseChunkOffset:   true,
-		ChunkOffsetBytes: 0 + 4,
+		Name:        "xyzz",
+		File:        strings.NewReader("m ip"),
+		OffsetBytes: 0 + 4,
 	}
 	chunk3 := UserArtifactChunk{
-		Name:             "xyzz",
-		File:             strings.NewReader("sum"),
-		UseChunkOffset:   true,
-		ChunkOffsetBytes: 0 + 4 + 4,
+		Name:        "xyzz",
+		File:        strings.NewReader("sum"),
+		OffsetBytes: 0 + 4 + 4,
 	}
 	chunks := [3]UserArtifactChunk{chunk1, chunk2, chunk3}
 	wg.Add(3)

--- a/frontend/src/liboperator/operator/errors.go
+++ b/frontend/src/liboperator/operator/errors.go
@@ -53,6 +53,10 @@ func NewNotFoundError(msg string, e error) error {
 	return &AppError{Msg: msg, StatusCode: http.StatusNotFound, Err: e}
 }
 
+func NewConflictError(msg string, e error) error {
+	return &AppError{Msg: msg, StatusCode: http.StatusConflict, Err: e}
+}
+
 func NewServiceUnavailableError(msg string, e error) error {
 	return &AppError{Msg: msg, StatusCode: http.StatusServiceUnavailable, Err: e}
 }


### PR DESCRIPTION
This PR covers the implemtation of `PUT /v1/userartifacts/{hash}` at the level of HO REST API only.
For HO client APIs(e.g. golang) & rest of HO REST APIs(e.g. `GET /v1/userartifacts/{hash}/:stat`), it would be covered at different PR or changes.