### PR TITLE
Add `cvd display` interface to host orchestrator

### DIFF
--- a/frontend/src/host_orchestrator/api/v1/messages.go
+++ b/frontend/src/host_orchestrator/api/v1/messages.go
@@ -167,3 +167,39 @@ type StartCVDRequest struct {
 	// Start from the relevant snaphost if not empty.
 	SnapshotID string `json:"snapshot_id,omitempty"`
 }
+
+type DisplayAddRequest struct {
+	Width         int `json:"width"`
+	Height        int `json:"height"`
+	DPI           int `json:"dpi,omitempty"`
+	RefreshRateHZ int `json:"refresh_rate_hz,omitempty"`
+}
+
+type DisplayAddResponse = struct {
+	DisplayNumber int `json:"display_number"`
+}
+
+type DisplayMode struct {
+	Windowed []int `json:"windowed"`
+}
+
+type Display struct {
+	DPI           []int       `json:"dpi"`
+	Mode          DisplayMode `json:"mode"`
+	RefreshRateHZ int         `json:"refresh-rate"`
+}
+
+type DisplayListResponse struct {
+	Displays map[int]Display `json:displays`
+}
+
+type DisplayRemoveResponse = EmptyResponse
+
+type DisplayScreenshotRequest struct {
+	DisplayNumber int `json:"display_number,omitempty"`
+}
+
+type DisplayScreenshotResponse struct {
+	ScreenshotBytesBase64 string `json:screenshot_bytes"`
+	ScreenshotMimeType    string `json:"screenshot_mime_type"`
+}

--- a/frontend/src/host_orchestrator/orchestrator/controller.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller.go
@@ -88,6 +88,14 @@ func (c *Controller) AddRoutes(router *mux.Router) {
 		httpHandler(newExecCVDCommandHandler(c.Config, c.OperationManager, &powerwashCvdCommand{}))).Methods("POST")
 	router.Handle("/cvds/{group}/{name}/:powerbtn",
 		httpHandler(newExecCVDCommandHandler(c.Config, c.OperationManager, &powerbtnCvdCommand{}))).Methods("POST")
+	router.Handle("/cvds/{group}/{name}/displays",
+		httpHandler(newCreateDisplayAddHandler(c.Config, c.OperationManager))).Methods("POST")
+	router.Handle("/cvds/{group}/{name}/displays",
+		httpHandler(newCreateDisplayListHandler(c.Config, c.OperationManager))).Methods("GET")
+	router.Handle("/cvds/{group}/{name}/displays/{displayNumber}",
+		httpHandler(newCreateDisplayRemoveHandler(c.Config, c.OperationManager))).Methods("DELETE")
+	router.Handle("/cvds/{group}/{name}/displays/{displayNumber}/:screenshot",
+		httpHandler(newCreateDisplayScreenshotHandler(c.Config, c.OperationManager))).Methods("GET")
 	router.Handle("/cvds/{group}/{name}/snapshots",
 		httpHandler(newCreateSnapshotHandler(c.Config, c.OperationManager))).Methods("POST")
 	router.Handle("/operations", httpHandler(&listOperationsHandler{om: c.OperationManager})).Methods("GET")
@@ -343,6 +351,120 @@ func (h *createSnapshotHandler) Handle(r *http.Request) (interface{}, error) {
 		ExecContext:      exec.CommandContext,
 	}
 	return NewCreateSnapshotAction(opts).Run()
