### PR TITLE
Fix missing std includes in `//cuttlefish/host/commands/cvd`

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/acloud/config.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/acloud/config.cpp
@@ -17,6 +17,8 @@
 #include "cuttlefish/host/commands/cvd/acloud/config.h"
 
 #include <fstream>
+#include <sstream>
+#include <string>
 
 #include <google/protobuf/text_format.h>
 

--- a/base/cvd/cuttlefish/host/commands/cvd/acloud/config.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/acloud/config.h
@@ -16,9 +16,10 @@
 
 #pragma once
 
-#include "cuttlefish/host/commands/cvd/acloud/user_config.pb.h"
+#include <string>
 
 #include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/commands/cvd/acloud/user_config.pb.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/commands/cvd/acloud/converter.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/acloud/converter.cpp
@@ -20,6 +20,8 @@
 
 #include <optional>
 #include <regex>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include <android-base/file.h>

--- a/base/cvd/cuttlefish/host/commands/cvd/acloud/create_converter_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/acloud/create_converter_parser.cpp
@@ -16,6 +16,9 @@
 
 #include "cuttlefish/host/commands/cvd/acloud/create_converter_parser.h"
 
+#include <optional>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <android-base/logging.h>

--- a/base/cvd/cuttlefish/host/commands/cvd/cache/cache.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cache/cache.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstddef>
+#include <iterator>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/command_request.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/command_request.cpp
@@ -17,6 +17,8 @@
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
 
 #include <string>
+#include <string_view>
+#include <utility>
 #include <vector>
 
 #include <android-base/file.h>

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/command_request.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/command_request.h
@@ -19,10 +19,10 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 
-#include <iostream>  // TODO: schuffelen - replace many transitive dependencies
 #include <initializer_list>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "cuttlefish/common/libs/utils/result.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector_common_parser.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/command_sequence.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/command_sequence.cpp
@@ -16,6 +16,11 @@
 #include "cuttlefish/host/commands/cvd/cli/command_sequence.h"
 
 #include <memory>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <unordered_set>
+#include <vector>
 
 #include <android-base/strings.h>
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/command_sequence.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/command_sequence.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <ostream>
 #include <vector>
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_common.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/acloud_common.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/host_tool_target.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/host_tool_target.h
@@ -19,6 +19,7 @@
 #include <sys/types.h>
 
 #include <string>
+#include <vector>
 
 #include "cuttlefish/common/libs/utils/result.h"
 #include "cuttlefish/host/commands/cvd/utils/flags_collector.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/try_acloud.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/try_acloud.cpp
@@ -21,6 +21,7 @@
 
 #include <csignal>
 #include <memory>
+#include <string>
 #include <thread>
 #include <utility>
 #include <vector>

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/interruptible_terminal.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/interruptible_terminal.cpp
@@ -18,6 +18,9 @@
 
 #include <errno.h>
 
+#include <optional>
+#include <string>
+
 #include <android-base/scopeguard.h>
 
 #include "cuttlefish/common/libs/fs/shared_select.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/cf_configs_instances.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/cf_configs_instances.cpp
@@ -17,6 +17,7 @@
 #include "cuttlefish/host/commands/cvd/cli/parser/cf_configs_instances.h"
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <android-base/logging.h>

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/cf_flags_validator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/cf_flags_validator.cpp
@@ -16,11 +16,12 @@
 
 #include "cuttlefish/host/commands/cvd/cli/parser/cf_flags_validator.h"
 
+#include <sstream>
+
 #include <google/protobuf/util/json_util.h>
-#include "json/json.h"
+#include <json/value.h>
 
 #include "cuttlefish/common/libs/utils/result.h"
-#include "cuttlefish/host/commands/cvd/cli/parser/cf_configs_common.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/load_config.pb.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/configs_inheritance_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/configs_inheritance_test.cc
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-#include <android-base/file.h>
+#include <string>
 
+#include <android-base/file.h>
 #include <gtest/gtest.h>
 
 #include "cuttlefish/host/commands/cvd/cli/parser/cf_configs_common.h"
