### PR TITLE
Disable VCS stamping to make available to build frontend packages

### DIFF
--- a/frontend/debian/rules
+++ b/frontend/debian/rules
@@ -20,8 +20,8 @@ GEN_SSL_CERT_OUT_DIR := ./.sslcert
 
 .PHONY: override_dh_auto_build
 override_dh_auto_build:
-	$(GOUTIL) $(ORCHESTRATOR_SOURCE_DIR) build -v -buildmode=pie -ldflags="-w"
-	$(GOUTIL) $(OPERATOR_SOURCE_DIR) build -v -buildmode=pie -ldflags="-w"
+	$(GOUTIL) $(ORCHESTRATOR_SOURCE_DIR) build -v -buildmode=pie -buildvcs=false -ldflags="-w"
+	$(GOUTIL) $(OPERATOR_SOURCE_DIR) build -v -buildmode=pie -buildvcs=false -ldflags="-w"
 	$(BUILD_WEBUI)
 	$(GEN_SSL_CERT) -o $(GEN_SSL_CERT_OUT_DIR)
 


### PR DESCRIPTION
Without explicitly disabling VCS stamping, it gets an error for building CF frontend deb package in the Container.

```
# cd /mnt/build; git status --porcelain
fatal: detected dubious ownership in repository at '/mnt/build'
To add an exception for this directory, call:

        git config --global --add safe.directory /mnt/build
error obtaining VCS status: exit status 128
        Use -buildvcs=false to disable VCS stamping.
make[1]: *** [debian/rules:23: override_dh_auto_build] Error 1
make[1]: Leaving directory '/mnt/build/frontend'
make: *** [debian/rules:11: binary] Error 2
dpkg-buildpackage: error: debian/rules binary subprocess returned exit status 2
debuild: fatal error at line 1182:
dpkg-buildpackage -us -uc -ui -i -b failed
```