### PR TITLE
Use AutoSetup for super_image_mixer.cc

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -358,9 +358,7 @@ cf_cc_library(
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:fetcher_config",
         "//cuttlefish/host/libs/config:known_paths",
-        "//cuttlefish/host/libs/feature",
         "//libbase",
-        "@fruit",
     ],
 )
 

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk_flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk_flags.cc
@@ -222,7 +222,7 @@ static fruit::Component<> DiskChangesComponent(
       .install(AutoSetup<Gem5ImageUnpacker>::Component)
       // Create esp if necessary
       .install(AutoSetup<InitializeEspImage>::Component)
-      .install(SuperImageRebuilderComponent);
+      .install(AutoSetup<RebuildSuperImageIfNecessary>::Component);
 }
 
 Result<void> DiskImageFlagsVectorization(

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/super_image_mixer.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/super_image_mixer.h
@@ -14,20 +14,16 @@
 // limitations under the License.
 #pragma once
 
-#include <fruit/fruit.h>
+#include <string>
 
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 #include "cuttlefish/host/libs/config/fetcher_config.h"
-#include "cuttlefish/host/libs/feature/feature.h"
 
 namespace cuttlefish {
 
-class SuperImageRebuilder : public SetupFeature {};
+Result<void> RebuildSuperImageIfNecessary(
+    const FetcherConfig&, const CuttlefishConfig::InstanceSpecific&);
 
-fruit::Component<fruit::Required<const FetcherConfig,
-                                 const CuttlefishConfig::InstanceSpecific>,
-                 SuperImageRebuilder>
-SuperImageRebuilderComponent();
 Result<bool> SuperImageNeedsRebuilding(const FetcherConfig& fetcher_config,
                                        const std::string& default_target_zip,
                                        const std::string& system_target_zip);


### PR DESCRIPTION
This makes the public interface a function, which takes it a step closer to extracting from the fruit logic.

Tested with mixing an aosp_cf_x86_64_only_phone-trunk_staging-userdebug build with an aosp_x86_64-trunk_staging-userdebug build.

Bug: b/431075516