### PR TITLE
Introduce HO API `PUT /cvd_imgs_dirs/{id}`

### DIFF
--- a/frontend/src/host_orchestrator/api/v1/messages.go
+++ b/frontend/src/host_orchestrator/api/v1/messages.go
@@ -141,6 +141,10 @@ type CreateImageDirectoryResponse struct {
 	ID string `json:"name"`
 }
 
+type UpdateImageDirectoryRequest struct {
+	UserArtifactChecksum string `json:"user_artifact_checksum"`
+}
+
 type CreateSnapshotRequest struct {
 	// [Optional]
 	// Value must match regex: "^([a-z0-9\\-]+)$".

--- a/frontend/src/host_orchestrator/orchestrator/controller_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller_test.go
@@ -16,6 +16,7 @@ package orchestrator
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -388,6 +389,26 @@ func TestCreateImageDirectoryIsHandled(t *testing.T) {
 		t.Fatal(err)
 	}
 	controller := Controller{ImageDirectoriesManager: &testIDM{}, OperationManager: NewMapOM()}
+
+	makeRequest(rr, req, &controller)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("request was not handled. This failure implies an API breaking change.")
+	}
+}
+
+func TestUpdateImageDirectoryIsHandled(t *testing.T) {
+	rr := httptest.NewRecorder()
+	body, err := json.Marshal(apiv1.UpdateImageDirectoryRequest{UserArtifactChecksum: "aaa"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest("PUT", "/cvd_imgs_dirs/foo", bytes.NewBuffer(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	controller := Controller{ImageDirectoriesManager: &testIDM{}, OperationManager: NewMapOM(), UserArtifactsManager: &testUAM{}}
 
 	makeRequest(rr, req, &controller)
 

--- a/frontend/src/host_orchestrator/orchestrator/controller_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller_test.go
@@ -227,6 +227,10 @@ func (testIDM) CreateImageDirectory() (string, error) {
 	return "", nil
 }
 
+func (testIDM) UpdateImageDirectory(imageDirName, dir string) error {
+	return nil
+}
+
 func TestCreateUploadDirectoryIsHandled(t *testing.T) {
 	rr := httptest.NewRecorder()
 	req, err := http.NewRequest("POST", "/userartifacts", strings.NewReader("{}"))

--- a/frontend/src/host_orchestrator/orchestrator/controller_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller_test.go
@@ -213,6 +213,14 @@ func (testUAM) ExtractArtifact(checksum string) error {
 	return nil
 }
 
+func (testUAM) UpdatedArtifactPath(checksum string) string {
+	return ""
+}
+
+func (testUAM) ExtractedArtifactPath(checksum string) string {
+	return ""
+}
+
 func (testUAM) GetDirPath(string) string {
 	return ""
 }

--- a/frontend/src/host_orchestrator/orchestrator/userartifacts.go
+++ b/frontend/src/host_orchestrator/orchestrator/userartifacts.go
@@ -153,10 +153,6 @@ func (m *UserArtifactsManagerImpl) GetDirPath(name string) string {
 	return filepath.Join(m.LegacyRootDir, name)
 }
 
-func (m *UserArtifactsManagerImpl) GetFilePath(dir, filename string) string {
-	return filepath.Join(m.LegacyRootDir, dir, filename)
-}
-
 func (m *UserArtifactsManagerImpl) UpdateArtifact(checksum string, chunk UserArtifactChunk) error {
 	if chunk.OffsetBytes < 0 {
 		return operator.NewBadRequestError(fmt.Sprintf("invalid value (chunk_offset:%d)", chunk.OffsetBytes), nil)

--- a/frontend/src/host_orchestrator/orchestrator/userartifacts_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/userartifacts_test.go
@@ -177,7 +177,7 @@ func TestUpdateArtifactWithDirSucceeds(t *testing.T) {
 	}
 
 	wg.Wait()
-	b, _ := ioutil.ReadFile(am.GetFilePath(upDir.Name, "xyzz"))
+	b, _ := ioutil.ReadFile(filepath.Join(legacyRootDir, upDir.Name, "xyzz"))
 	if diff := cmp.Diff("lorem ipsum", string(b)); diff != "" {
 		t.Errorf("aritfact content mismatch (-want +got):\n%s", diff)
 	}

--- a/frontend/src/libhoclient/host_orchestrator_client.go
+++ b/frontend/src/libhoclient/host_orchestrator_client.go
@@ -124,6 +124,9 @@ type UserArtifactsClient interface {
 type ImageDirectoriesClient interface {
 	// Create an empty image directory.
 	CreateImageDirectory() (*hoapi.Operation, error)
+	// Update image directory to include uploaded or extracted user artifact at
+	// Host Orchestrator.
+	UpdateImageDirectoryWithUserArtifact(id, filename string) (*hoapi.Operation, error)
 }
 
 // Operations that could be performend on a given instance.
@@ -619,6 +622,19 @@ func (c *HostOrchestratorClientImpl) ExtractArtifact(filename string) (*hoapi.Op
 func (c *HostOrchestratorClientImpl) CreateImageDirectory() (*hoapi.Operation, error) {
 	op := &hoapi.Operation{}
 	if err := c.HTTPHelper.NewPostRequest("/cvd_imgs_dirs", nil).JSONResDo(op); err != nil {
+		return nil, err
+	}
+	return op, nil
+}
+
+func (c *HostOrchestratorClientImpl) UpdateImageDirectoryWithUserArtifact(id, filename string) (*hoapi.Operation, error) {
+	checksum, err := sha256Checksum(filename)
+	if err != nil {
+		return nil, err
+	}
+	req := hoapi.UpdateImageDirectoryRequest{UserArtifactChecksum: checksum}
+	op := &hoapi.Operation{}
+	if err := c.HTTPHelper.NewPutRequest("/cvd_imgs_dirs/"+id, req).JSONResDo(op); err != nil {
 		return nil, err
 	}
 	return op, nil

--- a/frontend/src/libhoclient/httputils.go
+++ b/frontend/src/libhoclient/httputils.go
@@ -61,23 +61,11 @@ func (h *HTTPHelper) NewDeleteRequest(path string) *HTTPRequestBuilder {
 }
 
 func (h *HTTPHelper) NewPostRequest(path string, jsonBody any) *HTTPRequestBuilder {
-	body := []byte{}
-	var err error
-	if jsonBody != nil {
-		if body, err = json.Marshal(jsonBody); err != nil {
-			return &HTTPRequestBuilder{helper: h, request: nil, err: err}
-		}
-	}
-	var req *http.Request
-	if req, err = http.NewRequest(http.MethodPost, h.RootEndpoint+path, bytes.NewBuffer(body)); err != nil {
-		return &HTTPRequestBuilder{helper: h, request: nil, err: err}
-	}
-	req.Header.Set("Content-Type", "application/json")
-	return &HTTPRequestBuilder{
-		helper:  h,
-		request: req,
-		err:     err,
-	}
+	return h.newRequestWithJson(http.MethodPost, path, jsonBody)
+}
+
+func (h *HTTPHelper) NewPutRequest(path string, jsonBody any) *HTTPRequestBuilder {
+	return h.newRequestWithJson(http.MethodPut, path, jsonBody)
 }
 
 func (h *HTTPHelper) NewUploadFileRequest(ctx context.Context, path string, body io.Reader, contentType string) *HTTPRequestBuilder {
@@ -89,7 +77,27 @@ func (h *HTTPHelper) NewUploadFileRequest(ctx context.Context, path string, body
 	return &HTTPRequestBuilder{
 		helper:  h,
 		request: req,
-		err:     err,
+		err:     nil,
+	}
+}
+
+func (h *HTTPHelper) newRequestWithJson(method, path string, jsonBody any) *HTTPRequestBuilder {
+	body := []byte{}
+	var err error
+	if jsonBody != nil {
+		if body, err = json.Marshal(jsonBody); err != nil {
+			return &HTTPRequestBuilder{helper: h, request: nil, err: err}
+		}
+	}
+	var req *http.Request
+	if req, err = http.NewRequest(method, h.RootEndpoint+path, bytes.NewBuffer(body)); err != nil {
+		return &HTTPRequestBuilder{helper: h, request: nil, err: err}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return &HTTPRequestBuilder{
+		helper:  h,
+		request: req,
+		err:     nil,
 	}
 }
 


### PR DESCRIPTION
This PR covers:
- Introducing HO API `PUT/cvd_imgs_dirs/{id}`.
- Introducing corresponding HO Golang client API `UpdateImageDirectoryWithUserArtifact`.

Please refer to https://github.com/google/android-cuttlefish/pull/1393, for the details of API set handled with `ImageDirectoriesHandler`.