### PR TITLE
Build and package Gfxstream

### DIFF
--- a/base/cvd/BUILD.bazel
+++ b/base/cvd/BUILD.bazel
@@ -88,3 +88,19 @@ alias(
     actual = "@crosvm//:minijail_sources",
     visibility = ["//visibility:public"],
 )
+
+# Create an alias so that crosvm's rutabaga_gfx crate has visibility into the
+# gfxstream repository.
+alias(
+    name = "gfxstream_backend",
+    actual = "@gfxstream//host:gfxstream_backend",
+    visibility = ["//visibility:public"],
+)
+
+# Useful for `rust_library()`s which can not directly depend on a `cc_shared_library()`.
+# TODO: remove after ag/33719949 and update alias above to reference directly.
+cc_import(
+    name = "gfxstream_backend_import",
+    shared_library = ":gfxstream_backend",
+    visibility = ["//visibility:public"],
+)

--- a/base/cvd/MODULE.bazel
+++ b/base/cvd/MODULE.bazel
@@ -35,6 +35,7 @@ bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "protobuf", version = "29.1")
 bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "rules_flex", version = "0.4")
+bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_proto_grpc_cpp", version = "5.0.1")
 bazel_dep(name = "rules_python", version = "0.40.0")
 bazel_dep(name = "rules_rust", version = "0.60.0")
@@ -177,7 +178,7 @@ crosvm_bin.spec(
         "gdbstub",
         "gdbstub_arch",
         "geniezone",
-        # TODO: b/402274999 - add gfxstream
+        "gfxstream",
         "gpu",
         "gpu_display",
         "gunyah",
@@ -187,7 +188,6 @@ crosvm_bin.spec(
         "qcow",
         "usb",
     ],
-    # TODO: schuffelen - build gfxstream
     # TODO: schuffelen - fix the sandbox
     git = CROSVM_REMOTE,
     rev = CROSVM_REV,
@@ -197,6 +197,29 @@ crosvm_bin.annotation(
     crate = "crosvm",
     gen_all_binaries = True,
     patch_args = ["-p1"],
+    deps = [
+        "@@//:gfxstream_backend_import",
+    ],
+    rustc_flags = [
+        # Look for shared libraries in the same directory as the binary.
+        "-Clink-arg=-Wl,-rpath,$$ORIGIN",
+    ],
+)
+
+crosvm_bin.annotation(
+    crate = "rutabaga_gfx",
+    deps = [
+        "@@//:gfxstream_backend_import",
+    ],
+    rustc_flags = [
+        # Look for shared libraries in the same directory as this object.
+        "-Clink-arg=-Wl,-rpath,$$ORIGIN",
+    ],
+    build_script_env = {
+        # Disable the build script from trying to automatically locate
+        # Gfxstream as the dep is directly provided above.
+        "CARGO_FEATURE_GFXSTREAM_STUB": "blah",
+    },
 )
 
 crosvm_bin.annotation(
@@ -301,6 +324,12 @@ git_repository(
     build_file = "@//:BUILD.swiftshader.bazel",
     commit = "4c3426403b9c89253322265323ca658a2476faca",
     remote = "https://swiftshader.googlesource.com/SwiftShader.git",
+)
+
+git_repository(
+    name = "gfxstream",
+    commit = "620cd8d0e1e839228d1894da4508d08b8ac798bc",
+    remote = "https://github.com/google/gfxstream.git",
 )
 
 git_repository(

--- a/base/cvd/cuttlefish/package/BUILD.bazel
+++ b/base/cvd/cuttlefish/package/BUILD.bazel
@@ -39,6 +39,7 @@ package_files(
         "cuttlefish-common/bin/graphics_detector": "//cuttlefish/host/graphics_detector",
         "cuttlefish-common/bin/health": "//cuttlefish/host/commands/health",
         "cuttlefish-common/bin/kernel_log_monitor": "//cuttlefish/host/commands/kernel_log_monitor",
+        "cuttlefish-common/bin/libgfxstream_backend.so": "@gfxstream//host:gfxstream_backend",
         "cuttlefish-common/bin/libvk_lavapipe.so": "@mesa//:vk_lavapipe",
         "cuttlefish-common/bin/libvk_swiftshader.so": "@swiftshader//:vk_swiftshader",
         "cuttlefish-common/bin/log_tee": "//cuttlefish/host/commands/log_tee",
@@ -91,7 +92,8 @@ package_files(
         "cuttlefish-common/etc/modem_simulator/files/iccprofile_for_sim0_for_CtsCarrierApiTestCases.xml": "//cuttlefish/host/commands/modem_simulator:etc/files/iccprofile_for_sim0_for_CtsCarrierApiTestCases.xml",
         "cuttlefish-common/etc/modem_simulator/files/iccprofile_for_sim0.xml": "//cuttlefish/host/commands/modem_simulator:etc/files/iccprofile_for_sim0.xml",
         "cuttlefish-common/etc/modem_simulator/files/numeric_operator.xml": "//cuttlefish/host/commands/modem_simulator:etc/files/numeric_operator.xml",
-        # "cuttlefish-common/bin/crosvm": "@crosvm_bin//:crosvm__crosvm", # TODO: b/402274999 - currently requires --gpu_mode=guest_swiftshader --enable_sandbox=false
+        # "cuttlefish-common/bin/crosvm": "@crosvm_bin//:crosvm__crosvm", # TODO: b/402274999 - currently requires --enable_sandbox=false
+
     },
     package_file_symlink_to_package_file = {
         "cuttlefish-common/bin/resize.f2fs": "cuttlefish-common/bin/fsck.f2fs",


### PR DESCRIPTION
Bug: b/403290370
Test: `bazel build @crosvm_bin//:crosvm__crosvm`
Test: Uncomment the `# cuttlefish-common/bin/crosvm` line in cuttlefish/package/BUILD.bazel

```
bazel run //cuttlefish/package:cvd -- \
    create \
    --gpu_mode=gfxstream \
    --host_substitutions=all
```
Confirm in the host logs that the bazel built crosvm is being used.

Confirm in gdb that crosvm is using the bazel built libgfxstream_backend.so

