### PR TITLE
Store the correct webrtc_device_id on the database

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_streaming_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_streaming_configs.cpp
@@ -18,7 +18,6 @@
 #include <string>
 #include <vector>
 
-#include "cuttlefish/host/commands/assemble_cvd/flags_defaults.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/cf_configs_common.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/load_config.pb.h"
 
@@ -31,7 +30,11 @@ std::string DeviceId(const Instance& instance) {
   if (instance.streaming().has_device_id()) {
     return instance.streaming().device_id();
   } else {
-    return CF_DEFAULTS_WEBRTC_DEVICE_ID;
+    // Leave it empty when not specified in the config so that cvd start has a
+    // chance to pick a good default. Unlike other flags, webrtc_device_id is
+    // always set by the user or cvd and never relies on the default value on
+    // cvd_internal_start.
+    return "";
   }
 }
 


### PR DESCRIPTION
`cvd load` would explicitly pass cvd_internal_start's default value of --webrtc_device_id to `cvd create`. This value includes a placeholder for the instance number which cvd_internal_start replaces, but the value is stored in the instance database with the placeholder intact. This result in the wrong WebUI URL printed by `cvd load` and `cvd fleet`.