### PR TITLE
Fix `cvd display` commands

### DIFF
--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_display_controller.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_display_controller.cpp
@@ -107,11 +107,11 @@ Result<int> CrosvmDisplayController::RunCrosvmDisplayCommand(
 
   Result<std::string> res = RunAndCaptureStdout(std::move(command));
   if (res.ok()) {
+    *stdout_str = CF_EXPECT(std::move(res));
     return 0;
   } else {
     LOG(ERROR) << "Failed to run crosvm display command:\n"
                << res.error().FormatForEnv();
-    CF_EXPECT(std::move(res));
     return 0;
   }
 }


### PR DESCRIPTION
Small fix for 57a27ae74985daee513dcde6df578bed83b79dc8

Same thing as https://github.com/google/android-cuttlefish/pull/1487 for the 1.18 release