### PR TITLE
Introduce ImageDirectoriesManager in Host Orchestrator

### DIFF
--- a/frontend/src/host_orchestrator/api/v1/messages.go
+++ b/frontend/src/host_orchestrator/api/v1/messages.go
@@ -136,6 +136,11 @@ type ListUploadDirectoriesResponse struct {
 
 type StatArtifactResponse struct{}
 
+type CreateImageDirectoryResponse struct {
+	// [Output Only] Identifier of created image directory.
+	ID string `json:"name"`
+}
+
 type CreateSnapshotRequest struct {
 	// [Optional]
 	// Value must match regex: "^([a-z0-9\\-]+)$".

--- a/frontend/src/host_orchestrator/main.go
+++ b/frontend/src/host_orchestrator/main.go
@@ -134,6 +134,10 @@ func main() {
 		log.Fatalf("Unable to prepare UserArtifactsManager: %v", err)
 	}
 	defer os.RemoveAll(uam.WorkDir)
+	idmOpts := orchestrator.ImageDirectoriesManagerOpts{
+		RootDir: filepath.Join(*imRootDir, "image_dirs"),
+	}
+	idm := orchestrator.NewImageDirectoriesManagerImpl(idmOpts)
 	debugStaticVars := debug.StaticVariables{}
 	debugVarsManager := debug.NewVariablesManager(debugStaticVars)
 	imController := orchestrator.Controller{
@@ -144,10 +148,11 @@ func main() {
 				UseGCEMetadata: *buildAPICredsUseGCEMetadata,
 			},
 		},
-		OperationManager:      om,
-		WaitOperationDuration: 2 * time.Minute,
-		UserArtifactsManager:  uam,
-		DebugVariablesManager: debugVarsManager,
+		OperationManager:        om,
+		WaitOperationDuration:   2 * time.Minute,
+		UserArtifactsManager:    uam,
+		ImageDirectoriesManager: idm,
+		DebugVariablesManager:   debugVarsManager,
 	}
 	proxy := newOperatorProxy(*operatorPort)
 

--- a/frontend/src/host_orchestrator/orchestrator/controller_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller_test.go
@@ -221,6 +221,12 @@ func (testUAM) ExtractArtifactWithDir(string, string) error {
 	return nil
 }
 
+type testIDM struct{}
+
+func (testIDM) CreateImageDirectory() (string, error) {
+	return "", nil
+}
+
 func TestCreateUploadDirectoryIsHandled(t *testing.T) {
 	rr := httptest.NewRecorder()
 	req, err := http.NewRequest("POST", "/userartifacts", strings.NewReader("{}"))
@@ -355,6 +361,21 @@ func TestExtractUserArtifactIsHandled(t *testing.T) {
 		t.Fatal(err)
 	}
 	controller := Controller{UserArtifactsManager: &testUAM{}, OperationManager: NewMapOM()}
+
+	makeRequest(rr, req, &controller)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("request was not handled. This failure implies an API breaking change.")
+	}
+}
+
+func TestCreateImageDirectoryIsHandled(t *testing.T) {
+	rr := httptest.NewRecorder()
+	req, err := http.NewRequest("POST", "/cvd_imgs_dirs", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller := Controller{ImageDirectoriesManager: &testIDM{}, OperationManager: NewMapOM()}
 
 	makeRequest(rr, req, &controller)
 

--- a/frontend/src/host_orchestrator/orchestrator/imagedirectories.go
+++ b/frontend/src/host_orchestrator/orchestrator/imagedirectories.go
@@ -1,0 +1,53 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/google/uuid"
+)
+
+type ImageDirectoriesManager interface {
+	// Create an empty image directory.
+	CreateImageDirectory() (string, error)
+}
+
+// Options for creating instances of ImageDirectoriesManager implementations.
+type ImageDirectoriesManagerOpts struct {
+	// Root directory for storing image directories.
+	RootDir string
+}
+
+// An implementation of the ImageDirectoriesManager interface.
+type ImageDirectoriesManagerImpl struct {
+	ImageDirectoriesManagerOpts
+}
+
+func NewImageDirectoriesManagerImpl(opts ImageDirectoriesManagerOpts) *ImageDirectoriesManagerImpl {
+	return &ImageDirectoriesManagerImpl{ImageDirectoriesManagerOpts: opts}
+}
+
+func (m *ImageDirectoriesManagerImpl) CreateImageDirectory() (string, error) {
+	if err := createDir(m.RootDir); err != nil {
+		return "", fmt.Errorf("failed to create root directory for storing image directories: %w", err)
+	}
+	dirname := uuid.New().String()
+	if err := createDir(filepath.Join(m.RootDir, dirname)); err != nil {
+		return "", fmt.Errorf("failed to create an image directory: %w", err)
+	}
+	return dirname, nil
+}

--- a/frontend/src/host_orchestrator/orchestrator/imagedirectories_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/imagedirectories_test.go
@@ -1,0 +1,38 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	orchtesting "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/testing"
+)
+
+func TestCreateImageDirectory(t *testing.T) {
+	rootDir := orchtesting.TempDir(t)
+	defer orchtesting.RemoveDir(t, rootDir)
+	opts := ImageDirectoriesManagerOpts{RootDir: rootDir}
+	idm := NewImageDirectoriesManagerImpl(opts)
+
+	dir, err := idm.CreateImageDirectory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(rootDir, dir)); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/frontend/src/libhoclient/host_orchestrator_client.go
+++ b/frontend/src/libhoclient/host_orchestrator_client.go
@@ -120,6 +120,12 @@ type UserArtifactsClient interface {
 	ExtractFile(uploadDir string, filename string) (*hoapi.Operation, error)
 }
 
