### PR TITLE
Remove gflags parsing from the `ParseGflags` feature

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd.cc
@@ -621,6 +621,19 @@ Result<int> AssembleCvdMain(int argc, char** argv) {
     CF_EXPECT(help_flag.Parse(args), "Failed to process help flag");
   }
 
+  {
+    std::string process_name = "assemble_cvd";
+    std::vector<char*> pseudo_argv = {process_name.data()};
+    for (auto& arg : args) {
+      pseudo_argv.push_back(arg.data());
+    }
+    int argc = pseudo_argv.size();
+    auto argv = pseudo_argv.data();
+    gflags::AllowCommandLineReparsing();  // Support future non-gflags flags
+    gflags::ParseCommandLineNonHelpFlags(&argc, &argv,
+                                         /* remove_flags */ false);
+  }
+
   SystemImageDirFlag system_image_dir =
       CF_EXPECT(SystemImageDirFlag::FromGlobalGflags());
 

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flag_feature.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flag_feature.cpp
@@ -41,16 +41,6 @@ class ParseGflagsImpl : public ParseGflags {
     return {static_cast<FlagFeature*>(&config_)};
   }
   Result<void> Process(std::vector<std::string>& args) override {
-    std::string process_name = "assemble_cvd";
-    std::vector<char*> pseudo_argv = {process_name.data()};
-    for (auto& arg : args) {
-      pseudo_argv.push_back(arg.data());
-    }
-    int argc = pseudo_argv.size();
-    auto argv = pseudo_argv.data();
-    gflags::AllowCommandLineReparsing();  // Support future non-gflags flags
-    gflags::ParseCommandLineNonHelpFlags(&argc, &argv,
-                                         /* remove_flags */ false);
     return {};
   }
   bool WriteGflagsCompatHelpXml(std::ostream& out) const override {


### PR DESCRIPTION
There is still an implicit dependency between
`gflags::ParseCommandLine...` and the `FromGlobalGflags` methods in the new flag types.