### PR TITLE
Update build_packages.sh

### DIFF
--- a/tools/buildutils/build_packages.sh
+++ b/tools/buildutils/build_packages.sh
@@ -5,7 +5,7 @@ set -e -x
 function install_debuild_dependencies() {
   echo "Installing debuild dependencies"
   sudo apt-get update
-  sudo DEBIAN_FRONTEND=noninteractive apt-get -y \
+  sudo DEBIAN_FRONTEND=noninteractive apt-get -y --allow-downgrades \
     -o Dpkg::Options::="--force-confold" \
     -o Dpkg::Options::="--force-confdef" \
     upgrade


### PR DESCRIPTION
Fix: The Script does not run when a package needs to be Downgraded which Prevents the Cuttlefish**.deb packages from being Built/Generated.

Error:
The following packages will be DOWNGRADED:
  firefox
176 upgraded, 0 newly installed, 1 downgraded, 0 to remove and 15 not upgraded. N: Some packages may have been kept back due to phasing. E: Packages were downgraded and -y was used without --allow-downgrades.