### PR TITLE
Swap from remaining `aosp-main` builds

### DIFF
--- a/e2etests/cvd/BUILD.bazel
+++ b/e2etests/cvd/BUILD.bazel
@@ -9,8 +9,8 @@ launch_cvd_boot_test(
 
 launch_cvd_boot_test(
     name = "fetch_and_launch_aosp_main_x64_phone",
-    branch = "aosp-main",
-    target = "aosp_cf_x86_64_phone-trunk_staging-userdebug",
+    branch = "aosp-android-latest-release",
+    target = "aosp_cf_x86_64_only_phone-userdebug",
 )
 
 launch_cvd_boot_test(
@@ -50,29 +50,29 @@ cvd_load_boot_test(
 
 cvd_command_boot_test(
     name = "list_env_services",
-    branch = "aosp-main",
+    branch = "aosp-android-latest-release",
     cvd_command = [
         "env",
         "ls",
     ],
-    target = "aosp_cf_x86_64_phone-trunk_staging-userdebug",
+    target = "aosp_cf_x86_64_only_phone-userdebug",
 )
 
 cvd_command_boot_test(
     name = "take_bugreport",
-    branch = "aosp-main",
+    branch = "aosp-android-latest-release",
     cvd_command = ["host_bugreport"],
-    target = "aosp_cf_x86_64_phone-trunk_staging-userdebug",
+    target = "aosp_cf_x86_64_only_phone-userdebug",
 )
 
 cvd_command_boot_test(
     name = "list_displays",
-    branch = "aosp-main",
+    branch = "aosp-android-latest-release",
     cvd_command = [
         "display",
         "list",
     ],
-    target = "aosp_cf_x86_64_phone-trunk_staging-userdebug",
+    target = "aosp_cf_x86_64_only_phone-userdebug",
 )
 
 # TODO(b/329100411) test loading older branches

--- a/e2etests/cvd/environment_specs/aosp_main_x64_phone.json
+++ b/e2etests/cvd/environment_specs/aosp_main_x64_phone.json
@@ -3,16 +3,16 @@
     {
       "name": "ins-1",
       "disk": {
-        "default_build": "@ab\/aosp-main\/aosp_cf_x86_64_phone-trunk_staging-userdebug",
+        "default_build": "@ab\/aosp-android-latest-release\/aosp_cf_x86_64_only_phone-userdebug",
         "super": {
-          "system": "@ab\/aosp-main\/aosp_cf_x86_64_phone-trunk_staging-userdebug"
+          "system": "@ab\/aosp-android-latest-release\/aosp_cf_x86_64_only_phone-userdebug"
         }
       },
       "boot": {
         "kernel": {
           "build": "@ab\/aosp_kernel-common-android16-6.12\/kernel_virt_x86_64"
         },
-        "build": "@ab\/aosp-main\/aosp_cf_x86_64_phone-trunk_staging-userdebug"
+        "build": "@ab\/aosp-android-latest-release\/aosp_cf_x86_64_only_phone-userdebug"
       },
       "vm": {
         "cpus": 4,
@@ -37,6 +37,6 @@
     "enable": true
   },
   "common": {
-    "host_package": "@ab\/aosp-main\/aosp_cf_x86_64_phone-trunk_staging-userdebug"
+    "host_package": "@ab\/aosp-android-latest-release\/aosp_cf_x86_64_only_phone-userdebug"
   }
 }

--- a/e2etests/cvd/environment_specs/aosp_main_x64_phone_x2.json
+++ b/e2etests/cvd/environment_specs/aosp_main_x64_phone_x2.json
@@ -3,13 +3,13 @@
     {
       "name": "ins-1",
       "disk": {
-        "default_build": "@ab\/aosp-main\/aosp_cf_x86_64_phone-trunk_staging-userdebug"
+        "default_build": "@ab\/aosp-android-latest-release\/aosp_cf_x86_64_only_phone-userdebug"
       }
     },
     {
       "name": "ins-2",
       "disk": {
-        "default_build": "@ab\/aosp-main\/aosp_cf_x86_64_phone-trunk_staging-userdebug"
+        "default_build": "@ab\/aosp-android-latest-release\/aosp_cf_x86_64_only_phone-userdebug"
       }
     }
   ],
@@ -17,6 +17,6 @@
     "enable": true
   },
   "common": {
-    "host_package": "@ab\/aosp-main\/aosp_cf_x86_64_phone-trunk_staging-userdebug"
+    "host_package": "@ab\/aosp-android-latest-release\/aosp_cf_x86_64_only_phone-userdebug"
   }
 }

