### PR TITLE
Extract `WaitForFile` out of `files.cpp`

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
@@ -103,7 +103,6 @@ cf_cc_library(
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:in_sandbox",
-        "//cuttlefish/common/libs/utils:inotify",
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/common/libs/utils:users",
         "//libbase",
@@ -452,6 +451,19 @@ cf_cc_library(
 )
 
 cf_cc_library(
+    name = "wait_for_file",
+    srcs = ["wait_for_file.cc"],
+    hdrs = ["wait_for_file.h"],
+    deps = [
+        "//cuttlefish/common/libs/utils:contains",
+        "//cuttlefish/common/libs/utils:files",
+        "//cuttlefish/common/libs/utils:inotify",
+        "//cuttlefish/common/libs/utils:result",
+        "//libbase",
+    ],
+)
+
+cf_cc_library(
     name = "wait_for_unix_socket",
     srcs = ["wait_for_unix_socket.cpp"],
     hdrs = ["wait_for_unix_socket.h"],
@@ -460,5 +472,6 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/common/libs/utils:subprocess",
         "//cuttlefish/common/libs/utils:subprocess_managed_stdio",
+        "//cuttlefish/common/libs/utils:wait_for_file",
     ],
 )

--- a/base/cvd/cuttlefish/common/libs/utils/files.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/files.cpp
@@ -19,7 +19,6 @@
 #ifdef __linux__
 #include <linux/fiemap.h>
 #include <linux/fs.h>
-#include <sys/inotify.h>
 #include <sys/sendfile.h>
 #endif
 
@@ -50,9 +49,7 @@
 #include <memory>
 #include <numeric>
 #include <ostream>
-#include <regex>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include <android-base/file.h>
@@ -66,7 +63,6 @@
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/contains.h"
 #include "cuttlefish/common/libs/utils/in_sandbox.h"
-#include "cuttlefish/common/libs/utils/inotify.h"
 #include "cuttlefish/common/libs/utils/result.h"
 #include "cuttlefish/common/libs/utils/users.h"
 
@@ -669,98 +665,6 @@ Result<void> WalkDirectory(
   }
   return {};
 }