+}
+
+type displayAddHandler struct {
+	Config Config
+	OM     OperationManager
+}
+
+func newCreateDisplayAddHandler(c Config, om OperationManager) *displayAddHandler {
+	return &displayAddHandler{Config: c, OM: om}
+}
+
+func (h *displayAddHandler) Handle(r *http.Request) (interface{}, error) {
+	req := &apiv1.DisplayAddRequest{}
+	err := json.NewDecoder(r.Body).Decode(req)
+	if err != nil {
+		return nil, operator.NewBadRequestError("malformed DisplayAddRequest JSON in request", err)
+	}
+
+	vars := mux.Vars(r)
+	group := vars["group"]
+	name := vars["name"]
+	opts := DisplayAddActionOpts{
+		Request:          req,
+		Selector:         cvd.Selector{Group: group, Instance: name},
+		Paths:            h.Config.Paths,
+		OperationManager: h.OM,
+		ExecContext:      exec.CommandContext,
+	}
+	return NewDisplayAddAction(opts).Run()
+}
+
+type displayListHandler struct {
+	Config Config
+	OM     OperationManager
+}
+
+func newCreateDisplayListHandler(c Config, om OperationManager) *displayListHandler {
+	return &displayListHandler{Config: c, OM: om}
+}
+
+func (h *displayListHandler) Handle(r *http.Request) (interface{}, error) {
+	vars := mux.Vars(r)
+	group := vars["group"]
+	name := vars["name"]
+	opts := DisplayListActionOpts{
+		Selector:         cvd.Selector{Group: group, Instance: name},
+		Paths:            h.Config.Paths,
+		OperationManager: h.OM,
+		ExecContext:      exec.CommandContext,
+	}
+	return NewDisplayListAction(opts).Run()
+}
+
+type displayRemoveHandler struct {
+	Config Config
+	OM     OperationManager
+}
+
+func newCreateDisplayRemoveHandler(c Config, om OperationManager) *displayRemoveHandler {
+	return &displayRemoveHandler{Config: c, OM: om}
+}
+
+func (h *displayRemoveHandler) Handle(r *http.Request) (interface{}, error) {
+	vars := mux.Vars(r)
+	group := vars["group"]
+	name := vars["name"]
+
+	displayNumberStr := vars["displayNumber"]
+	displayNumber, err := strconv.Atoi(displayNumberStr)
+	if err != nil {
+		return nil, operator.NewBadRequestError("invalid display number", err)
+	}
+
+	opts := DisplayRemoveActionOpts{
+		DisplayNumber:    displayNumber,
+		Selector:         cvd.Selector{Group: group, Instance: name},
+		Paths:            h.Config.Paths,
+		OperationManager: h.OM,
+		ExecContext:      exec.CommandContext,
+	}
+	return NewDisplayRemoveAction(opts).Run()
+}
+
+type displayScreenshotHandler struct {
+	Config Config
+	OM     OperationManager
+}
+
+func newCreateDisplayScreenshotHandler(c Config, om OperationManager) *displayScreenshotHandler {
+	return &displayScreenshotHandler{Config: c, OM: om}
+}
+
+func (h *displayScreenshotHandler) Handle(r *http.Request) (interface{}, error) {
+	vars := mux.Vars(r)
+	group := vars["group"]
+	name := vars["name"]
+
+	displayNumberStr := vars["displayNumber"]
+	displayNumber, err := strconv.Atoi(displayNumberStr)
+	if err != nil {
+		return nil, operator.NewBadRequestError("invalid display number", err)
+	}
+
+	req := &apiv1.DisplayScreenshotRequest{
+		DisplayNumber: displayNumber,
+	}
+	opts := DisplayScreenshotActionOpts{
+		Request:          req,
+		Selector:         cvd.Selector{Group: group, Instance: name},
+		Paths:            h.Config.Paths,
+		OperationManager: h.OM,
+		ExecContext:      exec.CommandContext,
+	}
+	return NewDisplayScreenshotAction(opts).Run()
 }
 
 type startCVDHandler struct {

--- a/frontend/src/host_orchestrator/orchestrator/displayaddaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/displayaddaction.go
@@ -1,0 +1,105 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator
+
+import (
+	"fmt"
+
+	apiv1 "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
+	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/cvd"
+	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/exec"
+	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
+)
+
+type DisplayAddActionOpts struct {
+	Request          *apiv1.DisplayAddRequest
+	Selector         cvd.Selector
+	Paths            IMPaths
+	OperationManager OperationManager
+	ExecContext      exec.ExecContext
+}
+
+type DisplayAddAction struct {
+	req      *apiv1.DisplayAddRequest
+	selector cvd.Selector
+	paths    IMPaths
+	om       OperationManager
+	cvdCLI   *cvd.CLI
+}
+
+func NewDisplayAddAction(opts DisplayAddActionOpts) *DisplayAddAction {
+	return &DisplayAddAction{
+		req:      opts.Request,
+		selector: opts.Selector,
+		paths:    opts.Paths,
+		om:       opts.OperationManager,
+		cvdCLI:   cvd.NewCLI(opts.ExecContext),
+	}
+}
+
+func toCvdDisplayAddOpts(req *apiv1.DisplayAddRequest) cvd.DisplayAddOpts {
+	opts := cvd.DisplayAddOpts{
+		Width:  req.Width,
+		Height: req.Height,
+	}
+	if req.DPI != 0 {
+		opts.DPI = req.DPI
+	}
+	if req.RefreshRateHZ != 0 {
+		opts.RefreshRateHZ = req.RefreshRateHZ
+	}
+	return opts
+}
+
+func findNewDisplayNumber(oldDisplays *cvd.Displays, newDisplays *cvd.Displays) (int, error) {
+	oldDisplaysLen := len(oldDisplays.Displays)
+	newDisplaysLen := len(newDisplays.Displays)
+	if newDisplaysLen-oldDisplaysLen != 1 {
+		return -1, fmt.Errorf("display counts differ by more than 1: old:%d new:%d", oldDisplaysLen, newDisplaysLen)
+	}
+
+	for displayNumber := range newDisplays.Displays {
+		_, found := oldDisplays.Displays[displayNumber]
+		if !found {
+			return displayNumber, nil
+		}
+	}
+	return -1, fmt.Errorf("unreachable?")
+}
+
+func (a *DisplayAddAction) Run() (*apiv1.DisplayAddResponse, error) {
+	oldDisplays, err := a.cvdCLI.DisplayList(a.selector)
+	if err != nil {
+		return nil, operator.NewInternalError("cvd display add: failed to list old displays:", err)
+	}
+
+	if err := a.cvdCLI.DisplayAdd(a.selector, toCvdDisplayAddOpts(a.req)); err != nil {
+		return nil, operator.NewInternalError("cvd display add failed", err)
+	}
+
+	newDisplays, err := a.cvdCLI.DisplayList(a.selector)
+	if err != nil {
+		return nil, operator.NewInternalError("cvd display add: failed to list new displays:", err)
+	}
+
+	newDisplayNumber, err := findNewDisplayNumber(oldDisplays, newDisplays)
+	if err != nil {
+		return nil, operator.NewInternalError("cvd display add: failed to determine new display number:", err)
+	}
+
+	return &apiv1.DisplayAddResponse{
+		DisplayNumber: newDisplayNumber,
+	}, nil
+}

--- a/frontend/src/host_orchestrator/orchestrator/displaylistaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/displaylistaction.go
@@ -1,0 +1,77 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator
+
+import (
+	apiv1 "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
+	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/cvd"
+	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/exec"
+	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
+)
+
+type DisplayListActionOpts struct {
+	Selector         cvd.Selector
+	Paths            IMPaths
+	OperationManager OperationManager
+	ExecContext      exec.ExecContext
+}
+
+type DisplayListAction struct {
+	selector cvd.Selector
+	paths    IMPaths
+	om       OperationManager
+	cvdCLI   *cvd.CLI
+}
+
+func NewDisplayListAction(opts DisplayListActionOpts) *DisplayListAction {
+	return &DisplayListAction{
+		selector: opts.Selector,
+		paths:    opts.Paths,
+		om:       opts.OperationManager,
+		cvdCLI:   cvd.NewCLI(opts.ExecContext),
+	}
+}
+
+func toApiv1DisplayMode(m cvd.DisplayMode) apiv1.DisplayMode {
+	return apiv1.DisplayMode{
+		Windowed: m.Windowed,
+	}
+}
+
+func toApiv1Display(d *cvd.Display) apiv1.Display {
+	return apiv1.Display{
+		DPI:           d.DPI,
+		RefreshRateHZ: d.RefreshRateHZ,
+		Mode:          toApiv1DisplayMode(d.Mode),
+	}
+}
+
+func toApiv1DisplayResponse(d *cvd.Displays) *apiv1.DisplayListResponse {
+	resp := &apiv1.DisplayListResponse{
+		Displays: make(map[int]apiv1.Display),
+	}
+	for displayNum, display := range d.Displays {
+		resp.Displays[displayNum] = toApiv1Display(display)
+	}
+	return resp
+}
+
+func (a *DisplayListAction) Run() (*apiv1.DisplayListResponse, error) {
+	displays, err := a.cvdCLI.DisplayList(a.selector)
+	if err != nil {
+		return nil, operator.NewInternalError("cvd display list failed", err)
+	}
+	return toApiv1DisplayResponse(displays), nil
+}

--- a/frontend/src/host_orchestrator/orchestrator/displayremoveaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/displayremoveaction.go
@@ -1,0 +1,56 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator
+
+import (
+	apiv1 "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
+	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/cvd"
+	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/exec"
+	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
+)
+
+type DisplayRemoveActionOpts struct {
+	DisplayNumber    int
+	Selector         cvd.Selector
+	Paths            IMPaths
+	OperationManager OperationManager
+	ExecContext      exec.ExecContext
+}
+
+type DisplayRemoveAction struct {
+	displayNumber int
+	selector      cvd.Selector
+	paths         IMPaths
+	om            OperationManager
+	cvdCLI        *cvd.CLI
+}
+
+func NewDisplayRemoveAction(opts DisplayRemoveActionOpts) *DisplayRemoveAction {
+	return &DisplayRemoveAction{
+		displayNumber: opts.DisplayNumber,
+		selector:      opts.Selector,
+		paths:         opts.Paths,
+		om:            opts.OperationManager,
+		cvdCLI:        cvd.NewCLI(opts.ExecContext),
+	}
+}
+
+func (a *DisplayRemoveAction) Run() (*apiv1.DisplayRemoveResponse, error) {
+	if err := a.cvdCLI.DisplayRemove(a.selector, a.displayNumber); err != nil {
+		return nil, operator.NewInternalError("cvd display remove failed:", err)
+	}
+
+	return &apiv1.DisplayRemoveResponse{}, nil
+}

--- a/frontend/src/host_orchestrator/orchestrator/displayscreenshotaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/displayscreenshotaction.go
@@ -1,0 +1,91 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator
+
+import (
+	"encoding/base64"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	apiv1 "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
+	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/cvd"
+	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/exec"
+	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
+)
+
+type DisplayScreenshotActionOpts struct {
+	Request          *apiv1.DisplayScreenshotRequest
+	Selector         cvd.Selector
+	Paths            IMPaths
+	OperationManager OperationManager
+	ExecContext      exec.ExecContext
+}
+
+type DisplayScreenshotAction struct {
+	req      *apiv1.DisplayScreenshotRequest
+	selector cvd.Selector
+	paths    IMPaths
+	om       OperationManager
+	cvdCLI   *cvd.CLI
+}
+
+func NewDisplayScreenshotAction(opts DisplayScreenshotActionOpts) *DisplayScreenshotAction {
+	return &DisplayScreenshotAction{
+		req:      opts.Request,
+		selector: opts.Selector,
+		paths:    opts.Paths,
+		om:       opts.OperationManager,
+		cvdCLI:   cvd.NewCLI(opts.ExecContext),
+	}
+}
+
+func (a *DisplayScreenshotAction) Run() (apiv1.Operation, error) {
+	op := a.om.New()
+	go func(op apiv1.Operation) {
+		result := &OperationResult{}
+		result.Value, result.Error = a.createScreenshot(op)
+		if err := a.om.Complete(op.Name, result); err != nil {
+			log.Printf("error completing operation %q: %v\n", op.Name, err)
+		}
+	}(op)
+	return op, nil
+}
+
+func (a *DisplayScreenshotAction) createScreenshot(op apiv1.Operation) (*apiv1.DisplayScreenshotResponse, error) {
+	tempdir, err := ioutil.TempDir("", "screenshot")
+	if err != nil {
+		return nil, operator.NewInternalError("failed to create temp directory", err)
+	}
+
+	defer os.RemoveAll(tempdir)
+
+	screenshotPath := filepath.Join(tempdir, "screenshot.png")
+
+	if err := a.cvdCLI.DisplayScreenshot(a.selector, 0, screenshotPath); err != nil {
+		return nil, operator.NewInternalError("cvd display screenshot failed", err)
+	}
+
+	screenshotBytes, err := ioutil.ReadFile(screenshotPath)
+	if err != nil {
+		return nil, operator.NewInternalError("failed to read screenshot file", err)
+	}
+
+	return &apiv1.DisplayScreenshotResponse{
+		ScreenshotBytesBase64: base64.StdEncoding.EncodeToString(screenshotBytes),
+		ScreenshotMimeType:    "image/png",
+	}, nil
+}


### PR DESCRIPTION
Bug: b/435448037
Test:

```
cd frontend/src/host_orchestrator
    
go build .
    
./host_orchestrator
    
cvd create
    
curl -i -X GET http://127.0.0.1:2080/cvds/cvd_1/1/displays
    
curl -i -X POST -H 'Content-Type: application/json' -d '{"width": 500, "height": 500, "dpi": 320}' http://127.0.0.1:2080/cvds/cvd_1/1/displays
    
curl -i -X GET http://127.0.0.1:2080/cvds/cvd_1/1/displays
    
curl -i -X DELETE http://127.0.0.1:2080/cvds/cvd_1/1/displays/1
    
curl -i -X GET http://127.0.0.1:2080/cvds/cvd_1/1/displays

curl -i -X GET http://127.0.0.1:2080/cvds/cvd_1/1/displays/0/:screenshot
    
curl -i -X GET http://127.0.0.1:2080/operations/[NAME RETURNED FROM PREVIOUS CURL COMMAND]/result
    
gofmt -w .
```