### PR TITLE
Fix memory leak when running cvd fetch unit tests

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd_test.cpp
@@ -47,11 +47,15 @@ class FetchCvdTests : public ::testing::Test {
     // Create a fake cas client that outputs the command line when invoked.
     std::string script = fmt::format(
         R"(#!/bin/bash
-if [[ "$1" == "-help" ]]; then
-  echo "Usage of casdownloader:" >&2
-fi
+# leave evidence that the script executed
 rm -rf {CAS_OUTPUT_FILEPATH}
 echo $@ > {CAS_OUTPUT_FILEPATH}
+
+# handle command line flags
+if [[ "$1" == "-help" ]]; then
+  echo "Usage of casdownloader:" >&2
+  exit 0
+fi
 )",
         fmt::arg("CAS_OUTPUT_FILEPATH", cas_output_filepath_));
     cas_downloader_path_ = CreateTempFileWithText(

--- a/base/cvd/cuttlefish/host/libs/web/cas/cas_downloader.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/cas/cas_downloader.cpp
@@ -197,16 +197,19 @@ Result<std::unique_ptr<CasDownloader>> CasDownloader::Create(
   std::vector<std::string> cas_flags;
 
   std::string config_filepath = cas_downloader_flags.cas_config_filepath;
+  Json::Value config_flags;
   if (config_filepath.empty()) {
-    Json::Value config_flags = ConvertToConfigFlags(cas_downloader_flags);
-    cas_flags = CreateCasFlags(downloader_path, config_flags);
+    config_flags = ConvertToConfigFlags(cas_downloader_flags);
   } else {
     std::string config_contents = CF_EXPECT(ReadFileContents(config_filepath));
     Json::Value config = CF_EXPECT(ParseJson(config_contents));
     downloader_path = config[kKeyDownloaderPath].asString();
     prefer_uncompressed = config["prefer-uncompressed"].asBool();
-    cas_flags = CreateCasFlags(downloader_path, config[kKeyFlags]);
+    config_flags = config[kKeyFlags];
   }
+  CF_EXPECT(!downloader_path.empty(),
+            "No cas downloader path provided in flags or config");
+  cas_flags = CreateCasFlags(downloader_path, config_flags);
 
   CF_EXPECTF(FileExists(downloader_path),
              "CAS Downloader binary not found: '{}'", downloader_path);


### PR DESCRIPTION
Creating a build api without a CAS downloader path still tried to execute the binary, but failed because it was given an empty string. That failure in the forked process caused memory leaks to be reported because of the early exit.