### PR TITLE
Expose default_vvmtruststore_file_name in env config

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_disk_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_disk_configs.cpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 
+#include "cuttlefish/host/commands/assemble_cvd/flags_defaults.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/cf_configs_common.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/load_config.pb.h"
 
@@ -27,6 +28,21 @@ namespace cuttlefish {
 
 using cvd::config::EnvironmentSpecification;
 using cvd::config::Instance;
+
+static std::string DefaultVvmtrustoreFileName(const Instance& instance) {
+  // Only one VvmtrustoreFileName is supporyed per instance. The the flag will
+  // be given the last value provided if there is more than one.
+  std::string default_vvmtruststore_file_name =
+      CF_DEFAULTS_DEFAULT_VVMTRUSTSTORE_FILE_NAME;
+
+  for (const auto& partition : instance.disk().extra_partitions()) {
+    if (partition.has_default_vvmtruststore_file_name()) {
+      default_vvmtruststore_file_name =
+          partition.default_vvmtruststore_file_name();
+    }
+  }
+  return default_vvmtruststore_file_name;
+}
 
 std::vector<std::string> GenerateDiskFlags(
     const EnvironmentSpecification& config) {
@@ -41,6 +57,8 @@ std::vector<std::string> GenerateDiskFlags(
   }
   return std::vector<std::string>{
       GenerateVecFlag("blank_data_image_mb", data_image_mbs),
+      GenerateInstanceFlag("default_vvmtruststore_file_name", config,
+                           DefaultVvmtrustoreFileName),
   };
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_config.proto
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_config.proto
@@ -96,6 +96,11 @@ message Disk {
   optional bool download_target_files_zip = 4;
   optional uint32 blank_data_image_mb = 5;
   optional string otatools = 6;
+  repeated ExtraPartition extra_partitions = 7;
+}
+
+message ExtraPartition {
+  optional string default_vvmtruststore_file_name = 1;
 }
 
 message Super {


### PR DESCRIPTION
ExtraPartition is created as a repeated file to be able to extend it in the future.

Bug: b/411021381