-
-#ifdef __linux__
-class InotifyWatcher {
- public:
-  InotifyWatcher(int inotify, const std::string& path, int watch_mode)
-      : inotify_(inotify) {
-    watch_ = inotify_add_watch(inotify_, path.c_str(), watch_mode);
-  }
-  virtual ~InotifyWatcher() { inotify_rm_watch(inotify_, watch_); }
-
- private:
-  int inotify_;
-  int watch_;
-};
-
-static Result<void> WaitForFileInternal(const std::string& path, int timeoutSec,
-                                        int inotify) {
-  CF_EXPECT_NE(path, "", "Path is empty");
-
-  if (FileExists(path, true)) {
-    return {};
-  }
-
-  const auto targetTime =
-      std::chrono::system_clock::now() + std::chrono::seconds(timeoutSec);
-
-  const std::string parentPath = android::base::Dirname(path);
-  const std::string filename = android::base::Basename(path);
-
-  CF_EXPECT(WaitForFile(parentPath, timeoutSec),
-            "Error while waiting for parent directory creation");
-
-  auto watcher = InotifyWatcher(inotify, parentPath.c_str(), IN_CREATE);
-
-  if (FileExists(path, true)) {
-    return {};
-  }
-
-  while (true) {
-    const auto currentTime = std::chrono::system_clock::now();
-
-    if (currentTime >= targetTime) {
-      return CF_ERR("Timed out");
-    }
-
-    const auto timeRemain =
-        std::chrono::duration_cast<std::chrono::microseconds>(targetTime -
-                                                              currentTime)
-            .count();
-    const auto secondInUsec =
-        std::chrono::microseconds(std::chrono::seconds(1)).count();
-    struct timeval timeout;
-
-    timeout.tv_sec = timeRemain / secondInUsec;
-    timeout.tv_usec = timeRemain % secondInUsec;
-
-    fd_set readfds;
-
-    FD_ZERO(&readfds);
-    FD_SET(inotify, &readfds);
-
-    auto ret = select(inotify + 1, &readfds, NULL, NULL, &timeout);
-
-    if (ret == 0) {
-      return CF_ERR("select() timed out");
-    } else if (ret < 0) {
-      return CF_ERRNO("select() failed");
-    }
-
-    auto names = GetCreatedFileListFromInotifyFd(inotify);
-
-    CF_EXPECT(!names.empty(),
-              "Failed to get names from inotify " << strerror(errno));
-
-    if (Contains(names, filename)) {
-      return {};
-    }
-  }
-
-  return CF_ERR("This shouldn't be executed");
-}
-
-auto WaitForFile(const std::string& path, int timeoutSec)
-    -> decltype(WaitForFileInternal(path, timeoutSec, 0)) {
-  android::base::unique_fd inotify(inotify_init1(IN_CLOEXEC));
-
-  CF_EXPECT(WaitForFileInternal(path, timeoutSec, inotify.get()));
-
-  return {};
-}
-
-#endif
 
 namespace {
 

--- a/base/cvd/cuttlefish/common/libs/utils/files.h
+++ b/base/cvd/cuttlefish/common/libs/utils/files.h
@@ -105,10 +105,6 @@ Result<void> WalkDirectory(
     const std::string& dir,
     const std::function<bool(const std::string&)>& callback);
 
-#ifdef __linux__
-Result<void> WaitForFile(const std::string& path, int timeoutSec);
-#endif
-
 // parameter to EmulateAbsolutePath
 struct InputPathForm {
   /** If nullopt, uses the process' current working dir

--- a/base/cvd/cuttlefish/common/libs/utils/wait_for_file.cc
+++ b/base/cvd/cuttlefish/common/libs/utils/wait_for_file.cc
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/common/libs/utils/wait_for_file.h"
+
+#ifdef __linux__
+#include <sys/inotify.h>
+#endif
+#include <sys/select.h>
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+#include <android-base/file.h>
+#include <android-base/unique_fd.h>
+
+#include "cuttlefish/common/libs/utils/contains.h"
+#include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/common/libs/utils/inotify.h"
+#include "cuttlefish/common/libs/utils/result.h"
+
+#ifdef __linux__
+
+namespace cuttlefish {
+namespace {
+class InotifyWatcher {
+ public:
+  InotifyWatcher(int inotify, const std::string& path, int watch_mode)
+      : inotify_(inotify) {
+    watch_ = inotify_add_watch(inotify_, path.c_str(), watch_mode);
+  }
+  virtual ~InotifyWatcher() { inotify_rm_watch(inotify_, watch_); }
+
+ private:
+  int inotify_;
+  int watch_;
+};
+
+Result<void> WaitForFileInternal(const std::string& path, int timeoutSec,
+                                 int inotify) {
+  CF_EXPECT_NE(path, "", "Path is empty");
+
+  if (FileExists(path, true)) {
+    return {};
+  }
+
+  const auto targetTime =
+      std::chrono::system_clock::now() + std::chrono::seconds(timeoutSec);
+
+  const std::string parentPath = android::base::Dirname(path);
+  const std::string filename = android::base::Basename(path);
+
+  CF_EXPECT(WaitForFile(parentPath, timeoutSec),
+            "Error while waiting for parent directory creation");
+
+  auto watcher = InotifyWatcher(inotify, parentPath.c_str(), IN_CREATE);
+
+  if (FileExists(path, true)) {
+    return {};
+  }
+
+  while (true) {
+    const auto currentTime = std::chrono::system_clock::now();
+
+    if (currentTime >= targetTime) {
+      return CF_ERR("Timed out");
+    }
+
+    const auto timeRemain =
+        std::chrono::duration_cast<std::chrono::microseconds>(targetTime -
+                                                              currentTime)
+            .count();
+    const auto secondInUsec =
+        std::chrono::microseconds(std::chrono::seconds(1)).count();
+    struct timeval timeout;
+
+    timeout.tv_sec = timeRemain / secondInUsec;
+    timeout.tv_usec = timeRemain % secondInUsec;
+
+    fd_set readfds;
+
+    FD_ZERO(&readfds);
+    FD_SET(inotify, &readfds);
+
+    auto ret = select(inotify + 1, &readfds, NULL, NULL, &timeout);
+
+    if (ret == 0) {
+      return CF_ERR("select() timed out");
+    } else if (ret < 0) {
+      return CF_ERRNO("select() failed");
+    }
+
+    auto names = GetCreatedFileListFromInotifyFd(inotify);
+
+    CF_EXPECT(!names.empty(),
+              "Failed to get names from inotify " << strerror(errno));
+
+    if (Contains(names, filename)) {
+      return {};
+    }
+  }
+
+  return CF_ERR("This shouldn't be executed");
+}
+
+}  // namespace
+
+Result<void> WaitForFile(const std::string& path, int timeoutSec) {
+  android::base::unique_fd inotify(inotify_init1(IN_CLOEXEC));
+
+  CF_EXPECT(WaitForFileInternal(path, timeoutSec, inotify.get()));
+
+  return {};
+}
+
+#endif
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/wait_for_file.h
+++ b/base/cvd/cuttlefish/common/libs/utils/wait_for_file.h
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #pragma once
 
 #include <string>
@@ -23,9 +22,7 @@
 namespace cuttlefish {
 
 #ifdef __linux__
-Result<void> WaitForUnixSocket(const std::string& path, int timeoutSec);
-Result<void> WaitForUnixSocketListeningWithoutConnect(const std::string& path,
-                                                      int timeoutSec);
+Result<void> WaitForFile(const std::string& path, int timeoutSec);
 #endif
 
-}
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/wait_for_unix_socket.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/wait_for_unix_socket.cpp
@@ -24,6 +24,7 @@
 #include "cuttlefish/common/libs/utils/result.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"
 #include "cuttlefish/common/libs/utils/subprocess_managed_stdio.h"
+#include "cuttlefish/common/libs/utils/wait_for_file.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
@@ -191,6 +191,7 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/common/libs/utils:subprocess",
+        "//cuttlefish/common/libs/utils:wait_for_file",
         "//cuttlefish/host/commands/run_cvd/launch:log_tee_creator",
         "//cuttlefish/host/libs/config:config_utils",
         "//cuttlefish/host/libs/config:cuttlefish_config",

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/mcu.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/mcu.cpp
@@ -28,6 +28,7 @@
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/result.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"
+#include "cuttlefish/common/libs/utils/wait_for_file.h"
 #include "cuttlefish/host/commands/run_cvd/launch/log_tee_creator.h"
 #include "cuttlefish/host/libs/config/config_utils.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"


### PR DESCRIPTION
`files.cpp` is a large file.

Bug: b/434282027