### PR TITLE
Downgrade go for the load_config proto module.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang/go.mod
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang/go.mod
@@ -1,5 +1,5 @@
 module github.com/google/android-cuttlefish/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang
 
-go 1.24.4
+go 1.22
 
 require google.golang.org/protobuf v1.36.6 // indirect


### PR DESCRIPTION
Here the go version is 1.24; since google/cloud-android-orchestration is the intended client for this module and the go version there is 1.22, the versions mismatch and cause errors when building artefacts. It seems to be easiest to just downgrade this to make them match.