### PR TITLE
Add reasonable defaults to `base/cvd/.bazelrc`

### DIFF
--- a/base/cvd/.bazelrc
+++ b/base/cvd/.bazelrc
@@ -1,1 +1,3 @@
+build --build_tag_filters=-clang_tidy,-clang-tidy
 build --copt=-fdiagnostics-color=always
+build --test_summary=terse


### PR DESCRIPTION
With this change, `bazel build '//...'` no longer runs clang-tidy, and test results don't take up many lines of output.

The clang-tidy targets are somewhat inconvenient that they are evaluated during the `build` step, but only report results at `test` time.

Bug: b/425437146