### PR TITLE
Upgrade all debian actions to use bookworm

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -18,7 +18,7 @@ jobs:
   document-cvd:
     runs-on: ubuntu-22.04
     container:
-      image: debian@sha256:823849b88ae7e9b6ceb605fbdf51566499c234a9cfca8da1e4f22234fd65a09c # debian:bullseye-20250317 (amd64)
+      image: debian@sha256:9258a75a7e4323c9e5562b361effc84ee747920116d8adfc98a465a5cdc9150e # debian:bookworm-20250407 (amd64)
     steps:
     - name: Checkout repository
       uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
@@ -44,7 +44,7 @@ jobs:
   deploy:
     runs-on: ubuntu-22.04
     container:
-      image: debian@sha256:823849b88ae7e9b6ceb605fbdf51566499c234a9cfca8da1e4f22234fd65a09c # debian:bullseye-20250317 (amd64)
+      image: debian@sha256:9258a75a7e4323c9e5562b361effc84ee747920116d8adfc98a465a5cdc9150e # debian:bookworm-20250407 (amd64)
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -195,14 +195,12 @@ jobs:
   build-debian-package:
     runs-on: ubuntu-22.04-4core
     container:
-      image: debian@sha256:823849b88ae7e9b6ceb605fbdf51566499c234a9cfca8da1e4f22234fd65a09c # debian:bullseye-20250317 (amd64)
+      image: debian@sha256:9258a75a7e4323c9e5562b361effc84ee747920116d8adfc98a465a5cdc9150e # debian:bookworm-20250407 (amd64)
     steps:
     - name: Check for dockerenv file
       run: (ls /.dockerenv && echo 'Found dockerenv') || (echo 'No dockerenv')
     - name: setup apt
-      run: |
-        echo 'deb http://deb.debian.org/debian bullseye-backports main' | tee /etc/apt/sources.list.d/backports.list
-        apt update -y && apt upgrade -y
+      run: apt update -y && apt upgrade -y
     - name: install dependencies
       run: apt install -y git devscripts config-package-dev debhelper-compat golang protobuf-compiler yq
     - name: go version

--- a/.github/workflows/update-bazel-cache.yaml
+++ b/.github/workflows/update-bazel-cache.yaml
@@ -43,14 +43,12 @@ jobs:
     if: ${{ github.repository_owner == 'google' }}
     runs-on: ubuntu-22.04-4core
     container:
-      image: debian@sha256:823849b88ae7e9b6ceb605fbdf51566499c234a9cfca8da1e4f22234fd65a09c # debian:bullseye-20250317 (amd64)
+      image: debian@sha256:9258a75a7e4323c9e5562b361effc84ee747920116d8adfc98a465a5cdc9150e # debian:bookworm-20250407 (amd64)
     steps:
     - name: Check for dockerenv file
       run: (ls /.dockerenv && echo 'Found dockerenv') || (echo 'No dockerenv')
     - name: setup apt
-      run: |
-        echo 'deb http://deb.debian.org/debian bullseye-backports main' | tee /etc/apt/sources.list.d/backports.list
-        apt update -y && apt upgrade -y
+      run: apt update -y && apt upgrade -y
     - name: install dependencies
       run: apt install -y git devscripts config-package-dev debhelper-compat golang protobuf-compiler yq
     - name: go version


### PR DESCRIPTION
[PR #1301](https://github.com/google/android-cuttlefish/pull/1301/files) introduced some usage of the bookworm version of debian, and [PR #1342](https://github.com/google/android-cuttlefish/pull/1342) additionally added dependencies on the `yq` tool, which only became available in bookworm: https://packages.debian.org/bookworm/yq

Some uses of the yq tool were still under bullseye and those have now started to fail.

Bug: b/433356585