### PR TITLE
Add ms-tpm-20-ref

### DIFF
--- a/base/cvd/BUILD.ms-tpm-20-ref.bazel
+++ b/base/cvd/BUILD.ms-tpm-20-ref.bazel
@@ -1,0 +1,126 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+# From PLATFORM_INC in TPMCmd/Makefile.am
+PLATFORM_INC = [
+    "TPMCmd/Platform/include",
+    "TPMCmd/Platform/include/prototypes",
+]
+
+# From SIMULATOR_INC in TPMCmd/Makefile.am
+SIMULATOR_INC = [
+    "TPMCmd/Simulator/include",
+    "TPMCmd/Simulator/include/prototypes",
+]
+
+# From TPM_INC in TPMCmd/Makefile.am
+TPM_INC = [
+    "TPMCmd/tpm/include",
+    "TPMCmd/tpm/include/platform_interface",
+    "TPMCmd/tpm/include/platform_interface/prototypes",
+    "TPMCmd/tpm/include/private",
+    "TPMCmd/tpm/include/private/prototypes",
+    "TPMCmd/tpm/include/public",
+    "TPMCmd/tpm/cryptolibs",
+    "TPMCmd/tpm/cryptolibs/common/include",
+    "TPMCmd/tpm/cryptolibs/Ossl/include",
+    "TPMCmd/tpm/cryptolibs/TpmBigNum/include",
+    "TPMCmd/TpmConfiguration",
+]
+
+# From configure.ac
+DEFINES = [
+    "HASH_LIB=Ossl",
+    "SYM_LIB=Ossl",
+    "MATH_LIB=TpmBigNum",
+    "BN_MATH_LIB=Ossl",
+]
+
+# From configure.ac
+COMPILER_FLAGS = [
+    "-std=gnu11",
+    "-Werror",
+    "-Wall",
+    "-Wformat-security",
+    "-fstack-protector-all",
+    "-fPIC",
+]
+
+# From configure.ac
+LINK_FLAGS = [
+    "-Wl,--no-undefined",
+    "-Wl,-z,noexecstack",
+    "-Wl,-z,now",
+    "-Wl,-z,relro",
+]
+
+# Use the provided configuration, plus patches in build_external/ms-tpm-20-ref.
+cc_library(
+    name = "tpm_configuration",
+    srcs = glob(["TPMCmd/TpmConfiguration/**/*.h"]),
+    includes = ["TPMCmd/TpmConfiguration"],
+)
+
+# From PLATFORM_H in bootstrap
+cc_library(
+    name = "platform_headers",
+    srcs = glob(["TPMCmd/Platform/**/*.h"]),
+    includes = PLATFORM_INC,
+    deps = [":tpm_configuration"],
+)
+
+# From SIMULATOR_H in bootstrap
+cc_library(
+    name = "simulator_headers",
+    srcs = glob(["TPMCmd/Simulator/**/*.h"]),
+    includes = SIMULATOR_INC,
+)
+
+# From TPM_H in bootstrap; added .inl files
+cc_library(
+    name = "tpm_headers",
+    srcs = glob([
+        "TPMCmd/tpm/**/*.h",
+        "TPMCmd/tpm/**/*.inl",
+    ]),
+    includes = TPM_INC,
+)
+
+cc_library(
+    name = "platform",
+    srcs = glob(["TPMCmd/Platform/**/*.c"]),
+    copts = COMPILER_FLAGS,
+    defines = DEFINES,
+    deps = [
+        ":platform_headers",
+        ":tpm_headers",
+    ],
+)
+
+cc_library(
+    name = "tpm",
+    srcs = glob(["TPMCmd/tpm/**/*.c"]),
+    copts = COMPILER_FLAGS,
+    defines = DEFINES,
+    deps = [
+        ":platform_headers",
+        ":tpm_headers",
+        "@boringssl//:crypto",
+        "@boringssl//:ssl",
+    ],
+)
+
+cc_binary(
+    name = "simulator",
+    srcs = glob(["TPMCmd/Simulator/**/*.c"]),
+    copts = COMPILER_FLAGS,
+    defines = DEFINES,
+    linkopts = LINK_FLAGS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":platform",
+        ":simulator_headers",
+        ":tpm",
+        "@boringssl//:crypto",
+    ],
+)

