### PR TITLE
Set pipefail in generate_font_cc.sh.

### DIFF
--- a/base/cvd/cuttlefish/host/libs/confui/generate_font_cc.sh
+++ b/base/cvd/cuttlefish/host/libs/confui/generate_font_cc.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -o pipefail
+
 fontfile="$1"
 varname="$2"
 


### PR DESCRIPTION
Minor nit, but if xxd is missing or fails, this should cause the build to fail here and not as a linker failure elsewhere.