### PR TITLE
Convenient wrappers for `RunWithManagedStdio`

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
@@ -349,6 +349,7 @@ cf_cc_library(
     hdrs = ["subprocess_managed_stdio.h"],
     deps = [
         "//cuttlefish/common/libs/fs",
+        "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/common/libs/utils:subprocess",
         "//libbase",
     ],

--- a/base/cvd/cuttlefish/common/libs/utils/disk_usage.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/disk_usage.cpp
@@ -41,11 +41,7 @@ Result<std::size_t> GetDiskUsage(const std::string& path,
   du_cmd.AddParameter("--block-size=" + size_arg);
   du_cmd.AddParameter(path);
 
-  std::string out;
-  std::string err;
-  int return_code = RunWithManagedStdio(std::move(du_cmd), nullptr, &out, &err);
-  CF_EXPECTF(return_code == 0, "Failed to run `du` command.  stderr: {}", err);
-  CF_EXPECTF(!out.empty(), "No output read from `du` command. stderr: {}", err);
+  std::string out = CF_EXPECT(RunAndCaptureStdout(std::move(du_cmd)));
   std::vector<std::string> split_out =
       android::base::Tokenize(out, kWhitespaceCharacters);
   CF_EXPECTF(!split_out.empty(),

--- a/base/cvd/cuttlefish/common/libs/utils/network.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/network.cpp
@@ -128,8 +128,7 @@ std::set<std::string> TapInterfacesInUse() {
     cmd->AddParameter(fdinfo);
   }
 
-  std::string stdout_str, stderr_str;
-  RunWithManagedStdio(std::move(*cmd), nullptr, &stdout_str, &stderr_str);
+  std::string stdout_str = RunAndCaptureStdout(std::move(*cmd)).value_or("");
 
   auto lines = android::base::Split(stdout_str, "\n");
   std::set<std::string> tap_interfaces;

--- a/base/cvd/cuttlefish/common/libs/utils/subprocess_managed_stdio.cc
+++ b/base/cvd/cuttlefish/common/libs/utils/subprocess_managed_stdio.cc
@@ -51,7 +51,7 @@ class ThreadJoiner {
 
 }  // namespace
 
-int RunWithManagedStdio(Command&& cmd_tmp, const std::string* stdin_str,
+int RunWithManagedStdio(Command cmd_tmp, const std::string* stdin_str,
                         std::string* stdout_str, std::string* stderr_str,
                         SubprocessOptions options) {
   /*
@@ -138,6 +138,20 @@ int RunWithManagedStdio(Command&& cmd_tmp, const std::string* stdin_str,
     return -1;
   }
   return code;
+}
+
+Result<std::string> RunAndCaptureStdout(Command command) {
+  std::string standard_out;
+  std::string standard_err;
+  std::string command_str = command.GetShortName();
+  int exit_code = RunWithManagedStdio(std::move(command), nullptr,
+                                      &standard_out, &standard_err);
+  LOG(DEBUG) << "Ran " << command_str << " with stdout:\n" << standard_out;
+  LOG(DEBUG) << "Ran " << command_str << " with stderr:\n" << standard_err;
+  CF_EXPECTF(exit_code == 0,
+             "Failed to execute '{}' <args>: exit code = {}, stdout = '{}', stderr = '{}'",
+             command_str, exit_code, standard_out, standard_err);
+  return standard_out;
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/subprocess_managed_stdio.h
+++ b/base/cvd/cuttlefish/common/libs/utils/subprocess_managed_stdio.h
@@ -17,9 +17,13 @@
 
 #include <string>
 
+#include "cuttlefish/common/libs/utils/result.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"
 
 namespace cuttlefish {
+
+// Success is defined by the exit code being `0`.
+Result<std::string> RunAndCaptureStdout(Command);
 
 /*
  * Consumes a Command and runs it, optionally managing the stdio channels.
@@ -33,8 +37,8 @@ namespace cuttlefish {
  * If some setup fails, `command` fails to start, or `command` exits due to a
  * signal, the return value will be negative.
  */
-int RunWithManagedStdio(Command&& cmd_tmp, const std::string* stdin,
-                        std::string* stdout, std::string* stderr,
+int RunWithManagedStdio(Command, const std::string* stdin, std::string* stdout,
+                        std::string* stderr,
                         SubprocessOptions options = SubprocessOptions());
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/wait_for_unix_socket.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/wait_for_unix_socket.cpp
@@ -80,16 +80,9 @@ Result<void> WaitForUnixSocketListeningWithoutConnect(const std::string& path,
     Command lsof("/usr/bin/lsof");
     lsof.AddParameter(/*"format"*/ "-F", /*"connection state"*/ "TST");
     lsof.AddParameter(path);
-    std::string lsof_out;
-    std::string lsof_err;
-    int rval =
-        RunWithManagedStdio(std::move(lsof), nullptr, &lsof_out, &lsof_err);
-    if (rval != 0) {
-      return CF_ERR("Failed to run `lsof`, stderr: " << lsof_err);
-    }
+    std::string lsof_out = CF_EXPECT(RunAndCaptureStdout(std::move(lsof)));
 
     LOG(DEBUG) << "lsof stdout:|" << lsof_out << "|";
-    LOG(DEBUG) << "lsof stderr:|" << lsof_err << "|";
 
     std::smatch socket_state_match;
     if (std::regex_search(lsof_out, socket_state_match, socket_state_regex)) {

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/clean.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/clean.cc
@@ -104,6 +104,7 @@ Result<void> CleanPriorFiles(const std::vector<std::string>& paths,
   if (!InSandbox() && (!prior_dirs.empty() || !prior_files.empty())) {
     Command lsof("lsof");
     lsof.AddParameter("-t");
+    lsof.AddParameter("-Q");  // ignore failed search terms
     for (const auto& prior_dir : prior_dirs) {
       lsof.AddParameter("+D").AddParameter(prior_dir);
     }
@@ -111,18 +112,16 @@ Result<void> CleanPriorFiles(const std::vector<std::string>& paths,
       lsof.AddParameter(prior_file);
     }
 
-    std::string lsof_out;
-    std::string lsof_err;
-    int rval =
-        RunWithManagedStdio(std::move(lsof), nullptr, &lsof_out, &lsof_err);
-    if (rval != 0 && !lsof_err.empty()) {
-      LOG(ERROR) << "Failed to run `lsof`, received message: " << lsof_err;
+    Result<std::string> lsof_out = RunAndCaptureStdout(std::move(lsof));
+    if (lsof_out.ok()) {
+      std::vector<std::string> pids = android::base::Split(*lsof_out, "\n");
+      CF_EXPECTF(
+          lsof_out->empty(),
+          "Instance directory files in use. Try `cvd reset`? Observed PIDs: {}",
+          fmt::join(pids, ", "));
+    } else {
+      LOG(ERROR) << "Failed to run `lsof`: " << lsof_out.error().FormatForEnv();
     }
-    auto pids = android::base::Split(lsof_out, "\n");
-    CF_EXPECTF(
-        lsof_out.empty(),
-        "Instance directory files in use. Try `cvd reset`? Observed PIDs: {}",
-        fmt::join(pids, ", "));
   }
 
   for (const auto& path : paths) {

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/graphics_flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/graphics_flags.cc
@@ -539,7 +539,7 @@ GetGraphicsAvailabilityWithSubprocessCheck() {
   auto graphics_detector_binary_result = GraphicsDetectorBinaryPath();
   if (!graphics_detector_binary_result.ok()) {
     LOG(ERROR) << "Failed to run graphics detector, graphics detector path "
-               << " not available: "
+               << " not available: \n"
                << graphics_detector_binary_result.error().FormatForEnv()
                << ". Assuming no availability.";
     return {};
@@ -550,15 +550,15 @@ GetGraphicsAvailabilityWithSubprocessCheck() {
   Command graphics_detector_cmd(graphics_detector_binary_result.value());
   graphics_detector_cmd.AddParameter(graphics_availability_file.path);
 
-  std::string graphics_detector_stdout;
-  auto ret = RunWithManagedStdio(std::move(graphics_detector_cmd), nullptr,
-                                 &graphics_detector_stdout, nullptr);
-  if (ret != 0) {
-    LOG(ERROR) << "Failed to run graphics detector, bad return value: " << ret
-               << ". Assuming no availability.";
+  Result<std::string> graphics_detector_stdout =
+      RunAndCaptureStdout(std::move(graphics_detector_cmd));
+  if (!graphics_detector_stdout.ok()) {
+    LOG(ERROR)
+        << "Failed to run graphics detector, assuming no availability: \n"
+        << graphics_detector_stdout.error().FormatForEnv();
     return {};
   }
-  LOG(DEBUG) << graphics_detector_stdout;
+  LOG(DEBUG) << *graphics_detector_stdout;
 
   auto graphics_availability_content_result =
       ReadFileContents(graphics_availability_file.path);

--- a/base/cvd/cuttlefish/host/commands/cvd/acloud/converter.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/acloud/converter.cpp
@@ -81,10 +81,7 @@ static Result<BranchBuildTargetInfo> GetDefaultBranchBuildTarget(
     repo_cmd.SetWorkingDirectory(fd_top);
   }
 
-  std::string repo_stdout;
-  CF_EXPECT_EQ(
-      RunWithManagedStdio(std::move(repo_cmd), nullptr, &repo_stdout, nullptr),
-      0);
+  std::string repo_stdout = CF_EXPECT(RunAndCaptureStdout(std::move(repo_cmd)));
 
   Command git_cmd("git");
   git_cmd.AddParameter("remote");
@@ -92,10 +89,7 @@ static Result<BranchBuildTargetInfo> GetDefaultBranchBuildTarget(
     git_cmd.SetWorkingDirectory(fd_top);
   }
 
-  std::string git_stdout;
-  CF_EXPECT_EQ(
-      RunWithManagedStdio(std::move(git_cmd), nullptr, &git_stdout, nullptr),
-      0);
+  std::string git_stdout = CF_EXPECT(RunAndCaptureStdout(std::move(git_cmd)));
 
   git_stdout.erase(std::remove(git_stdout.begin(), git_stdout.end(), '\n'),
                    git_stdout.cend());
@@ -133,10 +127,7 @@ Result<std::vector<std::string>> BashTokenize(const std::string& str) {
   command.AddParameter("-c");
   command.AddParameter("printf '%s\n' ", str);
 
-  std::string bash_stdout;
-  CF_EXPECT(
-      RunWithManagedStdio(std::move(command), nullptr, &bash_stdout, nullptr),
-      0);
+  std::string bash_stdout = CF_EXPECT(RunAndCaptureStdout(std::move(command)));
 
   return android::base::Split(bash_stdout, "\n");
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
@@ -454,7 +454,6 @@ cf_cc_library(
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/common/libs/utils:subprocess",
-        "//cuttlefish/common/libs/utils:subprocess_managed_stdio",
         "//cuttlefish/host/commands/cvd/acloud",
         "//cuttlefish/host/commands/cvd/cli:command_request",
         "//cuttlefish/host/commands/cvd/cli:types",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/try_acloud.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/try_acloud.cpp
@@ -32,7 +32,6 @@
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/result.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"
-#include "cuttlefish/common/libs/utils/subprocess_managed_stdio.h"
 #include "cuttlefish/host/commands/cvd/acloud/config.h"
 #include "cuttlefish/host/commands/cvd/acloud/converter.h"
 #include "cuttlefish/host/commands/cvd/acloud/create_converter_parser.h"
@@ -61,12 +60,7 @@ constexpr char kDetailedHelpText[] =
    
     - Or `cvdr` for remote instance management.)";
 
-bool CheckIfCvdrExist() {
-  auto cmd = Command("which").AddParameter(kCvdrBinName);
-  int ret = RunWithManagedStdio(std::move(cmd), nullptr, nullptr, nullptr,
-                                SubprocessOptions());
-  return ret == 0;
-}
+bool CheckIfCvdrExist() { return Execute({"which", kCvdrBinName}) == 0; }
 
 }  // namespace
 

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_record.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_record.cpp
@@ -104,8 +104,7 @@ Result<Json::Value> LocalInstance::FetchStatus(std::chrono::seconds timeout) {
 }
 
 Result<void> LocalInstance::PressPowerBtn() {
-  auto bin_check = 
-      HostToolTarget(host_artifacts_path()).GetPowerBtnBinPath();
+  auto bin_check = HostToolTarget(host_artifacts_path()).GetPowerBtnBinPath();
   if (bin_check.ok()) {
     return PressPowerBtnLegacy();
   }
@@ -115,18 +114,12 @@ Result<void> LocalInstance::PressPowerBtn() {
                "powerbtn not supported in vm manager " << config->vm_manager());
   auto instance = config->ForInstance(id());
 
-  Command command(instance.crosvm_binary());
-  command.AddParameter("powerbtn");
-  command.AddParameter(instance.CrosvmSocketPath());
+  Command command = Command(instance.crosvm_binary())
+                        .AddParameter("powerbtn")
+                        .AddParameter(instance.CrosvmSocketPath());
 
   LOG(INFO) << "Pressing power button";
-  std::string output;
-  std::string error;
-  auto ret = RunWithManagedStdio(std::move(command), NULL, &output, &error);
-  CF_EXPECT_EQ(ret, 0,
-               "crosvm powerbtn returned: " << ret << "\n"
-                                            << output << "\n"
-                                            << error);
+  CF_EXPECT(RunAndCaptureStdout(std::move(command)));
   return {};
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/reset_client_utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/reset_client_utils.cpp
@@ -62,7 +62,6 @@ static Command CreateStopCvdCommand(const std::string& stopper_path,
 Result<void> RunStopCvd(const GroupProcInfo& group_info,
                         bool clear_runtime_dirs) {
   const auto& stopper_path = group_info.stop_cvd_path_;
-  int ret_code = 0;
   cvd_common::Envs stop_cvd_envs;
   stop_cvd_envs["HOME"] = group_info.home_;
   if (group_info.android_host_out_) {
@@ -79,42 +78,32 @@ Result<void> RunStopCvd(const GroupProcInfo& group_info,
   if (clear_runtime_dirs) {
     Command first_stop_cvd = CreateStopCvdCommand(
         stopper_path, stop_cvd_envs, {"--clear_instance_dirs=true"});
-    LOG(ERROR) << "Running HOME=" << stop_cvd_envs.at("HOME") << " "
-               << stopper_path << " --clear_instance_dirs=true";
-    std::string stdout_str;
-    std::string stderr_str;
-    ret_code = RunWithManagedStdio(std::move(first_stop_cvd), nullptr,
-                                   std::addressof(stdout_str),
-                                   std::addressof(stderr_str));
-    // TODO(kwstephenkim): deletes manually if `stop_cvd --clear_instance_dirs`
-    // failed.
-  }
-  if (!clear_runtime_dirs || ret_code != 0) {
-    if (clear_runtime_dirs) {
+    LOG(INFO) << "Running HOME=" << stop_cvd_envs.at("HOME") << " "
+              << stopper_path << " --clear_instance_dirs=true";
+    if (RunAndCaptureStdout(std::move(first_stop_cvd)).ok()) {
+      LOG(INFO) << "\"" << stopper_path << " successfully "
+                << "\" stopped instances at HOME=" << group_info.home_;
+      return {};
+    } else {
       LOG(ERROR) << "Failed to run " << stopper_path
                  << " --clear_instance_dirs=true";
       LOG(ERROR) << "Perhaps --clear_instance_dirs is not taken.";
       LOG(ERROR) << "Trying again without it";
     }
-    Command second_stop_cvd =
-        CreateStopCvdCommand(stopper_path, stop_cvd_envs, {});
-    LOG(ERROR) << "Running HOME=" << stop_cvd_envs.at("HOME") << " "
-               << stopper_path;
-    std::string stdout_str;
-    std::string stderr_str;
-    ret_code = RunWithManagedStdio(std::move(second_stop_cvd), nullptr,
-                                   std::addressof(stdout_str),
-                                   std::addressof(stderr_str));
+    // TODO(kwstephenkim): deletes manually if `stop_cvd --clear_instance_dirs`
+    // failed.
   }
-  if (ret_code != 0) {
-    std::stringstream error;
-    error << "HOME=" << group_info.home_
-          << group_info.stop_cvd_path_ + " Failed.";
-    return CF_ERR(error.str());
+  Command second_stop_cvd =
+      CreateStopCvdCommand(stopper_path, stop_cvd_envs, {});
+  LOG(INFO) << "Running HOME=" << stop_cvd_envs.at("HOME") << " "
+            << stopper_path;
+  if (RunAndCaptureStdout(std::move(second_stop_cvd)).ok()) {
+    LOG(INFO) << "\"" << stopper_path << " successfully "
+              << "\" stopped instances at HOME=" << group_info.home_;
+    return {};
   }
-  LOG(ERROR) << "\"" << stopper_path << " successfully "
-             << "\" stopped instances at HOME=" << group_info.home_;
-  return {};
+  return CF_ERRF("`HOME={} {}` Failed", group_info.home_,
+                 group_info.stop_cvd_path_);
 }
 
 Result<void> RunStopCvdAll(bool clear_runtime_dirs) {

--- a/base/cvd/cuttlefish/host/commands/health/health.cpp
+++ b/base/cvd/cuttlefish/host/commands/health/health.cpp
@@ -116,17 +116,20 @@ int main(int argc, char** argv) {
     }
   }
 
-  cuttlefish::Command command(instance.crosvm_binary());
-  command.AddParameter("battery");
-  command.AddParameter("goldfish");
-  command.AddParameter(key);
-  command.AddParameter(value);
-  command.AddParameter(GetControlSocketPath(*config));
+  cuttlefish::Command command =
+      cuttlefish::Command(instance.crosvm_binary())
+          .AddParameter("battery")
+          .AddParameter("goldfish")
+          .AddParameter(key)
+          .AddParameter(value)
+          .AddParameter(GetControlSocketPath(*config));
 
-  std::string output, error;
-  auto ret = RunWithManagedStdio(std::move(command), NULL, &output, &error);
-  if (ret != 0) {
-    LOG(ERROR) << "goldfish battery returned: " << ret << "\n" << output << "\n" << error;
+  cuttlefish::Result<std::string> res =
+      cuttlefish::RunAndCaptureStdout(std::move(command));
+  if (res.ok()) {
+    return 0;
+  } else {
+    LOG(ERROR) << "goldfish battery failed: " << res.error().FormatForEnv();
+    return 1;
   }
-  return ret;
 }

--- a/base/cvd/cuttlefish/host/commands/powerbtn_cvd/powerbtn_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/powerbtn_cvd/powerbtn_cvd.cc
@@ -35,18 +35,12 @@ Result<void> PowerbtnCvdMain() {
       CF_EXPECT(CuttlefishConfig::Get(), "Failed to obtain config object");
   auto instance = config->ForInstance(FLAGS_instance_num);
 
-  Command command(instance.crosvm_binary());
-  command.AddParameter("powerbtn");
-  command.AddParameter(instance.CrosvmSocketPath());
+  Command command = Command(instance.crosvm_binary())
+                        .AddParameter("powerbtn")
+                        .AddParameter(instance.CrosvmSocketPath());
 
   LOG(INFO) << "Pressing power button";
-  std::string output;
-  std::string error;
-  auto ret = RunWithManagedStdio(std::move(command), NULL, &output, &error);
-  CF_EXPECT_EQ(ret, 0,
-               "crosvm powerbtn returned: " << ret << "\n"
-                                            << output << "\n"
-                                            << error);
+  CF_EXPECT(RunAndCaptureStdout(std::move(command)));
   return {};
 }
 

--- a/base/cvd/cuttlefish/host/libs/avb/avb.cpp
+++ b/base/cvd/cuttlefish/host/libs/avb/avb.cpp
@@ -93,16 +93,7 @@ Result<std::string> Avb::InfoImage(const std::string& image_path) const {
                             .AddParameter(kInfoImage)
                             .AddParameter("--image")
                             .AddParameter(image_path);
-
-  std::string standard_out, standard_err;
-  int exit_code = RunWithManagedStdio(std::move(avbtool_cmd), nullptr,
-                                      &standard_out, &standard_err);
-  CF_EXPECTF(exit_code == 0,
-             "Failed to run avbtool {} on '{}': code = {}, stdout = '{}', "
-             "stderr = '{}'",
-             kInfoImage, image_path, exit_code, standard_out, standard_err);
-
-  return standard_out;
+  return CF_EXPECT(RunAndCaptureStdout(std::move(avbtool_cmd)));
 }
 
 Command Avb::GenerateMakeVbMetaImage(

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -60,7 +60,6 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:in_sandbox",
         "//cuttlefish/common/libs/utils:subprocess",
-        "//cuttlefish/common/libs/utils:subprocess_managed_stdio",
         "//cuttlefish/host/libs/config:config_constants",
         "//libbase",
     ],

--- a/base/cvd/cuttlefish/host/libs/config/config_utils.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/config_utils.cpp
@@ -33,7 +33,6 @@
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/in_sandbox.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"
-#include "cuttlefish/common/libs/utils/subprocess_managed_stdio.h"
 #include "cuttlefish/host/libs/config/config_constants.h"
 
 namespace cuttlefish {
@@ -177,10 +176,8 @@ bool HostSupportsQemuCli() {
   static bool supported =
 #ifdef __linux__
       InSandbox() ||
-      RunWithManagedStdio(
-          Command("/usr/lib/cuttlefish-common/bin/capability_query.py")
-              .AddParameter("qemu_cli"),
-          nullptr, nullptr, nullptr) == 0;
+      Execute({"/usr/lib/cuttlefish-common/bin/capability_query.py",
+               "qemu_cli"}) == 0;
 #else
       true;
 #endif

--- a/base/cvd/cuttlefish/host/libs/image_aggregator/qcow2.cc
+++ b/base/cvd/cuttlefish/host/libs/image_aggregator/qcow2.cc
@@ -62,18 +62,7 @@ Result<Qcow2Image> Qcow2Image::Create(const std::string& crosvm_path,
                            .AddParameter(backing_file)
                            .AddParameter(output_overlay_path);
 
-  std::string stdout_str;
-  std::string stderr_str;
-  int return_code = RunWithManagedStdio(std::move(create_cmd), nullptr,
-                                        &stdout_str, &stderr_str);
-  CF_EXPECT_EQ(return_code, 0,
-               "Failed to run `"
-                   << crosvm_path << " create_qcow2 --backing-file "
-                   << backing_file << " " << output_overlay_path << "`"
-                   << "stdout:\n###\n"
-                   << stdout_str << "\n###"
-                   << "stderr:\n###\n"
-                   << stderr_str << "\n###");
+  CF_EXPECT(RunAndCaptureStdout(std::move(create_cmd)));
 
   return CF_EXPECT(OpenExisting(std::move(output_overlay_path)));
 }

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_display_controller.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_display_controller.cpp
@@ -105,16 +105,15 @@ Result<int> CrosvmDisplayController::RunCrosvmDisplayCommand(
   }
   command.AddParameter(crosvm_control_path);
 
-  std::string err;
-  auto ret = RunWithManagedStdio(std::move(command), NULL, stdout_str, &err);
-  if (ret != 0) {
-    LOG(ERROR) << "Failed to run crosvm display command: ret code: " << ret
-               << "\n"
-               << err << std::endl;
-    return CF_ERRF("Failed to run crosvm display command: ret code: {}", ret);
+  Result<std::string> res = RunAndCaptureStdout(std::move(command));
+  if (res.ok()) {
+    return 0;
+  } else {
+    LOG(ERROR) << "Failed to run crosvm display command:\n"
+               << res.error().FormatForEnv();
+    CF_EXPECT(std::move(res));
+    return 0;
   }
-
-  return 0;
 }
 
 }  // namespace vm_manager

--- a/base/cvd/cuttlefish/host/libs/vm_manager/qemu_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/qemu_manager.cpp
@@ -92,16 +92,8 @@ Result<std::pair<int, int>> GetQemuVersion(const std::string& qemu_binary) {
   Command qemu_version_cmd(qemu_binary);
   qemu_version_cmd.AddParameter("-version");
 
-  std::string qemu_version_input, qemu_version_output, qemu_version_error;
-  cuttlefish::SubprocessOptions options;
-  options.Verbose(false);
-  int qemu_version_ret = cuttlefish::RunWithManagedStdio(
-      std::move(qemu_version_cmd), &qemu_version_input, &qemu_version_output,
-      &qemu_version_error, std::move(options));
-  CF_EXPECT(qemu_version_ret == 0,
-            qemu_binary << " -version returned unexpected response "
-                        << qemu_version_output << ". Stderr was "
-                        << qemu_version_error);
+  std::string qemu_version_output =
+      CF_EXPECT(RunAndCaptureStdout(std::move(qemu_version_cmd)));
 
   // Snip around the extra text we don't care about
   qemu_version_output.erase(0, std::string("QEMU emulator version ").length());


### PR DESCRIPTION
https://www.github.com/google/android-cuttlefish/pull/1432/files#r2226344612 points out that many callers have the same logic around calling RunWithManagedStdio. We should have a nicer interface for the common case.