### PR TITLE
ExtractArtifact doesn't deal with http 409 status in HO client API level

### DIFF
--- a/frontend/src/libhoclient/host_orchestrator_client.go
+++ b/frontend/src/libhoclient/host_orchestrator_client.go
@@ -110,8 +110,6 @@ type UserArtifactsClient interface {
 	UploadArtifact(filename string) error
 	// Extract artifact into the artifacts repository.
 	// Artifacts are identified by their SHA256 checksum in the artifacts repository
-	// Returning *hoapi.Operation as nil when there's an error or there's no operation for
-	// extracting given artifact since it's already extracted before.
 	ExtractArtifact(filename string) (*hoapi.Operation, error)
 	// Creates a directory in the host where user artifacts can be uploaded to.
 	CreateUploadDir() (string, error)
@@ -606,11 +604,7 @@ func (c *HostOrchestratorClientImpl) ExtractArtifact(filename string) (*hoapi.Op
 	}
 	op := &hoapi.Operation{}
 	if err := c.HTTPHelper.NewPostRequest("/v1/userartifacts/"+checksum+"/:extract", nil).JSONResDo(op); err != nil {
-		if apiCallError, ok := err.(*ApiCallError); ok && apiCallError.HTTPStatusCode == http.StatusConflict {
-			return nil, nil
-		} else {
-			return nil, err
-		}
+		return nil, err
 	}
 	return op, nil
 }

--- a/frontend/src/libhoclient/host_orchestrator_client_test.go
+++ b/frontend/src/libhoclient/host_orchestrator_client_test.go
@@ -222,32 +222,6 @@ func TestExtractArtifactSucceeds(t *testing.T) {
 	}
 }
 
-func TestExtractArtifactReceive409WhenArtifactIsAlreadyExtracted(t *testing.T) {
-	tempDir := createTempDir(t)
-	defer os.RemoveAll(tempDir)
-	testFile := createTempFile(t, tempDir, "waldo", []byte("waldo"))
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch ep := r.Method + " " + r.URL.Path; ep {
-		case "GET /v1/userartifacts/d2c055002a6cdf8dd9edf90c7a666cb5f7f2d25da8519ec206f56777d74e0c7d":
-			writeOK(w, hoapi.StatArtifactResponse{})
-		case "POST /v1/userartifacts/d2c055002a6cdf8dd9edf90c7a666cb5f7f2d25da8519ec206f56777d74e0c7d/:extract":
-			writeErr(w, http.StatusConflict)
-		default:
-			t.Fatal("unexpected endpoint: " + ep)
-		}
-	}))
-	defer ts.Close()
-	client := NewHostOrchestratorClient(ts.URL)
-
-	op, err := client.ExtractArtifact(testFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if op != nil {
-		t.Fatal("unexpected operation: " + op.Name)
-	}
-}
-
 func TestCreateCVDWithUserProjectOverride(t *testing.T) {
 	fakeRes := &hoapi.CreateCVDResponse{CVDs: []*hoapi.CVD{{Name: "1"}}}
 	token := "foo"


### PR DESCRIPTION
Since http status 409 is returned as the operation result instead of `POST /v1/userartifacts/{checksum}/:wait`, checking http status here was actually no-op. For preventing any confusion for reading code in the future, this PR aims for cleaning up related code.