--- a/base/cvd/MODULE.bazel
+++ b/base/cvd/MODULE.bazel
@@ -620,3 +620,16 @@ git_repository(
     commit = "dbcb4e93c352b11bdc7c746665f2fa05bae0f251",  # v0.1.12
     remote = "https://github.com/google/pica/",
 )
+
+git_repository(
+    name = "ms-tpm-20-ref",
+    build_file = "@//:BUILD.ms-tpm-20-ref.bazel",
+    commit = "ee21db0a941decd3cac67925ea3310873af60ab3", # v1.83r1
+    remote = "https://github.com/microsoft/ms-tpm-20-ref",
+    patches = [
+        "@//build_external/ms-tpm-20-ref:0001-Turn-off-ALG_CAMELLIA.patch",
+        "@//build_external/ms-tpm-20-ref:0002-Use-the-BoringSSL-bignum_st-structure.patch",
+        "@//build_external/ms-tpm-20-ref:0003-Don-t-use-EC_POINTs_mul.patch",
+    ],
+    patch_strip = 1,
+)

--- a/base/cvd/build_external/ms-tpm-20-ref/0001-Turn-off-ALG_CAMELLIA.patch
+++ b/base/cvd/build_external/ms-tpm-20-ref/0001-Turn-off-ALG_CAMELLIA.patch
@@ -1,0 +1,26 @@
+From 0c70c00ee0b5968e36377be15a052940af6b6175 Mon Sep 17 00:00:00 2001
+From: HONG Yifan <elsk@google.com>
+Date: Fri, 18 Jul 2025 18:54:33 +0000
+Subject: [PATCH 1/3] Turn off ALG_CAMELLIA.
+
+Not supported by boringssl.
+---
+ TPMCmd/TpmConfiguration/TpmConfiguration/TpmProfile_Common.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/TPMCmd/TpmConfiguration/TpmConfiguration/TpmProfile_Common.h b/TPMCmd/TpmConfiguration/TpmConfiguration/TpmProfile_Common.h
+index a8dc129..5b28851 100644
+--- a/TPMCmd/TpmConfiguration/TpmConfiguration/TpmProfile_Common.h
++++ b/TPMCmd/TpmConfiguration/TpmConfiguration/TpmProfile_Common.h
+@@ -45,7 +45,7 @@
+ 
+ #define     SM4_128                     (NO  * ALG_SM4)
+ 
+-#define ALG_CAMELLIA                ALG_YES
++#define ALG_CAMELLIA                ALG_NO
+ 
+ #define     CAMELLIA_128                (YES * ALG_CAMELLIA)
+ #define     CAMELLIA_192                (NO  * ALG_CAMELLIA)
+-- 
+2.50.0.727.gbf7dc18ff4-goog
+

