### PR TITLE
Create a `VmManagerFlag` type

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/architecture.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/architecture.cpp
@@ -20,6 +20,7 @@
 #include <sys/utsname.h>
 
 #include <cstdlib>
+#include <ostream>
 #include <string>
 
 #include <android-base/logging.h>
@@ -61,6 +62,21 @@ bool IsHostCompatible(Arch arch) {
   Arch host_arch = HostArch();
   return arch == host_arch || (arch == Arch::Arm && host_arch == Arch::Arm64) ||
          (arch == Arch::X86 && host_arch == Arch::X86_64);
+}
+
+std::ostream& operator<<(std::ostream& out, Arch arch) {
+  switch (arch) {
+    case Arch::Arm:
+      return out << "arm";
+    case Arch::Arm64:
+      return out << "arm64";
+    case Arch::RiscV64:
+      return out << "riscv64";
+    case Arch::X86:
+      return out << "x86";
+    case Arch::X86_64:
+      return out << "x86_64";
+  }
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -258,6 +258,7 @@ cf_cc_library(
         "//cuttlefish/host/commands/assemble_cvd/flags:initramfs_path",
         "//cuttlefish/host/commands/assemble_cvd/flags:kernel_path",
         "//cuttlefish/host/commands/assemble_cvd/flags:system_image_dir",
+        "//cuttlefish/host/commands/assemble_cvd/flags:vm_manager",
         "//cuttlefish/host/libs/config:ap_boot_flow",
         "//cuttlefish/host/libs/config:config_constants",
         "//cuttlefish/host/libs/config:cuttlefish_config",

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
@@ -23,7 +23,6 @@
 
 #include "cuttlefish/common/libs/utils/known_paths.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags_defaults.h"
-#include "cuttlefish/host/libs/config/config_constants.h"
 #include "cuttlefish/host/libs/config/display.h"
 
 #define DEFINE_vec DEFINE_string
@@ -73,8 +72,6 @@ DEFINE_vec(serial_number, CF_DEFAULTS_SERIAL_NUMBER,
               "Serial number to use for the device");
 DEFINE_vec(use_random_serial, fmt::format("{}", CF_DEFAULTS_USE_RANDOM_SERIAL),
            "Whether to use random serial for the device.");
-DEFINE_vec(vm_manager, CF_DEFAULTS_VM_MANAGER,
-              "What virtual machine manager to use, one of {qemu_cli, crosvm}");
 DEFINE_vec(gpu_mode, CF_DEFAULTS_GPU_MODE,
            "What gpu configuration to use, one of {auto, custom, drm_virgl, "
            "gfxstream, gfxstream_guest_angle, "

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.h
@@ -45,7 +45,6 @@ DECLARE_vec(guest_enforce_security);
 DECLARE_vec(memory_mb);
 DECLARE_vec(serial_number);
 DECLARE_vec(use_random_serial);
-DECLARE_vec(vm_manager);
 DECLARE_vec(gpu_mode);
 DECLARE_vec(gpu_vhost_user_mode);
 DECLARE_vec(hwcomposer);

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/BUILD.bazel
@@ -81,3 +81,17 @@ cf_cc_library(
         "@gflags",
     ],
 )
+
+cf_cc_library(
+    name = "vm_manager",
+    srcs = ["vm_manager.cc"],
+    hdrs = ["vm_manager.h"],
+    deps = [
+        "//cuttlefish/common/libs/utils:result",
+        "//cuttlefish/host/commands/assemble_cvd:flags_defaults",
+        "//cuttlefish/host/commands/assemble_cvd:guest_config",
+        "//cuttlefish/host/libs/config:cuttlefish_config",
+        "//libbase",
+        "@gflags",
+    ],
+)

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/vm_manager.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/vm_manager.cc
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "cuttlefish/host/commands/assemble_cvd/flags/vm_manager.h"
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <android-base/strings.h>
+#include <gflags/gflags.h>
+
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/commands/assemble_cvd/flags_defaults.h"
+#include "cuttlefish/host/commands/assemble_cvd/guest_config.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
+
+DEFINE_string(vm_manager, CF_DEFAULTS_VM_MANAGER,
+              "What virtual machine manager to use, one of {qemu_cli, crosvm}");
+
+namespace cuttlefish {
+
+Result<VmManagerFlag> VmManagerFlag::FromGlobalGflags(
+    const std::vector<GuestConfig>& guest_configs) {
+  // TODO: b/250988697 - Support multiple multiple VM managers in one group
+  CF_EXPECT(!guest_configs.empty());
+  for (const GuestConfig& guest_config : guest_configs) {
+    CF_EXPECT_EQ(guest_config.target_arch, guest_configs[0].target_arch,
+                 "All instance target architectures should be the same");
+  }
+
+  std::vector<std::string> vm_manager_str_vec =
+      android::base::Split(FLAGS_vm_manager, ",");
+
+  VmmMode default_vmm = IsHostCompatible(guest_configs[0].target_arch)
+                            ? VmmMode::kCrosvm
+                            : VmmMode::kQemu;
+
+  std::vector<VmmMode> vmm_vec;
+  for (std::string_view vmm_str : vm_manager_str_vec) {
+    vmm_vec.emplace_back(vmm_str.empty() ? default_vmm
+                                         : CF_EXPECT(ParseVmm(vmm_str)));
+  }
+  if (vmm_vec.empty()) {
+    vmm_vec.emplace_back(default_vmm);
+  }
+  for (VmmMode mode : vmm_vec) {
+    CF_EXPECT_EQ(mode, vmm_vec[0], "All VMMs must be the same");
+  }
+  return VmManagerFlag(vmm_vec[0]);
+}
+
+VmManagerFlag::VmManagerFlag(VmmMode mode) : mode_(mode) {}
+
+VmmMode VmManagerFlag::Mode() const { return mode_; }
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/vm_manager.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/vm_manager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 The Android Open Source Project
+ * Copyright (C) 2019 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,23 +15,25 @@
  */
 #pragma once
 
-#include <ostream>
-#include <string>
+#include <vector>
+
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/commands/assemble_cvd/guest_config.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 namespace cuttlefish {
 
-enum class Arch {
-  Arm,
-  Arm64,
-  RiscV64,
-  X86,
-  X86_64,
+class VmManagerFlag {
+ public:
+  static Result<VmManagerFlag> FromGlobalGflags(
+      const std::vector<GuestConfig>&);
+
+  VmmMode Mode() const;
+
+ private:
+  explicit VmManagerFlag(VmmMode);
+
+  VmmMode mode_;
 };
-
-const std::string& HostArchStr();
-Arch HostArch();
-bool IsHostCompatible(Arch arch);
-
-std::ostream& operator<<(std::ostream&, Arch);
 
 }  // namespace cuttlefish


### PR DESCRIPTION
This expresses the dependency in choosing a default VMM based on the guest architecture.

It's currently instantiated in two places to avoid changing type signatures on the `flags.cc` members.

Bug: b/435031349