### PR TITLE
Create types for InstanceCompositeDisk and ApCompositeDisk

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/initialize_instance_composite_disk.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/initialize_instance_composite_disk.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "cuttlefish/common/libs/utils/result.h"
 #include "cuttlefish/host/commands/assemble_cvd/disk/factory_reset_protected.h"
 #include "cuttlefish/host/commands/assemble_cvd/disk/generate_persistent_bootconfig.h"
@@ -24,11 +26,26 @@
 
 namespace cuttlefish {
 
-Result<void> InitializeInstanceCompositeDisk(
-    const CuttlefishConfig&, const CuttlefishConfig::InstanceSpecific&,
-    AutoSetup<FactoryResetProtectedImage::Create>::Type&,
-    AutoSetup<BootConfigPartition::CreateIfNeeded>::Type& bootconfig_partition,
-    AutoSetup<PersistentVbmeta::Create>::Type&,
-    AutoSetup<ApPersistentVbmeta::Create>::Type&);
+class InstanceCompositeDisk {
+ public:
+  static Result<InstanceCompositeDisk> Create(
+      const CuttlefishConfig&, const CuttlefishConfig::InstanceSpecific&,
+      AutoSetup<FactoryResetProtectedImage::Create>::Type&,
+      AutoSetup<BootConfigPartition::CreateIfNeeded>::Type&,
+      AutoSetup<PersistentVbmeta::Create>::Type&);
+
+ private:
+  InstanceCompositeDisk() = default;
+};
+
+class ApCompositeDisk {
+ public:
+  static Result<std::optional<ApCompositeDisk>> Create(
+      const CuttlefishConfig&, const CuttlefishConfig::InstanceSpecific&,
+      AutoSetup<ApPersistentVbmeta::Create>::Type&);
+
+ private:
+  ApCompositeDisk() = default;
+};
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk_flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk_flags.cc
@@ -241,7 +241,8 @@ static fruit::Component<> DiskChangesPerInstanceComponent(
       .install(AutoSetup<BootConfigPartition::CreateIfNeeded>::Component)
       .install(AutoSetup<PersistentVbmeta::Create>::Component)
       .install(AutoSetup<ApPersistentVbmeta::Create>::Component)
-      .install(AutoSetup<InitializeInstanceCompositeDisk>::Component)
+      .install(AutoSetup<InstanceCompositeDisk::Create>::Component)
+      .install(AutoSetup<ApCompositeDisk::Create>::Component)
       .install(AutoSetup<InitializeDataImage>::Component)
       .install(AutoSetup<InitializePflash>::Component)
       .addMultibinding<AutoSetup<BootConfigPartition::CreateIfNeeded>::Type,


### PR DESCRIPTION
Having these types in hand will guarantee that the files they represent on disk have been initialized.

Bug: b/431041073