### PR TITLE
cvd/utils/flags_collector refactor

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/host_tool_target.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/host_tool_target.cpp
@@ -33,7 +33,7 @@
 namespace cuttlefish {
 namespace {
 
-Result<std::vector<FlagInfoPtr>> GetSupportedFlags(
+Result<std::vector<FlagInfo>> GetSupportedFlags(
     const std::string& artifacts_path, const std::string bin_name) {
   auto bin_path = fmt::format("{}/{}", artifacts_path, bin_name);
   Command command(bin_path);
@@ -60,12 +60,12 @@ HostToolTarget::HostToolTarget(const std::string& artifacts_path)
 
 Result<FlagInfo> HostToolTarget::GetFlagInfo(
     const std::string& bin_name, const std::string& flag_name) const {
-  std::vector<FlagInfoPtr> flags = CF_EXPECTF(
+  std::vector<FlagInfo> flags = CF_EXPECTF(
       GetSupportedFlags(artifacts_path_, bin_name),
       "Failed to obtain supported flags for the '{}' tool", bin_name);
-  for (auto& flag : flags) {
-    if (flag->Name() == flag_name) {
-      return *flag.release();
+  for (FlagInfo& flag : flags) {
+    if (flag.Name() == flag_name) {
+      return flag;
     }
   }
   return CF_ERRF("Flag '{}' not supported by the '{}' tool", flag_name,

--- a/base/cvd/cuttlefish/host/commands/cvd/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/utils/BUILD.bazel
@@ -32,7 +32,6 @@ cc_library(
     hdrs = ["flags_collector.h"],
     copts = COPTS + [ "-Werror=sign-compare" ],
     deps = [
-        "//cuttlefish/common/libs/utils:contains",
         "//libbase",
         "@tinyxml2",
     ],

--- a/base/cvd/cuttlefish/host/commands/cvd/utils/flags_collector.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/utils/flags_collector.h
@@ -16,36 +16,26 @@
 
 #pragma once
 
-#include <memory>
 #include <optional>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace cuttlefish {
 
 class FlagInfo {
  public:
-  using FlagInfoFieldMap = std::unordered_map<std::string, std::string>;
-  static std::unique_ptr<FlagInfo> Create(
-      const FlagInfoFieldMap& field_value_map);
+  FlagInfo(std::string name, std::string type);
+
   const std::string& Name() const { return name_; }
   const std::string& Type() const { return type_; }
 
  private:
-  // field_value_map must have needed fields; guaranteed by the factory
-  // function, static Create().
-  FlagInfo(const FlagInfoFieldMap& field_value_map)
-      : name_(field_value_map.at("name")), type_(field_value_map.at("type")) {}
-
   // TODO(kwstephenkim): add more fields
   std::string name_;
   std::string type_;
 };
 
-using FlagInfoPtr = std::unique_ptr<FlagInfo>;
-
-std::optional<std::vector<FlagInfoPtr>> CollectFlagsFromHelpxml(
+std::optional<std::vector<FlagInfo>> CollectFlagsFromHelpxml(
     const std::string& xml_str);
 
 }  // namespace cuttlefish


### PR DESCRIPTION
- Remove `unique_ptr`s in favor of copying / moving structures
- Remove `unordered_map` from the flags_collector header

Bug: b/419656778