### PR TITLE
Read avb metadata straight into memory rather than going through a temporary directory and file

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_image_utils.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_image_utils.h
@@ -49,7 +49,7 @@ void RepackGem5BootImage(const std::string& initrd_path,
                          const std::string& unpack_dir,
                          const std::string& input_ramdisk_path);
 Result<std::string> ReadAndroidVersionFromBootImage(
-    const std::string& temp_dir_parent, const std::string& boot_image_path);
+    const std::string& boot_image_path);
 
 void UnpackRamdisk(const std::string& original_ramdisk_path,
                    const std::string& ramdisk_stage_dir);

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/guest_config.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/guest_config.cc
@@ -88,9 +88,9 @@ Result<std::vector<GuestConfig>> ReadGuestConfig(
     }
 
     GuestConfig guest_config;
-    guest_config.android_version_number = CF_EXPECT(
-        ReadAndroidVersionFromBootImage(FLAGS_early_tmp_dir, cur_boot_image),
-        "Failed to read guest's android version");
+    guest_config.android_version_number =
+        CF_EXPECT(ReadAndroidVersionFromBootImage(cur_boot_image),
+                  "Failed to read guest's android version");
 
     if (InSandbox()) {
       // TODO: b/359309462 - real sandboxing for extract-ikconfig

--- a/base/cvd/cuttlefish/host/libs/avb/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/avb/BUILD.bazel
@@ -17,7 +17,6 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/common/libs/utils:subprocess",
-        "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:known_paths",
         "@fruit",
     ],

--- a/base/cvd/cuttlefish/host/libs/avb/avb.h
+++ b/base/cvd/cuttlefish/host/libs/avb/avb.h
@@ -56,8 +56,7 @@ class Avb {
   Result<void> AddHashFooter(const std::string& image_path,
                              const std::string& partition_name,
                              const off_t partition_size_bytes) const;
-  Result<void> WriteInfoImage(const std::string& image_path,
-                              const std::string& output_path) const;
+  Result<std::string> InfoImage(const std::string& image_path) const;
   Result<void> MakeVbMetaImage(
       const std::string& output_path,
       const std::vector<ChainPartition>& chained_partitions,


### PR DESCRIPTION
https://github.com/google/android-cuttlefish/blob/287ffbb338b31b12517544022c8116377ce4ef36/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_image_utils.cc#L504

https://github.com/google/android-cuttlefish/blob/287ffbb338b31b12517544022c8116377ce4ef36/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_image_utils.cc#L194

https://github.com/google/android-cuttlefish/blob/287ffbb338b31b12517544022c8116377ce4ef36/base/cvd/cuttlefish/host/libs/avb/avb.cpp#L101

https://github.com/google/android-cuttlefish/blob/287ffbb338b31b12517544022c8116377ce4ef36/base/cvd/cuttlefish/host/libs/avb/avb.cpp#L91

The temporary directory only exists to hold one file. The file is only created in order to immediately read it from disk. The directory and file are immediately deleted afterwards.

Bug: b/433586538