### PR TITLE
Bump LLVM version to 19.1.

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -136,7 +136,7 @@ jobs:
   build-debian-package:
     runs-on: ubuntu-22.04-4core
     container:
-      image: debian@sha256:823849b88ae7e9b6ceb605fbdf51566499c234a9cfca8da1e4f22234fd65a09c # debian:bullseye-20250317 (amd64)
+      image: debian@sha256:defe49aa5a875725310dff6b398aa7b49b595121adf9ddabc6f69274ffcceca3 # debian:bookworm-20250610 (amd64)
     steps:
     - name: Check for dockerenv file
       run: (ls /.dockerenv && echo 'Found dockerenv') || (echo 'No dockerenv')

--- a/base/cvd/MODULE.bazel
+++ b/base/cvd/MODULE.bazel
@@ -73,7 +73,7 @@ git_override(
 
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
 llvm.toolchain(
-    llvm_version = "18.1.8",
+    llvm_version = "19.1.0",
 )
 
 use_repo(llvm, "llvm_toolchain")


### PR DESCRIPTION
Otherwise, the clang in the toolchain requires libtinfo to be installed on the build host, and this dependency no longer exists in later versions.

The runtime dependency in the package and workflow builds can probably be removed too, but will do that in a later separate pr (since this change should be applied first).