### PR TITLE
Detect fastboot started triggered by GBL

### DIFF
--- a/base/cvd/cuttlefish/host/commands/kernel_log_monitor/kernel_log_server.cc
+++ b/base/cvd/cuttlefish/host/commands/kernel_log_monitor/kernel_log_server.cc
@@ -66,6 +66,7 @@ constexpr struct {
     {kAdbdStartedMessage, Event::AdbdStarted, kBare},
     {kFastbootdStartedMessage, Event::FastbootStarted, kBare},
     {kFastbootStartedMessage, Event::FastbootStarted, kBare},
+    {kGblFastbootStartedMessage, Event::FastbootStarted, kBare},
     {kScreenChangedMessage, Event::ScreenChanged, kKeyValuePair},
     {kBootloaderLoadedMessage, Event::BootloaderLoaded, kBare},
     {kKernelLoadedMessage, Event::KernelLoaded, kBare},

--- a/base/cvd/cuttlefish/host/libs/config/config_constants.h
+++ b/base/cvd/cuttlefish/host/libs/config/config_constants.h
@@ -46,6 +46,8 @@ inline constexpr char kHibernationExitMessage[] =
     "PM: hibernation: hibernation exit";
 inline constexpr char kFastbootStartedMessage[] =
     "Listening for fastboot command on tcp";
+inline constexpr char kGblFastbootStartedMessage[] =
+    "Started Fastboot over TCP";
 inline constexpr char kScreenChangedMessage[] = "VIRTUAL_DEVICE_SCREEN_CHANGED";
 inline constexpr char kDisplayPowerModeChangedMessage[] =
     "VIRTUAL_DEVICE_DISPLAY_POWER_MODE_CHANGED";

--- a/base/cvd/cuttlefish/host/libs/config/fastboot/launch.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/fastboot/launch.cpp
@@ -46,8 +46,8 @@ class FastbootProxy : public CommandSource, public KernelLogPipeConsumer {
         log_pipe_provider_(log_pipe_provider) {}
 
   Result<std::vector<MonitorCommand>> Commands() override {
-    const std::string ethernet_host = instance_.ethernet_ipv6() + "%" +
-                                      instance_.ethernet_bridge_name();
+    const std::string ethernet_host =
+        instance_.ethernet_ipv6() + "%" + instance_.ethernet_bridge_name();
 
     Command tunnel(SocketVsockProxyBinary());
     tunnel.AddParameter("--events_fd=", kernel_log_pipe_);
@@ -67,8 +67,13 @@ class FastbootProxy : public CommandSource, public KernelLogPipeConsumer {
 
   std::string Name() const override { return "FastbootProxy"; }
   bool Enabled() const override {
-    return instance_.boot_flow() == CuttlefishConfig::InstanceSpecific::BootFlow::Android &&
-           fastboot_config_.ProxyFastboot();
+    const auto boot_flow = instance_.boot_flow();
+    const bool is_android_boot =
+        boot_flow == CuttlefishConfig::InstanceSpecific::BootFlow::Android ||
+        boot_flow ==
+            CuttlefishConfig::InstanceSpecific::BootFlow::AndroidEfiLoader;
+
+    return is_android_boot && fastboot_config_.ProxyFastboot();
   }
 
  private:


### PR DESCRIPTION
Also enable fastboot proxy for AndroidEfiLoader boot flow

Test: can use GBL fastboot
Bug: 401619000