### PR TITLE
Limit number of concurrent jobs per branch/PR

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -6,6 +6,13 @@ on:
     branches-ignore:
       - main  # push events to main branch occur after PRs are merged, when the same checks were run
 
+
+concurrency:
+  # limits the workflow to a single run per branch/PR
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # previous runs are cancelled when a new run is started
+  cancel-in-progress: true
+
 jobs:
   staticcheck:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This setting will stop Presubmit runs when a new run is triggered.  For example, when pushing in quick succession to a PR, only the latest run is needed and prior actions can be cancelled.

reference:
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs

Bug: 418057083