### PR TITLE
Update README to match refactor.

### DIFF
--- a/base/cvd/README.md
+++ b/base/cvd/README.md
@@ -7,7 +7,7 @@ package, but can also be compiled and run on its own.
 ## Compiling and running
 
 ```sh
-bazel run cuttlefish:cvd -- reset -y
+bazel run cuttlefish/package:cvd -- reset -y
 ```
 
 ## Running the unit tests


### PR DESCRIPTION
In #976 the bazel hierarchy was updated but the README wasn't; do so.