### PR TITLE
Extract `//cuttlefish/common/libs/fs:[epoll,shared_fd_stream]`

### DIFF
--- a/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
@@ -6,15 +6,31 @@ package(
 )
 
 cc_library(
+    name = "epoll",
+    srcs = ["epoll.cpp"],
+    hdrs = ["epoll.h"],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+    deps = [
+        "//cuttlefish/common/libs/fs",
+        "//cuttlefish/common/libs/utils:result",
+    ],
+)
+
+clang_tidy_test(
+    name = "epoll_clang_tidy",
+    srcs = [":epoll"],
+    tags = ["clang_tidy", "clang-tidy"],
+)
+
+cc_library(
     name = "fs",
     srcs = [
-        "epoll.cpp",
         "shared_buf.cc",
         "shared_fd.cpp",
         "shared_fd_stream.cpp",
     ],
     hdrs = [
-        "epoll.h",
         "shared_buf.h",
         "shared_fd.h",
         "shared_fd_stream.h",

--- a/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
@@ -28,12 +28,10 @@ cc_library(
     srcs = [
         "shared_buf.cc",
         "shared_fd.cpp",
-        "shared_fd_stream.cpp",
     ],
     hdrs = [
         "shared_buf.h",
         "shared_fd.h",
-        "shared_fd_stream.h",
         "shared_select.h",
     ],
     copts = COPTS,
@@ -78,4 +76,21 @@ clang_tidy_test(
         "clang-tidy",
         "clang_tidy",
     ],
+)
+
+cc_library(
+    name = "shared_fd_stream",
+    srcs = ["shared_fd_stream.cpp"],
+    hdrs = ["shared_fd_stream.h"],
+    copts = COPTS,
+    strip_include_prefix = "//cuttlefish",
+    deps = [
+        "//cuttlefish/common/libs/fs",
+    ],
+)
+
+clang_tidy_test(
+    name = "shared_fd_stream_clang_tidy",
+    srcs = [":shared_fd_stream"],
+    tags = ["clang_tidy", "clang-tidy"],
 )

--- a/base/cvd/cuttlefish/host/libs/web/http_client/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/BUILD.bazel
@@ -27,6 +27,7 @@ cc_library(
     strip_include_prefix = "//cuttlefish",
     deps = [
         "//cuttlefish/common/libs/fs",
+        "//cuttlefish/common/libs/fs:shared_fd_stream",
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:json",
         "//cuttlefish/common/libs/utils:result",


### PR DESCRIPTION
https://bazel.build/docs/bazel-and-cpp

Bug: b/418834985
Test: `bazel test '//...' --test_summary=terse`