### PR TITLE
Add missing default condition to build files' select

### DIFF
--- a/base/cvd/BUILD.libffi.bazel
+++ b/base/cvd/BUILD.libffi.bazel
@@ -92,9 +92,11 @@ cc_library(
     ] + select({
         "@platforms//cpu:x86_64": COPTS_X86_64,
         "@platforms//cpu:arm64": COPTS_ARM64,
+        "//conditions:default": [],
     }),
     deps = [":libffi_include"] + select({
         "@platforms//cpu:x86_64": DEPS_X86_64,
         "@platforms//cpu:arm64": DEPS_ARM64,
+        "//conditions:default": [],
     }),
 )


### PR DESCRIPTION
Which allows building for platforms other than x86_64 and arm64.