### PR TITLE
Retrogress protobuf version for load_config proto.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang/go.mod
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang/go.mod
@@ -1,5 +1,5 @@
 module github.com/google/android-cuttlefish/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang
 
-go 1.22
+go 1.19
 
-require google.golang.org/protobuf v1.36.6 // indirect
+require google.golang.org/protobuf v1.32.0

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang/go.sum
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang/go.sum
@@ -1,2 +1,4 @@
-google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
-google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+google.golang.org/protobuf v1.32.0 h1:pPC6BG5ex8PDFnkbrGU3EixyhKcQ2aDuBS36lqK/C7I=
+google.golang.org/protobuf v1.32.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=


### PR DESCRIPTION
For bookworm, we need to target a go version of 1.19. Unfortunately, go doesn't make it easy to examine dependencies and figure this out automatically, but thankfully at least here we only have one dependency. Digging through git logs yields a prior tagged release of protobuf that is compatible with the go version we are targeting, so use that instead.