### PR TITLE
Stop supporting legacy HO golang client APIs dealing with user artifacts

### DIFF
--- a/e2etests/orchestration/bugreport_test/main_test.go
+++ b/e2etests/orchestration/bugreport_test/main_test.go
@@ -38,21 +38,18 @@ func TestBugReport(t *testing.T) {
 			log.Printf("failed to collect HO logs: %s", err)
 		}
 	})
-	uploadDir, err := srv.CreateUploadDir()
+	imageDir, err := common.PrepareArtifact(srv, "../artifacts/images.zip")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := common.UploadAndExtract(srv, uploadDir, "../artifacts/images.zip"); err != nil {
-		t.Fatal(err)
-	}
-	if err := common.UploadAndExtract(srv, uploadDir, "../artifacts/cvd-host_package.tar.gz"); err != nil {
-		t.Fatal(err)
-	}
-	cvd, err := common.CreateCVDFromUserArtifactsDir(srv, uploadDir)
+	hostPkgDir, err := common.PrepareArtifact(srv, "../artifacts/cvd-host_package.tar.gz")
 	if err != nil {
-		t.Fatalf("failed creating instance: %s", err)
+		t.Fatal(err)
 	}
-
+	cvd, err := common.CreateCVDFromImageDirs(srv, hostPkgDir, imageDir)
+	if err != nil {
+		t.Fatal(err)
+	}
 	zipFilename, err := createBugReport(srv, cvd.Group)
 	if err != nil {
 		t.Fatalf("failed creating bugreport: %s", err)

--- a/e2etests/orchestration/create_from_images_zip_test/main_test.go
+++ b/e2etests/orchestration/create_from_images_zip_test/main_test.go
@@ -35,14 +35,12 @@ func TestCreateInstance(t *testing.T) {
 			log.Printf("failed to collect HO logs: %s", err)
 		}
 	})
-	uploadDir, err := srv.CreateUploadDir()
+	imageDir, err := common.PrepareArtifact(srv, "../artifacts/images.zip")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := common.UploadAndExtract(srv, uploadDir, "../artifacts/images.zip"); err != nil {
-		t.Fatal(err)
-	}
-	if err := common.UploadAndExtract(srv, uploadDir, "../artifacts/cvd-host_package.tar.gz"); err != nil {
+	hostPkgDir, err := common.PrepareArtifact(srv, "../artifacts/cvd-host_package.tar.gz")
+	if err != nil {
 		t.Fatal(err)
 	}
 	const group_name = "foo"
@@ -50,7 +48,7 @@ func TestCreateInstance(t *testing.T) {
   {
     "common": {
       "group_name": "` + group_name + `",
-      "host_package": "@user_artifacts/` + uploadDir + `"
+      "host_package": "@image_dirs/` + hostPkgDir + `"
 
     },
     "instances": [
@@ -61,7 +59,7 @@ func TestCreateInstance(t *testing.T) {
           "cpus": 8
         },
         "disk": {
-          "default_build": "@user_artifacts/` + uploadDir + `"
+          "default_build": "@image_dirs/` + imageDir + `"
         },
         "streaming": {
           "device_id": "cvd-1"

--- a/e2etests/orchestration/powerbtn_test/BUILD.bazel
+++ b/e2etests/orchestration/powerbtn_test/BUILD.bazel
@@ -24,7 +24,6 @@ go_test(
     tags = ["host-ready"],
     deps = [
         "//orchestration/common",
-        "@com_github_google_android_cuttlefish_frontend_src_host_orchestrator//api/v1:api",
         "@com_github_google_android_cuttlefish_frontend_src_libhoclient//:libhoclient",
     ],
 )

--- a/e2etests/orchestration/powerbtn_test/main_test.go
+++ b/e2etests/orchestration/powerbtn_test/main_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/google/android-cuttlefish/e2etests/orchestration/common"
 
-	hoapi "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
 	hoclient "github.com/google/android-cuttlefish/frontend/src/libhoclient"
 )
 
@@ -40,11 +39,15 @@ func TestPowerBtn(t *testing.T) {
 			log.Printf("failed to collect HO logs: %s", err)
 		}
 	})
-	uploadDir, err := srv.CreateUploadDir()
+	imageDir, err := common.PrepareArtifact(srv, "../artifacts/images.zip")
 	if err != nil {
 		t.Fatal(err)
 	}
-	cvd, err := createDevice(srv, uploadDir)
+	hostPkgDir, err := common.PrepareArtifact(srv, "../artifacts/cvd-host_package.tar.gz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cvd, err := common.CreateCVDFromImageDirs(srv, hostPkgDir, imageDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,14 +85,4 @@ func TestPowerBtn(t *testing.T) {
 	if !strings.Contains(stdoutStr, eventName) {
 		t.Errorf("event %q was not captured", eventName)
 	}
-}
-
-func createDevice(srv hoclient.HostOrchestratorClient, dir string) (*hoapi.CVD, error) {
-	if err := common.UploadAndExtract(srv, dir, "../artifacts/images.zip"); err != nil {
-		return nil, err
-	}
-	if err := common.UploadAndExtract(srv, dir, "../artifacts/cvd-host_package.tar.gz"); err != nil {
-		return nil, err
-	}
-	return common.CreateCVDFromUserArtifactsDir(srv, dir)
 }

--- a/e2etests/orchestration/powerwash_test/BUILD.bazel
+++ b/e2etests/orchestration/powerwash_test/BUILD.bazel
@@ -24,7 +24,6 @@ go_test(
     tags = ["host-ready"],
     deps = [
         "//orchestration/common",
-        "@com_github_google_android_cuttlefish_frontend_src_host_orchestrator//api/v1:api",
         "@com_github_google_android_cuttlefish_frontend_src_libhoclient//:libhoclient",
     ],
 )

--- a/e2etests/orchestration/powerwash_test/main_test.go
+++ b/e2etests/orchestration/powerwash_test/main_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/google/android-cuttlefish/e2etests/orchestration/common"
 
-	hoapi "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
 	hoclient "github.com/google/android-cuttlefish/frontend/src/libhoclient"
 )
 
@@ -39,11 +38,15 @@ func TestPowerwash(t *testing.T) {
 			log.Printf("failed to collect HO logs: %s", err)
 		}
 	})
