### PR TITLE
Create a ChromeOsStateImage type

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd.cc
@@ -362,9 +362,12 @@ Result<const CuttlefishConfig*> InitFilesystemAndCreateConfig(
     for (const auto& instance : config.Instances()) {
       Result<MetadataImage> metadata = MetadataImage::Reuse(instance);
       Result<MiscImage> misc = MiscImage::Reuse(instance);
-      if (metadata.ok() && misc.ok()) {
-        DiskBuilder os_builder = OsCompositeDiskBuilder(
-            config, instance, *metadata, *misc, system_image_dir);
+      Result<std::optional<ChromeOsStateImage>> chrome_os_state =
+          CF_EXPECT(ChromeOsStateImage::Reuse(instance));
+      if (chrome_os_state.ok() && metadata.ok() && misc.ok()) {
+        DiskBuilder os_builder =
+            OsCompositeDiskBuilder(config, instance, *chrome_os_state,
+                                   *metadata, *misc, system_image_dir);
         creating_os_disk |= CF_EXPECT(os_builder.WillRebuildCompositeDisk());
       } else {
         creating_os_disk = true;

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/BUILD.bazel
@@ -76,6 +76,7 @@ cf_cc_library(
     hdrs = ["chromeos_composite_disk.h"],
     deps = [
         "//cuttlefish/common/libs/utils:files",
+        "//cuttlefish/host/commands/assemble_cvd/disk:chromeos_state",
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/image_aggregator",
     ],
@@ -257,6 +258,7 @@ cf_cc_library(
         "//cuttlefish/host/commands/assemble_cvd/disk:android_composite_disk_config",
         "//cuttlefish/host/commands/assemble_cvd/disk:android_efi_loader_composite_disk",
         "//cuttlefish/host/commands/assemble_cvd/disk:chromeos_composite_disk",
+        "//cuttlefish/host/commands/assemble_cvd/disk:chromeos_state",
         "//cuttlefish/host/commands/assemble_cvd/disk:fuchsia_composite_disk",
         "//cuttlefish/host/commands/assemble_cvd/disk:linux_composite_disk",
         "//cuttlefish/host/commands/assemble_cvd/disk:metadata_image",
@@ -265,6 +267,7 @@ cf_cc_library(
         "//cuttlefish/host/libs/config:boot_flow",
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/image_aggregator",
+        "//libbase",
     ],
 )
 

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/chromeos_composite_disk.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/chromeos_composite_disk.cc
@@ -19,18 +19,20 @@
 #include <vector>
 
 #include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/host/commands/assemble_cvd/disk/chromeos_state.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 #include "cuttlefish/host/libs/image_aggregator/image_aggregator.h"
 
 namespace cuttlefish {
 
 std::vector<ImagePartition> ChromeOsCompositeDiskConfig(
-    const CuttlefishConfig::InstanceSpecific& instance) {
+    const CuttlefishConfig::InstanceSpecific& instance,
+    const ChromeOsStateImage& chrome_os_state) {
   std::vector<ImagePartition> partitions;
 
   partitions.emplace_back(ImagePartition{
       .label = "STATE",
-      .image_file_path = AbsolutePath(instance.chromeos_state_image()),
+      .image_file_path = chrome_os_state.FilePath(),
       .type = kLinuxFilesystem,
   });
   partitions.emplace_back(ImagePartition{

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/chromeos_composite_disk.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/chromeos_composite_disk.h
@@ -18,12 +18,14 @@
 
 #include <vector>
 
+#include "cuttlefish/host/commands/assemble_cvd/disk/chromeos_state.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 #include "cuttlefish/host/libs/image_aggregator/image_aggregator.h"
 
 namespace cuttlefish {
 
 std::vector<ImagePartition> ChromeOsCompositeDiskConfig(
-    const CuttlefishConfig::InstanceSpecific& instance);
+    const CuttlefishConfig::InstanceSpecific& instance,
+    const ChromeOsStateImage&);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/chromeos_state.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/chromeos_state.cc
@@ -18,6 +18,7 @@
 
 #include <optional>
 #include <string>
+#include <utility>
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/result.h"
@@ -40,6 +41,16 @@ Result<std::optional<ChromeOsStateImage>> ChromeOsStateImage::CreateIfNecessary(
   if (!FileExists(path)) {
     CF_EXPECT(CreateBlankImage(path, kImageSizeMb,kFilesystemFormat));
   }
+  return ChromeOsStateImage(std::move(path));
+}
+
+Result<std::optional<ChromeOsStateImage>> ChromeOsStateImage::Reuse(
+    const CuttlefishConfig::InstanceSpecific& instance) {
+  if (instance.boot_flow() != BootFlow::ChromeOs) {
+    return std::nullopt;
+  }
+  std::string path = AbsolutePath(instance.PerInstancePath(kImageName));
+  CF_EXPECT(FileExists(path));
   return ChromeOsStateImage(std::move(path));
 }
 

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/chromeos_state.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/chromeos_state.h
@@ -28,6 +28,8 @@ class ChromeOsStateImage {
  public:
   static Result<std::optional<ChromeOsStateImage>> CreateIfNecessary(
       const CuttlefishConfig::InstanceSpecific&);
+  static Result<std::optional<ChromeOsStateImage>> Reuse(
+      const CuttlefishConfig::InstanceSpecific&);
 
   const std::string& FilePath() const;
  private:

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/chromeos_state.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/chromeos_state.h
@@ -16,12 +16,24 @@
 
 #pragma once
 
+#include <optional>
+#include <string>
+
 #include "cuttlefish/common/libs/utils/result.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 namespace cuttlefish {
 
-Result<void> InitializeChromeOsState(
-    const CuttlefishConfig::InstanceSpecific& instance);
+class ChromeOsStateImage {
+ public:
+  static Result<std::optional<ChromeOsStateImage>> CreateIfNecessary(
+      const CuttlefishConfig::InstanceSpecific&);
+
+  const std::string& FilePath() const;
+ private:
+  ChromeOsStateImage(std::string);
+
+  std::string path_;
+};
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/os_composite_disk.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/os_composite_disk.cc
@@ -16,11 +16,15 @@
 
 #include "cuttlefish/host/commands/assemble_cvd/disk/os_composite_disk.h"
 
+#include <optional>
 #include <vector>
+
+#include <android-base/logging.h>
 
 #include "cuttlefish/host/commands/assemble_cvd/disk/android_composite_disk_config.h"
 #include "cuttlefish/host/commands/assemble_cvd/disk/android_efi_loader_composite_disk.h"
 #include "cuttlefish/host/commands/assemble_cvd/disk/chromeos_composite_disk.h"
+#include "cuttlefish/host/commands/assemble_cvd/disk/chromeos_state.h"
 #include "cuttlefish/host/commands/assemble_cvd/disk/fuchsia_composite_disk.h"
 #include "cuttlefish/host/commands/assemble_cvd/disk/linux_composite_disk.h"
 #include "cuttlefish/host/commands/assemble_cvd/disk/metadata_image.h"
@@ -34,6 +38,7 @@ namespace cuttlefish {
 
 std::vector<ImagePartition> GetOsCompositeDiskConfig(
     const CuttlefishConfig::InstanceSpecific& instance,
+    const std::optional<ChromeOsStateImage>& chrome_os_state,
     const MetadataImage& metadata, const MiscImage& misc,
     const SystemImageDirFlag& system_image_dir) {
   switch (instance.boot_flow()) {
@@ -44,7 +49,8 @@ std::vector<ImagePartition> GetOsCompositeDiskConfig(
       return AndroidEfiLoaderCompositeDiskConfig(instance, metadata, misc,
                                                  system_image_dir);
     case BootFlow::ChromeOs:
-      return ChromeOsCompositeDiskConfig(instance);
+      CHECK(chrome_os_state.has_value());
+      return ChromeOsCompositeDiskConfig(instance, *chrome_os_state);
     case BootFlow::ChromeOsDisk:
       return {};
     case BootFlow::Linux:

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/os_composite_disk.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/os_composite_disk.h
@@ -16,8 +16,10 @@
 
 #pragma once
 
+#include <optional>
 #include <vector>
 
+#include "cuttlefish/host/commands/assemble_cvd/disk/chromeos_state.h"
 #include "cuttlefish/host/commands/assemble_cvd/disk/metadata_image.h"
 #include "cuttlefish/host/commands/assemble_cvd/disk/misc_image.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags/system_image_dir.h"
@@ -27,7 +29,8 @@
 namespace cuttlefish {
 
 std::vector<ImagePartition> GetOsCompositeDiskConfig(
-    const CuttlefishConfig::InstanceSpecific& instance, const MetadataImage&,
+    const CuttlefishConfig::InstanceSpecific& instance,
+    const std::optional<ChromeOsStateImage>&, const MetadataImage&,
     const MiscImage&, const SystemImageDirFlag&);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk_flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk_flags.cc
@@ -153,6 +153,7 @@ Result<void> ResolveInstanceFiles(const InitramfsPathFlag& initramfs_path,
 DiskBuilder OsCompositeDiskBuilder(
     const CuttlefishConfig& config,
     const CuttlefishConfig::InstanceSpecific& instance,
+    const std::optional<ChromeOsStateImage>& chrome_os_state,
     const MetadataImage& metadata, const MiscImage& misc,
     const SystemImageDirFlag& system_image_dir) {
   auto builder =
@@ -167,8 +168,8 @@ DiskBuilder OsCompositeDiskBuilder(
         .CompositeDiskPath(instance.chromeos_disk());
   }
   return builder
-      .Partitions(
-          GetOsCompositeDiskConfig(instance, metadata, misc, system_image_dir))
+      .Partitions(GetOsCompositeDiskConfig(instance, chrome_os_state, metadata,
+                                           misc, system_image_dir))
       .HeaderPath(instance.PerInstancePath("os_composite_gpt_header.img"))
       .FooterPath(instance.PerInstancePath("os_composite_gpt_footer.img"))
       .CompositeDiskPath(instance.os_composite_disk_path());
@@ -513,7 +514,7 @@ Result<void> CreateDynamicDiskFiles(
     MiscImage misc = CF_EXPECT(MiscImage::ReuseOrCreate(instance));
 
     DiskBuilder os_disk_builder = OsCompositeDiskBuilder(
-        config, instance, metadata, misc, system_image_dir);
+        config, instance, chrome_os_state, metadata, misc, system_image_dir);
     const auto os_built_composite = CF_EXPECT(os_disk_builder.BuildCompositeDiskIfNecessary());
 
     BootloaderEnvPartition bootloader_env_partition =

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk_flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk_flags.cc
@@ -463,7 +463,9 @@ Result<void> CreateDynamicDiskFiles(
     std::unique_ptr<Avb> avb = GetDefaultAvb();
     CF_EXPECT(avb.get());
 
-    CF_EXPECT(InitializeChromeOsState(instance));
+    std::optional<ChromeOsStateImage> chrome_os_state =
+        CF_EXPECT(ChromeOsStateImage::CreateIfNecessary(instance));
+
     CF_EXPECT(RepackKernelRamdisk(config, instance, *avb));
     CF_EXPECT(VbmetaEnforceMinimumSize(instance));
     CF_EXPECT(BootloaderPresentCheck(instance));

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk_flags.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk_flags.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/commands/assemble_cvd/disk/chromeos_state.h"
 #include "cuttlefish/host/commands/assemble_cvd/disk/metadata_image.h"
 #include "cuttlefish/host/commands/assemble_cvd/disk/misc_image.h"
 #include "cuttlefish/host/commands/assemble_cvd/disk_builder.h"
@@ -42,7 +43,8 @@ Result<void> DiskImageFlagsVectorization(CuttlefishConfig& config,
                                          const SystemImageDirFlag&);
 DiskBuilder OsCompositeDiskBuilder(
     const CuttlefishConfig& config,
-    const CuttlefishConfig::InstanceSpecific& instance, const MetadataImage&,
+    const CuttlefishConfig::InstanceSpecific& instance,
+    const std::optional<ChromeOsStateImage>&, const MetadataImage&,
     const MiscImage&, const SystemImageDirFlag&);
 DiskBuilder ApCompositeDiskBuilder(const CuttlefishConfig& config,
                                    const CuttlefishConfig::InstanceSpecific& instance);

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
@@ -468,8 +468,6 @@ class CuttlefishConfig {
 
     std::string esp_image_path() const;
 
-    std::string chromeos_state_image() const;
-
     std::string otheros_esp_grub_config() const;
 
     std::string ap_esp_grub_config() const;

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
@@ -1548,10 +1548,6 @@ std::string CuttlefishConfig::InstanceSpecific::ap_uboot_env_image_path() const 
   return AbsolutePath(PerInstancePath("ap_uboot_env.img"));
 }
 
-std::string CuttlefishConfig::InstanceSpecific::chromeos_state_image() const {
-  return AbsolutePath(PerInstancePath("chromeos_state.img"));
-}
-
 std::string CuttlefishConfig::InstanceSpecific::esp_image_path() const {
   return AbsolutePath(PerInstancePath("esp.img"));
 }


### PR DESCRIPTION
This type will represent creating the file on disk, so accepting an argument of the type establishes an ordering between creating the file and using the file.

Bug: b/432833719