### PR TITLE
Factor alloc_utils out.

### DIFF
--- a/base/cvd/allocd/BUILD.bazel
+++ b/base/cvd/allocd/BUILD.bazel
@@ -7,8 +7,6 @@ package(
 cc_binary(
     name = "allocd",
     srcs = [
-        "alloc_utils.cpp",
-        "alloc_utils.h",
         "allocd.cpp",
         "request.h",
         "resource.cpp",
@@ -28,10 +26,26 @@ cc_binary(
     ],
     includes = [""],
     deps = [
+        ":alloc_utils",
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/host/libs/config:logging",
         "//libbase",
         "@gflags",
         "@jsoncpp",
+    ],
+)
+
+cc_library(
+    name = "alloc_utils",
+    srcs = [
+        "alloc_utils.cpp",
+    ],
+    hdrs = [
+        "alloc_utils.h",
+    ],
+    deps = [
+        "//cuttlefish/common/libs/fs",
+        "//cuttlefish/host/libs/config:logging",
+        "//libbase",
     ],
 )

--- a/base/cvd/allocd/alloc_utils.h
+++ b/base/cvd/allocd/alloc_utils.h
@@ -25,7 +25,6 @@
 #include <sstream>
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
-#include "request.h"
 
 namespace cuttlefish {
 


### PR DESCRIPTION
Currently, we statically allocate resources--namely, tap interfaces--for a given number of instances. This means that we are creating many interfaces that we may not actually use.

The previous mechanism partially implemented to solve this problem was to delegate allocation to a sidecar daemon, allocd, that would receive RPCs to signal that resources should be allocated and tore down. However, we can use a simpler design that creates interfaces before the vmm starts and tears them down after the vmm exits.

The existing implementation shells out to use the platform ip(8), ebtables(8), and dnsmasq(8) commands to make the necessary network changes. While we could reimplemnt these using netlink, for now, it makes sense to just expose the existing implementation from allocd so we can borrow it later.