### PR TITLE
Update `zlib` version in `MODULE.bazel`

### DIFF
--- a/base/cvd/MODULE.bazel
+++ b/base/cvd/MODULE.bazel
@@ -41,7 +41,7 @@ bazel_dep(name = "rules_rust", version = "0.60.0")
 bazel_dep(name = "tinyxml2", version = "10.0.0")
 bazel_dep(name = "toolchains_llvm", version = "1.2.0")
 bazel_dep(name = "sandboxed_api")
-bazel_dep(name = "zlib", version = "1.3.1.bcr.3")
+bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
 
 # this needs to be at parity with with build_external/crosvm/crosvm.config.toml
 CROSVM_REMOTE = "https://chromium.googlesource.com/crosvm/crosvm"


### PR DESCRIPTION
Fixes this message:
```
WARNING: For repository 'zlib', the root module requires module version zlib@1.3.1.bcr.3, but got zlib@1.3.1.bcr.5 in the resolved dependency graph. Please update the version in your MODULE.bazel or set --check_direct_dependencies=off
```

Bug: b/418866898
Test: `bazel test '//...' --test_summary=terse`