-	uploadDir, err := srv.CreateUploadDir()
+	imageDir, err := common.PrepareArtifact(srv, "../artifacts/images.zip")
 	if err != nil {
 		t.Fatal(err)
 	}
-	cvd, err := createDevice(srv, uploadDir)
+	hostPkgDir, err := common.PrepareArtifact(srv, "../artifacts/cvd-host_package.tar.gz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cvd, err := common.CreateCVDFromImageDirs(srv, hostPkgDir, imageDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,14 +77,4 @@ func TestPowerwash(t *testing.T) {
 	if !errors.As(err, &exitCodeErr) {
 		t.Fatal(err)
 	}
-}
-
-func createDevice(srv hoclient.HostOrchestratorClient, dir string) (*hoapi.CVD, error) {
-	if err := common.UploadAndExtract(srv, dir, "../artifacts/images.zip"); err != nil {
-		return nil, err
-	}
-	if err := common.UploadAndExtract(srv, dir, "../artifacts/cvd-host_package.tar.gz"); err != nil {
-		return nil, err
-	}
-	return common.CreateCVDFromUserArtifactsDir(srv, dir)
 }

--- a/e2etests/orchestration/upload_file_test/BUILD.bazel
+++ b/e2etests/orchestration/upload_file_test/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
     ],
     tags = ["host-ready-special"],
     deps = [
+        "@com_github_google_android_cuttlefish_frontend_src_host_orchestrator//api/v1:api",
         "@com_github_google_android_cuttlefish_frontend_src_libhoclient//:libhoclient",
         "@com_github_google_go_cmp//cmp",
     ],

--- a/frontend/src/libhoclient/host_orchestrator_client_test.go
+++ b/frontend/src/libhoclient/host_orchestrator_client_test.go
@@ -36,7 +36,7 @@ func TestUploadFileChunkSizeBytesIsZeroPanic(t *testing.T) {
 
 	srv := NewHostOrchestratorClient("https://test.com")
 
-	srv.UploadFileWithOptions("dir", "baz", UploadOptions{ChunkSizeBytes: 0})
+	srv.upload("/v1/userartifacts/foo", "baz", UploadOptions{ChunkSizeBytes: 0})
 }
 
 func TestUploadFileExponentialBackoff(t *testing.T) {
@@ -56,7 +56,7 @@ func TestUploadFileExponentialBackoff(t *testing.T) {
 
 	srv := NewHostOrchestratorClient(ts.URL)
 
-	err := srv.UploadFileWithOptions("dir", waldoFile, UploadOptions{
+	err := srv.upload("/v1/userartifacts/foo", waldoFile, UploadOptions{
 		BackOffOpts: ExpBackOffOptions{
 			InitialDuration: 100 * time.Millisecond,
 			Multiplier:      2,
@@ -90,7 +90,7 @@ func TestUploadFileExponentialBackoffReachedElapsedTime(t *testing.T) {
 
 	srv := NewHostOrchestratorClient(ts.URL)
 
-	err := srv.UploadFileWithOptions("dir", waldoFile, UploadOptions{
+	err := srv.upload("/v1/userartifacts/foo", waldoFile, UploadOptions{
 		BackOffOpts: ExpBackOffOptions{
 			InitialDuration:     100 * time.Millisecond,
 			RandomizationFactor: 0.5,


### PR DESCRIPTION
To stop supporting legacy user artifacts API in HO golang client level, HO E2E tests should switch into new ones.