### PR TITLE
Set /mnt/build as safe directory in git configuration at Containerfile

### DIFF
--- a/tools/buildutils/cw/Containerfile
+++ b/tools/buildutils/cw/Containerfile
@@ -8,6 +8,4 @@ RUN apt install -y sudo devscripts
 COPY ./tools/buildutils/installbazel.sh /installbazel.sh
 RUN /installbazel.sh && rm /installbazel.sh
 
-COPY ./tools/buildutils/build_package.sh /build_package.sh
-
-ENTRYPOINT ["/build_package.sh"]
+ENTRYPOINT ["tools/buildutils/cw/entrypoint.sh"]

--- a/tools/buildutils/cw/entrypoint.sh
+++ b/tools/buildutils/cw/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2025 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This configuration setting is required for building frontend package on the
+# docker instance.
+git config --global --add safe.directory ${PWD}
+
+tools/buildutils/build_package.sh $@


### PR DESCRIPTION
Unlike base debian package, frontend debian package wasn't buildable with following tools/buildutils/cw/README.md because of the error around safe directory git configuration. This commit adds a line in Containerfile to make every container instance is set with this configuration at the runtime.