### PR TITLE
Expose a zip file accessor from `BuildApi`

### DIFF
--- a/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
@@ -35,6 +35,9 @@ cf_cc_library(
         "//cuttlefish/host/libs/web/http_client",
         "//cuttlefish/host/libs/web/http_client:http_file",
         "//cuttlefish/host/libs/web/http_client:http_json",
+        "//cuttlefish/host/libs/zip:remote_zip",
+        "//cuttlefish/host/libs/zip:zip_cc",
+        "//cuttlefish/host/libs/zip:zip_file",
         "//libbase",
         "@jsoncpp",
     ],
@@ -83,6 +86,7 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/libs/web:android_build",
         "//cuttlefish/host/libs/web:android_build_string",
+        "//cuttlefish/host/libs/zip:zip_cc",
     ],
 )
 
@@ -109,6 +113,8 @@ cf_cc_library(
         "//cuttlefish/host/libs/web:credential_source",
         "//cuttlefish/host/libs/web/cas:cas_downloader",
         "//cuttlefish/host/libs/web/http_client",
+        "//cuttlefish/host/libs/zip:zip_cc",
+        "//cuttlefish/host/libs/zip:zip_file",
         "//libbase",
         "@fmt",
     ],

--- a/base/cvd/cuttlefish/host/libs/web/android_build_api.h
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_api.h
@@ -30,6 +30,7 @@
 #include "cuttlefish/host/libs/web/cas/cas_downloader.h"
 #include "cuttlefish/host/libs/web/credential_source.h"
 #include "cuttlefish/host/libs/web/http_client/http_client.h"
+#include "cuttlefish/host/libs/zip/zip_cc.h"
 
 namespace cuttlefish {
 
@@ -56,6 +57,9 @@ class AndroidBuildApi : public BuildApi {
       const Build& build, const std::string& target_directory,
       const std::string& artifact_name,
       const std::string& backup_artifact_name) override;
+
+  Result<ReadableZip> OpenZipArchive(const Build& build,
+                                     const std::string& archive_name) override;
 
  private:
   Result<std::vector<std::string>> Headers();
@@ -100,6 +104,11 @@ class AndroidBuildApi : public BuildApi {
 
   Result<Build> GetBuild(const DeviceBuildString& build_string);
   Result<Build> GetBuild(const DirectoryBuildString& build_string);
+
+  Result<ReadableZip> OpenZipArchive(const DeviceBuild& build,
+                                     const std::string& archive_name);
+  Result<ReadableZip> OpenZipArchive(const DirectoryBuild& build,
+                                     const std::string& archive_name);
 
   HttpClient& http_client;
   CredentialSource* credential_source;

--- a/base/cvd/cuttlefish/host/libs/web/build_api.h
+++ b/base/cvd/cuttlefish/host/libs/web/build_api.h
@@ -20,6 +20,7 @@
 #include "cuttlefish/common/libs/utils/result.h"
 #include "cuttlefish/host/libs/web/android_build.h"
 #include "cuttlefish/host/libs/web/android_build_string.h"
+#include "cuttlefish/host/libs/zip/zip_cc.h"
 
 namespace cuttlefish {
 
@@ -36,6 +37,9 @@ class BuildApi {
       const Build& build, const std::string& target_directory,
       const std::string& artifact_name,
       const std::string& backup_artifact_name) = 0;
+
+  virtual Result<ReadableZip> OpenZipArchive(const Build& build,
+                                             const std::string& artifact_name) = 0;
 };
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/web/caching_build_api.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/caching_build_api.cpp
@@ -28,6 +28,8 @@
 #include "cuttlefish/host/libs/web/android_build_api.h"
 #include "cuttlefish/host/libs/web/android_build_string.h"
 #include "cuttlefish/host/libs/web/build_api.h"
+#include "cuttlefish/host/libs/zip/zip_cc.h"
+#include "cuttlefish/host/libs/zip/zip_file.h"
 
 namespace cuttlefish {
 namespace {
@@ -140,6 +142,13 @@ Result<std::string> CachingBuildApi::DownloadFileWithBackup(
   }
   return CF_EXPECT(CreateHardLink(paths.cache_backup_artifact,
                                   paths.target_backup_artifact));
+}
+
+Result<ReadableZip> CachingBuildApi::OpenZipArchive(
+    const Build& build, const std::string& zip_name) {
+  // TODO: schuffelen - cache only needed zip file parts
+  CF_EXPECT(build_api_.DownloadFile(build, cache_base_path_, zip_name));
+  return ZipOpenRead(cache_base_path_ + "/" + zip_name);
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/web/caching_build_api.h
+++ b/base/cvd/cuttlefish/host/libs/web/caching_build_api.h
@@ -20,6 +20,7 @@
 #include "cuttlefish/common/libs/utils/result.h"
 #include "cuttlefish/host/libs/web/android_build.h"
 #include "cuttlefish/host/libs/web/build_api.h"
+#include "cuttlefish/host/libs/zip/zip_cc.h"
 
 namespace cuttlefish {
 
@@ -37,6 +38,9 @@ class CachingBuildApi : public BuildApi {
       const Build& build, const std::string& target_directory,
       const std::string& artifact_name,
       const std::string& backup_artifact_name) override;
+
+  Result<ReadableZip> OpenZipArchive(const Build& build,
+                                     const std::string& zip_name) override;
 
  private:
   Result<bool> CanCache(const std::string& target_directory);


### PR DESCRIPTION
The non-caching implementation uses a lazy-loading mechanism to only download needed parts of the zip file. The caching implementation eagerly downloads the entire file. Optimizing the cached version is TODO.

Bug: b/435770397