### PR TITLE
Extract qcow2 code from a free function into a new type.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -126,6 +126,7 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/image_aggregator",
+        "//cuttlefish/host/libs/image_aggregator:qcow2",
         "//libbase",
     ],
 )

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/BUILD.bazel
@@ -301,7 +301,7 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:data_image",
-        "//cuttlefish/host/libs/image_aggregator",
+        "//cuttlefish/host/libs/image_aggregator:qcow2",
     ],
 )
 

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/sd_card.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/sd_card.cc
@@ -20,7 +20,7 @@
 #include "cuttlefish/common/libs/utils/result.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 #include "cuttlefish/host/libs/config/data_image.h"
-#include "cuttlefish/host/libs/image_aggregator/image_aggregator.h"
+#include "cuttlefish/host/libs/image_aggregator/qcow2.h"
 
 namespace cuttlefish {
 
@@ -38,8 +38,8 @@ Result<void> InitializeSdCard(
             "Failed to create \"" << instance.sdcard_path() << "\"");
   if (config.vm_manager() == VmmMode::kQemu) {
     const std::string crosvm_path = instance.crosvm_binary();
-    CreateQcowOverlay(crosvm_path, instance.sdcard_path(),
-                      instance.sdcard_overlay_path());
+    CF_EXPECT(Qcow2Image::Create(crosvm_path, instance.sdcard_path(),
+                                 instance.sdcard_overlay_path()));
   }
   return {};
 }

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk_builder.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk_builder.cpp
@@ -24,6 +24,7 @@
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 #include "cuttlefish/host/libs/image_aggregator/image_aggregator.h"
+#include "cuttlefish/host/libs/image_aggregator/qcow2.h"
 
 namespace cuttlefish {
 
@@ -254,7 +255,8 @@ Result<bool> DiskBuilder::BuildOverlayIfNecessary() {
   }
 
   CF_EXPECT(!crosvm_path_.empty(), "crosvm binary missing");
-  CreateQcowOverlay(crosvm_path_, composite_disk_path_, overlay_path_);
+  CF_EXPECT(
+      Qcow2Image::Create(crosvm_path_, composite_disk_path_, overlay_path_));
 
   return true;
 #endif

--- a/base/cvd/cuttlefish/host/libs/image_aggregator/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/image_aggregator/BUILD.bazel
@@ -28,9 +28,7 @@ cf_cc_library(
         "-Wno-packed-non-pod",
     ],
     deps = [
-        ":cdisk_spec_cc_proto",
         "//cuttlefish/common/libs/fs",
-        "//cuttlefish/common/libs/utils:cf_endian",
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/common/libs/utils:size_utils",
@@ -39,9 +37,26 @@ cf_cc_library(
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:known_paths",
         "//cuttlefish/host/libs/config:mbr",
+        "//cuttlefish/host/libs/image_aggregator:cdisk_spec_cc_proto",
+        "//cuttlefish/host/libs/image_aggregator:qcow2",
         "//libbase",
         "//libsparse",
         "@protobuf",
         "@zlib",
+    ],
+)
+
+cf_cc_library(
+    name = "qcow2",
+    srcs = ["qcow2.cc"],
+    hdrs = ["qcow2.h"],
+    copts = COPTS + [
+        "-Wno-packed-non-pod",
+    ],
+    deps = [
+        "//cuttlefish/common/libs/fs",
+        "//cuttlefish/common/libs/utils:cf_endian",
+        "//cuttlefish/common/libs/utils:result",
+        "//cuttlefish/common/libs/utils:subprocess",
     ],
 )

--- a/base/cvd/cuttlefish/host/libs/image_aggregator/image_aggregator.h
+++ b/base/cvd/cuttlefish/host/libs/image_aggregator/image_aggregator.h
@@ -64,22 +64,4 @@ void CreateCompositeDisk(std::vector<ImagePartition> partitions,
                          const std::string& footer_file,
                          const std::string& output_composite_path,
                          bool read_only);
-
-/**
- * Generate a qcow overlay backed by a given implementation file.
- *
- * qcow, or "QEMU Copy-On-Write" is a file format containing a list of disk
- * offsets and file contents. This can be combined with a backing file, to
- * represent an original disk file plus disk updates over that file. The qcow
- * files can be swapped out and replaced without affecting the original. qcow
- * is supported by QEMU and crosvm.
- *
- * The crosvm binary at `crosvm_path` is used to generate an overlay file at
- * `output_overlay_path` that functions as an overlay on the file at
- * `backing_file`.
- */
-void CreateQcowOverlay(const std::string& crosvm_path,
-                       const std::string& backing_file,
-                       const std::string& output_overlay_path);
-
 }

