### PR TITLE
Add option to set bazel disk cache dir while building base package

### DIFF
--- a/base/debian/rules
+++ b/base/debian/rules
@@ -55,6 +55,11 @@ endif
 
 cuttlefish_common := debian/cuttlefish-base/usr/lib/cuttlefish-common
 
+disk_cache_arg :=
+ifneq ($(strip $(BAZEL_DISK_CACHE_DIR)),)
+  disk_cache_arg := --disk_cache="$(BAZEL_DISK_CACHE_DIR)"
+endif
+
 %:
 	dh $@ --with=config-package
 
@@ -66,7 +71,7 @@ override_dh_installinit:
 # the `--workspace_status_command` flag path depends on the current working directory of base/cvd
 .PHONY: override_dh_auto_build
 override_dh_auto_build:
-	cd cvd && bazel build ${compilation_mode} ${conlyopts} ${copts} ${cxxopts} ${linkopts} 'cuttlefish/package:cvd' --spawn_strategy=local --workspace_status_command=../stamp_helper.sh --build_tag_filters=-clang-tidy
+	cd cvd && bazel build ${disk_cache_arg} ${compilation_mode} ${conlyopts} ${copts} ${cxxopts} ${linkopts} 'cuttlefish/package:cvd' --spawn_strategy=local --workspace_status_command=../stamp_helper.sh --build_tag_filters=-clang-tidy
 	dh_auto_build
 
 # Only generate optimized DWARF if debug is enabled


### PR DESCRIPTION
This option can be set while executing debuild using command

$ debuild -e BAZEL_DISK_CACHE_DIR=$HOME/bazel-disk-cache -i -us -uc -b