### PR TITLE
Construct chunkState for efficiently managing concurrent updated chunks

### DIFF
--- a/frontend/src/host_orchestrator/go.mod
+++ b/frontend/src/host_orchestrator/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20240822182916-7bea0dafdbde
+	github.com/google/btree v1.1.3
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0

--- a/frontend/src/host_orchestrator/go.sum
+++ b/frontend/src/host_orchestrator/go.sum
@@ -33,6 +33,8 @@ github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20240822182916-7bea0dafdbde h1:laMjSvqBHvDZ9DB+YaM6I4y5t0a7zYQRorYLM1VJsyM=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20240822182916-7bea0dafdbde/go.mod h1:iA3V13fYW7It3n+LqvgOkXAOhw56XAjS1vH43+kU/4o=
+github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
+github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/frontend/src/host_orchestrator/orchestrator/BUILD.bazel
+++ b/frontend/src/host_orchestrator/orchestrator/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "orchestrator",
     srcs = [
+        "chunkstate.go",
         "controller.go",
         "createcvdaction.go",
         "createcvdbugreportaction.go",
@@ -33,6 +34,7 @@ go_library(
 go_test(
     name = "orchestrator_test",
     srcs = [
+        "chunkstate_test.go",
         "controller_test.go",
         "createcvdaction_test.go",
         "instancemanager_test.go",

--- a/frontend/src/host_orchestrator/orchestrator/chunkstate.go
+++ b/frontend/src/host_orchestrator/orchestrator/chunkstate.go
@@ -1,0 +1,138 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator
+
+import (
+	"sync"
+	"fmt"
+
+	"github.com/google/btree"
+)
+
+// Structure for managing the state of updated chunk for efficiently knowing whether the user
+// artifact may need to calculate hash sum or not.
+type ChunkState struct {
+	fileSize int64
+	items    *btree.BTree
+	mutex    sync.RWMutex
+}
+
+type chunkStateItem struct {
+	// Starting byte offset of the continuous range having same state whether updated or not.
+	offset int64
+	// State description whether given byte offset of the user artifact is updated or not.
+	isUpdated bool
+}
+
+func (i chunkStateItem) Less(item btree.Item) bool {
+	return i.offset < item.(chunkStateItem).offset
+}
+
+func NewChunkState(fileSize int64) *ChunkState {
+	cs := ChunkState{
+		fileSize: fileSize,
+		items:    btree.New(2),
+		mutex:    sync.RWMutex{},
+	}
+	cs.items.ReplaceOrInsert(chunkStateItem{offset: 0, isUpdated: false})
+	return &cs
+}
+
+func (cs *ChunkState) getItem(offset int64) *chunkStateItem {
+	entry := cs.items.Get(chunkStateItem{offset: offset})
+	if item, ok := entry.(chunkStateItem); ok {
+		return &item
+	} else {
+		return nil
+	}
+}
+
+func (cs *ChunkState) getPrevItem(offset int64) *chunkStateItem {
+	var record *chunkStateItem
+	cs.items.DescendLessOrEqual(chunkStateItem{offset: offset - 1}, func(item btree.Item) bool {
+		entry := item.(chunkStateItem)
+		record = &entry
+		return false
+	})
+	return record
+}
+
+func (cs *ChunkState) getNextItem(offset int64) *chunkStateItem {
+	var record *chunkStateItem
+	cs.items.AscendGreaterOrEqual(chunkStateItem{offset: offset + 1}, func(item btree.Item) bool {
+		entry := item.(chunkStateItem)
+		record = &entry
+		return false
+	})
+	return record
+}
+
+func (cs *ChunkState) Update(start int64, end int64) error {
+	if start < 0 {
+		return fmt.Errorf("invalid start offset of the range")
+	}
+	if end > cs.fileSize {
+		return fmt.Errorf("invalid end offset of the range")
+	}
+	cs.mutex.Lock()
+	defer cs.mutex.Unlock()
+	if item := cs.getItem(start); item != nil {
+		if !item.isUpdated {
+			cs.items.Delete(*item)
+			if item.offset == 0 {
+				cs.items.ReplaceOrInsert(chunkStateItem{offset: start, isUpdated: true})
+			}
+		}
+	} else if prev := cs.getPrevItem(start); prev != nil {
+		if !prev.isUpdated {
+			cs.items.ReplaceOrInsert(chunkStateItem{offset: start, isUpdated: true})
+		}
+	} else {
+		return fmt.Errorf("previous item should exist")
+	}
+
+	for next := cs.getNextItem(start); ; next = cs.getNextItem(start) {
+		if next == nil {
+			cs.items.ReplaceOrInsert(chunkStateItem{offset: end, isUpdated: false})
+			break
+		}
+		if next.offset < end {
+			cs.items.Delete(*next)
+		} else if next.offset == end {
+			if next.isUpdated {
+				cs.items.Delete(*next)
+			} else {
+				break
+			}
+		} else {
+			if next.isUpdated {
+				cs.items.ReplaceOrInsert(chunkStateItem{offset: end, isUpdated: false})
+			}
+			break
+		}
+	}
+	return nil
+}
+
+func (cs *ChunkState) IsCompleted() bool {
+	cs.mutex.RLock()
+	defer cs.mutex.RUnlock()
+	if cs.items.Len() != 2 {
+		return false
+	}
+	first := chunkStateItem{offset: 0, isUpdated: true}
+	last := chunkStateItem{offset: cs.fileSize, isUpdated: false}
+	return cs.items.Min() == first && cs.items.Max() == last
+}

--- a/frontend/src/host_orchestrator/orchestrator/chunkstate_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/chunkstate_test.go
@@ -1,0 +1,185 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/google/btree"
+	"github.com/google/go-cmp/cmp"
+)
+
+func getChunkStateItemList(cs *ChunkState) []chunkStateItem {
+	var items []chunkStateItem
+	cs.items.Ascend(func(item btree.Item) bool {
+		items = append(items, item.(chunkStateItem))
+		return true
+	})
+	return items
+}
+
+func TestChunkStateUpdateSucceedsForSeparatedChunks(t *testing.T) {
+	cs := NewChunkState(100)
+	cs.Update(0, 10)
+	cs.Update(40, 50)
+	cs.Update(90, 100)
+	items := getChunkStateItemList(cs)
+	expected := []chunkStateItem{
+		{offset: 0, isUpdated: true},
+		{offset: 10, isUpdated: false},
+		{offset: 40, isUpdated: true},
+		{offset: 50, isUpdated: false},
+		{offset: 90, isUpdated: true},
+		{offset: 100, isUpdated: false},
+	}
+	if diff := cmp.Diff(expected, items, cmp.AllowUnexported(chunkStateItem{})); diff != "" {
+		t.Fatalf("chunk state mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestChunkStateUpdateSucceedsForSubranges(t *testing.T) {
+	cs := NewChunkState(100)
+	cs.Update(40, 50)
+	cs.Update(60, 70)
+	cs.Update(30, 80)
+	cs.Update(50, 60)
+	cs.Update(65, 75)
+	items := getChunkStateItemList(cs)
+	expected := []chunkStateItem{
+		{offset: 0, isUpdated: false},
+		{offset: 30, isUpdated: true},
+		{offset: 80, isUpdated: false},
+	}
+	if diff := cmp.Diff(expected, items, cmp.AllowUnexported(chunkStateItem{})); diff != "" {
+		t.Fatalf("chunk state mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestChunkStateUpdateSucceedsForOverlappingRanges(t *testing.T) {
+	cs := NewChunkState(100)
+	cs.Update(10, 30)
+	cs.Update(20, 40)
+	cs.Update(70, 90)
+	cs.Update(60, 80)
+	items := getChunkStateItemList(cs)
+	expected := []chunkStateItem{
+		{offset: 0, isUpdated: false},
+		{offset: 10, isUpdated: true},
+		{offset: 40, isUpdated: false},
+		{offset: 60, isUpdated: true},
+		{offset: 90, isUpdated: false},
+	}
+	if diff := cmp.Diff(expected, items, cmp.AllowUnexported(chunkStateItem{})); diff != "" {
+		t.Fatalf("chunk state mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestChunkStateUpdateSucceedsForSameStartOrEnd(t *testing.T) {
+	cs := NewChunkState(100)
+	cs.Update(10, 15)
+	cs.Update(10, 12)
+	cs.Update(20, 22)
+	cs.Update(20, 25)
+	cs.Update(55, 60)
+	cs.Update(58, 60)
+	cs.Update(65, 70)
+	cs.Update(68, 70)
+	items := getChunkStateItemList(cs)
+	expected := []chunkStateItem{
+		{offset: 0, isUpdated: false},
+		{offset: 10, isUpdated: true},
+		{offset: 15, isUpdated: false},
+		{offset: 20, isUpdated: true},
+		{offset: 25, isUpdated: false},
+		{offset: 55, isUpdated: true},
+		{offset: 60, isUpdated: false},
+		{offset: 65, isUpdated: true},
+		{offset: 70, isUpdated: false},
+	}
+	if diff := cmp.Diff(expected, items, cmp.AllowUnexported(chunkStateItem{})); diff != "" {
+		t.Fatalf("chunk state mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestChunkStateUpdateSucceedsForMergingChunks(t *testing.T) {
+	cs := NewChunkState(100)
+	cs.Update(10, 20)
+	cs.Update(30, 40)
+	cs.Update(50, 60)
+	cs.Update(20, 30)
+	cs.Update(40, 50)
+	items := getChunkStateItemList(cs)
+	expected := []chunkStateItem{
+		{offset: 0, isUpdated: false},
+		{offset: 10, isUpdated: true},
+		{offset: 60, isUpdated: false},
+	}
+	if diff := cmp.Diff(expected, items, cmp.AllowUnexported(chunkStateItem{})); diff != "" {
+		t.Fatalf("chunk state mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestChunkStateUpdateSucceedsForInvalidRanges(t *testing.T) {
+	cs := NewChunkState(100)	
+	if err := cs.Update(-1, 10); err == nil {
+		t.Fatalf("expected an error");
+	}
+	if err := cs.Update(90, 101); err == nil {
+		t.Fatalf("expected an error");
+	}
+	items := getChunkStateItemList(cs)
+	expected := []chunkStateItem{
+		{offset: 0, isUpdated: false},
+	}
+	if diff := cmp.Diff(expected, items, cmp.AllowUnexported(chunkStateItem{})); diff != "" {
+		t.Fatalf("chunk state mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestChunkStateIsCompleted(t *testing.T) {
+	cs := NewChunkState(100)
+	cs.Update(0, 20)
+	cs.Update(80, 100)
+	cs.Update(20, 80)
+	if !cs.IsCompleted() {
+		t.Fatalf("expected as completed")
+	}
+}
+
+func TestChunkStateIsNotCompletedWithMissingStart(t *testing.T) {
+	cs := NewChunkState(100)
+	cs.Update(1, 100)
+	if cs.IsCompleted() {
+		t.Fatalf("expected as not completed")
+	}
+}
+
+func TestChunkStateIsNotCompletedWithMissingIntermediate(t *testing.T) {
+	cs := NewChunkState(100)
+	cs.Update(0, 20)
+	cs.Update(80, 100)
+	cs.Update(20, 79)
+	if cs.IsCompleted() {
+		t.Fatalf("expected as not completed")
+	}
+}
+
+func TestChunkStateIsNotCompletedWithMissingEnd(t *testing.T) {
+	cs := NewChunkState(100)
+	cs.Update(0, 99)
+	if cs.IsCompleted() {
+		t.Fatalf("expected as not completed")
+	}
+}


### PR DESCRIPTION
Design document: go/ho-upload-api-v1

At the newly proposed design of Host Orchestrator upload API, it supposes to handle concurrent chunks within one REST API `PUT /v1/userartifacts/{hash}`. With this API's given preconditions that the user artifact is immutable & API returns error status 409(conflict) when already it exists there, we typically calculate the hash sum before replying on REST API request when it actually writes a chunk.

However, calculating hash sum is too heavy task to do with this REST API, as the size of CF image(few gigabytes) & CVD host package(hundreds of megabytes) is too large comparing to the size of each chunk(tens of kilobytes) of the legacy APIs as reference. The estimated time complexity of each REST API is **O(artifact_size)** per REST API request, and total number of REST API requests is approximately **{size of artifact}/{size of chunk}**.

This PR suggests to minimize the number of calculating hash sum, by checking ranges of updated chunks. I imported `github.com/google/btree` because B-tree is efficient(**O(log N)**) for searching, inserting, and deleting elements. What I want to solve here is similar to the merge interval algorithm problem, but noting that the order of ranges are random since it's coming from the client concurrently.

With this PR, we can let `UserArtifactManager` to calculate hash sum only when updated chunk covers all bytes of the file. Without assuming ranges of chunks are heavily overlapped, the time complexity of `update(start int64, end int64)` is **O(log chunk_number)**. The time complexity of `isCompleted()` is just constant time(**O(1)**).

Also this struct is designed to be safe from concurrent execution.

