### PR TITLE
screen_connector_common.h refactoring

### DIFF
--- a/base/cvd/cuttlefish/host/libs/screen_connector/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/screen_connector/BUILD.bazel
@@ -7,6 +7,9 @@ package(
 
 cc_library(
     name = "screen_connector_common",
+    srcs = [
+        "screen_connector_common.cc",
+    ],
     hdrs = [
         "screen_connector_common.h",
     ],

--- a/base/cvd/cuttlefish/host/libs/screen_connector/screen_connector.h
+++ b/base/cvd/cuttlefish/host/libs/screen_connector/screen_connector.h
@@ -42,8 +42,7 @@
 namespace cuttlefish {
 
 template <typename ProcessedFrameType>
-class ScreenConnector : public ScreenConnectorInfo,
-                        public ScreenConnectorFrameRenderer {
+class ScreenConnector : public ScreenConnectorFrameRenderer {
  public:
   static_assert(cuttlefish::is_movable<ProcessedFrameType>::value,
                 "ProcessedFrameType should be std::move-able.");

--- a/base/cvd/cuttlefish/host/libs/screen_connector/screen_connector_common.cc
+++ b/base/cvd/cuttlefish/host/libs/screen_connector/screen_connector_common.cc
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/host/libs/screen_connector/screen_connector_common.h"
+
+#include <stdint.h>
+
+#include <vector>
+
+#include <android-base/logging.h>
+
+#include "common/libs/utils/size_utils.h"
+#include "host/libs/config/cuttlefish_config.h"
+
+namespace cuttlefish {
+
+namespace ScreenConnectorInfo {
+
+static std::vector<CuttlefishConfig::DisplayConfig> DisplayConfigs() {
+  auto config = CuttlefishConfig::Get();
+  CHECK(config) << "Config is Missing";
+  return config->ForDefaultInstance().display_configs();
+}
+
+static constexpr uint32_t BytesPerPixel() { return 4; }
+
+uint32_t ScreenHeight(uint32_t display_number) {
+  std::vector<CuttlefishConfig::DisplayConfig> displays = DisplayConfigs();
+  CHECK_GT(displays.size(), display_number);
+  return displays[display_number].height;
+}
+
+uint32_t ScreenWidth(uint32_t display_number) {
+  std::vector<CuttlefishConfig::DisplayConfig> displays = DisplayConfigs();
+  CHECK_GT(displays.size(), display_number);
+  return displays[display_number].width;
+}
+
+uint32_t ComputeScreenStrideBytes(const uint32_t w) {
+  return AlignToPowerOf2(w * BytesPerPixel(), 4);
+}
+
+uint32_t ComputeScreenSizeInBytes(const uint32_t w, const uint32_t h) {
+  return ComputeScreenStrideBytes(w) * h;
+}
+
+};  // namespace ScreenConnectorInfo
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/screen_connector/screen_connector_common.h
+++ b/base/cvd/cuttlefish/host/libs/screen_connector/screen_connector_common.h
@@ -16,13 +16,10 @@
 
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
+
 #include <functional>
-
-#include <android-base/logging.h>
-
-#include "common/libs/utils/size_utils.h"
-#include "host/libs/config/cuttlefish_config.h"
+#include <type_traits>
 
 namespace cuttlefish {
 
@@ -35,67 +32,28 @@ struct is_movable {
 // this callback type is going directly to socket-based or wayland
 // ScreenConnector
 using GenerateProcessedFrameCallbackImpl =
-    std::function<void(std::uint32_t /*display_number*/,       //
-                       std::uint32_t /*frame_width*/,          //
-                       std::uint32_t /*frame_height*/,         //
-                       std::uint32_t /*frame_fourcc_format*/,  //
-                       std::uint32_t /*frame_stride_bytes*/,   //
-                       std::uint8_t* /*frame_pixels*/)>;
+    std::function<void(uint32_t /*display_number*/,       //
+                       uint32_t /*frame_width*/,          //
+                       uint32_t /*frame_height*/,         //
+                       uint32_t /*frame_fourcc_format*/,  //
+                       uint32_t /*frame_stride_bytes*/,   //
+                       uint8_t* /*frame_pixels*/)>;
 
-struct ScreenConnectorInfo {
-  // functions are intended to be inlined
-  static constexpr std::uint32_t BytesPerPixel() { return 4; }
-  static std::uint32_t ScreenCount() {
-    auto config = ChkAndGetConfig();
-    auto instance = config->ForDefaultInstance();
-    auto display_configs = instance.display_configs();
-    return static_cast<std::uint32_t>(display_configs.size());
-  }
-  static std::uint32_t ScreenHeight(std::uint32_t display_number) {
-    auto config = ChkAndGetConfig();
-    auto instance = config->ForDefaultInstance();
-    auto display_configs = instance.display_configs();
-    CHECK_GT(display_configs.size(), display_number);
-    return display_configs[display_number].height;
-  }
-  static std::uint32_t ScreenWidth(std::uint32_t display_number) {
-    auto config = ChkAndGetConfig();
-    auto instance = config->ForDefaultInstance();
-    auto display_configs = instance.display_configs();
-    CHECK_GE(display_configs.size(), display_number);
-    return display_configs[display_number].width;
-  }
-  static std::uint32_t ComputeScreenStrideBytes(const std::uint32_t w) {
-    return AlignToPowerOf2(w * BytesPerPixel(), 4);
-  }
-  static std::uint32_t ComputeScreenSizeInBytes(const std::uint32_t w,
-                                                const std::uint32_t h) {
-    return ComputeScreenStrideBytes(w) * h;
-  }
-  static std::uint32_t ScreenStrideBytes(const std::uint32_t display_number) {
-    return ComputeScreenStrideBytes(ScreenWidth(display_number));
-  }
-  static std::uint32_t ScreenSizeInBytes(const std::uint32_t display_number) {
-    return ComputeScreenStrideBytes(ScreenWidth(display_number)) *
-           ScreenHeight(display_number);
-  }
+namespace ScreenConnectorInfo {
 
- private:
-  static auto ChkAndGetConfig()
-      -> decltype(cuttlefish::CuttlefishConfig::Get()) {
-    auto config = cuttlefish::CuttlefishConfig::Get();
-    CHECK(config) << "Config is Missing";
-    return config;
-  }
-};
+uint32_t ScreenHeight(uint32_t display_number);
+uint32_t ScreenWidth(uint32_t display_number);
+uint32_t ComputeScreenStrideBytes(uint32_t w);
+uint32_t ComputeScreenSizeInBytes(uint32_t w, uint32_t h);
+
+}  // namespace ScreenConnectorInfo
 
 struct ScreenConnectorFrameRenderer {
-  virtual bool RenderConfirmationUi(std::uint32_t display_number,
-                                    std::uint32_t frame_width,
-                                    std::uint32_t frame_height,
-                                    std::uint32_t frame_fourcc_format,
-                                    std::uint32_t frame_stride_bytes,
-                                    std::uint8_t* frame_bytes) = 0;
+  virtual bool RenderConfirmationUi(uint32_t display_number,
+                                    uint32_t frame_width, uint32_t frame_height,
+                                    uint32_t frame_fourcc_format,
+                                    uint32_t frame_stride_bytes,
+                                    uint8_t* frame_bytes) = 0;
   virtual bool IsCallbackSet() const = 0;
   virtual ~ScreenConnectorFrameRenderer() = default;
 };
@@ -103,7 +61,7 @@ struct ScreenConnectorFrameRenderer {
 // this is inherited by the data type that represents the processed frame
 // being moved around.
 struct ScreenConnectorFrameInfo {
-  std::uint32_t display_number_;
+  uint32_t display_number_;
   bool is_success_;
 };
 


### PR DESCRIPTION
- Move implementations to a source file, reducing header transitive includes.
- Reduce use of `auto`: abseil.io/tips/232
- Don't use `std::` prefixes on integer types: https://google.github.io/styleguide/cppguide.html#Integer_Types
- Delete some unused functions.
- Change `ScreenConnector` from a struct with static functions to a namespace with free functions, as there is no state.
- Replace a CHECK_GE with a CHECK_GT in one function.

Bug: b/420772194