### PR TITLE
Introduce HO API GET /v1/userartifacts/{checksum}

### DIFF
--- a/frontend/src/host_orchestrator/api/v1/messages.go
+++ b/frontend/src/host_orchestrator/api/v1/messages.go
@@ -134,6 +134,8 @@ type ListUploadDirectoriesResponse struct {
 	Items []*UploadDirectory `json:"items"`
 }
 
+type StatArtifactResponse struct{}
+
 type CreateSnapshotRequest struct {
 	// [Optional]
 	// Value must match regex: "^([a-z0-9\\-]+)$".

--- a/frontend/src/host_orchestrator/orchestrator/controller.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller.go
@@ -109,6 +109,8 @@ func (c *Controller) AddRoutes(router *mux.Router) {
 		httpHandler(&extractUserArtifactHandler{c.OperationManager, c.UserArtifactsManager})).Methods("POST")
 	router.Handle("/v1/userartifacts/{checksum}",
 		httpHandler(&createUpdateUserArtifactHandler{c.UserArtifactsManager, false})).Methods("PUT")
+	router.Handle("/v1/userartifacts/{checksum}",
+		httpHandler(&statUserArtifactHandler{c.UserArtifactsManager})).Methods("GET")
 	// Debug endpoints.
 	router.Handle("/_debug/varz", httpHandler(&getDebugVariablesHandler{c.DebugVariablesManager})).Methods("GET")
 	router.Handle("/_debug/statusz", okHandler()).Methods("GET")
@@ -607,6 +609,14 @@ func (h *createUpdateUserArtifactHandler) Handle(r *http.Request) (interface{}, 
 		}
 		return nil, h.m.UpdateArtifact(vars["checksum"], chunk)
 	}
+}
+
+type statUserArtifactHandler struct {
+	m UserArtifactsManager
+}
+
+func (h *statUserArtifactHandler) Handle(r *http.Request) (interface{}, error) {
+	return h.m.StatArtifact(mux.Vars(r)["checksum"])
 }
 
 type extractUserArtifactHandler struct {

--- a/frontend/src/host_orchestrator/orchestrator/controller.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller.go
@@ -573,16 +573,22 @@ func (h *createUpdateUserArtifactHandler) Handle(r *http.Request) (interface{}, 
 			return nil, operator.NewBadRequestError("invalid directory name", err)
 		}
 		if err != nil {
-			log.Println("deprecated: use `chunk_offset_bytes`")
+			log.Println("use of deprecated `chunk_number`")
 			chunkNumberRaw := r.FormValue("chunk_number")
 			chunkNumber, err := strconv.Atoi(chunkNumberRaw)
 			if err != nil {
 				return nil, operator.NewBadRequestError(
-					fmt.Sprintf("Invalid chunk_number value: %q", chunkNumberRaw), err)
+					fmt.Sprintf("Invalid chunk_number form field value: %q", chunkNumberRaw), err)
+			}
+			if chunkNumber < 0 {
+				return nil, operator.NewBadRequestError(fmt.Sprintf("invalid value (chunk_number:%d)", chunkNumber), nil)
 			}
 			chunkSizeBytes, err := parseFormValueInt(r, "chunk_size_bytes")
 			if err != nil {
 				return nil, err
+			}
+			if chunkNumber < 0 {
+				return nil, operator.NewBadRequestError(fmt.Sprintf("invalid value (chunk_size_bytes:%d)", chunkSizeBytes), nil)
 			}
 			chunkOffsetBytes = int64(chunkNumber-1) * chunkSizeBytes
 		}

--- a/frontend/src/host_orchestrator/orchestrator/controller_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller_test.go
@@ -209,7 +209,7 @@ func (testUAM) StatArtifact(checksum string) (*apiv1.StatArtifactResponse, error
 	return &apiv1.StatArtifactResponse{}, nil
 }
 
-func (testUAM) GetDirPath(string, bool) string {
+func (testUAM) GetDirPath(string) string {
 	return ""
 }
 

--- a/frontend/src/host_orchestrator/orchestrator/controller_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller_test.go
@@ -205,6 +205,10 @@ func (testUAM) UpdateArtifact(checksum string, chunk UserArtifactChunk) error {
 	return nil
 }
 
+func (testUAM) StatArtifact(checksum string) (*apiv1.StatArtifactResponse, error) {
+	return &apiv1.StatArtifactResponse{}, nil
+}
+
 func (testUAM) GetDirPath(string, bool) string {
 	return ""
 }

--- a/frontend/src/host_orchestrator/orchestrator/controller_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller_test.go
@@ -314,6 +314,21 @@ func TestUploadUserArtifactIsHandled(t *testing.T) {
 	}
 }
 