--- a/base/cvd/build_external/ms-tpm-20-ref/0002-Use-the-BoringSSL-bignum_st-structure.patch
+++ b/base/cvd/build_external/ms-tpm-20-ref/0002-Use-the-BoringSSL-bignum_st-structure.patch
@@ -1,0 +1,96 @@
+From 5ce566293ce6af677b158039ce3e3268c4f60cc4 Mon Sep 17 00:00:00 2001
+From: HONG Yifan <elsk@google.com>
+Date: Fri, 18 Jul 2025 19:17:10 +0000
+Subject: [PATCH 2/3] Use the BoringSSL bignum_st structure
+
+Original author is joerichey@google.com.
+
+Original patch comments:
+
+The BoringSSl structure has width instead of top. I belive this is roughly
+equiavlent, but we should verify this somehow.
+---
+ TPMCmd/tpm/cryptolibs/Ossl/BnToOsslMath.c     | 12 +++++------
+ .../Ossl/include/Ossl/BnToOsslMath.h          | 21 -------------------
+ 2 files changed, 6 insertions(+), 27 deletions(-)
+
+diff --git a/TPMCmd/tpm/cryptolibs/Ossl/BnToOsslMath.c b/TPMCmd/tpm/cryptolibs/Ossl/BnToOsslMath.c
+index 92ad417..5d9b53d 100644
+--- a/TPMCmd/tpm/cryptolibs/Ossl/BnToOsslMath.c
++++ b/TPMCmd/tpm/cryptolibs/Ossl/BnToOsslMath.c
+@@ -45,10 +45,10 @@ BOOL OsslToTpmBn(bigNum bn, BIGNUM* osslBn)
+     {
+         int i;
+         //
+-        GOTO_ERROR_UNLESS((unsigned)osslBn->top <= BnGetAllocated(bn));
+-        for(i = 0; i < osslBn->top; i++)
++        GOTO_ERROR_UNLESS((unsigned)osslBn->width <= BnGetAllocated(bn));
++        for(i = 0; i < osslBn->width; i++)
+             bn->d[i] = osslBn->d[i];
+-        BnSetTop(bn, osslBn->top);
++        BnSetTop(bn, osslBn->width);
+     }
+     return TRUE;
+ Error:
+@@ -67,7 +67,7 @@ BIGNUM* BigInitialized(BIGNUM* toInit, bigConst initializer)
+         return NULL;
+     toInit->d     = (BN_ULONG*)&initializer->d[0];
+     toInit->dmax  = (int)initializer->allocated;
+-    toInit->top   = (int)initializer->size;
++    toInit->width = (int)initializer->size;
+     toInit->neg   = 0;
+     toInit->flags = 0;
+     return toInit;
+@@ -96,7 +96,7 @@ static void BIGNUM_print(const char* label, const BIGNUM* a, BOOL eol)
+     }
+     if(a->neg)
+         printf("-");
+-    for(i = a->top, d = &a->d[i - 1]; i > 0; i--)
++    for(i = a->width, d = &a->d[i - 1]; i > 0; i--)
+     {
+         int      j;
+         BN_ULONG l = *d--;
+@@ -149,7 +149,7 @@ BOOL BnMathLibraryCompatibilityCheck(void)
+     // Convert the test data to an OpenSSL BIGNUM
+     BN_bin2bn(test, sizeof(test), osslTemp);
+     // Make sure the values are consistent
+-    GOTO_ERROR_UNLESS(osslTemp->top == (int)tpmTemp->size);
++    GOTO_ERROR_UNLESS(osslTemp->width == (int)tpmTemp->size);
+     for(i = 0; i < tpmTemp->size; i++)
+         GOTO_ERROR_UNLESS(osslTemp->d[i] == tpmTemp->d[i]);
+     OSSL_LEAVE();
+diff --git a/TPMCmd/tpm/cryptolibs/Ossl/include/Ossl/BnToOsslMath.h b/TPMCmd/tpm/cryptolibs/Ossl/include/Ossl/BnToOsslMath.h
+index 6c73a45..c9583bd 100644
+--- a/TPMCmd/tpm/cryptolibs/Ossl/include/Ossl/BnToOsslMath.h
++++ b/TPMCmd/tpm/cryptolibs/Ossl/include/Ossl/BnToOsslMath.h
+@@ -17,27 +17,6 @@
+ #include <openssl/ec.h>
+ #include <openssl/bn.h>
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x30100000L
+-// Check the bignum_st definition against the one below and either update the
+-// version check or provide the new definition for this version.
+-#  error Untested OpenSSL version
+-#elif OPENSSL_VERSION_NUMBER >= 0x10100000L
+-// from crypto/bn/bn_lcl.h (OpenSSL 1.x) or crypto/bn/bn_local.h (OpenSSL 3.0)
+-struct bignum_st
+-{
+-    BN_ULONG* d;   /* Pointer to an array of 'BN_BITS2' bit
+-                                    * chunks. */
+-    int       top; /* Index of last used d +1. */
+-                   /* The next are internal book keeping for bn_expand. */
+-    int dmax;      /* Size of the d array. */
+-    int neg;       /* one if the number is negative */
+-    int flags;
+-};
+-#else
+-#  define EC_POINT_get_affine_coordinates EC_POINT_get_affine_coordinates_GFp
+-#  define EC_POINT_set_affine_coordinates EC_POINT_set_affine_coordinates_GFp
+-#endif  // OPENSSL_VERSION_NUMBER
+-
+ //** Macros and Defines
+ 
+ // Make sure that the library is using the correct size for a crypt word
+-- 
+2.50.0.727.gbf7dc18ff4-goog
+

--- a/base/cvd/build_external/ms-tpm-20-ref/0003-Don-t-use-EC_POINTs_mul.patch
+++ b/base/cvd/build_external/ms-tpm-20-ref/0003-Don-t-use-EC_POINTs_mul.patch
@@ -1,0 +1,52 @@
+From 7554f9dc9bac4f0df3b22de4e4b3c6505f94bccb Mon Sep 17 00:00:00 2001
+From: HONG Yifan <elsk@google.com>
+Date: Fri, 18 Jul 2025 19:29:17 +0000
+Subject: [PATCH 3/3] Don't use EC_POINTs_mul
+
+Original author is joerichey@google.com.
+
+Original patch comments:
+
+BoringSSL does not support this method. It has been proposed for deprecation.
+See: https://github.com/openssl/openssl/issues/8332
+
+Normal code paths will never hit this anyway. The S point is optional and
+rarely specificed.
+---
+ TPMCmd/tpm/cryptolibs/Ossl/BnToOsslMath.c | 10 +---------
+ 1 file changed, 1 insertion(+), 9 deletions(-)
+
+diff --git a/TPMCmd/tpm/cryptolibs/Ossl/BnToOsslMath.c b/TPMCmd/tpm/cryptolibs/Ossl/BnToOsslMath.c
+index 5d9b53d..aae0f2c 100644
+--- a/TPMCmd/tpm/cryptolibs/Ossl/BnToOsslMath.c
++++ b/TPMCmd/tpm/cryptolibs/Ossl/BnToOsslMath.c
+@@ -489,7 +489,6 @@ LIB_EXPORT BOOL BnEccModMult2(bigPoint            R,  // OUT: computed point
+ )
+ {
+     EC_POINT* pR = EC_POINT_new(E->G);
+-    EC_POINT* pS = EcPointInitialized(S, E);
+     BIG_INITIALIZED(bnD, d);
+     EC_POINT* pQ = EcPointInitialized(Q, E);
+     BIG_INITIALIZED(bnU, u);
+@@ -498,17 +497,10 @@ LIB_EXPORT BOOL BnEccModMult2(bigPoint            R,  // OUT: computed point
+         EC_POINT_mul(E->G, pR, bnD, pQ, bnU, E->CTX);
+     else
+     {
+-        const EC_POINT* points[2];
+-        const BIGNUM*   scalars[2];
+-        points[0]  = pS;
+-        points[1]  = pQ;
+-        scalars[0] = bnD;
+-        scalars[1] = bnU;
+-        EC_POINTs_mul(E->G, pR, NULL, 2, points, scalars, E->CTX);
++        return FALSE;
+     }
+     PointFromOssl(R, pR, E);
+     EC_POINT_free(pR);
+-    EC_POINT_free(pS);
+     EC_POINT_free(pQ);
+     return !BnEqualZero(R->z);
+ }
+-- 
+2.50.0.727.gbf7dc18ff4-goog
+

--- a/base/cvd/cuttlefish/package/BUILD.bazel
+++ b/base/cvd/cuttlefish/package/BUILD.bazel
@@ -69,6 +69,7 @@ package_files(
         "cuttlefish-common/bin/mkfs.fat": "@dosfstools//:mkfs.fat",
         "cuttlefish-common/bin/mkuserimg_mke2fs.py": "//libext4_utils:mkuserimg_mke2fs.py",
         "cuttlefish-common/bin/modem_simulator": "//cuttlefish/host/commands/modem_simulator",
+        "cuttlefish-common/bin/ms-tpm-20-ref": "@ms-tpm-20-ref//:simulator",
         "cuttlefish-common/bin/mtools": "@mtools//:mtools",
         "cuttlefish-common/bin/openwrt_control_server": "//cuttlefish/host/commands/openwrt_control_server",
         "cuttlefish-common/bin/operator_proxy": "//cuttlefish/host/frontend/operator_proxy",


### PR DESCRIPTION
- Dropped -Wno-error=deprecated-declarations because we don't need it when building agianst BoringSSL
- Applied a few patches to make it build properly against boringssl.

Bug: b/402294836