### PR TITLE
Remove the misc_info_txt flag

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
@@ -518,7 +518,6 @@ DEFINE_string(boot_image, CF_DEFAULTS_BOOT_IMAGE,
               "boot.img in the directory specified by -system_image_dir.");
 DEFINE_string(super_image, CF_DEFAULTS_SUPER_IMAGE,
               "Location of the super partition image.");
-DEFINE_string(misc_info_txt, "", "Location of the misc_info.txt file.");
 DEFINE_string(
     vendor_boot_image, CF_DEFAULTS_VENDOR_BOOT_IMAGE,
     "Location of cuttlefish vendor boot image. If empty it is assumed to "

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.h
@@ -240,7 +240,6 @@ DECLARE_bool(resume);
 
 DECLARE_string(boot_image);
 DECLARE_string(super_image);
-DECLARE_string(misc_info_txt);
 DECLARE_string(vendor_boot_image);
 DECLARE_string(vbmeta_image);
 DECLARE_string(vbmeta_system_image);

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk_flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk_flags.cc
@@ -84,7 +84,6 @@ Result<void> ResolveInstanceFiles(const InitramfsPathFlag& initramfs_path,
 
   std::string default_boot_image = "";
   std::string default_super_image = "";
-  std::string default_misc_info_txt = "";
   std::string default_vendor_boot_image = "";
   std::string default_vbmeta_image = "";
   std::string default_vbmeta_system_image = "";
@@ -111,8 +110,6 @@ Result<void> ResolveInstanceFiles(const InitramfsPathFlag& initramfs_path,
     // be placed in --system_image_dir location.
     default_boot_image += comma_str + cur_system_image_dir + "/boot.img";
     default_super_image += comma_str + cur_system_image_dir + "/super.img";
-    default_misc_info_txt +=
-        comma_str + cur_system_image_dir + "/misc_info.txt";
     default_vendor_boot_image += comma_str + cur_system_image_dir + "/vendor_boot.img";
     default_vbmeta_image += comma_str + cur_system_image_dir + "/vbmeta.img";
     default_vbmeta_system_image += comma_str + cur_system_image_dir + "/vbmeta_system.img";
@@ -133,8 +130,6 @@ Result<void> ResolveInstanceFiles(const InitramfsPathFlag& initramfs_path,
   SetCommandLineOptionWithMode("boot_image", default_boot_image.c_str(),
                                google::FlagSettingMode::SET_FLAGS_DEFAULT);
   SetCommandLineOptionWithMode("super_image", default_super_image.c_str(),
-                               google::FlagSettingMode::SET_FLAGS_DEFAULT);
-  SetCommandLineOptionWithMode("misc_info_txt", default_misc_info_txt.c_str(),
                                google::FlagSettingMode::SET_FLAGS_DEFAULT);
   SetCommandLineOptionWithMode("vendor_boot_image",
                                default_vendor_boot_image.c_str(),
@@ -213,8 +208,6 @@ Result<void> DiskImageFlagsVectorization(
       android::base::Split(FLAGS_boot_image, ",");
   std::vector<std::string> super_image =
       android::base::Split(FLAGS_super_image, ",");
-  std::vector<std::string> misc_info =
-      android::base::Split(FLAGS_misc_info_txt, ",");
   std::vector<std::string> vendor_boot_image =
       android::base::Split(FLAGS_vendor_boot_image, ",");
   std::vector<std::string> vbmeta_image =
@@ -274,11 +267,6 @@ Result<void> DiskImageFlagsVectorization(
       CF_EXPECT(InstanceNumsCalculator().FromGlobalGflags().Calculate());
   for (const auto& num : instance_nums) {
     auto instance = config.ForInstance(num);
-    if (instance_index >= misc_info.size()) {
-      instance.set_misc_info_txt(misc_info[0]);
-    } else {
-      instance.set_misc_info_txt(misc_info[instance_index]);
-    }
     if (instance_index >= boot_image.size()) {
       cur_boot_image = boot_image[0];
     } else {

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
@@ -654,7 +654,6 @@ class CuttlefishConfig {
     std::string new_data_image() const;
     std::string super_image() const;
     std::string new_super_image() const;
-    std::string misc_info_txt() const;
     std::string vendor_boot_image() const;
     std::string new_vendor_boot_image() const;
     std::string vbmeta_image() const;
@@ -888,7 +887,6 @@ class CuttlefishConfig {
     void set_new_data_image(const std::string& new_data_image);
     void set_super_image(const std::string& super_image);
     void set_new_super_image(const std::string& super_image);
-    void set_misc_info_txt(const std::string& misc_info);
     void set_vendor_boot_image(const std::string& vendor_boot_image);
     void set_new_vendor_boot_image(const std::string& new_vendor_boot_image);
     void set_vbmeta_image(const std::string& vbmeta_image);

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
@@ -268,14 +268,6 @@ void CuttlefishConfig::MutableInstanceSpecific::set_new_super_image(
     const std::string& super_image) {
   (*Dictionary())[kNewSuperImage] = super_image;
 }
-static constexpr char kMiscInfoTxt[] = "misc_info_txt";
-std::string CuttlefishConfig::InstanceSpecific::misc_info_txt() const {
-  return (*Dictionary())[kMiscInfoTxt].asString();
-}
-void CuttlefishConfig::MutableInstanceSpecific::set_misc_info_txt(
-    const std::string& misc_info) {
-  (*Dictionary())[kMiscInfoTxt] = misc_info;
-}
 static constexpr char kVendorBootImage[] = "vendor_boot_image";
 std::string CuttlefishConfig::InstanceSpecific::vendor_boot_image() const {
   return (*Dictionary())[kVendorBootImage].asString();


### PR DESCRIPTION
https://github.com/google/android-cuttlefish/blob/81d945157656e3fc56f386c5291c6d28b667bef0/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h#L657

https://github.com/google/android-cuttlefish/blob/81d945157656e3fc56f386c5291c6d28b667bef0/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp#L521

The flag value is only stored in `CuttlefishConfig` but nothing reads it from `CuttlefishConfig`. It was originally introduced in aosp/2359203 but then not used in the follow-up CL aosp/2318835.

Bug: b/432331402