### PR TITLE
Introduce PrepareImageDirectory under UserArtifactsManager of HO

### DIFF
--- a/frontend/src/host_orchestrator/api/v1/messages.go
+++ b/frontend/src/host_orchestrator/api/v1/messages.go
@@ -136,6 +136,10 @@ type ListUploadDirectoriesResponse struct {
 
 type StatArtifactResponse struct{}
 
+type PrepareImageDirectoryRequest struct {
+	Checksums []string `json:"checksums"`
+}
+
 type PrepareImageDirectoryResponse struct {
 	// [Output Only]
 	Dir string `json:"dir"`

--- a/frontend/src/host_orchestrator/api/v1/messages.go
+++ b/frontend/src/host_orchestrator/api/v1/messages.go
@@ -136,6 +136,11 @@ type ListUploadDirectoriesResponse struct {
 
 type StatArtifactResponse struct{}
 
+type PrepareImageDirectoryResponse struct {
+	// [Output Only]
+	Dir string `json:"dir"`
+}
+
 type CreateSnapshotRequest struct {
 	// [Optional]
 	// Value must match regex: "^([a-z0-9\\-]+)$".

--- a/frontend/src/host_orchestrator/orchestrator/controller.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller.go
@@ -118,6 +118,8 @@ func (c *Controller) AddRoutes(router *mux.Router) {
 		httpHandler(&statUserArtifactHandler{c.UserArtifactsManager})).Methods("GET")
 	router.Handle("/v1/userartifacts/{checksum}/:extract",
 		httpHandler(&extractUserArtifactHandler{c.OperationManager, c.UserArtifactsManager, true})).Methods("POST")
+	router.Handle("/v1/userartifacts/:prepare_img_dir",
+		httpHandler(&prepareImageDirectoryHandler{c.UserArtifactsManager})).Methods("POST")
 	// Debug endpoints.
 	router.Handle("/_debug/varz", httpHandler(&getDebugVariablesHandler{c.DebugVariablesManager})).Methods("GET")
 	router.Handle("/_debug/statusz", okHandler()).Methods("GET")
@@ -706,6 +708,18 @@ func (h *extractUserArtifactHandler) Handle(r *http.Request) (interface{}, error
 		}
 	}()
 	return op, nil
+}
+
+type prepareImageDirectoryHandler struct {
+	m UserArtifactsManager
+}
+
+func (h *prepareImageDirectoryHandler) Handle(r *http.Request) (interface{}, error) {
+	req := &apiv1.PrepareImageDirectoryRequest{}
+	if err := json.NewDecoder(r.Body).Decode(req); err != nil {
+		return nil, operator.NewBadRequestError("malformed JSON in request", err)
+	}
+	return h.m.PrepareImageDirectory(req.Checksums)
 }
 
 type getDebugVariablesHandler struct {

--- a/frontend/src/host_orchestrator/orchestrator/controller_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller_test.go
@@ -16,6 +16,7 @@ package orchestrator
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -359,6 +360,26 @@ func TestExtractUserArtifactIsHandled(t *testing.T) {
 		t.Fatal(err)
 	}
 	controller := Controller{UserArtifactsManager: &testUAM{}, OperationManager: NewMapOM()}
+
+	makeRequest(rr, req, &controller)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("request was not handled. This failure implies an API breaking change.")
+	}
+}
+
+func TestPrepareImageDirectoryIsHandled(t *testing.T) {
+	rr := httptest.NewRecorder()
+	body, err := json.Marshal(apiv1.PrepareImageDirectoryRequest{Checksums: []string{"foo", "bar"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest("POST", "/v1/userartifacts/:prepare_img_dir", bytes.NewBuffer(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	controller := Controller{UserArtifactsManager: &testUAM{}}
 
 	makeRequest(rr, req, &controller)
 

--- a/frontend/src/host_orchestrator/orchestrator/controller_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller_test.go
@@ -213,6 +213,10 @@ func (testUAM) ExtractArtifact(checksum string) error {
 	return nil
 }
 
+func (testUAM) PrepareImageDirectory(checksums []string) (*apiv1.PrepareImageDirectoryResponse, error) {
+	return nil, nil
+}
+
 func (testUAM) GetDirPath(string) string {
 	return ""
 }


### PR DESCRIPTION
As the concern about suggestion at https://github.com/google/android-cuttlefish/pull/1364 was arisen with passing a list at the string field(`default_build`) of canonical config, this PR is for introducing new HO API to access multiple user artifacts from single directory by creating some symlinks. Also this PR introduces its golang client API, to be used for `cvdr`.

Below is the summary of API structure.

HO REST API endpoint:
```
POST /v1/userartifacts/:prepare_img_dir
```

Request struct of HO REST API:
```
type PrepareImageDirectoryRequest struct {
	Checksums []string `json:"checksums"`
}
```

Response struct of HO REST API:
```
type PrepareImageDirectoryResponse struct {
	Dir string `json:"dir"`
}
```

HO golang client API:
```
// Output string is the directory name under user artifact root dir.
PrepareImageDirectory(filenames []string) (string, error)
```