+func TestStatUserArtifactIsHandled(t *testing.T) {
+	req, err := http.NewRequest("GET", "/v1/userartifacts/foo", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller := Controller{UserArtifactsManager: &testUAM{}}
+	rr := httptest.NewRecorder()
+
+	makeRequest(rr, req, &controller)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("request was not handled. This failure implies an API breaking change.")
+	}
+}
+
 func TestGetDebugVarzIsHandled(t *testing.T) {
 	rr := httptest.NewRecorder()
 	req, err := http.NewRequest("GET", "/_debug/varz", strings.NewReader("{}"))

--- a/frontend/src/host_orchestrator/orchestrator/createcvdaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/createcvdaction.go
@@ -116,7 +116,7 @@ func (a *CreateCVDAction) launchWithCanonicalConfig(op apiv1.Operation) (*apiv1.
 	log.Printf("environment config:\n%s", string(data))
 	data = bytes.ReplaceAll(data,
 		[]byte(apiv1.EnvConfigUserArtifactsVar+"/"),
-		[]byte(a.userArtifactsDirResolver.GetDirPath("", true)+"/"))
+		[]byte(a.userArtifactsDirResolver.GetDirPath("")+"/"))
 	configFile, err := createTempFile("cvdload*.json", data, 0640)
 	if err != nil {
 		return nil, err

--- a/frontend/src/host_orchestrator/orchestrator/userartifacts.go
+++ b/frontend/src/host_orchestrator/orchestrator/userartifacts.go
@@ -51,6 +51,8 @@ type UserArtifactChunk struct {
 type UserArtifactsManager interface {
 	// Update artifact with the passed chunk
 	UpdateArtifact(checksum string, chunk UserArtifactChunk) error
+	// Stat artifact whether artifact with given checksum exists or not.
+	StatArtifact(checksum string) (*apiv1.StatArtifactResponse, error)
 
 	UserArtifactsDirResolver
 	// Creates a new directory for uploading user artifacts in the future.
@@ -185,6 +187,15 @@ func (m *UserArtifactsManagerImpl) UpdateArtifactWithDir(dir string, chunk UserA
 		return err
 	}
 	return nil
+}
+
+func (m *UserArtifactsManagerImpl) StatArtifact(checksum string) (*apiv1.StatArtifactResponse, error) {
+	if exists, err := dirExists(filepath.Join(m.RootDir, checksum)); err != nil {
+		return nil, fmt.Errorf("failed to check existence of directory: %w", err)
+	} else if !exists {
+		return nil, operator.NewNotFoundError(fmt.Sprintf("user artifact(checksum:%q) not found", checksum), nil)
+	}
+	return &apiv1.StatArtifactResponse{}, nil
 }
 
 func (m *UserArtifactsManagerImpl) getRWMutex(checksum string) *sync.RWMutex {

--- a/frontend/src/host_orchestrator/orchestrator/userartifacts_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/userartifacts_test.go
@@ -204,7 +204,7 @@ func TestUpdateArtifactWithSingleChunkSucceeds(t *testing.T) {
 	if err := uam.UpdateArtifact(checksum, chunk); err != nil {
 		t.Fatal(err)
 	}
-	b, err := ioutil.ReadFile(filepath.Join(uam.GetDirPath(checksum, false), testFileName))
+	b, err := ioutil.ReadFile(filepath.Join(rootDir, getSha256Sum(testFileData), testFileName))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -328,7 +328,7 @@ func TestUpdateArtifactWithMultipleSerialChunkSucceeds(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	b, err := ioutil.ReadFile(filepath.Join(uam.GetDirPath(getSha256Sum(testFileData), false), testFileName))
+	b, err := ioutil.ReadFile(filepath.Join(rootDir, getSha256Sum(testFileData), testFileName))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -361,7 +361,7 @@ func TestUpdateArtifactWithMultipleParallelChunkSucceeds(t *testing.T) {
 		}(chunk)
 	}
 	wg.Wait()
-	b, err := ioutil.ReadFile(filepath.Join(uam.GetDirPath(getSha256Sum(testFileData), false), testFileName))
+	b, err := ioutil.ReadFile(filepath.Join(rootDir, getSha256Sum(testFileData), testFileName))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR covers the implementation of `GET /v1/userartifacts/{checksum}` at the level of HO REST API only.
Details are described at the design docuement. Its Golang client API will be covered at different PR.

Also, noting that this PR is based on commits listed at https://github.com/google/android-cuttlefish/pull/1144.

Design document: go/ho-upload-api-v1