@@ -39,18 +40,17 @@ TEST(FlagsInheritanceTest, MergeTwoIndependentJson) {
 
   const char* src_string = R""""(
 {
-    "instances" :
-    [
+    "instances": [
         {
-            "graphics":{
-                "displays":[
+            "graphics": {
+                "displays": [
                     {
                         "width": 720,
                         "height": 1280,
                         "dpi": 320
                     }
                 ]
-			}
+            }
         }
     ]
 }
@@ -101,15 +101,15 @@ TEST(FlagsInheritanceTest, MergeTwoOverlappedJson) {
             "vm": {
                 "memory_mb": 2048
             },
-            "graphics":{
-                "displays":[
+            "graphics": {
+                "displays": [
                     {
                         "width": 720,
                         "height": 1280,
                         "dpi": 320
                     }
                 ]
-			}
+            }
         }
     ]
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/fetch_config_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/fetch_config_parser.cpp
@@ -18,6 +18,7 @@
 
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include <android-base/strings.h>

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/flags_parser_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/flags_parser_test.cc
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <string>
+
 #include <android-base/file.h>
 #include <gtest/gtest.h>
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/boot_configs_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/boot_configs_test.cc
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "cuttlefish/host/commands/cvd/cli/parser/test_common.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_graphics_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_graphics_configs.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <android-base/logging.h>

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_vm_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_vm_configs.cpp
@@ -17,11 +17,11 @@
 
 #include <cstdint>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <android-base/strings.h>
 #include <google/protobuf/util/json_util.h>
-#include "json/json.h"
 
 #include "cuttlefish/common/libs/utils/flags_validator.h"
 #include "cuttlefish/common/libs/utils/result.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/disk_configs_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/disk_configs_test.cc
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "cuttlefish/host/commands/cvd/cli/parser/test_common.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/vm_configs_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/vm_configs_test.cc
@@ -15,6 +15,8 @@
  */
 
 #include <algorithm>
+#include <string>
+#include <vector>
 
 #include <android-base/file.h>
 #include <gtest/gtest.h>

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/launch_cvd_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/launch_cvd_parser.cpp
@@ -18,6 +18,7 @@
 #include <optional>
 #include <regex>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "android-base/strings.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/launch_cvd_templates.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/launch_cvd_templates.cpp
@@ -15,11 +15,13 @@
  */
 #include "cuttlefish/host/commands/cvd/cli/parser/launch_cvd_templates.h"
 
+#include <map>
+#include <sstream>
 #include <string>
 #include <string_view>
 
 #include <google/protobuf/util/json_util.h>
-#include "json/json.h"
+#include <json/value.h>
 
 #include "cuttlefish/common/libs/utils/json.h"
 #include "cuttlefish/common/libs/utils/result.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.cpp
@@ -18,17 +18,23 @@
 
 #include <unistd.h>
 
+#include <algorithm>
+#include <cctype>
 #include <cstdio>
+#include <ostream>
 #include <set>
+#include <sstream>
+#include <stack>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include <android-base/file.h>
 #include <android-base/parseint.h>
 #include <android-base/strings.h>
 #include <fmt/format.h>
-#include "json/json.h"
+#include <json/value.h>
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/flag_parser.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <optional>
+#include <ostream>
 #include <string>
 #include <vector>
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/metrics_configs_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/metrics_configs_test.cc
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+#include <string>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include "json/json.h"
+#include <json/value.h>
 
 #include "cuttlefish/common/libs/utils/result.h"
 #include "cuttlefish/common/libs/utils/result_matchers.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/test_common.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/test_common.cc
@@ -15,6 +15,8 @@
  */
 
 #include <algorithm>
+#include <string>
+#include <vector>
 
 #include "cuttlefish/host/commands/cvd/cli/parser/cf_flags_validator.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/launch_cvd_parser.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/arguments_separator.cpp
@@ -16,6 +16,9 @@
 
 #include "cuttlefish/host/commands/cvd/cli/selector/arguments_separator.h"
 
+#include <string>
+#include <vector>
+
 #include <android-base/strings.h>
 
 #include "cuttlefish/host/commands/cvd/cli/selector/selector_common_parser.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/creation_analyzer.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/creation_analyzer.cpp
@@ -21,6 +21,9 @@
 #include <algorithm>
 #include <map>
 #include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include <android-base/parseint.h>
 #include <android-base/strings.h>
@@ -29,6 +32,7 @@
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/unique_resource_allocator.h"
 #include "cuttlefish/common/libs/utils/users.h"
+#include "cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.h"
 #include "cuttlefish/host/commands/cvd/utils/common.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/creation_analyzer.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/creation_analyzer.h
@@ -21,10 +21,11 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "cuttlefish/common/libs/utils/result.h"
-#include "cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.h"
+#include "cuttlefish/host/commands/cvd/cli/selector/selector_common_parser.h"
 #include "cuttlefish/host/commands/cvd/instances/cvd_persistent_data.pb.h"
 #include "cuttlefish/host/commands/cvd/instances/lock/instance_lock.h"
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/device_selector_utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/device_selector_utils.cpp
@@ -16,6 +16,9 @@
 
 #include "cuttlefish/host/commands/cvd/cli/selector/device_selector_utils.h"
 
+#include <optional>
+#include <string>
+
 #include <android-base/parseint.h>
 
 #include "cuttlefish/common/libs/utils/result.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/device_selector_utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/device_selector_utils.h
@@ -23,6 +23,7 @@
 
 #include <sys/types.h>
 
+#include <string>
 #include <optional>
 
 #include "cuttlefish/host/commands/cvd/cli/types.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/instance_database_helper.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/instance_database_helper.cpp
@@ -16,6 +16,10 @@
 #include "cuttlefish/host/commands/cvd/cli/selector/instance_database_helper.h"
 
 #include <cstdlib>
+#include <string>
+#include <optional>
+#include <utility>
+#include <vector>
 
 #include <android-base/file.h>
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/instance_database_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/instance_database_test.cpp
@@ -13,7 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string>
 #include <iostream>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/parser_names_helper.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/parser_names_helper.cpp
@@ -15,6 +15,8 @@
 
 #include "cuttlefish/host/commands/cvd/cli/selector/parser_names_helper.h"
 
+#include <utility>
+
 #include <android-base/strings.h>
 #include <gtest/gtest.h>
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
@@ -16,8 +16,13 @@
 
 #include "cuttlefish/host/commands/cvd/cli/selector/selector.h"
 
+#include <iostream>
+#include <memory>
+#include <ostream>
 #include <sstream>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include <android-base/parseint.h>
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector_common_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector_common_parser.cpp
@@ -19,6 +19,7 @@
 #include <unistd.h>
 
 #include <string>
+#include <optional>
 #include <unordered_set>
 #include <vector>
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector_option_parser_utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector_option_parser_utils.cpp
@@ -16,6 +16,9 @@
 
 #include "cuttlefish/host/commands/cvd/cli/selector/selector_option_parser_utils.h"
 
+#include <string>
+#include <vector>
+
 #include <android-base/strings.h>
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector_option_parser_utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector_option_parser_utils.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <optional>
 #include <string>
 #include <vector>

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.cpp
@@ -18,8 +18,12 @@
 
 #include <unistd.h>
 
+#include <optional>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include <android-base/parseint.h>
 #include <android-base/strings.h>

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.h
@@ -20,6 +20,7 @@
 
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "cuttlefish/common/libs/utils/result.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
@@ -17,6 +17,7 @@
 #include "cuttlefish/host/commands/cvd/cvd.h"
 
 #include <iostream>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd.cc
@@ -19,6 +19,8 @@
 #include <sys/stat.h>
 
 #include <chrono>
+#include <cstddef>
+#include <functional>
 #include <future>
 #include <iostream>
 #include <memory>

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd_parser.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd_parser.cc
@@ -16,6 +16,7 @@
 #include "cuttlefish/host/commands/cvd/fetch/fetch_cvd_parser.h"
 
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <iostream>
 #include <optional>

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_tracer.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_tracer.cpp
@@ -16,10 +16,14 @@
 #include "cuttlefish/host/commands/cvd/fetch/fetch_tracer.h"
 
 #include <chrono>
+#include <ctime>
 #include <iomanip>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <sstream>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include <fmt/format.h>

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/data_viewer.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/data_viewer.cpp
@@ -16,6 +16,9 @@
 
 #include "cuttlefish/host/commands/cvd/instances/data_viewer.h"
 
+#include <string>
+#include <utility>
+
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/data_viewer.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/data_viewer.h
@@ -20,6 +20,7 @@
 
 #include <functional>
 #include <mutex>
+#include <string>
 #include <thread>
 #include <unordered_map>
 

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_database.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_database.cpp
@@ -17,6 +17,10 @@
 #include "cuttlefish/host/commands/cvd/instances/instance_database.h"
 
 #include <optional>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_database.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_database.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <string>
+#include <optional>
 #include <unordered_set>
 #include <utility>
 #include <vector>

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_database_types.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_database_types.cpp
@@ -19,6 +19,8 @@
 #include <ctime>
 #include <iomanip>
 #include <sstream>
+#include <string>
+#include <utility>
 
 #include <android-base/parseint.h>
 #include <fmt/core.h>

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_group_record.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_group_record.cpp
@@ -17,7 +17,12 @@
 #include "cuttlefish/host/commands/cvd/instances/instance_group_record.h"
 
 #include <algorithm>
+#include <functional>
+#include <iterator>
 #include <set>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <android-base/parseint.h>
 

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_group_record.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_group_record.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_manager.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_manager.cpp
@@ -16,7 +16,11 @@
 
 #include "cuttlefish/host/commands/cvd/instances/instance_manager.h"
 
+#include <iostream>
 #include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <android-base/file.h>
 #include <android-base/scopeguard.h>

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_record.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_record.cpp
@@ -17,6 +17,9 @@
 #include "cuttlefish/host/commands/cvd/instances/instance_record.h"
 
 #include <fstream>
+#include <memory>
+#include <string>
+#include <utility>
 
 #include <android-base/logging.h>
 #include <fmt/format.h>

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_record.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_record.h
@@ -17,7 +17,9 @@
 #pragma once
 
 #include <chrono>
+#include <memory>
 #include <string>
+#include <utility>
 
 #include <json/json.h>
 

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/lock/instance_lock.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/lock/instance_lock.cpp
@@ -20,10 +20,15 @@
 
 #include <algorithm>
 #include <cstring>
+#include <iterator>
+#include <optional>
 #include <regex>
+#include <set>
 #include <sstream>
 #include <string>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include <android-base/file.h>
 #include <android-base/parseint.h>

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/lock/instance_lock.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/lock/instance_lock.h
@@ -15,8 +15,10 @@
  */
 #pragma once
 
+#include <optional>
 #include <set>
 #include <string>
+#include <vector>
 
 #include "cuttlefish/host/commands/cvd/instances/lock/lock_file.h"
 

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/lock/lock_file.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/lock/lock_file.cpp
@@ -20,6 +20,11 @@
 
 #include <algorithm>
 #include <cstring>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include <android-base/file.h>

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/reset_client_utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/reset_client_utils.cpp
@@ -19,7 +19,11 @@
 #include <signal.h>
 
 #include <iostream>  // std::endl
+#include <memory>
 #include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <android-base/file.h>
 #include <android-base/parseint.h>

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/run_cvd_proc_collector.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/run_cvd_proc_collector.cpp
@@ -17,7 +17,13 @@
 #include "cuttlefish/host/commands/cvd/instances/run_cvd_proc_collector.h"
 
 #include <cctype>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <unordered_map>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include "cuttlefish/common/libs/utils/contains.h"
 #include "cuttlefish/common/libs/utils/files.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/status_fetcher.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/status_fetcher.cpp
@@ -18,6 +18,8 @@
 
 #include <cctype>
 #include <string>
+#include <string_view>
+#include <utility>
 #include <vector>
 
 #include <android-base/parseint.h>

--- a/base/cvd/cuttlefish/host/commands/cvd/legacy/client.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/legacy/client.cpp
@@ -18,6 +18,11 @@
 
 #include <unistd.h>
 
+#include <string>
+#include <vector>
+#include <optional>
+#include <utility>
+
 #include <android-base/file.h>
 #include <google/protobuf/text_format.h>
 

--- a/base/cvd/cuttlefish/host/commands/cvd/legacy/run_server.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/legacy/run_server.cpp
@@ -20,6 +20,12 @@
 #include <sys/resource.h>
 #include <unistd.h>
 
+#include <cstdlib>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/utils/flag_parser.h"
 #include "cuttlefish/common/libs/utils/json.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/legacy/server_constants.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/legacy/server_constants.cpp
@@ -19,6 +19,7 @@
 #include <unistd.h>
 
 #include <sstream>
+#include <string>
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/commands/cvd/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/main.cc
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <android-base/file.h>

--- a/base/cvd/cuttlefish/host/commands/cvd/utils/common.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/utils/common.cpp
@@ -18,6 +18,9 @@
 
 #include <mutex>
 #include <ostream>
+#include <string>
+#include <string_view>
+#include <unordered_map>
 
 #include <android-base/file.h>
 #include <android-base/logging.h>

--- a/base/cvd/cuttlefish/host/commands/cvd/utils/common.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/utils/common.h
@@ -19,6 +19,8 @@
 #include <sys/types.h>
 
 #include <sstream>
+#include <string>
+#include <string_view>
 
 #include <android-base/logging.h>
 

--- a/base/cvd/cuttlefish/host/commands/cvd/utils/flags_collector.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/utils/flags_collector.cpp
@@ -19,6 +19,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <android-base/logging.h>

--- a/base/cvd/cuttlefish/host/commands/cvd/utils/interrupt_listener.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/utils/interrupt_listener.cpp
@@ -22,6 +22,7 @@
 #include <sys/socket.h>
 
 #include <atomic>
+#include <memory>
 #include <mutex>
 #include <thread>
 #include <vector>


### PR DESCRIPTION
This is best effort, only covers headers from the standard library, and doens't include enforcement to avoid regressions.

Bug: b/421493329
Test: bazel test '//...'