### PR TITLE
Empty the acloud_cvd_temp dir on cvd reset.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/reset.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/reset.cpp
@@ -158,6 +158,11 @@ class CvdResetCommandHandler : public CvdCommandHandler {
     }
     CF_EXPECT(KillAllCuttlefishInstances(
         /* clear_instance_dirs*/ options.clean_runtime_dir));
+
+    if (DirectoryExists("/tmp/acloud_cvd_temp/")) {
+      CF_EXPECT(RecursivelyRemoveDirectory("/tmp/acloud_cvd_temp/"));
+    }
+
     return {};
   }
   cvd_common::Args CmdList() const override { return {kResetSubcmd}; }


### PR DESCRIPTION
The acloud_cvd_temp directory contains instance lock files. If we are resetting with cvd reset, we should remove these, since we are resetting state completely anyway.

This will become more important later when we are making changes to the way instance locks are acquired, and starting from a clean slate with cvd reset is more convenient than manually removing lock files.