### PR TITLE
Log the right path in GetBinName.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/host_tool_target.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/host_tool_target.cpp
@@ -111,7 +111,7 @@ Result<std::string> HostToolTarget::GetBinName(
       return bin_name;
     }
   }
-  return CF_ERRF("'{}' does not contain any of '[{}]'.", artifacts_path_,
+  return CF_ERRF("'{}/bin/' does not contain any of '[{}]'.", artifacts_path_,
                  android::base::Join(alternatives, ", "));
 }
 


### PR DESCRIPTION
If for whatever reason you specify a host_path that already has `/bin` appended, then this error is confusing, since it prints out the full path that will have the binary in it, but the code is actually looking for the path plus bin; log that instead.