### PR TITLE
Cleanup TODO comment about removing wifi_tap_name from CF config

### DIFF
--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
@@ -1663,8 +1663,6 @@ void CuttlefishConfig::MutableInstanceSpecific::set_mobile_mac(
   (*Dictionary())[kMobileMac] = mac;
 }
 
-// TODO(b/199103204): remove this as well when
-// PRODUCT_ENFORCE_MAC80211_HWSIM is removed
 static constexpr char kWifiTapName[] = "wifi_tap_name";
 std::string CuttlefishConfig::InstanceSpecific::wifi_tap_name() const {
   return (*Dictionary())[kWifiTapName].asString();


### PR DESCRIPTION
We've moved the logic for deciding which Cuttlefish Wi-Fi implementation is used, from the compile time to the runtime. Since we're keeping both implementation with and without mac80211_hwsim, `wifi_tap_name()` is still needed either. Thus, this change removes the comment only, since it's no longer valid.