### PR TITLE
Create a type to represent the factory-reset-protected partition

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -33,6 +33,7 @@ cf_cc_binary(
         "//cuttlefish/host/commands/assemble_cvd:flags",
         "//cuttlefish/host/commands/assemble_cvd:flags_defaults",
         "//cuttlefish/host/commands/assemble_cvd:touchpad",
+        "//cuttlefish/host/commands/assemble_cvd/disk:factory_reset_protected",
         "//cuttlefish/host/commands/assemble_cvd/disk:metadata_image",
         "//cuttlefish/host/commands/assemble_cvd/disk:misc_image",
         "//cuttlefish/host/commands/assemble_cvd/flags:system_image_dir",

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd.cc
@@ -33,6 +33,7 @@
 #include "cuttlefish/common/libs/utils/tee_logging.h"
 #include "cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.h"
 #include "cuttlefish/host/commands/assemble_cvd/clean.h"
+#include "cuttlefish/host/commands/assemble_cvd/disk/factory_reset_protected.h"
 #include "cuttlefish/host/commands/assemble_cvd/disk/metadata_image.h"
 #include "cuttlefish/host/commands/assemble_cvd/disk/misc_image.h"
 #include "cuttlefish/host/commands/assemble_cvd/disk_flags.h"
@@ -249,7 +250,7 @@ Result<std::set<std::string>> PreservingOnResume(
   preserving.insert("persistent_composite_overlay.img");
   preserving.insert("pflash.img");
   preserving.insert("uboot_env.img");
-  preserving.insert("factory_reset_protected.img");
+  preserving.insert(FactoryResetProtectedImage::FileName());
   preserving.insert(MiscImage::Name());
   preserving.insert("vmmtruststore.img");
   preserving.insert(MetadataImage::Name());

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/BUILD.bazel
@@ -101,6 +101,7 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:data_image",
+        "//cuttlefish/host/libs/image_aggregator",
     ],
 )
 

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/factory_reset_protected.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/factory_reset_protected.cc
@@ -14,22 +14,26 @@
  * limitations under the License.
  */
 
-#include "host/commands/assemble_cvd/disk/factory_reset_protected.h"
+#include "cuttlefish/host/commands/assemble_cvd/disk/factory_reset_protected.h"
 
 #include <string>
 #include <utility>
 
-#include "common/libs/utils/files.h"
-#include "common/libs/utils/result.h"
+#include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/common/libs/utils/result.h"
 #include "cuttlefish/host/commands/assemble_cvd/disk/factory_reset_protected.h"
+#include "cuttlefish/host/libs/config/data_image.h"
 #include "cuttlefish/host/libs/image_aggregator/image_aggregator.h"
-#include "host/libs/config/data_image.h"
 
 namespace cuttlefish {
 
+std::string FactoryResetProtectedImage::FileName() {
+  return "factory_reset_protected.img";
+}
+
 Result<FactoryResetProtectedImage> FactoryResetProtectedImage::Create(
     const CuttlefishConfig::InstanceSpecific& instance) {
-  FactoryResetProtectedImage frp(instance.factory_reset_protected_path());
+  FactoryResetProtectedImage frp(instance.PerInstanceInternalPath(FileName()));
   if (FileExists(frp.path_)) {
     return frp;
   }

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/factory_reset_protected.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/factory_reset_protected.h
@@ -26,6 +26,8 @@ namespace cuttlefish {
 
 class FactoryResetProtectedImage {
  public:
+  static std::string FileName();
+
   static Result<FactoryResetProtectedImage> Create(
       const CuttlefishConfig::InstanceSpecific&);
 

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/factory_reset_protected.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/factory_reset_protected.h
@@ -16,12 +16,25 @@
 
 #pragma once
 
-#include "common/libs/utils/result.h"
-#include "host/libs/config/cuttlefish_config.h"
+#include <string>
+
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/image_aggregator/image_aggregator.h"
 
 namespace cuttlefish {
 
-Result<void> InitializeFactoryResetProtected(
-    const CuttlefishConfig::InstanceSpecific&);
+class FactoryResetProtectedImage {
+ public:
+  static Result<FactoryResetProtectedImage> Create(
+      const CuttlefishConfig::InstanceSpecific&);
+
+  ImagePartition Partition() const;
+
+ private:
+  explicit FactoryResetProtectedImage(std::string);
+
+  std::string path_;
+};
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/initialize_instance_composite_disk.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/initialize_instance_composite_disk.h
@@ -26,7 +26,7 @@ namespace cuttlefish {
 
 Result<void> InitializeInstanceCompositeDisk(
     const CuttlefishConfig&, const CuttlefishConfig::InstanceSpecific&,
-    AutoSetup<InitializeFactoryResetProtected>::Type&,
+    AutoSetup<FactoryResetProtectedImage::Create>::Type&,
     AutoSetup<BootConfigPartition::CreateIfNeeded>::Type& bootconfig_partition,
     AutoSetup<GeneratePersistentVbmeta>::Type&);
 

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk_flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk_flags.cc
@@ -270,7 +270,7 @@ static fruit::Component<> DiskChangesPerInstanceComponent(
       .bindInstance(*instance)
       .install(AutoSetup<InitializeAccessKregistryImage>::Component)
       .install(AutoSetup<InitBootloaderEnvPartition>::Component)
-      .install(AutoSetup<InitializeFactoryResetProtected>::Component)
+      .install(AutoSetup<FactoryResetProtectedImage::Create>::Component)
       .install(AutoSetup<InitializeHwcomposerPmemImage>::Component)
       .install(AutoSetup<InitializePstore>::Component)
       .install(AutoSetup<InitializeSdCard>::Component)

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
@@ -525,8 +525,6 @@ class CuttlefishConfig {
     // Wifi MAC address inside the guest
     int wifi_mac_prefix() const;
 
-    std::string factory_reset_protected_path() const;
-
     // used for the persistent_composite_disk vbmeta
     std::string vbmeta_path() const;
 

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
@@ -2091,10 +2091,6 @@ int CuttlefishConfig::InstanceSpecific::audio_output_streams_count() const {
   return (*Dictionary())[kAudioOutputStreamsCount].asInt();
 }
 
-std::string CuttlefishConfig::InstanceSpecific::factory_reset_protected_path() const {
-  return PerInstanceInternalPath("factory_reset_protected.img");
-}
-
 std::string CuttlefishConfig::InstanceSpecific::PerInstancePath(
     const std::string& file_name) const {
   return (instance_dir() + "/") + file_name;


### PR DESCRIPTION
https://github.com/google/android-cuttlefish/blob/c79c39ceb2035ff7e9c1e2b732070aaef7312a88/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/factory_reset_protected.cc#L27

https://github.com/google/android-cuttlefish/blob/c79c39ceb2035ff7e9c1e2b732070aaef7312a88/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/initialize_instance_composite_disk.cc#L89

There's a dependency here to enforce the ordering, but the file path is accessible at any time from the config. Creating a type to represent the creation of the image enforces an ordering that accessing the path implies the file is already created.