### PR TITLE
HO can launch CF instances with user artifact v1 HO APIs

### DIFF
--- a/frontend/src/host_orchestrator/api/v1/messages.go
+++ b/frontend/src/host_orchestrator/api/v1/messages.go
@@ -39,6 +39,10 @@ type AndroidCIBundle struct {
 }
 
 // Prefix for specifying user artifact path while creating CVD with CreateCVDRequest.EnvConfig.
+const EnvConfigUserArtifactsVarV1 = "@userartifacts"
+
+// Prefix for specifying legacy user artifact path while creating CVD with CreateCVDRequest.EnvConfig.
+// Deprecated: use `EnvConfigUserArtifactsVarV1` instead
 const EnvConfigUserArtifactsVar = "@user_artifacts"
 
 // Use `X-Cutf-Host-Orchestrator-BuildAPI-Creds` http header to pass the Build API credentials.

--- a/frontend/src/host_orchestrator/main.go
+++ b/frontend/src/host_orchestrator/main.go
@@ -118,16 +118,17 @@ func main() {
 	}
 
 	imPaths := orchestrator.IMPaths{
-		RootDir:          *imRootDir,
-		InstancesDir:     filepath.Join(*imRootDir, "instances"),
-		CVDBugReportsDir: filepath.Join(*imRootDir, "cvdbugreports"),
-		SnapshotsRootDir: filepath.Join(*imRootDir, "snapshots"),
+		RootDir:              *imRootDir,
+		InstancesDir:         filepath.Join(*imRootDir, "instances"),
+		CVDBugReportsDir:     filepath.Join(*imRootDir, "cvdbugreports"),
+		SnapshotsRootDir:     filepath.Join(*imRootDir, "snapshots"),
+		UserArtifactsRootDir: filepath.Join(*imRootDir, "userartifacts"),
 	}
 
 	om := orchestrator.NewMapOM()
 	uamOpts := orchestrator.UserArtifactsManagerOpts{
 		LegacyRootDir: filepath.Join(*imRootDir, "user_artifacts"),
-		RootDir:       filepath.Join(*imRootDir, "userartifacts"),
+		RootDir:       imPaths.UserArtifactsRootDir,
 	}
 	uam, err := orchestrator.NewUserArtifactsManagerImpl(uamOpts)
 	if err != nil {

--- a/frontend/src/host_orchestrator/orchestrator/instancemanager.go
+++ b/frontend/src/host_orchestrator/orchestrator/instancemanager.go
@@ -42,10 +42,11 @@ func (s EmptyFieldError) Error() string {
 }
 
 type IMPaths struct {
-	RootDir          string
-	InstancesDir     string
-	CVDBugReportsDir string
-	SnapshotsRootDir string
+	RootDir              string
+	InstancesDir         string
+	CVDBugReportsDir     string
+	SnapshotsRootDir     string
+	UserArtifactsRootDir string
 }
 
 func CvdGroupToAPIObject(group *cvd.Group) []*apiv1.CVD {


### PR DESCRIPTION
This PR is to support HO launching CF instances with canonical config & new user artifact APIs.

Noting that **writing E2E test is out of scope** from this PR. I'm going to write in following PR with getting confirmation about this change.

Corresponding change for `cvdr` is suggested at https://github.com/google/cloud-android-orchestration/pull/435.

Internally, this PR suggests passing canonical config about user artifacts uploaded & extracted by new HO APIs with given structure. And below are the reasons why I suggested this structure and creating directories with storing symlinks inside.
```
"@userartifacts/{{.Checksum_1}},{{.Checksum_2}},{{.Checksum_3}},{{.Checksum_n}}"
```
- The design of new user artifact upload API assumes not uploading multiple files in a single directory. However, some execution flows of `cvdr create` requires to upload multiple images. For instance, `cvdr create --local_image` requires to upload all files listed at `device/google/cuttlefish/required_images`. It was able to upload those into single directory with legacy APIs, but not available with new APIs.
- Canonical config doesn't support to configure multiple directories. The structure of canonical config is defined at [load_config.proto](https://github.com/google/android-cuttlefish/blob/main/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_config.proto), but there's no repeated string field to configure. Even making a patch to support this functionality isn't simple, since lots of variables defined under `assemble_cvd` are written with assuming single directory per instance, such as [here](https://github.com/google/android-cuttlefish/blob/main/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/system_image_dir.h).
- Copying user artifact is still one of the valid options. But creating symlinks instead is much faster to launch CF instances.
- HO should receive the list of checksums inside canonical config. One of the alternative structures would be passing json array under `default_build` of canonical config, but this is different from the definition of canonical config defined at [load_config.proto](https://github.com/google/android-cuttlefish/blob/main/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_config.proto).
- HO cannot reuse `@user_artifacts` which is used for representing user artifacts uploaded/extracted with legacy APIs. Parent directory is different, and it requires to expose `{checksum}_extracted` dir name structure to the outside for that case.