### PR TITLE
Fix some mistakes in remote_zip.cc

### DIFF
--- a/base/cvd/cuttlefish/host/libs/zip/remote_zip_test.cc
+++ b/base/cvd/cuttlefish/host/libs/zip/remote_zip_test.cc
@@ -75,6 +75,8 @@ class HttpCallback {
             !absl::SimpleAtoi(range_parts[1], &end)) {
           start = 0;
           end = data_.size();
+        } else {
+          end++;  // our `end` is exclusive, but HTTP ranges are inclusive
         }
       }
     }
@@ -91,7 +93,7 @@ class HttpCallback {
                     .value = std::to_string(end - start),
                 },
                 HttpHeader{
-                    .name = "accepts-ranges",
+                    .name = "accept-ranges",
                     .value = "bytes",
                 },
             },


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Range

- The header is named "Accept-Ranges".
- Ranges given are inclusive, not exclusive.
- Successful reads should update the seek location.

Bug: b/423755602