### PR TITLE
Create a type to represent bootconfig creation

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -105,6 +105,7 @@ cc_library(
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/common/libs/utils:subprocess",
+        "//cuttlefish/host/commands/assemble_cvd/disk:generate_persistent_bootconfig",
         "//cuttlefish/host/libs/avb",
         "//cuttlefish/host/libs/config:config_utils",
         "//cuttlefish/host/libs/config:known_paths",

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_image_utils.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_image_utils.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "host/commands/assemble_cvd/boot_image_utils.h"
+#include "cuttlefish/host/commands/assemble_cvd/boot_image_utils.h"
 
 #include <string.h>
 #include <unistd.h>
@@ -28,13 +28,13 @@
 #include <android-base/scopeguard.h>
 #include <android-base/strings.h>
 
-#include "common/libs/fs/shared_fd.h"
-#include "common/libs/utils/files.h"
-#include "common/libs/utils/result.h"
-#include "common/libs/utils/subprocess.h"
-#include "host/libs/avb/avb.h"
-#include "host/libs/config/config_utils.h"
-#include "host/libs/config/known_paths.h"
+#include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/common/libs/utils/subprocess.h"
+#include "cuttlefish/host/libs/avb/avb.h"
+#include "cuttlefish/host/libs/config/config_utils.h"
+#include "cuttlefish/host/libs/config/known_paths.h"
 
 namespace cuttlefish {
 namespace {
@@ -409,10 +409,10 @@ bool RepackVendorBootImageWithEmptyRamdisk(
       new_vendor_boot_image_path, unpack_dir, bootconfig_supported);
 }
 
-void RepackGem5BootImage(const std::string& initrd_path,
-                         const std::string& bootconfig_path,
-                         const std::string& unpack_dir,
-                         const std::string& input_ramdisk_path) {
+void RepackGem5BootImage(
+    const std::string& initrd_path,
+    const std::optional<BootConfigPartition>& bootconfig_partition,
+    const std::string& unpack_dir, const std::string& input_ramdisk_path) {
   // Simulate per-instance what the bootloader would usually do
   // Since on other devices this runs every time, just do it here every time
   std::ofstream final_rd(initrd_path,
@@ -438,9 +438,11 @@ void RepackGem5BootImage(const std::string& initrd_path,
   auto vb_size = vendor_boot_bootconfig.tellg();
   vendor_boot_bootconfig.seekg(0);
 
-  std::ifstream persistent_bootconfig(bootconfig_path,
-                                      std::ios_base::binary |
-                                      std::ios_base::ate);
+  std::ifstream persistent_bootconfig =
+      bootconfig_partition
+          ? std::ifstream(bootconfig_partition->Path(),
+                          std::ios_base::binary | std::ios_base::ate)
+          : std::ifstream();
 
   auto pb_size = persistent_bootconfig.tellg();
   persistent_bootconfig.seekg(0);

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_image_utils.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_image_utils.h
@@ -17,8 +17,9 @@
 
 #include <string>
 
-#include "common/libs/utils/result.h"
-#include "host/libs/avb/avb.h"
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/commands/assemble_cvd/disk/generate_persistent_bootconfig.h"
+#include "cuttlefish/host/libs/avb/avb.h"
 
 namespace cuttlefish {
 
@@ -43,7 +44,7 @@ Result<void> UnpackBootImage(const std::string& boot_image_path,
 bool UnpackVendorBootImageIfNotUnpacked(
     const std::string& vendor_boot_image_path, const std::string& unpack_dir);
 void RepackGem5BootImage(const std::string& initrd_path,
-                         const std::string& bootconfig_path,
+                         const std::optional<BootConfigPartition>&,
                          const std::string& unpack_dir,
                          const std::string& input_ramdisk_path);
 Result<std::string> ReadAndroidVersionFromBootImage(

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/BUILD.bazel
@@ -211,9 +211,7 @@ cc_library(
         "//cuttlefish/host/libs/avb",
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:data_image",
-        "//cuttlefish/host/libs/config:known_paths",
-        "//cuttlefish/host/libs/feature",
-        "//cuttlefish/host/libs/vm_manager",
+        "//cuttlefish/host/libs/image_aggregator",
     ],
 )
 
@@ -280,6 +278,7 @@ cc_library(
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/commands/assemble_cvd/disk:factory_reset_protected",
+        "//cuttlefish/host/commands/assemble_cvd/disk:generate_persistent_bootconfig",
         "//cuttlefish/host/commands/assemble_cvd/disk:generate_persistent_vbmeta",
         "//cuttlefish/host/commands/assemble_cvd:disk_builder",
         "//cuttlefish/host/libs/config:ap_boot_flow",

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/generate_persistent_bootconfig.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/generate_persistent_bootconfig.cpp
@@ -18,24 +18,22 @@
 
 #include <memory>
 #include <string>
-#include <unordered_set>
 
-#include "common/libs/fs/shared_buf.h"
-#include "common/libs/fs/shared_fd.h"
-#include "common/libs/utils/files.h"
-#include "common/libs/utils/result.h"
-#include "common/libs/utils/size_utils.h"
-#include "host/commands/assemble_cvd/bootconfig_args.h"
-#include "host/libs/avb/avb.h"
-#include "host/libs/config/cuttlefish_config.h"
-#include "host/libs/config/data_image.h"
-#include "host/libs/config/known_paths.h"
-#include "host/libs/feature/feature.h"
-#include "host/libs/vm_manager/gem5_manager.h"
+#include "cuttlefish/common/libs/fs/shared_buf.h"
+#include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/common/libs/utils/size_utils.h"
+#include "cuttlefish/host/commands/assemble_cvd/bootconfig_args.h"
+#include "cuttlefish/host/commands/assemble_cvd/disk/generate_persistent_bootconfig.h"
+#include "cuttlefish/host/libs/avb/avb.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/data_image.h"
+#include "cuttlefish/host/libs/image_aggregator/image_aggregator.h"
 
 namespace cuttlefish {
 
-Result<void> GeneratePersistentBootconfig(
+Result<std::optional<BootConfigPartition>> BootConfigPartition::CreateIfNeeded(
     const CuttlefishConfig& config,
     const CuttlefishConfig::InstanceSpecific& instance) {
   //  Cuttlefish for the time being won't be able to support OTA from a
@@ -44,9 +42,11 @@ Result<void> GeneratePersistentBootconfig(
   //  testing run on cuttlefish is done within one launch cycle of the device.
   //  If this ever becomes an issue, this code will have to be rewritten.
   if (!instance.bootconfig_supported()) {
-    return {};
+    return std::nullopt;
   }
-  const auto bootconfig_path = instance.persistent_bootconfig_path();
+  const std::string bootconfig_path =
+      instance.PerInstanceInternalPath("bootconfig");
+
   if (!FileExists(bootconfig_path)) {
     CF_EXPECT(CreateBlankImage(bootconfig_path, 1 /* mb */, "none"),
               "Failed to create image at " << bootconfig_path);
@@ -87,7 +87,19 @@ Result<void> GeneratePersistentBootconfig(
     CF_EXPECT(avbtool->AddHashFooter(bootconfig_path, "bootconfig",
                                      bootconfig_size_bytes));
   }
-  return {};
+
+  return BootConfigPartition(std::move(bootconfig_path));
+}
+
+BootConfigPartition::BootConfigPartition(std::string path) : path_(path) {}
+
+const std::string& BootConfigPartition::Path() const { return path_; }
+
+ImagePartition BootConfigPartition::Partition() const {
+  return ImagePartition{
+      .label = "bootconfig",
+      .image_file_path = AbsolutePath(path_),
+  };
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/generate_persistent_bootconfig.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/generate_persistent_bootconfig.h
@@ -16,12 +16,25 @@
 
 #pragma once
 
-#include "common/libs/utils/result.h"
-#include "host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/image_aggregator/image_aggregator.h"
 
 namespace cuttlefish {
 
-Result<void> GeneratePersistentBootconfig(
-    const CuttlefishConfig&, const CuttlefishConfig::InstanceSpecific&);
+class BootConfigPartition {
+ public:
+  static Result<std::optional<BootConfigPartition>> CreateIfNeeded(
+      const CuttlefishConfig&, const CuttlefishConfig::InstanceSpecific&);
+
+  const std::string& Path() const;
+
+  ImagePartition Partition() const;
+
+ private:
+  BootConfigPartition(std::string path);
+
+  std::string path_;
+};
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/generate_persistent_vbmeta.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/generate_persistent_vbmeta.cpp
@@ -54,7 +54,7 @@ static bool PrepareVBMetaImage(const std::string& path, bool has_boot_config) {
 Result<void> GeneratePersistentVbmeta(
     const CuttlefishConfig::InstanceSpecific& instance,
     AutoSetup<InitBootloaderEnvPartition>::Type& /* dependency */,
-    AutoSetup<GeneratePersistentBootconfig>::Type& /* dependency */) {
+    AutoSetup<BootConfigPartition::CreateIfNeeded>::Type& /* dependency */) {
   CF_EXPECT(PrepareVBMetaImage(instance.vbmeta_path(),
                                instance.bootconfig_supported()));
   if (instance.ap_boot_flow() == APBootFlow::Grub) {

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/generate_persistent_vbmeta.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/generate_persistent_vbmeta.h
@@ -27,6 +27,6 @@ namespace cuttlefish {
 Result<void> GeneratePersistentVbmeta(
     const CuttlefishConfig::InstanceSpecific&,
     AutoSetup<InitBootloaderEnvPartition>::Type&,
-    AutoSetup<GeneratePersistentBootconfig>::Type&);
+    AutoSetup<BootConfigPartition::CreateIfNeeded>::Type&);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/initialize_instance_composite_disk.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/initialize_instance_composite_disk.h
@@ -18,6 +18,7 @@
 
 #include "common/libs/utils/result.h"
 #include "host/commands/assemble_cvd/disk/factory_reset_protected.h"
+#include "host/commands/assemble_cvd/disk/generate_persistent_bootconfig.h"
 #include "host/commands/assemble_cvd/disk/generate_persistent_vbmeta.h"
 #include "host/libs/config/cuttlefish_config.h"
 
@@ -26,6 +27,7 @@ namespace cuttlefish {
 Result<void> InitializeInstanceCompositeDisk(
     const CuttlefishConfig&, const CuttlefishConfig::InstanceSpecific&,
     AutoSetup<InitializeFactoryResetProtected>::Type&,
+    AutoSetup<BootConfigPartition::CreateIfNeeded>::Type& bootconfig_partition,
     AutoSetup<GeneratePersistentVbmeta>::Type&);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
@@ -527,8 +527,6 @@ class CuttlefishConfig {
 
     std::string factory_reset_protected_path() const;
 
-    std::string persistent_bootconfig_path() const;
-
     // used for the persistent_composite_disk vbmeta
     std::string vbmeta_path() const;
 

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
@@ -2101,11 +2101,6 @@ std::string CuttlefishConfig::InstanceSpecific::factory_reset_protected_path() c
   return PerInstanceInternalPath("factory_reset_protected.img");
 }
 
-std::string CuttlefishConfig::InstanceSpecific::persistent_bootconfig_path()
-    const {
-  return PerInstanceInternalPath("bootconfig");
-}
-
 std::string CuttlefishConfig::InstanceSpecific::PerInstancePath(
     const std::string& file_name) const {
   return (instance_dir() + "/") + file_name;


### PR DESCRIPTION
There is currently an ordering that
[`GeneratePersistentBootConfig`](https://github.com/google/android-cuttlefish/blob/d801cb68a44df2f81df9213715dca93c48652f8a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/generate_persistent_bootconfig.cpp#L38) must be called before
[`InitializeInstanceCompositeDisk`](https://github.com/google/android-cuttlefish/blob/d801cb68a44df2f81df9213715dca93c48652f8a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/initialize_instance_composite_disk.cc#L108). This is currently enforced indirectly by the `AutoSetup` dependencies through
[`GeneratePersistentVbmeta`](https://github.com/google/android-cuttlefish/blob/d801cb68a44df2f81df9213715dca93c48652f8a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/initialize_instance_composite_disk.cc#L93) to
[`GeneratePersistentBootConfig`](https://github.com/google/android-cuttlefish/blob/d801cb68a44df2f81df9213715dca93c48652f8a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/generate_persistent_vbmeta.cpp#L57) but not explicitly enforced.

This ordering would be better enforced by a type representing the bootconfig file. The only way to access the path to this file should be through the type, which represents the successful creation of the bootconfig file.

Bug: b/424883911