--- a/base/cvd/cuttlefish/host/libs/image_aggregator/qcow2.cc
+++ b/base/cvd/cuttlefish/host/libs/image_aggregator/qcow2.cc
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/host/libs/image_aggregator/qcow2.h"
+
+#include <string>
+#include <utility>
+
+#include "cuttlefish/common/libs/fs/shared_buf.h"
+#include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/common/libs/utils/cf_endian.h"
+#include "cuttlefish/common/libs/utils/subprocess.h"
+
+namespace cuttlefish {
+
+namespace {
+
+struct __attribute__((packed)) QcowHeader {
+  Be32 magic;
+  Be32 version;
+  Be64 backing_file_offset;
+  Be32 backing_file_size;
+  Be32 cluster_bits;
+  Be64 size;
+  Be32 crypt_method;
+  Be32 l1_size;
+  Be64 l1_table_offset;
+  Be64 refcount_table_offset;
+  Be32 refcount_table_clusters;
+  Be32 nb_snapshots;
+  Be64 snapshots_offset;
+};
+
+static_assert(sizeof(QcowHeader) == 72);
+
+}  // namespace
+
+struct Qcow2Image::Impl {
+  QcowHeader header_;
+};
+
+Result<Qcow2Image> Qcow2Image::Create(const std::string& crosvm_path,
+                                      const std::string& backing_file,
+                                      const std::string& output_overlay_path) {
+  Command create_cmd = Command(crosvm_path)
+                           .AddParameter("create_qcow2")
+                           .AddParameter("--backing-file")
+                           .AddParameter(backing_file)
+                           .AddParameter(output_overlay_path);
+
+  std::string stdout_str;
+  std::string stderr_str;
+  int return_code = RunWithManagedStdio(std::move(create_cmd), nullptr,
+                                        &stdout_str, &stderr_str);
+  CF_EXPECT_EQ(return_code, 0,
+               "Failed to run `"
+                   << crosvm_path << " create_qcow2 --backing-file "
+                   << backing_file << " " << output_overlay_path << "`"
+                   << "stdout:\n###\n"
+                   << stdout_str << "\n###"
+                   << "stderr:\n###\n"
+                   << stderr_str << "\n###");
+
+  return CF_EXPECT(OpenExisting(output_overlay_path));
+}
+
+Result<Qcow2Image> Qcow2Image::OpenExisting(const std::string& path) {
+  SharedFD fd = SharedFD::Open(path, O_CLOEXEC, O_RDONLY);
+  CF_EXPECT(fd->IsOpen(), fd->StrError());
+
+  std::unique_ptr<Impl> impl(new Impl());
+  CF_EXPECT(impl.get());
+
+  CF_EXPECT_EQ(ReadExactBinary(fd, &impl->header_), sizeof(QcowHeader));
+
+  std::string magic(reinterpret_cast<char*>(&impl->header_),
+                    MagicHeader().size());
+  CF_EXPECT_EQ(magic, MagicHeader());
+
+  return Qcow2Image(std::move(impl));
+}
+
+std::string Qcow2Image::MagicHeader() { return "QFI\xfb"; }
+
+Qcow2Image::Qcow2Image(Qcow2Image&&) = default;
+Qcow2Image::~Qcow2Image() = default;
+Qcow2Image& Qcow2Image::operator=(Qcow2Image&&) = default;
+
+Result<uint64_t> Qcow2Image::Size() const {
+  CF_EXPECT(impl_.get());
+
+  return impl_->header_.size.as_uint64_t();
+}
+
+Qcow2Image::Qcow2Image(std::unique_ptr<Impl> impl) : impl_(std::move(impl)) {}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/image_aggregator/qcow2.h
+++ b/base/cvd/cuttlefish/host/libs/image_aggregator/qcow2.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <stdint.h>
+
+#include <memory>
+#include <string>
+
+#include "cuttlefish/common/libs/utils/result.h"
+
+namespace cuttlefish {
+
+/**
+ * qcow, or "QEMU Copy-On-Write" is a file format containing a list of disk
+ * offsets and file contents. This can be combined with a backing file, to
+ * represent an original disk file plus disk updates over that file. The qcow
+ * files can be swapped out and replaced without affecting the original. qcow
+ * is supported by QEMU and crosvm.
+ */
+class Qcow2Image {
+ public:
+  /**
+   * Generate a qcow overlay backed by a given implementation file.
+   *
+   * The crosvm binary at `crosvm_path` is used to generate an overlay file at
+   * `output_overlay_path` that functions as an overlay on the file at
+   * `backing_file`.
+   */
+  static Result<Qcow2Image> Create(const std::string& crosvm_path,
+                                   const std::string& backing_file,
+                                   const std::string& output_overlay_path);
+  static Result<Qcow2Image> OpenExisting(const std::string& path);
+
+  Qcow2Image(Qcow2Image&&);
+  ~Qcow2Image();
+  Qcow2Image& operator=(Qcow2Image&&);
+
+  static std::string MagicHeader();
+
+  Result<uint64_t> Size() const;
+
+ private:
+  struct Impl;
+
+  explicit Qcow2Image(std::unique_ptr<Impl>);
+
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace cuttlefish


### PR DESCRIPTION
This type will fit into a type hierarchy of disk image representations including raw images, android-sparse images, and composite disks that can describe representations of vitual disks that consist of multiple host files.

The "private implementation" idiom is used to hide implementation details of the qcow2 header type, but this may be excessive.

Bug: b/432327319