### PR TITLE
root-canal -> rootcanal

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
@@ -135,7 +135,7 @@ DEFINE_vec(
     "Stop the bootflow in u-boot. You can continue the boot by connecting "
     "to the device console and typing in \"boot\".");
 DEFINE_bool(enable_host_bluetooth, CF_DEFAULTS_ENABLE_HOST_BLUETOOTH,
-            "Enable the root-canal which is Bluetooth emulator in the host.");
+            "Enable the rootcanal which is Bluetooth emulator in the host.");
 DEFINE_int32(
     rootcanal_instance_num, CF_DEFAULTS_ROOTCANAL_INSTANCE_NUM,
     "If it is greater than 0, use an existing rootcanal instance which is "

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/process_restarter.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/process_restarter.cpp
@@ -34,7 +34,7 @@ sandbox2::PolicyBuilder ProcessRestarterPolicy(const HostInfo& host) {
       .AddFileAt(sandboxer_proxy, host.HostToolExe("adb_connector"))
       .AddFileAt(sandboxer_proxy, host.HostToolExe("casimir"))
       .AddFileAt(sandboxer_proxy, host.HostToolExe("crosvm"))
-      .AddFileAt(sandboxer_proxy, host.HostToolExe("root-canal"))
+      .AddFileAt(sandboxer_proxy, host.HostToolExe("rootcanal"))
       .AddFileAt(sandboxer_proxy, host.HostToolExe("vhost_device_vsock"))
       .AddPolicyOnSyscall(__NR_prctl,
                           {ARG_32(0), JEQ32(PR_SET_PDEATHSIG, ALLOW)})

--- a/base/cvd/cuttlefish/host/commands/run_cvd/doc/linkage.dot
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/doc/linkage.dot
@@ -33,7 +33,7 @@ digraph {
 
     bt_connector
     netsim
-    root_canal [label = "root-canal"]
+    root_canal [label = "rootcanal"]
     root_canal_log_tee [label = "log_tee"]
   }
 

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/root_canal.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/root_canal.cpp
@@ -44,8 +44,8 @@ class RootCanal : public CommandSource {
 
   // CommandSource
   Result<std::vector<MonitorCommand>> Commands() override {
-    // Create the root-canal command with the process_restarter
-    // as runner to restart root-canal when it crashes.
+    // Create the rootcanal command with the process_restarter
+    // as runner to restart rootcanal when it crashes.
     Command rootcanal(ProcessRestarterBinary());
     rootcanal.AddParameter("-when_killed");
     rootcanal.AddParameter("-when_dumped");

--- a/base/cvd/cuttlefish/host/libs/config/known_paths.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/known_paths.cpp
@@ -123,7 +123,7 @@ std::string ProcessRestarterBinary() {
   return HostBinaryPath("process_restarter");
 }
 
-std::string RootCanalBinary() { return HostBinaryPath("root-canal"); }
+std::string RootCanalBinary() { return HostBinaryPath("rootcanal"); }
 
 std::string ScreenRecordingServerBinary() {
   return HostBinaryPath("screen_recording_server");


### PR DESCRIPTION
The upstream project prefers the non-hyphenated name.