### PR TITLE
Use DEFINE_uint64 instead of DEFINE_uint32

### DIFF
--- a/base/cvd/allocd/test_client.cpp
+++ b/base/cvd/allocd/test_client.cpp
@@ -34,8 +34,8 @@ DEFINE_bool(ifcreate, false, "Request a new Interface");
 DEFINE_bool(shutdown, false, "Shutdown Resource Allocation Server");
 DEFINE_bool(stop_session, false, "Remove all resources from session");
 DEFINE_string(ifdestroy, "", "Request an interface be destroyed");
-DEFINE_uint32(ifid, -1, "Global Resource ID");
-DEFINE_uint32(session, -1, "Session ID");
+DEFINE_uint64(ifid, -1, "Global Resource ID");
+DEFINE_uint64(session, -1, "Session ID");
 
 int main(int argc, char* argv[]) {
   cuttlefish::DefaultSubprocessLogging(argv);

--- a/base/cvd/cuttlefish/host/commands/cvd_send_sms/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_send_sms/main.cc
@@ -42,9 +42,9 @@ EXAMPLES
 
 DEFINE_string(sender_number, "+16501234567",
               "sender phone number in E.164 format");
-DEFINE_uint32(instance_number, 1,
+DEFINE_uint64(instance_number, 1,
               "number of the cvd instance to send the sms to, default is 1");
-DEFINE_uint32(modem_id, 0,
+DEFINE_uint64(modem_id, 0,
               "modem id needed for multisim devices, default is 0");
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/host/commands/cvd_send_sms/sms_sender.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_send_sms/sms_sender.cc
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <codecvt>
 #include <cstddef>
+#include <cstdint>
 #include <iomanip>
 #include <iostream>
 #include <map>
@@ -33,7 +34,7 @@ SmsSender::SmsSender(SharedFD modem_simulator_client_fd)
     : modem_simulator_client_fd_(modem_simulator_client_fd) {}
 
 bool SmsSender::Send(const std::string& sms_body,
-                     const std::string& sender_number, uint32_t modem_id) {
+                     const std::string& sender_number, uint64_t modem_id) {
   if (!modem_simulator_client_fd_->IsOpen()) {
     LOG(ERROR) << "Failed to connect to remote modem simulator, error: "
                << modem_simulator_client_fd_->StrError();

--- a/base/cvd/cuttlefish/host/commands/cvd_send_sms/sms_sender.h
+++ b/base/cvd/cuttlefish/host/commands/cvd_send_sms/sms_sender.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include "common/libs/fs/shared_fd.h"
@@ -27,7 +28,7 @@ class SmsSender {
 
   // Returns true if SMS was successfully sent, returns false otherwise.
   bool Send(const std::string& sms_body, const std::string& sender_number,
-            uint32_t modem_id = 0);
+            uint64_t modem_id = 0);
 
  private:
   SharedFD modem_simulator_client_fd_;


### PR DESCRIPTION
to improve compatibility with older versions of gflags which didn't support the latter.