+// Manage image directories created by the user.
+type ImageDirectoriesClient interface {
+	// Create an empty image directory.
+	CreateImageDirectory() (*hoapi.Operation, error)
+}
+
 // Operations that could be performend on a given instance.
 type InstanceOperationsClient interface {
 	// Create cvd bugreport.
@@ -160,6 +166,7 @@ type SnapshotsClient interface {
 type HostOrchestratorClient interface {
 	InstancesClient
 	UserArtifactsClient
+	ImageDirectoriesClient
 	InstanceOperationsClient
 	InstanceConnectionsClient
 	OperationsClient
@@ -604,6 +611,14 @@ func (c *HostOrchestratorClientImpl) ExtractArtifact(filename string) (*hoapi.Op
 	}
 	op := &hoapi.Operation{}
 	if err := c.HTTPHelper.NewPostRequest("/v1/userartifacts/"+checksum+"/:extract", nil).JSONResDo(op); err != nil {
+		return nil, err
+	}
+	return op, nil
+}
+
+func (c *HostOrchestratorClientImpl) CreateImageDirectory() (*hoapi.Operation, error) {
+	op := &hoapi.Operation{}
+	if err := c.HTTPHelper.NewPostRequest("/cvd_imgs_dirs", nil).JSONResDo(op); err != nil {
 		return nil, err
 	}
 	return op, nil

--- a/frontend/src/libhoclient/host_orchestrator_client_test.go
+++ b/frontend/src/libhoclient/host_orchestrator_client_test.go
@@ -222,6 +222,26 @@ func TestExtractArtifactSucceeds(t *testing.T) {
 	}
 }
 
+func TestCreateImageDirectorySucceeds(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch ep := r.Method + " " + r.URL.Path; ep {
+		case "POST /cvd_imgs_dirs":
+			writeOK(w, hoapi.Operation{Name: "foo"})
+		default:
+			t.Fatal("unexpected endpoint: " + ep)
+		}
+	}))
+	defer ts.Close()
+	client := NewHostOrchestratorClient(ts.URL)
+
+	expected := &hoapi.Operation{Name: "foo"}
+	if op, err := client.CreateImageDirectory(); err != nil {
+		t.Fatal(err)
+	} else if diff := cmp.Diff(expected, op); diff != "" {
+		t.Fatalf("response mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestCreateCVDWithUserProjectOverride(t *testing.T) {
 	fakeRes := &hoapi.CreateCVDResponse{CVDs: []*hoapi.CVD{{Name: "1"}}}
 	token := "foo"


### PR DESCRIPTION
From https://github.com/google/android-cuttlefish/pull/1375#pullrequestreview-2999123088, there was a discussion for introducing API set around managing image directories. As the result of discussion, 5 APIs is getting introduced into HO.

- [P1] `POST /cvd_imgs_dirs`: Create an empty image directory. Reply `apiv1.Operation` in advance. As the operation result, ID is returned.
- [P1] `PUT /cvd_img_dirs/{id}`: Create or modify symlink under image directory. Reply `apiv1.Operation` in advance. If artifact doesn't exist, return 404. If symlink already exists, modify it.
- [P2] `GET /cvd_imgs_dirs`: List IDs of image directories.
- [P2] `DELETE /cvd_img_dirs/{id}`: Delete the image directory. Reply `apiv1.Operation` in advance.
- [P2] `GET /cvd_img_dirs/{id}`: Describe details of the image directories.

This PR introduces HO API `POST /cvd_imgs_dirs` and its corresponding golang client API. About the rest of APIs listed above, those will be implemented in different PRs.