### PR TITLE
Add new secure_env flags to account for https://github.com/google/android-cuttlefish/pull/1347

### DIFF
--- a/base/cvd/cuttlefish/host/commands/secure_env/secure_env_only_oemlock.cpp
+++ b/base/cvd/cuttlefish/host/commands/secure_env/secure_env_only_oemlock.cpp
@@ -64,6 +64,10 @@ DEFINE_string(gatekeeper_impl, "tpm",
 DEFINE_string(oemlock_impl, "tpm",
               "The oemlock implementation. \"tpm\" or \"software\"");
 
+DEFINE_int32(jcardsim_fd_in, -1, "A pipe for jcardsim communication");
+DEFINE_int32(jcardsim_fd_out, -1, "A pipe for jcardsim communication");
+DEFINE_bool(enable_jcard_simulator, false, "Whether to enable jcardsimulator.");
+
 namespace cuttlefish {
 namespace {
 


### PR DESCRIPTION
Substituting `run_cvd` and `secure_env` leads to this error:
```
ERROR: unknown command line flag 'enable_jcard_simulator'
ERROR: unknown command line flag 'jcardsim_fd_in'
ERROR: unknown command line flag 'jcardsim_fd_out'
Detected unexpected exit of monitored subprocess /usr/local/google/home/schuffelen/dl4/bin/secure_env
Subprocess /usr/local/google/home/schuffelen/dl4/bin/secure_env (996884) has exited with exit code 1
```

Bug: b/428807372