### PR TITLE
Make `cvd host_bugreport` more robust

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
@@ -80,6 +80,9 @@ cf_cc_library(
         "//cuttlefish/host/commands/cvd/cli/selector",
         "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/commands/cvd/utils",
+        "//cuttlefish/host/libs/zip:zip_cc",
+        "//cuttlefish/host/libs/zip:zip_file",
+        "//libbase",
         "@fmt",
     ],
 )

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/bugreport.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/bugreport.cpp
@@ -22,10 +22,13 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <fmt/core.h>
 
+#include "android-base/file.h"
+#include "android-base/logging.h"
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/flag_parser.h"
 #include "cuttlefish/common/libs/utils/result.h"
@@ -37,8 +40,11 @@
 #include "cuttlefish/host/commands/cvd/cli/selector/selector.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/host/commands/cvd/cli/utils.h"
+#include "cuttlefish/host/commands/cvd/instances/instance_group_record.h"
 #include "cuttlefish/host/commands/cvd/instances/instance_manager.h"
 #include "cuttlefish/host/commands/cvd/utils/common.h"
+#include "cuttlefish/host/libs/zip/zip_cc.h"
+#include "cuttlefish/host/libs/zip/zip_file.h"
 
 namespace cuttlefish {
 namespace {
@@ -46,11 +52,47 @@ namespace {
 constexpr char kSummaryHelpText[] =
     "Run cvd bugreport --help for command description";
 
+// Accepts a copy of the args to not modify the original.
+Result<std::string> OutputFileFromArgs(cvd_common::Args args) {
+  // This flag must match the one defined in
+  // //cuttlefish/host/commands/host_bugreport/main.cc
+  std::string output = "host_bugreport.zip";
+  std::vector<Flag> flags = {
+      GflagsCompatFlag("output", output),
+  };
+  CF_EXPECT(ConsumeFlags(flags, args));
+  return output;
+}
+
+Result<void> AddFetchLogIfPresent(const LocalInstanceGroup& instance_group,
+                                  const std::string& output_file) {
+  std::string fetch_log_path = instance_group.ProductOutPath() + "/fetch.log";
+  if (!FileExists(fetch_log_path)) {
+    // The fetch log is in the parent of the host artifacts path when cvd create
+    // --config_file was used.
+    fetch_log_path =
+        android::base::Dirname(instance_group.HostArtifactsPath()) +
+        "/fetch.log";
+  }
+  if (!FileExists(fetch_log_path)) {
+    // There will be no fetch log when running from local sources
+    return {};
+  }
+  LOG(INFO) << "Attaching fetch.log to report";
+  WritableZip archive = CF_EXPECT(ZipOpenReadWrite(output_file));
+  CF_EXPECT(AddFileAt(archive, fetch_log_path, "fetch.log"));
+  CF_EXPECT(WritableZip::Finalize(std::move(archive)));
+  return {};
+}
+
 class CvdBugreportCommandHandler : public CvdCommandHandler {
  public:
   CvdBugreportCommandHandler(InstanceManager& instance_manager);
 
   Result<void> Handle(const CommandRequest& request) override;
+  Result<void> HandleHelp(const cvd_common::Envs& env,
+                          const cvd_common::Args& cmd_args,
+                          const CommandRequest& request);
   cvd_common::Args CmdList() const override;
   Result<std::string> SummaryHelp() const override;
   bool ShouldInterceptHelp() const override;
@@ -77,19 +119,24 @@ Result<void> CvdBugreportCommandHandler::Handle(const CommandRequest& request) {
 
   std::string android_host_out;
   std::string home = CF_EXPECT(SystemWideUserHome());
-  if (!CF_EXPECT(HasHelpFlag(cmd_args))) {
-    bool has_instance_groups = CF_EXPECT(instance_manager_.HasInstanceGroups());
-    CF_EXPECTF(!!has_instance_groups, "{}", NoGroupMessage(request));
 
-    auto instance_group =
-        CF_EXPECT(selector::SelectGroup(instance_manager_, request));
-    android_host_out = instance_group.HostArtifactsPath();
-    home = instance_group.HomeDir();
-    env["HOME"] = home;
-    env[kAndroidHostOut] = android_host_out;
-  } else {
-    android_host_out = CF_EXPECT(AndroidHostPath(env));
+  if (CF_EXPECT(HasHelpFlag(cmd_args))) {
+    CF_EXPECT(HandleHelp(env, cmd_args, request));
+    return {};
   }
+
+  std::string output_file =
+      CF_EXPECT(OutputFileFromArgs(cmd_args), "Failed to parse output flag");
+
+  bool has_instance_groups = CF_EXPECT(instance_manager_.HasInstanceGroups());
+  CF_EXPECTF(!!has_instance_groups, "{}", NoGroupMessage(request));
+
+  auto instance_group =
+      CF_EXPECT(selector::SelectGroup(instance_manager_, request));
+  android_host_out = instance_group.HostArtifactsPath();
+  home = instance_group.HomeDir();
+  env["HOME"] = home;
+  env[kAndroidHostOut] = android_host_out;
   auto bin_path = ConcatToString(android_host_out, "/bin/", kHostBugreportBin);
 
   ConstructCommandParam construct_cmd_param{.bin_path = bin_path,
@@ -100,11 +147,32 @@ Result<void> CvdBugreportCommandHandler::Handle(const CommandRequest& request) {
                                             .command_name = kHostBugreportBin};
   Command command = CF_EXPECT(ConstructCommand(construct_cmd_param));
 
+  // Wait for the command to finish but ignore the result. The command will fail
+  // for reasons like the device failing to initialize the home directory or
+  // errors during fetch, which are still debuggable states that require a
+  // report.
+  (void)command.Start().Wait();
+
+  auto result = AddFetchLogIfPresent(instance_group, output_file);
+  if (!result.ok()) {
+    LOG(ERROR) << "Failed to add fetch log to bugreport: "
+               << result.error().FormatForEnv();
+  }
+
+  return {};
+}
+
+Result<void> CvdBugreportCommandHandler::HandleHelp(
+    const cvd_common::Envs& env, const cvd_common::Args& cmd_args,
+    const CommandRequest& request) {
+  std::string android_host_out = CF_EXPECT(AndroidHostPath(env));
+  Command command = CF_EXPECT(
+      ConstructCvdHelpCommand(kHostBugreportBin, env, cmd_args, request));
+
   siginfo_t infop;  // NOLINT(misc-include-cleaner)
   command.Start().Wait(&infop, WEXITED);
 
   CF_EXPECT(CheckProcessExitedNormally(infop));
-
   return {};
 }
 

--- a/base/cvd/cuttlefish/host/libs/zip/zip_cc.h
+++ b/base/cvd/cuttlefish/host/libs/zip/zip_cc.h
@@ -224,7 +224,12 @@ class ReadableZip {
 
 class WritableZip : public ReadableZip {
  public:
-  static Result<WritableZip> FromSource(WritableZipSource);
+  enum class OpenBehavior {
+    KeepIfExists,
+    Truncate,
+  };
+  static Result<WritableZip> FromSource(
+      WritableZipSource, OpenBehavior open_behavior = OpenBehavior::Truncate);
 
   WritableZip(WritableZip&&);
   ~WritableZip() override;
@@ -239,6 +244,8 @@ class WritableZip : public ReadableZip {
   static Result<void> Finalize(WritableZip);
 
  private:
+  static Result<WritableZip> FromSource(WritableZipSource, int flags);
+
   WritableZip(std::unique_ptr<Impl>);
 };
 

--- a/base/cvd/cuttlefish/host/libs/zip/zip_file.cc
+++ b/base/cvd/cuttlefish/host/libs/zip/zip_file.cc
@@ -31,7 +31,8 @@ Result<ReadableZip> ZipOpenRead(const std::string& fs_path) {
 
 Result<WritableZip> ZipOpenReadWrite(const std::string& fs_path) {
   WritableZipSource source = CF_EXPECT(WritableZipSource::FromFile(fs_path));
-  return CF_EXPECT(WritableZip::FromSource(std::move(source)));
+  return CF_EXPECT(WritableZip::FromSource(
+      std::move(source), WritableZip::OpenBehavior::KeepIfExists));
 }
 
 Result<void> AddFile(WritableZip& zip, const std::string& fs_path) {


### PR DESCRIPTION
- The internal subcommand no longer fails when it manages to gather at least some information. It still logs any problems it encounters.
- The final bugreport archive includes the fetch.log file when it's available
- Enables appending to an existing file with the libzip wrapper