### PR TITLE
Extract the `ExternalNetworkMode` enum out of `cuttlefish_config.h`

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -267,6 +267,7 @@ cf_cc_library(
         "//cuttlefish/host/libs/config:config_constants",
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:display",
+        "//cuttlefish/host/libs/config:external_network_mode",
         "//cuttlefish/host/libs/config:fetcher_config",
         "//cuttlefish/host/libs/config:host_tools_version",
         "//cuttlefish/host/libs/config:instance_nums",

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -105,6 +105,7 @@ cf_cc_library(
         "//cuttlefish/host/libs/config:config_constants",
         "//cuttlefish/host/libs/config:config_fragment",
         "//cuttlefish/host/libs/config:config_utils",
+        "//cuttlefish/host/libs/config:external_network_mode",
         "//cuttlefish/host/libs/config:secure_hals",
         "//cuttlefish/host/libs/config:vmm_mode",
         "//libbase",
@@ -162,6 +163,17 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:subprocess",
         "//cuttlefish/host/libs/config:known_paths",
         "//libbase",
+    ],
+)
+
+cf_cc_library(
+    name = "external_network_mode",
+    srcs = ["external_network_mode.cc"],
+    hdrs = ["external_network_mode.h"],
+    deps = [
+        "//cuttlefish/common/libs/utils:result",
+        "//libbase",
+        "@fmt",
     ],
 )
 

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
@@ -17,7 +17,6 @@
 
 #include <sys/types.h>
 
-#include <array>
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -27,8 +26,6 @@
 #include <string_view>
 #include <vector>
 
-#include <fmt/ostream.h>
-
 #include "cuttlefish/common/libs/utils/architecture.h"
 #include "cuttlefish/common/libs/utils/device_type.h"
 #include "cuttlefish/common/libs/utils/result.h"
@@ -37,6 +34,7 @@
 #include "cuttlefish/host/libs/config/config_constants.h"
 #include "cuttlefish/host/libs/config/config_fragment.h"
 #include "cuttlefish/host/libs/config/config_utils.h"
+#include "cuttlefish/host/libs/config/external_network_mode.h"
 #include "cuttlefish/host/libs/config/secure_hals.h"
 #include "cuttlefish/host/libs/config/vmm_mode.h"
 
