### PR TITLE
Improve cvd fetch error messages

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
@@ -238,6 +238,7 @@ cf_cc_library(
     hdrs = ["login.h"],
     deps = [
         "//cuttlefish/common/libs/utils:environment",
+        "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:flag_parser",
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/commands/cvd/cli:command_request",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.cpp
@@ -65,6 +65,7 @@ Result<void> CvdFetchCommandHandler::Handle(const CommandRequest& request) {
 
   Result<void> result = FetchCvdMain(flags);
   if (flags.build_api_flags.enable_caching) {
+    LOG(DEBUG) << "Running automatic cache cleanup";
     const std::string cache_directory = PerUserCacheDir();
     const PruneResult prune_result = CF_EXPECTF(
         PruneCache(cache_directory, flags.build_api_flags.max_cache_size_gb),

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/login.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/login.cpp
@@ -23,6 +23,7 @@
 #include <android-base/strings.h>
 
 #include "cuttlefish/common/libs/utils/environment.h"
+#include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/flag_parser.h"
 #include "cuttlefish/common/libs/utils/result.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
@@ -89,7 +90,13 @@ class CvdLoginCommand : public CvdCommandHandler {
   bool ShouldInterceptHelp() const override { return true; }
 
   Result<std::string> DetailedHelp(std::vector<std::string>&) const override {
-    return kHelpMessage;
+    std::string google_appendix;
+    if (DirectoryExists("/google")) {
+      google_appendix =
+          "\nIf running on corp, use the wrapper script in "
+          "google3/cloud/android/login";
+    }
+    return kHelpMessage + google_appendix;
   }
 };
 

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/BUILD.bazel
@@ -72,6 +72,8 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/commands/cvd/fetch:fetch_cvd_parser",
         "//cuttlefish/host/commands/cvd/utils:common",
+        "//cuttlefish/host/libs/web:android_build_api",
+        "//cuttlefish/host/libs/web:android_build_url",
         "//cuttlefish/host/libs/web:build_api",
         "//cuttlefish/host/libs/web:caching_build_api",
         "//cuttlefish/host/libs/web:credential_source",

--- a/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
@@ -28,13 +28,13 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/libs/web:android_build",
         "//cuttlefish/host/libs/web:android_build_string",
+        "//cuttlefish/host/libs/web:android_build_url",
         "//cuttlefish/host/libs/web:build_api",
         "//cuttlefish/host/libs/web:credential_source",
         "//cuttlefish/host/libs/web/cas:cas_downloader",
         "//cuttlefish/host/libs/web/http_client",
         "//cuttlefish/host/libs/web/http_client:http_file",
         "//cuttlefish/host/libs/web/http_client:http_json",
-        "//cuttlefish/host/libs/web/http_client:url_escape",
         "//libbase",
         "@jsoncpp",
     ],
@@ -62,6 +62,17 @@ cf_cc_test(
         "//cuttlefish/host/libs/web:android_build_string",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
+    ],
+)
+
+cf_cc_library(
+    name = "android_build_url",
+    srcs = ["android_build_url.cpp"],
+    hdrs = ["android_build_url.h"],
+    deps = [
+        "//cuttlefish/common/libs/utils:result",
+        "//cuttlefish/host/libs/web/http_client:url_escape",
+        "@fmt",
     ],
 )
 

--- a/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
@@ -24,6 +24,7 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:environment",
         "//cuttlefish/common/libs/utils:files",
+        "//cuttlefish/common/libs/utils:json",
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/libs/web:android_build",
         "//cuttlefish/host/libs/web:android_build_string",

--- a/base/cvd/cuttlefish/host/libs/web/android_build_api.h
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_api.h
@@ -25,6 +25,7 @@
 #include "cuttlefish/common/libs/utils/result.h"
 #include "cuttlefish/host/libs/web/android_build.h"
 #include "cuttlefish/host/libs/web/android_build_string.h"
+#include "cuttlefish/host/libs/web/android_build_url.h"
 #include "cuttlefish/host/libs/web/build_api.h"
 #include "cuttlefish/host/libs/web/cas/cas_downloader.h"
 #include "cuttlefish/host/libs/web/credential_source.h"
@@ -102,10 +103,8 @@ class AndroidBuildApi : public BuildApi {
 
   HttpClient& http_client;
   CredentialSource* credential_source;
-  std::string api_key_;
+  AndroidBuildUrl android_build_url_;
   std::chrono::seconds retry_period_;
-  std::string api_base_url_;
-  std::string project_id_;
   CasDownloader* cas_downloader_;
 };
 

--- a/base/cvd/cuttlefish/host/libs/web/android_build_api.h
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_api.h
@@ -42,8 +42,8 @@ class AndroidBuildApi : public BuildApi {
   AndroidBuildApi(AndroidBuildApi&&) = delete;
   virtual ~AndroidBuildApi() = default;
   AndroidBuildApi(HttpClient& http_client, CredentialSource* credential_source,
-                  std::string api_key, std::chrono::seconds retry_period,
-                  std::string api_base_url, std::string project_id,
+                  AndroidBuildUrl* android_build_url,
+                  std::chrono::seconds retry_period,
                   CasDownloader* cas_downloader = nullptr);
 
   Result<Build> GetBuild(const BuildString& build_string) override;
@@ -103,7 +103,7 @@ class AndroidBuildApi : public BuildApi {
 
   HttpClient& http_client;
   CredentialSource* credential_source;
-  AndroidBuildUrl android_build_url_;
+  AndroidBuildUrl* android_build_url_;
   std::chrono::seconds retry_period_;
   CasDownloader* cas_downloader_;
 };

--- a/base/cvd/cuttlefish/host/libs/web/android_build_url.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_url.cpp
@@ -1,0 +1,185 @@
+//
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cuttlefish/host/libs/web/android_build_url.h"
+
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <fmt/core.h>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
+#include "cuttlefish/host/libs/web/http_client/url_escape.h"
+
+namespace cuttlefish {
+
+namespace {
+
+class UrlBuilder {
+ public:
+  static UrlBuilder GetLatestBuildIdBaseUrl(std::string_view api_base) {
+    return UrlBuilder(fmt::format("{}/builds", api_base));
+  }
+
+  static UrlBuilder GetBuildStatusBaseUrl(std::string_view api_base,
+                                          std::string_view id,
+                                          std::string_view target) {
+    return UrlBuilder(fmt::format("{}/builds/{}/{}", api_base, UrlEscape(id),
+                                  UrlEscape(target)));
+  }
+
+  static UrlBuilder GetProductNameBaseUrl(std::string_view api_base,
+                                          std::string_view id,
+                                          std::string_view target) {
+    return UrlBuilder(fmt::format("{}/builds/{}/{}", api_base, UrlEscape(id),
+                                  UrlEscape(target)));
+  }
+
+  static UrlBuilder GetArtifactBaseUrl(std::string_view api_base,
+                                       std::string_view id,
+                                       std::string_view target) {
+    return UrlBuilder(fmt::format("{}/builds/{}/{}/attempts/latest/artifacts",
+                                  api_base, UrlEscape(id), UrlEscape(target)));
+  }
+
+  static UrlBuilder GetArtifactDownloadBaseUrl(std::string_view api_base,
+                                               std::string_view id,
+                                               std::string_view target,
+                                               std::string_view artifact) {
+    return UrlBuilder(fmt::format(
+        "{}/builds/{}/{}/attempts/latest/artifacts/{}/url", api_base,
+        UrlEscape(id), UrlEscape(target), UrlEscape(artifact)));
+  }
+
+  void AddQueryParameter(std::string_view key, std::string_view value) {
+    // key is not escaped because it should be a fixed parameter of the AB API
+    query_string_.push_back(fmt::format("{}={}", key, UrlEscape(value)));
+  }
+
+  void AddApiKeyAndProjectId(std::string_view api_key,
+                             std::string_view project_id) {
+    if (!api_key.empty()) {
+      AddQueryParameter("key", api_key);
+    }
+    if (!project_id.empty()) {
+      AddQueryParameter("$userProject", project_id);
+    }
+  }
+
+  std::string GetUrl() {
+    std::stringstream result;
+    result << base_url_;
+    if (!query_string_.empty()) {
+      fmt::print(result, "?{}", fmt::join(query_string_, "&"));
+    }
+    return result.str();
+  }
+
+ private:
+  UrlBuilder(std::string base_url) : base_url_(base_url) {}
+
+  std::string base_url_;
+  std::vector<std::string> query_string_;
+};
+
+std::string BuildNameRegexp(
+    const std::vector<std::string>& artifact_filenames) {
+  // surrounding with \Q and \E treats the text literally to avoid
+  // characters being treated as regex
+  auto it = artifact_filenames.begin();
+  std::string name_regex = "^\\Q" + *it + "\\E$";
+  std::string result = name_regex;
+  ++it;
+  for (const auto end = artifact_filenames.end(); it != end; ++it) {
+    name_regex = "^\\Q" + *it + "\\E$";
+    result += "|" + name_regex;
+  }
+  return result;
+}
+
+}  // namespace
+
+AndroidBuildUrl::AndroidBuildUrl(std::string api_base_url, std::string api_key,
+                                 std::string project_id)
+    : api_base_url_(std::move(api_base_url)),
+      api_key_(std::move(api_key)),
+      project_id_(std::move(project_id)) {}
+
+std::string AndroidBuildUrl::GetLatestBuildIdUrl(std::string_view branch,
+                                                 std::string_view target) {
+  UrlBuilder builder = UrlBuilder::GetLatestBuildIdBaseUrl(api_base_url_);
+  builder.AddQueryParameter("buildAttemptStatus", "complete");
+  builder.AddQueryParameter("buildType", "submitted");
+  builder.AddQueryParameter("maxResults", "1");
+  builder.AddQueryParameter("successful", "true");
+  builder.AddQueryParameter("branch", branch);
+  builder.AddQueryParameter("target", target);
+  builder.AddApiKeyAndProjectId(api_key_, project_id_);
+
+  return builder.GetUrl();
+}
+
+std::string AndroidBuildUrl::GetBuildStatusUrl(std::string_view id,
+                                               std::string_view target) {
+  UrlBuilder builder =
+      UrlBuilder::GetBuildStatusBaseUrl(api_base_url_, id, target);
+  builder.AddApiKeyAndProjectId(api_key_, project_id_);
+
+  return builder.GetUrl();
+}
+
+std::string AndroidBuildUrl::GetProductNameUrl(std::string_view id,
+                                               std::string_view target) {
+  UrlBuilder builder =
+      UrlBuilder::GetProductNameBaseUrl(api_base_url_, id, target);
+  builder.AddApiKeyAndProjectId(api_key_, project_id_);
+
+  return builder.GetUrl();
+}
+
+std::string AndroidBuildUrl::GetArtifactUrl(
+    std::string_view id, std::string_view target,
+    const std::vector<std::string>& artifact_filenames,
+    std::string_view page_token) {
+  UrlBuilder builder =
+      UrlBuilder::GetArtifactBaseUrl(api_base_url_, id, target);
+  builder.AddQueryParameter("maxResults", "100");
+  if (!artifact_filenames.empty()) {
+    builder.AddQueryParameter("nameRegexp",
+                              BuildNameRegexp(artifact_filenames));
+  }
+  if (!page_token.empty()) {
+    builder.AddQueryParameter("pageToken", page_token);
+  }
+  builder.AddApiKeyAndProjectId(api_key_, project_id_);
+
+  return builder.GetUrl();
+}
+
+std::string AndroidBuildUrl::GetArtifactDownloadUrl(std::string_view id,
+                                                    std::string_view target,
+                                                    std::string_view artifact) {
+  UrlBuilder builder = UrlBuilder::GetArtifactDownloadBaseUrl(api_base_url_, id,
+                                                              target, artifact);
+  builder.AddApiKeyAndProjectId(api_key_, project_id_);
+
+  return builder.GetUrl();
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/web/android_build_url.h
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_url.h
@@ -1,0 +1,46 @@
+//
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace cuttlefish {
+
+class AndroidBuildUrl {
+ public:
+  AndroidBuildUrl(std::string api_base_url, std::string api_key,
+                  std::string project_id);
+
+  std::string GetLatestBuildIdUrl(std::string_view branch,
+                                  std::string_view target);
+  std::string GetBuildStatusUrl(std::string_view id, std::string_view target);
+  std::string GetProductNameUrl(std::string_view id, std::string_view target);
+  std::string GetArtifactUrl(std::string_view id, std::string_view target,
+                             const std::vector<std::string>& artifact_filenames,
+                             std::string_view page_token);
+  std::string GetArtifactDownloadUrl(std::string_view id,
+                                     std::string_view target,
+                                     std::string_view artifact);
+
+ private:
+  std::string api_base_url_;
+  std::string api_key_;
+  std::string project_id_;
+};
+
+}  // namespace cuttlefish


### PR DESCRIPTION
and try to clean up the CLI output by not filling it with long API error responses.

Also cleanups to `AndroidBuildApi` to catch more error cases, lessen duplication, and in case we need to update API URLs in the future.  See commit messages for specifics.

Bug: 427744621