### PR TITLE
Enhance `adb` interactions in orchestration e2e tests.

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -213,6 +213,11 @@ jobs:
         sleep 30s # Add delay before restarting cuttlefish-host_orchestrator service.
         sudo podman exec -it tester sh -c 'echo "orchestrator_android_build_url=http://localhost:8090" >> /etc/default/cuttlefish-host_orchestrator && service cuttlefish-host_orchestrator restart'
         sudo podman exec --user=testrunner -it tester bazel --output_user_root=/tmp/cw_bazel/output test //orchestration/verify_access_token_test:verify_access_token_test_test
+        sudo podman rm -f tester
+        # Run upload_file_test
+        sudo podman run --name tester -d  --privileged --pids-limit=8192 -v /tmp/cw_bazel:/tmp/cw_bazel -v .:/src/workspace -w /src/workspace/e2etests android-cuttlefish-e2etest:latest
+        sudo podman exec -it tester usermod -a -G httpcvd testrunner
+        sudo podman exec --user=testrunner -it tester bazel --output_user_root=/tmp/cw_bazel/output test //orchestration/upload_file_test:upload_file_test_test
     - name: Upload test logs
       if: always()
       uses: actions/upload-artifact@v4

--- a/e2etests/orchestration/powerbtn_test/main_test.go
+++ b/e2etests/orchestration/powerbtn_test/main_test.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	"log"
 	"strings"
 	"testing"
@@ -31,6 +30,10 @@ import (
 const baseURL = "http://0.0.0.0:2080"
 
 func TestPowerBtn(t *testing.T) {
+	adbH := common.NewAdbHelper()
+	if err := adbH.StartServer(); err != nil {
+		t.Fatal(err)
+	}
 	srv := hoclient.NewHostOrchestratorClient(baseURL)
 	t.Cleanup(func() {
 		if err := common.CollectHOLogs(baseURL); err != nil {
@@ -46,11 +49,6 @@ func TestPowerBtn(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Monitor input devices events
-	adbBin := fmt.Sprintf("/var/lib/cuttlefish-common/user_artifacts/%s/bin/adb", uploadDir)
-	adbH := &common.AdbHelper{Bin: adbBin}
-	if err := adbH.StartServer(); err != nil {
-		t.Fatal(err)
-	}
 	if err := adbH.Connect(cvd.ADBSerial); err != nil {
 		t.Fatal(err)
 	}
@@ -62,6 +60,9 @@ func TestPowerBtn(t *testing.T) {
 	cmd := adbH.BuildShellCommand(cvd.ADBSerial, []string{"getevent", "-l", "-c 2", "/dev/input/event0"})
 	stdoutBuff := &bytes.Buffer{}
 	cmd.Stdout = stdoutBuff
+	if err := adbH.WaitForDevice(cvd.ADBSerial); err != nil {
+		t.Fatal(err)
+	}
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}

--- a/e2etests/orchestration/powerwash_test/main_test.go
+++ b/e2etests/orchestration/powerwash_test/main_test.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"log"
 	"os/exec"
 	"testing"
@@ -30,6 +29,10 @@ import (
 const baseURL = "http://0.0.0.0:2080"
 
 func TestPowerwash(t *testing.T) {
+	adbH := common.NewAdbHelper()
+	if err := adbH.StartServer(); err != nil {
+		t.Fatal(err)
+	}
 	srv := hoclient.NewHostOrchestratorClient(baseURL)
 	t.Cleanup(func() {
 		if err := common.CollectHOLogs(baseURL); err != nil {
@@ -44,8 +47,6 @@ func TestPowerwash(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	adbBin := fmt.Sprintf("/var/lib/cuttlefish-common/user_artifacts/%s/bin/adb", uploadDir)
-	adbH := &common.AdbHelper{Bin: adbBin}
 	if err := adbH.StartServer(); err != nil {
 		t.Fatal(err)
 	}

--- a/e2etests/orchestration/snapshot_test/main_test.go
+++ b/e2etests/orchestration/snapshot_test/main_test.go
@@ -33,6 +33,10 @@ import (
 const baseURL = "http://0.0.0.0:2080"
 
 func TestSnapshot(t *testing.T) {
+	adbH := common.NewAdbHelper()
+	if err := adbH.StartServer(); err != nil {
+		t.Fatal(err)
+	}
 	srv := hoclient.NewHostOrchestratorClient(baseURL)
 	t.Cleanup(func() {
 		if err := common.CollectHOLogs(baseURL); err != nil {
@@ -46,11 +50,6 @@ func TestSnapshot(t *testing.T) {
 	const groupName = "cvd"
 	cvd, err := createDevice(srv, groupName, uploadDir)
 	if err != nil {
-		t.Fatal(err)
-	}
-	adbBin := fmt.Sprintf("/var/lib/cuttlefish-common/user_artifacts/%s/bin/adb", uploadDir)
-	adbH := &common.AdbHelper{Bin: adbBin}
-	if err := adbH.StartServer(); err != nil {
 		t.Fatal(err)
 	}
 	if err := adbH.Connect(cvd.ADBSerial); err != nil {

--- a/e2etests/orchestration/upload_file_test/BUILD.bazel
+++ b/e2etests/orchestration/upload_file_test/BUILD.bazel
@@ -20,7 +20,7 @@ go_test(
     data = [
         "//orchestration/artifacts:cvd_host_package",
     ],
-    tags = ["host-ready"],
+    tags = ["host-ready-special"],
     deps = [
         "@com_github_google_android_cuttlefish_frontend_src_host_orchestrator//api/v1:api",
         "@com_github_google_android_cuttlefish_frontend_src_libhoclient//:libhoclient",

--- a/tools/testutils/cw/Containerfile
+++ b/tools/testutils/cw/Containerfile
@@ -28,8 +28,5 @@ FROM with_cuttlefish_packages
 
 RUN useradd -m "testrunner"
 
-# TODO: Remove when `adb` is no longer in cvd-host_package.tar.gz.
-RUN usermod -a -G httpcvd testrunner
-
 CMD [ "/usr/sbin/init" ]
 


### PR DESCRIPTION
- Use local `adb` to start server earlier.
- Execute `wait-for-device` before executing shell commands.