### PR TITLE
Delete unused code paths

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
@@ -254,8 +254,6 @@ DEFINE_bool(verify_sig_server_certificate,
             "trusted signing authority (Disallow self signed certificates). "
             "This is ignored if an insecure server is configured.");
 
-DEFINE_string(group_id, "", "The group name of instance");
-
 DEFINE_vec(
     webrtc_device_id, CF_DEFAULTS_WEBRTC_DEVICE_ID,
     "The for the device to register with the signaling server. Every "

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.h
@@ -116,8 +116,6 @@ DECLARE_bool(webrtc_sig_server_secure);
 
 DECLARE_bool(verify_sig_server_certificate);
 
-DECLARE_string(group_id);
-
 DECLARE_vec(webrtc_device_id);
 
 DECLARE_vec(uuid);

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -1235,8 +1235,6 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
               "Error in looking up num to webrtc_device_id_flag_map");
     instance.set_webrtc_device_id(num_to_webrtc_device_id_flag_map[num]);
 
-    instance.set_group_id(FLAGS_group_id);
-
     if (!is_first_instance || !start_webrtc_vec[instance_index]) {
       // Only the first instance starts the signaling server or proxy
       instance.set_start_webrtc_signaling_server(false);

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -377,16 +377,6 @@ Result<void> CvdStartCommandHandler::UpdateArgs(cvd_common::Args& args,
                                                 LocalInstanceGroup& group) {
   CF_EXPECT(UpdateInstanceArgs(args, group));
   CF_EXPECT(UpdateWebrtcDeviceIds(args, group));
-  // for backward compatibility, older cvd host tools don't accept group_id
-  HostToolTarget host_tool_target(group.HostArtifactsPath());
-  auto has_group_id_flag =
-      HostToolTarget(group.HostArtifactsPath())
-          .GetFlagInfo(CF_EXPECT(host_tool_target.GetStartBinName()),
-                       "group_id")
-          .ok();
-  if (has_group_id_flag) {
-    args.emplace_back("--group_id=" + group.GroupName());
-  }
   return {};
 }
 

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/streamer.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/streamer.cpp
@@ -260,8 +260,6 @@ class WebRtcServer : public virtual CommandSource,
 
     Command webrtc(WebRtcBinary(), KillSubprocessFallback(stopper));
 
-    webrtc.AddParameter("-group_id=", instance_.group_id());
-
     webrtc.UnsetFromEnvironment("http_proxy");
     sockets_.AppendCommandArguments(webrtc);
     // Currently there is no way to ensure the signaling server will already

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/recording_manager.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/recording_manager.h
@@ -18,6 +18,7 @@
 
 #include "cuttlefish/host/frontend/webrtc/libdevice/local_recorder.h"
 
+#include <condition_variable>
 #include <map>
 #include <memory>
 #include <mutex>

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/streamer.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/streamer.cpp
@@ -32,12 +32,9 @@
 #include <media/base/video_broadcaster.h>
 #include <pc/video_track_source.h>
 
-#include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/host/frontend/webrtc/libcommon/audio_device.h"
 #include "cuttlefish/host/frontend/webrtc/libcommon/peer_connection_utils.h"
-#include "cuttlefish/host/frontend/webrtc/libcommon/port_range_socket_factory.h"
 #include "cuttlefish/host/frontend/webrtc/libcommon/utils.h"
-#include "cuttlefish/host/frontend/webrtc/libcommon/vp8only_encoder_factory.h"
 #include "cuttlefish/host/frontend/webrtc/libdevice/audio_track_source_impl.h"
 #include "cuttlefish/host/frontend/webrtc/libdevice/camera_streamer.h"
 #include "cuttlefish/host/frontend/webrtc/libdevice/client_handler.h"

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/streamer.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/streamer.cpp
@@ -72,7 +72,6 @@ constexpr auto kControlPanelButtonLidSwitchOpen = "lid_switch_open";
 constexpr auto kControlPanelButtonHingeAngleValue = "hinge_angle_value";
 constexpr auto kCustomControlPanelButtonsField = "custom_control_panel_buttons";
 constexpr auto kMouseEnabled = "mouse_enabled";
-constexpr auto kGroupIdField = "group_id";
 
 constexpr int kRegistrationRetries = 3;
 constexpr int kRetryFirstIntervalMs = 1000;
@@ -428,7 +427,6 @@ void Streamer::Impl::OnOpen() {
       displays.append(display);
     }
 
-    device_info[kGroupIdField] = config_.group_id;
     device_info[kDisplaysField] = displays;
 
     Json::Value touchpads(Json::ValueType::arrayValue);

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/streamer.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/streamer.h
@@ -43,9 +43,6 @@ struct StreamerConfig {
   // The id with which to register with the operator server.
   std::string device_id;
 
-  // The group id with which to register with the operator server.
-  std::string group_id;
-
   // The port on which the client files are being served
   int client_files_port;
   ServerConfig operator_server;

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/streamer.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/streamer.h
@@ -16,10 +16,7 @@
 
 #pragma once
 
-#include <functional>
 #include <memory>
-#include <mutex>
-#include <optional>
 #include <string>
 #include <utility>
 #include <vector>

--- a/base/cvd/cuttlefish/host/frontend/webrtc/main.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/main.cpp
@@ -74,7 +74,6 @@ DEFINE_int32(audio_server_fd, -1, "An fd to listen on for audio frames");
 DEFINE_int32(camera_streamer_fd, -1, "An fd to send client camera frames");
 DEFINE_int32(sensors_fd, -1, "An fd to communicate with sensors_simulator.");
 DEFINE_string(client_dir, "webrtc", "Location of the client files");
-DEFINE_string(group_id, "", "The group id of device");
 
 namespace cuttlefish {
 
@@ -264,7 +263,6 @@ int CuttlefishMain() {
   StreamerConfig streamer_config;
 
   streamer_config.device_id = instance.webrtc_device_id();
-  streamer_config.group_id = FLAGS_group_id;
   streamer_config.client_files_port = client_server->port();
   streamer_config.tcp_port_range = instance.webrtc_tcp_port_range();
   streamer_config.udp_port_range = instance.webrtc_udp_port_range();

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
@@ -483,10 +483,6 @@ class CuttlefishConfig {
     // signaling server
     std::string webrtc_device_id() const;
 
-    // The group id the webrtc process should use to register with the
-    // signaling server
-    std::string group_id() const;
-
     // Whether this instance should start the webrtc signaling server
     bool start_webrtc_sig_server() const;
 
@@ -750,7 +746,6 @@ class CuttlefishConfig {
     void set_modem_simulator_ports(const std::string& modem_simulator_ports);
     void set_virtual_disk_paths(const std::vector<std::string>& disk_paths);
     void set_webrtc_device_id(const std::string& id);
-    void set_group_id(const std::string& id);
     void set_start_webrtc_signaling_server(bool start);
     void set_start_webrtc_sig_server_proxy(bool start);
     void set_start_rootcanal(bool start);

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
@@ -1862,15 +1862,6 @@ std::string CuttlefishConfig::InstanceSpecific::webrtc_device_id() const {
   return (*Dictionary())[kWebrtcDeviceId].asString();
 }
 
-static constexpr char kGroupId[] = "group_id";
-void CuttlefishConfig::MutableInstanceSpecific::set_group_id(
-    const std::string& id) {
-  (*Dictionary())[kGroupId] = id;
-}
-std::string CuttlefishConfig::InstanceSpecific::group_id() const {
-  return (*Dictionary())[kGroupId].asString();
-}
-
 static constexpr char kStartSigServer[] = "webrtc_start_sig_server";
 void CuttlefishConfig::MutableInstanceSpecific::set_start_webrtc_signaling_server(bool start) {
   (*Dictionary())[kStartSigServer] = start;

--- a/frontend/src/liboperator/operator/devices.go
+++ b/frontend/src/liboperator/operator/devices.go
@@ -41,8 +41,6 @@ type Device struct {
 	clientCount int
 }
 
-const DEFAULT_GROUP_ID = "default"
-
 func newDevice(id string, conn *JSONUnix, port int, privateData interface{}) *Device {
 	url, err := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", port))
 	if err != nil {
@@ -56,14 +54,12 @@ func newDevice(id string, conn *JSONUnix, port int, privateData interface{}) *De
 		w.Header().Add("x-cutf-proxy", "op-device")
 		w.WriteHeader(http.StatusBadGateway)
 	}
-	groupId := groupIdFromPrivateData(privateData)
 	return &Device{
 		conn:        conn,
 		Proxy:       proxy,
 		privateData: privateData,
 		Descriptor: apiv1.DeviceDescriptor{
-			DeviceId:  id,
-			GroupName: groupId,
+			DeviceId: id,
 		},
 		clients:     make(map[int]Client),
 		clientCount: 0,
@@ -134,20 +130,6 @@ func NewDevicePool() *DevicePool {
 		preDevices: make(map[string]*preDevice),
 		devices:    make(map[string]*Device),
 	}
-}
-
-func groupIdFromPrivateData(privateData interface{}) string {
-	deviceInfo, ok := privateData.(map[string]interface{})
-	if !ok {
-		return DEFAULT_GROUP_ID
-	}
-
-	groupId, ok := deviceInfo["group_id"].(string)
-	if !ok || len(groupId) == 0 {
-		return DEFAULT_GROUP_ID
-	}
-
-	return groupId
 }
 
 // PreRegister accepts a channel of boolean which it closes if the pre-registration is cancelled or

--- a/frontend/src/liboperator/operator/devices_test.go
+++ b/frontend/src/liboperator/operator/devices_test.go
@@ -198,30 +198,6 @@ func TestListDevices(t *testing.T) {
 	}
 }
 
-func MakeInfo(groupId string) map[string]interface{} {
-	return map[string]interface{}{
-		"group_id": groupId,
-	}
-}
-
-func TestListDevicesByGroupId(t *testing.T) {
-	p := NewDevicePool()
-
-	p.Register("1", nil, 0, MakeInfo("foo"))
-	p.Register("2", nil, 0, MakeInfo("foo"))
-	p.Register("3", nil, 0, MakeInfo("bar"))
-	p.Register("4", nil, 0, MakeInfo("bar"))
-	p.Register("5", nil, 0, MakeInfo("bar"))
-
-	if deviceCnt := len(p.DeviceDescriptors(DeviceDescriptorFilter{groupId: "foo"})); deviceCnt != 2 {
-		t.Error("List of devices in group foo should have size of 2, but have ", deviceCnt)
-	}
-
-	if deviceCnt := len(p.DeviceDescriptors(DeviceDescriptorFilter{groupId: "bar"})); deviceCnt != 3 {
-		t.Error("List of devices in group bar should have size of 3, but have ", deviceCnt)
-	}
-}
-
 func TestListDevicesByPreRegistrationData(t *testing.T) {
 	p := NewDevicePool()
 	register := func(id string, desc *apiv1.DeviceDescriptor) {
@@ -303,7 +279,7 @@ func TestListDevicesByPreRegistrationData(t *testing.T) {
 
 func TestListDevicesEmpty(t *testing.T) {
 	p := NewDevicePool()
-	p.Register("d", nil, 0, MakeInfo("foo"))
+	p.Register("d", nil, 0, map[string]interface{}{})
 	p.Unregister("d")
 
 	if deviceCnt := len(p.DeviceDescriptors(DeviceDescriptorFilter{})); deviceCnt != 0 {
@@ -313,35 +289,4 @@ func TestListDevicesEmpty(t *testing.T) {
 	if deviceCnt := len(p.DeviceDescriptors(DeviceDescriptorFilter{groupId: "foo"})); deviceCnt != 0 {
 		t.Error("List of devices in group foo should have size of 0, but have ", deviceCnt)
 	}
-}
-
-func TestGroupIdFromPrivateData(t *testing.T) {
-	info := MakeInfo("foo")
-	groupId := groupIdFromPrivateData(info)
-
-	if groupId != "foo" {
-		t.Error("info should have group_id as foo")
-	}
-
-}
-
-func TestDefaultGroup(t *testing.T) {
-	p := NewDevicePool()
-	p.Register("d1", nil, 0, MakeInfo("foo"))
-	p.Register("d2", nil, 0, map[string]interface{}{})
-	p.Register("d3", nil, 0, "")
-	p.Register("d4", nil, 0, MakeInfo(""))
-
-	if len(p.devices) != 4 {
-		t.Error("Error listing after 4 device registrations - expected 4 but ", len(p.devices))
-	}
-
-	if defaultDeviceCount := len(p.DeviceDescriptors(DeviceDescriptorFilter{groupId: DEFAULT_GROUP_ID})); defaultDeviceCount != 3 {
-		t.Error("Error after 3 device in default group - expected 3 but ", defaultDeviceCount)
-	}
-
-	if defaultDeviceCount := len(p.DeviceDescriptors(DeviceDescriptorFilter{groupId: DEFAULT_GROUP_ID})); defaultDeviceCount != 3 {
-		t.Error("Error after 3 device in default group - expected 3 but ", defaultDeviceCount)
-	}
-
 }


### PR DESCRIPTION
Before `cvd` starts a device it pre-registers it with the operator, providing the group name, instance name and webrtc device id. The operator associates this information with the device at registration time by matching the webrtc device id.

This PR eliminates the old way of sharing this information, which had `cvd` pass a `-group_id` flag to `cvd_internal_start`, which the `webRTC` process passed to the operator at registration time.