### PR TITLE
cuttlefish: delete dead gfx code

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
@@ -76,7 +76,7 @@ DEFINE_vec(use_random_serial, fmt::format("{}", CF_DEFAULTS_USE_RANDOM_SERIAL),
 DEFINE_vec(vm_manager, CF_DEFAULTS_VM_MANAGER,
               "What virtual machine manager to use, one of {qemu_cli, crosvm}");
 DEFINE_vec(gpu_mode, CF_DEFAULTS_GPU_MODE,
-           "What gpu configuration to use, one of {auto, custom, drm_virgl, "
+           "What gpu configuration to use, one of {auto, custom, "
            "gfxstream, gfxstream_guest_angle, "
            "gfxstream_guest_angle_host_swiftshader, "
            "gfxstream_guest_angle_host_lavapipe, guest_swiftshader}");

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -273,11 +273,6 @@ Result<std::vector<GuestConfig>> ReadGuestConfig(
         GetAndroidInfoConfig(instance_android_info_txt, "vhost_user_vsock");
     guest_config.vhost_user_vsock = res_vhost_user_vsock.value_or("") == "true";
 
-    auto res_prefer_drm_virgl_when_supported = GetAndroidInfoConfig(
-        instance_android_info_txt, "prefer_drm_virgl_when_supported");
-    guest_config.prefer_drm_virgl_when_supported =
-        res_prefer_drm_virgl_when_supported.value_or("") == "true";
-
     auto res_ti50_emulator =
         GetAndroidInfoConfig(instance_android_info_txt, "ti50_emulator");
     guest_config.ti50_emulator = res_ti50_emulator.value_or("");
@@ -1325,17 +1320,9 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
     }
 
     instance.set_hwcomposer(hwcomposer_vec[instance_index]);
-    if (!hwcomposer_vec[instance_index].empty()) {
-      if (hwcomposer_vec[instance_index] == kHwComposerRanchu) {
-        CF_EXPECT(gpu_mode != kGpuModeDrmVirgl,
-                  "ranchu hwcomposer not supported with --gpu_mode=drm_virgl");
-      }
-    }
 
     if (hwcomposer_vec[instance_index] == kHwComposerAuto) {
-      if (gpu_mode == kGpuModeDrmVirgl) {
-        instance.set_hwcomposer(kHwComposerDrm);
-      } else if (gpu_mode == kGpuModeNone) {
+      if (gpu_mode == kGpuModeNone) {
         instance.set_hwcomposer(kHwComposerNone);
       } else {
         instance.set_hwcomposer(kHwComposerRanchu);

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/graphics_flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/graphics_flags.cc
@@ -52,9 +52,6 @@ enum class RenderingMode {
 
 CF_UNUSED_ON_MACOS
 Result<RenderingMode> GetRenderingMode(const std::string& mode) {
-  if (mode == std::string(kGpuModeDrmVirgl)) {
-    return RenderingMode::kVirglRenderer;
-  }
   if (mode == std::string(kGpuModeGfxstream)) {
     return RenderingMode::kGfxstream;
   }
@@ -262,8 +259,7 @@ Result<std::string> SelectGpuMode(
     const std::string& gpu_mode_arg, VmmMode vmm,
     const GuestConfig& guest_config,
     const gfxstream::proto::GraphicsAvailability& graphics_availability) {
-  if (gpu_mode_arg != kGpuModeAuto && gpu_mode_arg != kGpuModeDrmVirgl &&
-      gpu_mode_arg != kGpuModeCustom && gpu_mode_arg != kGpuModeGfxstream &&
+  if (gpu_mode_arg != kGpuModeCustom && gpu_mode_arg != kGpuModeGfxstream &&
       gpu_mode_arg != kGpuModeGfxstreamGuestAngle &&
       gpu_mode_arg != kGpuModeGfxstreamGuestAngleHostSwiftShader &&
       gpu_mode_arg != kGpuModeGfxstreamGuestAngleHostLavapipe &&
@@ -291,9 +287,6 @@ Result<std::string> SelectGpuMode(
       if (vmm == VmmMode::kQemu && !UseQemuPrebuilt()) {
         LOG(INFO) << "Not using QEMU prebuilt (QEMU 8+): selecting guest swiftshader";
         return kGpuModeGuestSwiftshader;
-      } else if (guest_config.prefer_drm_virgl_when_supported) {
-        LOG(INFO) << "GPU mode from guest config: drm_virgl";
-        return kGpuModeDrmVirgl;
       } else if (!guest_config.gfxstream_supported) {
         LOG(INFO) << "GPU auto mode: guest does not support gfxstream, "
                      "enabling --gpu_mode=guest_swiftshader";
@@ -311,8 +304,7 @@ Result<std::string> SelectGpuMode(
   }
 
   if (gpu_mode_arg == kGpuModeGfxstream ||
-      gpu_mode_arg == kGpuModeGfxstreamGuestAngle ||
-      gpu_mode_arg == kGpuModeDrmVirgl) {
+      gpu_mode_arg == kGpuModeGfxstreamGuestAngle) {
     if (!ShouldEnableAcceleratedRendering(graphics_availability)) {
       LOG(ERROR) << "--gpu_mode=" << gpu_mode_arg
                  << " was requested but the prerequisites for accelerated "
@@ -601,7 +593,7 @@ Result<std::string> ConfigureGpuSettings(
   (void)guest_config;
   CF_EXPECT(gpu_mode_arg == kGpuModeAuto ||
             gpu_mode_arg == kGpuModeGuestSwiftshader ||
-            gpu_mode_arg == kGpuModeDrmVirgl || gpu_mode_arg == kGpuModeNone);
+            gpu_mode_arg == kGpuModeNone);
   std::string gpu_mode = gpu_mode_arg;
   if (gpu_mode == kGpuModeAuto) {
     gpu_mode = kGpuModeGuestSwiftshader;

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/guest_config.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/guest_config.h
@@ -33,7 +33,6 @@ struct GuestConfig {
   bool gfxstream_gl_program_binary_link_status_supported = false;
   bool vhost_user_vsock = false;
   bool supports_bgra_framebuffers = false;
-  bool prefer_drm_virgl_when_supported = false;
   bool mouse_supported = false;
   std::string ti50_emulator;
   std::optional<std::string> custom_keyboard_config;

--- a/base/cvd/cuttlefish/host/frontend/webrtc/doc/graphics.dot
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/doc/graphics.dot
@@ -5,7 +5,7 @@ digraph {
     browser [label = "Browser"]
     vnc_client [label = "VNC Client"]
   }
-  host_renderer [label = < <font color="blue">gfxstream</font> / virglrenderer >]
+  host_renderer [label = < <font color="blue">gfxstream</font>>]
   run_cvd
   wayland_socket [label = "internal/frames.sock", shape = "rectangle"]
   webrtc [label = < <b>webrtc</b> >, penwidth = 2]

--- a/base/cvd/cuttlefish/host/frontend/webrtc/doc/graphics.svg
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/doc/graphics.svg
@@ -32,7 +32,6 @@
 <ellipse fill="none" stroke="black" cx="167" cy="-377" rx="104.78" ry="18"/>
 <text text-anchor="start" x="94.5" y="-374.3" font-family="Times,serif" font-size="14.00"> </text>
 <text text-anchor="start" x="98.5" y="-374.3" font-family="Times,serif" font-size="14.00" fill="blue">gfxstream</text>
-<text text-anchor="start" x="153.5" y="-374.3" font-family="Times,serif" font-size="14.00"> / virglrenderer </text>
 </g>
 <!-- vmm -->
 <g id="node7" class="node">

--- a/base/cvd/cuttlefish/host/frontend/webrtc/main.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/main.cpp
@@ -354,9 +354,6 @@ int CuttlefishMain() {
   std::string user_friendly_gpu_mode;
   if (instance.gpu_mode() == kGpuModeGuestSwiftshader) {
     user_friendly_gpu_mode = "SwiftShader (Guest CPU Rendering)";
-  } else if (instance.gpu_mode() == kGpuModeDrmVirgl) {
-    user_friendly_gpu_mode =
-        "VirglRenderer (Accelerated Rendering using Host OpenGL)";
   } else if (instance.gpu_mode() == kGpuModeGfxstream) {
     user_friendly_gpu_mode =
         "Gfxstream (Accelerated Rendering using Host OpenGL and Vulkan)";

--- a/base/cvd/cuttlefish/host/libs/config/config_constants.h
+++ b/base/cvd/cuttlefish/host/libs/config/config_constants.h
@@ -68,7 +68,6 @@ inline constexpr char kVhostUserVsockModeFalse[] = "false";
 
 inline constexpr char kGpuModeAuto[] = "auto";
 inline constexpr char kGpuModeCustom[] = "custom";
-inline constexpr char kGpuModeDrmVirgl[] = "drm_virgl";
 inline constexpr char kGpuModeGfxstream[] = "gfxstream";
 inline constexpr char kGpuModeGfxstreamGuestAngle[] = "gfxstream_guest_angle";
 inline constexpr char kGpuModeGfxstreamGuestAngleHostSwiftShader[] =

--- a/base/cvd/cuttlefish/host/libs/screen_connector/screen_connector.h
+++ b/base/cvd/cuttlefish/host/libs/screen_connector/screen_connector.h
@@ -66,7 +66,6 @@ class ScreenConnector : public ScreenConnectorFrameRenderer {
     auto instance = config->ForDefaultInstance();
     std::unordered_set<std::string_view> valid_gpu_modes{
         cuttlefish::kGpuModeCustom,
-        cuttlefish::kGpuModeDrmVirgl,
         cuttlefish::kGpuModeGfxstream,
         cuttlefish::kGpuModeGfxstreamGuestAngle,
         cuttlefish::kGpuModeGfxstreamGuestAngleHostSwiftShader,

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
@@ -83,19 +83,6 @@ CrosvmManager::ConfigureGraphics(
         {"androidboot.hardware.vulkan", "pastel"},
         {"androidboot.opengles.version", "196609"},  // OpenGL ES 3.1
     };
-  } else if (instance.gpu_mode() == kGpuModeDrmVirgl) {
-    bootconfig_args = {
-        {"androidboot.cpuvulkan.version", "0"},
-        {"androidboot.hardware.gralloc", "minigbm"},
-        {"androidboot.hardware.hwcomposer", "ranchu"},
-        {"androidboot.hardware.hwcomposer.mode", "client"},
-        {"androidboot.hardware.hwcomposer.display_finder_mode", "drm"},
-        {"androidboot.hardware.hwcomposer.display_framebuffer_format",
-         instance.guest_uses_bgra_framebuffers() ? "bgra" : "rgba"},
-        {"androidboot.hardware.egl", "mesa"},
-        // No "hardware" Vulkan support, yet
-        {"androidboot.opengles.version", "196608"},  // OpenGL ES 3.0
-    };
   } else if (instance.gpu_mode() == kGpuModeGfxstream ||
              instance.gpu_mode() == kGpuModeGfxstreamGuestAngle ||
              instance.gpu_mode() ==
@@ -461,10 +448,6 @@ Result<void> ConfigureGpu(const CuttlefishConfig& config, Command* crosvm_cmd) {
   if (gpu_mode == kGpuModeGuestSwiftshader) {
     crosvm_cmd->AddParameter("--gpu=", gpu_displays_string, "backend=2D",
                              gpu_common_string);
-  } else if (gpu_mode == kGpuModeDrmVirgl) {
-    crosvm_cmd->AddParameter("--gpu=", gpu_displays_string,
-                             "backend=virglrenderer,context-types=virgl2",
-                             gpu_common_3d_string);
   } else if (gpu_mode == kGpuModeGfxstream) {
     crosvm_cmd->AddParameter(
         "--gpu=", gpu_displays_string,

--- a/base/cvd/cuttlefish/host/libs/vm_manager/qemu_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/qemu_manager.cpp
@@ -145,20 +145,6 @@ QemuManager::ConfigureGraphics(
         // OpenGL ES 3.1
         {"androidboot.opengles.version", "196609"},
     };
-  } else if (gpu_mode == kGpuModeDrmVirgl) {
-    bootconfig_args = {
-        {"androidboot.cpuvulkan.version", "0"},
-        {"androidboot.hardware.gralloc", "minigbm"},
-        {"androidboot.hardware.hwcomposer", "ranchu"},
-        {"androidboot.hardware.hwcomposer.mode", "client"},
-        {"androidboot.hardware.hwcomposer.display_finder_mode", "drm"},
-        {"androidboot.hardware.hwcomposer.display_framebuffer_format",
-         instance.guest_uses_bgra_framebuffers() ? "bgra" : "rgba"},
-        {"androidboot.hardware.egl", "mesa"},
-        // No "hardware" Vulkan support, yet
-        // OpenGL ES 3.0
-        {"androidboot.opengles.version", "196608"},
-    };
   } else if (gpu_mode == kGpuModeGfxstream ||
              gpu_mode == kGpuModeGfxstreamGuestAngle ||
              gpu_mode == kGpuModeGfxstreamGuestAngleHostSwiftShader ||
@@ -446,17 +432,10 @@ Result<std::vector<MonitorCommand>> QemuManager::StartCommands(
   qemu_cmd.AddParameter("chardev=charmonitor,id=monitor,mode=control");
 
   auto gpu_mode = instance.gpu_mode();
-  if (gpu_mode == kGpuModeDrmVirgl) {
-    qemu_cmd.AddParameter("-display");
-    qemu_cmd.AddParameter("egl-headless");
-
-    qemu_cmd.AddParameter("-vnc");
-    qemu_cmd.AddParameter("127.0.0.1:", instance.qemu_vnc_server_port());
-  } else if (gpu_mode == kGpuModeGuestSwiftshader ||
-             gpu_mode == kGpuModeGfxstream ||
-             gpu_mode == kGpuModeGfxstreamGuestAngle ||
-             gpu_mode == kGpuModeGfxstreamGuestAngleHostSwiftShader ||
-             gpu_mode == kGpuModeGfxstreamGuestAngleHostLavapipe) {
+  if (gpu_mode == kGpuModeGuestSwiftshader || gpu_mode == kGpuModeGfxstream ||
+      gpu_mode == kGpuModeGfxstreamGuestAngle ||
+      gpu_mode == kGpuModeGfxstreamGuestAngleHostSwiftShader ||
+      gpu_mode == kGpuModeGfxstreamGuestAngleHostLavapipe) {
     qemu_cmd.AddParameter("-vnc");
     qemu_cmd.AddParameter("127.0.0.1:", instance.qemu_vnc_server_port());
   } else {
@@ -474,8 +453,6 @@ Result<std::vector<MonitorCommand>> QemuManager::StartCommands(
     std::string gpu_device;
     if (gpu_mode == kGpuModeGuestSwiftshader || qemu_version.first < 6) {
       gpu_device = "virtio-gpu-pci";
-    } else if (gpu_mode == kGpuModeDrmVirgl) {
-      gpu_device = "virtio-gpu-gl-pci";
     } else if (gpu_mode == kGpuModeGfxstream) {
       gpu_device =
           "virtio-gpu-rutabaga,x-gfxstream-gles=on,gfxstream-vulkan=on,"


### PR DESCRIPTION
With the entire industry moving to Vulkan, it makes sense to delete OpenGL-based renderers whenever possible.  virgl was deleted from AOSP in 2024, so this Cuttlefish code path is essentially dead code anyways.

We hope to delete gfxstream GLES in the near future, but users still rely on it.