### PR TITLE
Docker image doesn't support building deb packages inside anymore.

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -304,7 +304,7 @@ jobs:
       shell: bash
       run: |
         tar -xvf debs.tar && mv android-cuttlefish/cuttlefish*.deb .
-        ./docker/image-builder.sh -m prebuilt
+        ./docker/image-builder.sh -m dev
         docker images
         sudo docker run --privileged -d -p 2080:2080 cuttlefish-orchestration:latest
         # Wait for HO service to start.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,24 +5,6 @@
 ARG BUILD_OPTION=prod
 
 
-FROM debian:12 AS host-package-builder
-
-USER root
-WORKDIR /root
-RUN set -x
-RUN apt update
-RUN apt install -y --no-install-recommends \
-    apt-utils \
-    curl \
-    devscripts \
-    equivs \
-    sudo
-
-# Build CF debian packages
-COPY . /root/android-cuttlefish
-RUN ["/bin/bash", "-c", "/root/android-cuttlefish/tools/buildutils/build_packages.sh"]
-
-
 FROM debian:12 AS runner-base
 
 # Expose Operator Port (HTTP:1080, HTTPS:1443)
@@ -54,8 +36,7 @@ RUN chmod +x /root/run_services.sh
 
 FROM runner-base AS runner-dev
 
-# Install CF debian packages.
-COPY --from=host-package-builder /root/android-cuttlefish/cuttlefish-*.deb /root/debian/
+COPY cuttlefish-*.deb /root/debian/
 RUN apt install -y --no-install-recommends -f \
     /root/debian/cuttlefish-base_*.deb \
     /root/debian/cuttlefish-user_*.deb \
@@ -73,15 +54,6 @@ RUN echo "deb https://artifacts.codelinaro.org/linaro-372-googlelt-gigabyte-ampe
 RUN apt update
 RUN apt install -y --no-install-recommends \
     cuttlefish-base cuttlefish-user cuttlefish-orchestration
-
-
-FROM runner-base AS runner-prebuilt
-
-COPY cuttlefish-*.deb /root/debian/
-RUN apt install -y --no-install-recommends -f \
-    /root/debian/cuttlefish-base_*.deb \
-    /root/debian/cuttlefish-user_*.deb \
-    /root/debian/cuttlefish-orchestration_*.deb
 
 
 FROM runner-${BUILD_OPTION} AS runner

--- a/docker/README.md
+++ b/docker/README.md
@@ -29,8 +29,8 @@ Please run below command to build manually.
 
 ```bash
 cd /path/to/android-cuttlefish
-cd docker
-./image-builder.sh -m dev
+tools/buildutils/build_packages.sh
+docker/image-builder.sh -m dev
 ```
 
 You can validate if the docker image is successfully built by checking

--- a/docker/image-builder.sh
+++ b/docker/image-builder.sh
@@ -11,9 +11,8 @@ usage() {
   echo "usage: $0 [-t <tag>] [-m <mode>]"
   echo "  -t: name or name:tag of docker image (default cuttlefish-orchestration)"
   echo "  -m: set mode for build image (default: prod)"
-  echo "      dev - Builds host packages from the local source"
   echo "      prod - Downloads and installs host packages"
-  echo "      prebuilt - Use *.deb files under repo dir as prebuilt of host packages"
+  echo "      dev  - Use *.deb files under repo dir as prebuilt of host packages"
 
 }
 


### PR DESCRIPTION
As presubmit checks doesn't validate the scene for building CF deb packages inside the docker image, we cannot keep those codes on Dockerfile.