### PR TITLE
Extract `//cuttlefish/host/commands/assemble_cvd:[clean,misc_info]` and fix clang-tidy issues

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -108,6 +108,7 @@ cc_library(
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/common/libs/utils:size_utils",
         "//cuttlefish/common/libs/utils:subprocess",
+        "//cuttlefish/host/commands/assemble_cvd:misc_info",
         "//cuttlefish/host/graphics_detector:graphics_detector_cc_proto",
         "//cuttlefish/host/libs/allocd:allocd_utils",
         "//cuttlefish/host/libs/avb",
@@ -197,5 +198,28 @@ cc_library(
 clang_tidy_test(
     name = "clean_clang_tidy",
     srcs = [":clean"],
+    tags = ["clang_tidy", "clang-tidy"],
+)
+
+cc_library(
+    name = "misc_info",
+    srcs = ["misc_info.cc"],
+    hdrs = ["misc_info.h"],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+    deps = [
+        "//cuttlefish/common/libs/fs",
+        "//cuttlefish/common/libs/utils:contains",
+        "//cuttlefish/common/libs/utils:result",
+        "//cuttlefish/host/libs/avb",
+        "//cuttlefish/host/libs/config:known_paths",
+        "//libbase",
+        "@fmt",
+    ],
+)
+
+clang_tidy_test(
+    name = "misc_info_clang_tidy",
+    srcs = [":misc_info"],
     tags = ["clang_tidy", "clang-tidy"],
 )

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -46,7 +46,6 @@ cc_library(
         "boot_config.cc",
         "boot_image_utils.cc",
         "bootconfig_args.cpp",
-        "clean.cc",
         "disk/factory_reset_protected.cc",
         "disk/gem5_image_unpacker.cpp",
         "disk/generate_persistent_bootconfig.cpp",
@@ -71,7 +70,6 @@ cc_library(
         "boot_config.h",
         "boot_image_utils.h",
         "bootconfig_args.h",
-        "clean.h",
         "disk/disk.h",
         "disk_builder.h",
         "disk_flags.h",
@@ -159,6 +157,7 @@ cc_binary(
         "//cuttlefish/common/libs/utils:flag_parser",
         "//cuttlefish/common/libs/utils:in_sandbox",
         "//cuttlefish/common/libs/utils:tee_logging",
+        "//cuttlefish/host/commands/assemble_cvd:clean",
         "//cuttlefish/host/libs/command_util",
         "//cuttlefish/host/libs/config:config_flag",
         "//cuttlefish/host/libs/config:custom_actions",
@@ -178,4 +177,25 @@ clang_tidy_test(
         "clang-tidy",
         "clang_tidy",
     ],
+)
+
+cc_library(
+    name = "clean",
+    srcs = ["clean.cc"],
+    hdrs = ["clean.h"],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+    deps = [
+        "//cuttlefish/common/libs/utils:in_sandbox",
+        "//cuttlefish/common/libs/utils:result",
+        "//cuttlefish/common/libs/utils:subprocess",
+        "//cuttlefish/host/libs/config:config_utils",
+        "//libbase",
+    ],
+)
+
+clang_tidy_test(
+    name = "clean_clang_tidy",
+    srcs = [":clean"],
+    tags = ["clang_tidy", "clang-tidy"],
 )

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/clean.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/clean.cc
@@ -100,7 +100,7 @@ Result<void> CleanPriorFiles(const std::vector<std::string>& paths,
   LOG(DEBUG) << fmt::format("Prior files: {}", fmt::join(prior_files, ", "));
 
   // TODO(schuffelen): Fix logic for host-sandboxing mode.
-  if (!InSandbox() && (prior_dirs.size() > 0 || prior_files.size() > 0)) {
+  if (!InSandbox() && (!prior_dirs.empty() || !prior_files.empty())) {
     Command lsof("lsof");
     lsof.AddParameter("-t");
     for (const auto& prior_dir : prior_dirs) {

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/misc_info.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/misc_info.cc
@@ -153,7 +153,7 @@ Result<MiscInfo> ParseMiscInfo(const std::string& misc_info_contents) {
   MiscInfo misc_info;
   for (auto& line : lines) {
     line = android::base::Trim(line);
-    if (line.size() == 0) {
+    if (line.empty()) {
       continue;
     }
     auto eq_pos = line.find('=');

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/misc_info.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/misc_info.h
@@ -36,7 +36,7 @@ struct VbmetaArgs {
   std::vector<std::string> extra_arguments;
 };
 
-Result<MiscInfo> ParseMiscInfo(const std::string& file_contents);
+Result<MiscInfo> ParseMiscInfo(const std::string& misc_info_contents);
 Result<void> WriteMiscInfo(const MiscInfo& misc_info,
                            const std::string& output_path);
 Result<MiscInfo> GetCombinedDynamicPartitions(


### PR DESCRIPTION
Bug: b/418819573
Test: `bazel test '//...'`