### PR TITLE
Fix disk creation in QEMU launch

### DIFF
--- a/base/cvd/cuttlefish/host/libs/image_aggregator/image_aggregator.cc
+++ b/base/cvd/cuttlefish/host/libs/image_aggregator/image_aggregator.cc
@@ -417,7 +417,7 @@ Result<void> AggregateImage(const std::vector<ImagePartition>& partitions,
     std::string padding_str;
     padding_str.resize(padding, '\0');
 
-    CF_EXPECTF(WriteAll(output, padding_str) != padding_str.size(),
+    CF_EXPECTF(WriteAll(output, padding_str) == padding_str.size(),
                "Could not write partition padding to '{}': {}", output_path,
                output->StrError());
   }


### PR DESCRIPTION
It was failing with this error:
```
assemble_cvd failed:
4. assemble_cvd.cc:669 | AssembleCvdMain | Failed to create config
3. assemble_cvd.cc:515 | InitFilesystemAndCreateConfig |
2. create_dynamic_disk_files.cc:134 | CreateDynamicDiskFiles |
1. disk_builder.cpp:220 | BuildCompositeDiskIfNecessary |
 | cuttlefish/host/libs/image_aggregator/image_aggregator.cc:422
 | Result<void> cuttlefish::AggregateImage(const std::vector<ImagePartition> &, const std::string &)
 v CF_EXPECT(WriteAll(output, padding_str) != padding_str.size())
Could not write partition padding to '/tmp/cvd/270178/1754349137140247/home/cuttlefish/instances/cvd-1/os_composite.img': Success
08-04 16:12:20.687 1092967 1092967 E cvd_internal_start: subprocess.cpp:207 Subprocess 1092986 was interrupted by a signal 'Aborted' (6)
08-04 16:12:20.687 1092967 1092967 E cvd_internal_start: main.cc:264 assemble_cvd returned -1
```

The error was introduced by [PR #1456](https://github.com/google/android-cuttlefish/pull/1456).

Bug: b/436353026