### PR TITLE
Return bootparams in-memory from UnpackBootImage

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -87,6 +87,7 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/common/libs/utils:subprocess",
+        "//cuttlefish/common/libs/utils:subprocess_managed_stdio",
         "//cuttlefish/host/commands/assemble_cvd/disk:generate_persistent_bootconfig",
         "//cuttlefish/host/libs/avb",
         "//cuttlefish/host/libs/config:config_utils",

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_image_utils.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_image_utils.h
@@ -39,8 +39,8 @@ bool RepackVendorBootImageWithEmptyRamdisk(
     const std::string& new_vendor_boot_image_path,
     const std::string& unpack_dir, bool bootconfig_supported);
 
-Result<void> UnpackBootImage(const std::string& boot_image_path,
-                             const std::string& unpack_dir);
+Result<std::string> UnpackBootImage(const std::string& boot_image_path,
+                                    const std::string& unpack_dir);
 
 bool UnpackVendorBootImageIfNotUnpacked(
     const std::string& vendor_boot_image_path, const std::string& unpack_dir);


### PR DESCRIPTION
It's only written to a file to be immediately read.

https://github.com/google/android-cuttlefish/blob/287ffbb338b31b12517544022c8116377ce4ef36/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_image_utils.cc#L292

https://github.com/google/android-cuttlefish/blob/287ffbb338b31b12517544022c8116377ce4ef36/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_image_utils.cc#L206

Doing this in-memory saves on IO.

Bug: b/433594073