--- a/e2etests/orchestration/artifacts/BUILD.bazel
+++ b/e2etests/orchestration/artifacts/BUILD.bazel
@@ -22,15 +22,15 @@ sh_binary(
 aosp_artifact(
     name = "cvd_host_package",
     artifact_name = "cvd-host_package.tar.gz",
-    build_id = "12937168",
-    build_target = "aosp_cf_x86_64_phone-trunk_staging-userdebug",
+    build_id = "13625421",
+    build_target = "aosp_cf_x86_64_only_phone-userdebug",
     out_name = "cvd-host_package.tar.gz",
 )
 
 aosp_artifact(
     name = "images_zip",
-    artifact_name = "aosp_cf_x86_64_phone-img-12937168.zip",
-    build_id = "12937168",
-    build_target = "aosp_cf_x86_64_phone-trunk_staging-userdebug",
+    artifact_name = "aosp_cf_x86_64_only_phone-img-13625421.zip",
+    build_id = "13625421",
+    build_target = "aosp_cf_x86_64_only_phone-userdebug",
     out_name = "images.zip",
 )

--- a/e2etests/orchestration/bugreport_test/main_test.go
+++ b/e2etests/orchestration/bugreport_test/main_test.go
@@ -116,7 +116,7 @@ func assertAdbBugReportIsIncluded(filename string) error {
 		return err
 	}
 	defer r.Close()
-	re, err := regexp.Compile(`^bugreport-aosp_cf_x86_64_phone-MAIN\..*\.zip$`)
+	re, err := regexp.Compile(`^bugreport-aosp_cf_x86_64_only_phone.*\.zip$`)
 	if err != nil {
 		return err
 	}

--- a/e2etests/orchestration/create_local_image_test/main_test.go
+++ b/e2etests/orchestration/create_local_image_test/main_test.go
@@ -113,7 +113,7 @@ func TestInstance(t *testing.T) {
 }
 
 func uploadImages(srv hoclient.HostOrchestratorClient, remoteDir, imgsZipSrc string) error {
-	outDir := "/tmp/aosp_cf_x86_64_phone-img-12198634"
+	outDir := "/tmp/aosp_cf_x86_64_only_phone-img-13625421"
 	if err := runCmd("unzip", "-d", outDir, imgsZipSrc); err != nil {
 		return err
 	}

--- a/e2etests/orchestration/create_single_instance_test/BUILD.bazel
+++ b/e2etests/orchestration/create_single_instance_test/BUILD.bazel
@@ -16,6 +16,6 @@ load("def.bzl", "create_single_instance_test")
 
 create_single_instance_test(
     name = "create_single_instance_test_test",
-    build_id = "13150599",
-    build_target = "aosp_cf_x86_64_phone-trunk_staging-userdebug",
+    build_id = "13625421",
+    build_target = "aosp_cf_x86_64_only_phone-userdebug",
 )

--- a/frontend/src/host_orchestrator/README.md
+++ b/frontend/src/host_orchestrator/README.md
@@ -22,6 +22,7 @@ go install github.com/swaggo/swag/cmd/swag@latest
 Generate updated documentation
 
 ```
+# run in `android-cuttlefish/frontend/src/host_orchestrator` directory
 $(go env GOPATH)/bin/swag init --outputTypes yaml
 ```
 

--- a/frontend/src/host_orchestrator/api/v1/messages.go
+++ b/frontend/src/host_orchestrator/api/v1/messages.go
@@ -32,7 +32,7 @@ const (
 )
 
 type AndroidCIBundle struct {
-	// If omitted, defaults to branch "aosp-main" and target `aosp_cf_x86_64_phone-trunk_staging-userdebug`.
+	// If omitted, defaults to branch "aosp-android-latest-release" and target `aosp_cf_x86_64_only_phone-userdebug`.
 	Build *AndroidCIBuild `json:"build,omitempty"`
 	// If omitted, it defaults to the `main` bundle type.
 	Type ArtifactsBundleType `json:"type"`
@@ -73,7 +73,7 @@ type AndroidCIBuild struct {
 }
 
 type AndroidCIBuildSource struct {
-	// Main build. If omitted, defaults to branch "aosp-main" and target `aosp_cf_x86_64_phone-trunk_staging-userdebug`.
+	// Main build. If omitted, defaults to branch "aosp-android-latest-release" and target `aosp_cf_x86_64_only_phone-userdebug`.
 	MainBuild *AndroidCIBuild `json:"main_build,omitempty"`
 	// Uses this specific kernel build target if set.
 	KernelBuild *AndroidCIBuild `json:"kernel_build,omitempty"`

--- a/frontend/src/host_orchestrator/docs/swagger.yaml
+++ b/frontend/src/host_orchestrator/docs/swagger.yaml
@@ -28,8 +28,8 @@ definitions:
       main_build:
         allOf:
         - $ref: '#/definitions/v1.AndroidCIBuild'
-        description: Main build. If omitted, defaults to branch "aosp-main" and target
-          `aosp_cf_x86_64_phone-trunk_staging-userdebug`.
+        description: Main build. If omitted, defaults to branch "aosp-android-latest-release"
+          and target `aosp_cf_x86_64_only_phone-userdebug`.
       system_image_build:
         allOf:
         - $ref: '#/definitions/v1.AndroidCIBuild'
@@ -40,7 +40,8 @@ definitions:
       build:
         allOf:
         - $ref: '#/definitions/v1.AndroidCIBuild'
-        description: If omitted, defaults to branch "aosp-main" and target `aosp_cf_x86_64_phone-trunk_staging-userdebug`.
+        description: If omitted, defaults to branch "aosp-android-latest-release"
+          and target `aosp_cf_x86_64_only_phone-userdebug`.
       type:
         allOf:
         - $ref: '#/definitions/v1.ArtifactsBundleType'

--- a/frontend/src/host_orchestrator/orchestrator/createcvdaction_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/createcvdaction_test.go
@@ -31,7 +31,7 @@ func TestCreateCVDInvalidRequestsEmptyFields(t *testing.T) {
 					AndroidCIBuildSource: &apiv1.AndroidCIBuildSource{
 						MainBuild: &apiv1.AndroidCIBuild{
 							BuildID: "1234",
-							Target:  "aosp_cf_x86_64_phone-trunk_staging-userdebug",
+							Target:  "aosp_cf_x86_64_only_phone-userdebug",
 						},
 					},
 				},

--- a/tools/cuttlefish-host-image-installer/utils/download-ci-cf.sh
+++ b/tools/cuttlefish-host-image-installer/utils/download-ci-cf.sh
@@ -4,7 +4,7 @@
 
 set -o errexit
 
-URL=https://ci.android.com/builds/latest/branches/aosp-main-throttled/targets/aosp_cf_arm64_only_phone-trunk_staging-userdebug/view/BUILD_INFO
+URL=https://ci.android.com/builds/latest/branches/aosp-android-latest-release/targets/aosp_cf_arm64_only_phone-userdebug/view/BUILD_INFO
 RURL=$(curl -Ls -o /dev/null -w %{url_effective} ${URL})
 echo $RURL
 


### PR DESCRIPTION
Use `aosp-android-latest-release` instead, which is now more updated.

Bug: 408034504