### PR TITLE
Request remote zip file sizes.

### DIFF
--- a/base/cvd/cuttlefish/host/libs/web/http_client/fake_http_client.h
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/fake_http_client.h
@@ -28,7 +28,7 @@ namespace cuttlefish {
 
 class FakeHttpClient : public HttpClient {
  public:
-  using Handler = std::function<std::string(const HttpRequest&)>;
+  using Handler = std::function<HttpResponse<std::string>(const HttpRequest&)>;
 
   // The longest string that is a complete substring of `url` is used to match
   // requests.

--- a/base/cvd/cuttlefish/host/libs/web/http_client/fake_http_client_test.cc
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/fake_http_client_test.cc
@@ -72,7 +72,9 @@ TEST(FakeHttpClientTest, ChoosesUrl) {
 TEST(FakeHttpClientTest, InvokesCallback) {
   FakeHttpClient http_client;
 
-  http_client.SetResponse([](const HttpRequest& req) { return req.url; });
+  http_client.SetResponse([](const HttpRequest& req) {
+    return HttpResponse<std::string>{.data = req.url, .http_code = 200};
+  });
 
   Result<HttpResponse<std::string>> res =
       HttpGetToString(http_client, "https://www.google.com");

--- a/base/cvd/cuttlefish/host/libs/web/http_client/http_client.cc
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/http_client.cc
@@ -15,8 +15,40 @@
 
 #include "cuttlefish/host/libs/web/http_client/http_client.h"
 
+#include <ctype.h>
+#include <stddef.h>
+
+#include <optional>
+#include <string_view>
+#include <vector>
+
 namespace cuttlefish {
+namespace {
+
+bool EqualsCaseInsensitive(const std::string_view a, const std::string_view b) {
+  if (a.size() != b.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < a.size(); i++) {
+    if (tolower(a[i]) != tolower(b[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace
 
 HttpClient::~HttpClient() = default;
+
+std::optional<std::string_view> HeaderValue(
+    const std::vector<HttpHeader>& headers, std::string_view header_name) {
+  for (const HttpHeader& header : headers) {
+    if (EqualsCaseInsensitive(header.name, header_name)) {
+      return header.value;
+    }
+  }
+  return std::nullopt;
+}
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/web/http_client/http_client.h
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/http_client.h
@@ -16,7 +16,9 @@
 #pragma once
 
 #include <functional>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <vector>
 
@@ -27,6 +29,11 @@
 namespace cuttlefish {
 
 struct HttpVoidResponse {};
+
+struct HttpHeader {
+  std::string name;
+  std::string value;
+};
 
 template <typename T>
 struct HttpResponse {
@@ -54,12 +61,17 @@ struct HttpResponse {
 
   typename std::conditional<std::is_void_v<T>, HttpVoidResponse, T>::type data;
   long http_code;
+  std::vector<HttpHeader> headers;
 };
+
+std::optional<std::string_view> HeaderValue(
+    const std::vector<HttpHeader>& headers, std::string_view header_name);
 
 enum class HttpMethod {
   kGet,
   kPost,
   kDelete,
+  kHead,
 };
 
 struct HttpRequest {

--- a/base/cvd/cuttlefish/host/libs/web/http_client/http_file.cc
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/http_file.cc
@@ -74,7 +74,7 @@ Result<HttpResponse<std::string>> HttpGetToFile(
   HttpRequest request = {
       .method = HttpMethod::kGet,
       .url = url,
-      .headers = headers,
+      .headers = std::move(headers),
   };
 
   HttpResponse<void> http_response =
@@ -91,7 +91,11 @@ Result<HttpResponse<std::string>> HttpGetToFile(
         "Unable to remove temporary file \"{}\"\nMay require manual removal",
         temp_path);
   }
-  return HttpResponse<std::string>{path, http_response.http_code};
+  return HttpResponse<std::string>{
+      .data = path,
+      .http_code = http_response.http_code,
+      .headers = std::move(http_response.headers),
+  };
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/web/http_client/http_json.cc
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/http_json.cc
@@ -17,6 +17,7 @@
 
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <android-base/logging.h>
@@ -37,9 +38,13 @@ HttpResponse<Json::Value> Parse(HttpResponse<std::string> response) {
     LOG(ERROR) << "Could not parse json: " << result.error().FormatForEnv();
     error_json["error"] = "Failed to parse json: " + result.error().Message();
     error_json["response"] = response.data;
-    return HttpResponse<Json::Value>{error_json, response.http_code};
+    return HttpResponse<Json::Value>{.data = error_json,
+                                     .http_code = response.http_code,
+                                     .headers = std::move(response.headers)};
   }
-  return HttpResponse<Json::Value>{*result, response.http_code};
+  return HttpResponse<Json::Value>{.data = *result,
+                                   .http_code = response.http_code,
+                                   .headers = std::move(response.headers)};
 }
 
 }  // namespace

--- a/base/cvd/cuttlefish/host/libs/web/http_client/http_string.cc
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/http_string.cc
@@ -19,6 +19,7 @@
 
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "cuttlefish/common/libs/utils/result.h"
@@ -40,7 +41,11 @@ Result<HttpResponse<std::string>> Download(HttpClient& http_client,
   };
   HttpResponse<void> http_response =
       CF_EXPECT(http_client.DownloadToCallback(request, callback));
-  return HttpResponse<std::string>{stream.str(), http_response.http_code};
+  return HttpResponse<std::string>{
+      .data = stream.str(),
+      .http_code = http_response.http_code,
+      .headers = std::move(http_response.headers),
+  };
 }
 
 }  // namespace

--- a/base/cvd/cuttlefish/host/libs/zip/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/zip/BUILD.bazel
@@ -14,6 +14,7 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/libs/web/http_client",
         "//cuttlefish/host/libs/zip:zip_cc",
+        "@abseil-cpp//absl/strings",
         "@fmt",
     ],
 )

--- a/base/cvd/cuttlefish/host/libs/zip/remote_zip.h
+++ b/base/cvd/cuttlefish/host/libs/zip/remote_zip.h
@@ -15,8 +15,6 @@
 
 #pragma once
 
-#include <stdint.h>
-
 #include <string>
 #include <vector>
 
@@ -27,9 +25,9 @@
 namespace cuttlefish {
 
 /* Creates a read-only zip archive that downloads files on-demand from a remote
- * URL. It assumes the remote web server supports HTTP range requests and
- * requires knowing the size of the remote file. `headers` are passed through
- * when making HTTP requests to the `HttpClient`. */
+ * URL. It requires and validates the remote web server supports HTTP range
+ * requests. `headers` are passed through when making HTTP requests to the
+ * `HttpClient`. */
 Result<ReadableZip> ZipFromUrl(HttpClient&, const std::string& url,
-                               uint64_t size, std::vector<std::string> headers);
+                               std::vector<std::string> headers);
 }


### PR DESCRIPTION
Also includes:

- Support HTTP HEAD requests in the HTTP client and always return HTTP response headers
- Utilities to find a response by its case-insensitive key

Bug: b/423755602