### PR TITLE
Update documentation on tools/buildutils/cw/README.md

### DIFF
--- a/tools/buildutils/cw/README.md
+++ b/tools/buildutils/cw/README.md
@@ -21,17 +21,17 @@ The run container command must be run at the root of the `android-cuttlefish` re
 ### base
 
 ```
-docker run -v=.:/mnt/build -w /mnt/build android-cuttlefish-build:latest base
+docker run -v=$PWD:/mnt/build -w /mnt/build android-cuttlefish-build:latest base
 ```
 
 Persist bazel cache among executions.
 
 ```
-docker run -v=$HOME/.cache/bazel:/root/.cache/bazel  -v=.:/mnt/build -w /mnt/build  android-cuttlefish-build:latest base
+docker run -v=$HOME/.cache/bazel:/root/.cache/bazel  -v=$PWD:/mnt/build -w /mnt/build  android-cuttlefish-build:latest base
 ```
 
 ### frontend
 
 ```
-docker run -v=.:/mnt/build -w /mnt/build android-cuttlefish-build:latest frontend
+docker run -v=$PWD:/mnt/build -w /mnt/build android-cuttlefish-build:latest frontend
 ```


### PR DESCRIPTION
Current doc on ` tools/buildutils/cw/README.md` may work well for `podman`, but there was an error for following the documentation with `docker`. This PR aims to update the documentation to be usable via `docker`.


The error message below is the reason why I created this PR.

```
$ docker run -v=$HOME/.cache/bazel:/root/.cache/bazel  -v=.:/mnt/build -w /mnt/build  android-cuttlefish-build:latest base 

docker: Error response from daemon: create .: volume name is too short, names should be at least two alphanumeric characters.
See 'docker run --help'.
```