### PR TITLE
Fix wifi mode selection again

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -461,11 +461,7 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
   if (guest_config_mac80211_hwsim.has_value()) {
     tmp_config_obj.set_virtio_mac80211_hwsim(*guest_config_mac80211_hwsim);
   } else {
-#ifdef ENFORCE_MAC80211_HWSIM
     tmp_config_obj.set_virtio_mac80211_hwsim(true);
-#else
-    tmp_config_obj.set_virtio_mac80211_hwsim(false);
-#endif
   }
 
   if ((FLAGS_ap_rootfs_image.empty()) != (FLAGS_ap_kernel_image.empty())) {


### PR DESCRIPTION
[PR #1016](https://github.com/google/android-cuttlefish/pull/1016) attempted to fix wifi earlier, but there was a remaining use of the build-time wifi mode selection that is not configured for the bazel build.

This was causing further unexpected breakages. The snapshot restore logic involves sending messages to the OpenWRT AP VM to inform it to restart:

https://github.com/google/android-cuttlefish/blob/d89601aeaab40014db677cc443bef6e48696279c/base/cvd/cuttlefish/host/commands/run_cvd/boot_state_machine.cc#L359

However, this process fails when the control server can't find the Wifi AP VM. More specifically, the implementation tries to scan the `launcher.log` file to find a `wan_ipaddr` message:

https://github.com/google/android-cuttlefish/blob/d89601aeaab40014db677cc443bef6e48696279c/base/cvd/cuttlefish/host/commands/openwrt_control_server/main.cpp#L201

This comes from some earlier configuration:

https://github.com/google/android-cuttlefish/blob/d89601aeaab40014db677cc443bef6e48696279c/base/cvd/cuttlefish/host/libs/config/openwrt_args.cpp#L69

That configuration is turned into a CLI argument passed to the OpenWRT AP VM CLI arguments to `crosvm`:

https://github.com/google/android-cuttlefish/blob/d89601aeaab40014db677cc443bef6e48696279c/base/cvd/cuttlefish/host/commands/run_cvd/launch/open_wrt.cpp#L153

When the OpenWRT AP VM isn't running, the crosvm command isn't invoked, the log message isn't written, the regex is unable to match the log message, so the RPC to send a message to the OpenWRT VM can't find the target IP address, so snapshot restore fails. Snapshot restore failure looked like this:

```
run_cvd F 07-30 21:36:58  1564  1565 boot_state_machine.cc:365] Check failed: status.ok() Failed to send network service reset14: Luci authentication request failed:
run_cvd F 07-30 21:36:58  1564  1565 boot_state_machine.cc:365]
run_cvd F 07-30 21:36:58  1564  1565 boot_state_machine.cc:365] 2. main.cpp:171 | UpdateLuciRpcAuthKey |
run_cvd F 07-30 21:36:58  1564  1565 boot_state_machine.cc:365] 1. main.cpp:140 | LuciRpcAddress |
run_cvd F 07-30 21:36:58  1564  1565 boot_state_machine.cc:365]  | third_party/android_cuttlefish/base/cvd/cuttlefish/host/commands/openwrt_control_server/main.cpp:217
run_cvd F 07-30 21:36:58  1564  1565 boot_state_machine.cc:365]  v Result<std::string> cuttlefish::(anonymous namespace)::OpenwrtControlServiceImpl::FindIpaddrLauncherLog()
run_cvd F 07-30 21:36:58  1564  1565 boot_state_machine.cc:365] IP address is not found from launcher.log
run_cvd E 07-30 21:36:58  1558  1558 boot_state_machine.cc:152] Failed to read a complete exit code, read 0 bytes only instead of the expected 4
```

Bug: b/408498813
Bug: b/408497913