@@ -45,15 +43,6 @@ class Value;
 }
 
 namespace cuttlefish {
-
-enum class ExternalNetworkMode {
-  kUnknown,
-  kTap,
-  kSlirp,
-};
-
-std::ostream& operator<<(std::ostream&, ExternalNetworkMode);
-Result<ExternalNetworkMode> ParseExternalNetworkMode(std::string_view);
 
 enum class GuestHwuiRenderer {
   kUnknown,
@@ -994,8 +983,3 @@ class CuttlefishConfig {
 bool IsRestoring(const CuttlefishConfig&);
 
 }  // namespace cuttlefish
-
-#if FMT_VERSION >= 90000
-template <>
-struct fmt::formatter<cuttlefish::ExternalNetworkMode> : ostream_formatter {};
-#endif

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
@@ -43,6 +43,7 @@
 #include "cuttlefish/host/libs/config/ap_boot_flow.h"
 #include "cuttlefish/host/libs/config/boot_flow.h"
 #include "cuttlefish/host/libs/config/config_constants.h"
+#include "cuttlefish/host/libs/config/external_network_mode.h"
 #include "cuttlefish/host/libs/config/vmm_mode.h"
 
 namespace cuttlefish {
@@ -53,29 +54,6 @@ const char* kInstances = "instances";
 std::string IdToName(const std::string& id) { return kCvdNamePrefix + id; }
 
 }  // namespace
-
-std::ostream& operator<<(std::ostream& out, ExternalNetworkMode net) {
-  switch (net) {
-    case ExternalNetworkMode::kUnknown:
-      return out << "unknown";
-    case ExternalNetworkMode::kTap:
-      return out << "tap";
-    case ExternalNetworkMode::kSlirp:
-      return out << "slirp";
-  }
-}
-Result<ExternalNetworkMode> ParseExternalNetworkMode(std::string_view str) {
-  if (android::base::EqualsIgnoreCase(str, "tap")) {
-    return ExternalNetworkMode::kTap;
-  } else if (android::base::EqualsIgnoreCase(str, "slirp")) {
-    return ExternalNetworkMode::kSlirp;
-  } else {
-    return CF_ERRF(
-        "\"{}\" is not a valid ExternalNetworkMode. Valid values are \"tap\" "
-        "and \"slirp\"",
-        str);
-  }
-}
 
 std::ostream& operator<<(std::ostream& out, GuestHwuiRenderer renderer) {
   return out << ToString(renderer);

--- a/base/cvd/cuttlefish/host/libs/config/external_network_mode.cc
+++ b/base/cvd/cuttlefish/host/libs/config/external_network_mode.cc
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/host/libs/config/external_network_mode.h"
+
+#include <cctype>
+#include <ostream>
+#include <string_view>
+
+#include <android-base/strings.h>
+
+#include "cuttlefish/common/libs/utils/result.h"
+
+namespace cuttlefish {
+
+std::ostream& operator<<(std::ostream& out, ExternalNetworkMode net) {
+  switch (net) {
+    case ExternalNetworkMode::kUnknown:
+      return out << "unknown";
+    case ExternalNetworkMode::kTap:
+      return out << "tap";
+    case ExternalNetworkMode::kSlirp:
+      return out << "slirp";
+  }
+}
+Result<ExternalNetworkMode> ParseExternalNetworkMode(std::string_view str) {
+  if (android::base::EqualsIgnoreCase(str, "tap")) {
+    return ExternalNetworkMode::kTap;
+  } else if (android::base::EqualsIgnoreCase(str, "slirp")) {
+    return ExternalNetworkMode::kSlirp;
+  } else {
+    return CF_ERRF(
+        "\"{}\" is not a valid ExternalNetworkMode. Valid values are \"tap\" "
+        "and \"slirp\"",
+        str);
+  }
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/config/external_network_mode.h
+++ b/base/cvd/cuttlefish/host/libs/config/external_network_mode.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <ostream>
+#include <string_view>
+
+#include <fmt/ostream.h>
+
+#include "cuttlefish/common/libs/utils/result.h"
+
+namespace cuttlefish {
+
+enum class ExternalNetworkMode {
+  kUnknown,
+  kTap,
+  kSlirp,
+};
+
+std::ostream& operator<<(std::ostream&, ExternalNetworkMode);
+Result<ExternalNetworkMode> ParseExternalNetworkMode(std::string_view);
+
+}  // namespace cuttlefish
+
+#if FMT_VERSION >= 90000
+template <>
+struct fmt::formatter<cuttlefish::ExternalNetworkMode> : ostream_formatter {};
+#endif

--- a/base/cvd/cuttlefish/host/libs/vm_manager/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/BUILD.bazel
@@ -45,6 +45,7 @@ cf_cc_library(
         "//cuttlefish/host/libs/command_util",
         "//cuttlefish/host/libs/config:config_constants",
         "//cuttlefish/host/libs/config:cuttlefish_config",
+        "//cuttlefish/host/libs/config:external_network_mode",
         "//cuttlefish/host/libs/config:known_paths",
         "//cuttlefish/host/libs/config:vmm_mode",
         "//cuttlefish/host/libs/feature",

--- a/base/cvd/cuttlefish/host/libs/vm_manager/qemu_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/qemu_manager.cpp
@@ -42,6 +42,7 @@
 #include "cuttlefish/common/libs/utils/wait_for_unix_socket.h"
 #include "cuttlefish/host/libs/config/config_constants.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/external_network_mode.h"
 #include "cuttlefish/host/libs/feature/command_source.h"
 #include "cuttlefish/host/libs/vm_manager/vhost_user.h"
 


### PR DESCRIPTION
https://github.com/google/android-cuttlefish/blob/d748b8ae5b18ccb5d0456c8ccc05da3682e0553a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h#L49

Bug: b/435771697