### PR TITLE
Make the config proto build target public

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/BUILD.bazel
@@ -8,6 +8,7 @@ package(
 proto_library(
     name = "load_config_proto",
     srcs = ["load_config.proto"],
+    visibility = ["//visibility:public"],
 )
 
 # This will generate a build artifact in bazel-bin. To update ./golang/,


### PR DESCRIPTION
To allow other protos to import.

Bug: 432538048