### PR TITLE
Remove the start_webrtc flag behavior

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
@@ -202,7 +202,7 @@ DEFINE_string(
     "With sandbox'ed crosvm, overrieds the security comp policy directory");
 
 DEFINE_vec(start_webrtc, fmt::format("{}", CF_DEFAULTS_START_WEBRTC),
-           "Whether to start the webrtc process.");
+           "(Deprecated, webrtc is enabled depending on the VMM)");
 
 DEFINE_vec(webrtc_assets_dir, CF_DEFAULTS_WEBRTC_ASSETS_DIR,
            "Path to WebRTC webpage assets.");

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.h
@@ -93,8 +93,6 @@ DECLARE_vec(enable_virtiofs);
 
 DECLARE_string(seccomp_policy_dir);
 
-DECLARE_vec(start_webrtc);
-
 DECLARE_vec(webrtc_assets_dir);
 
 DECLARE_bool(start_webrtc_sig_server);

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/streamer.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/streamer.cpp
@@ -268,7 +268,17 @@ class WebRtcServer : public virtual CommandSource,
 
   // SetupFeature
   bool Enabled() const override {
-    return sockets_.Enabled() && instance_.enable_webrtc();
+    if (!sockets_.Enabled()) {
+      return false;
+    }
+    switch (config_.vm_manager()) {
+      case VmmMode::kCrosvm:
+      case VmmMode::kQemu:
+        return true;
+      case VmmMode::kGem5:
+      case VmmMode::kUnknown:
+        return false;
+    }
   }
 
  private:

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
@@ -530,7 +530,6 @@ class CuttlefishConfig {
     std::string ril_broadcast() const;
     uint8_t ril_prefixlen() const;
 
-    bool enable_webrtc() const;
     std::string webrtc_assets_dir() const;
 
     // The range of TCP ports available for webrtc sessions.
@@ -750,7 +749,6 @@ class CuttlefishConfig {
     // Kernel and bootloader logging
     void set_enable_kernel_log(bool enable_kernel_log);
 
-    void set_enable_webrtc(bool enable_webrtc);
     void set_webrtc_assets_dir(const std::string& webrtc_assets_dir);
 
     // The range of TCP ports available for webrtc sessions.

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
@@ -62,6 +62,7 @@ CuttlefishConfig::MutableInstanceSpecific::MutableInstanceSpecific(
     : config_(config), id_(id) {
   // Legacy for acloud
   (*Dictionary())[kInstanceDir] = config_->InstancesPath(IdToName(id));
+  (*Dictionary())["enable_webrtc"] = true;
 }
 
 Json::Value* CuttlefishConfig::MutableInstanceSpecific::Dictionary() {
@@ -1024,14 +1025,6 @@ void CuttlefishConfig::MutableInstanceSpecific::set_enable_jcard_simulator(
 }
 bool CuttlefishConfig::InstanceSpecific::enable_jcard_simulator() const {
   return (*Dictionary())[kEnableJcardSimulator].asBool();
-}
-
-static constexpr char kEnableWebRTC[] = "enable_webrtc";
-void CuttlefishConfig::MutableInstanceSpecific::set_enable_webrtc(bool enable_webrtc) {
-  (*Dictionary())[kEnableWebRTC] = enable_webrtc;
-}
-bool CuttlefishConfig::InstanceSpecific::enable_webrtc() const {
-  return (*Dictionary())[kEnableWebRTC].asBool();
 }
 
 static constexpr char kWebRTCAssetsDir[] = "webrtc_assets_dir";

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
@@ -640,23 +640,21 @@ Result<std::vector<MonitorCommand>> CrosvmManager::StartCommands(
     disk_i++;
   }
 
-  if (instance.enable_webrtc()) {
-    auto display_configs = instance.display_configs();
-    CF_EXPECT(!display_configs.empty());
+  auto display_configs = instance.display_configs();
+  CF_EXPECT(!display_configs.empty());
 
-    const int display_cnt = instance.display_configs().size();
-    const int touchpad_cnt = instance.touchpad_configs().size();
-    const int total_touch_cnt = display_cnt + touchpad_cnt;
-    for (int touch_idx = 0; touch_idx < total_touch_cnt; ++touch_idx) {
-      crosvm_cmd.AddVhostUser("input", instance.touch_socket_path(touch_idx));
-    }
-    if (instance.enable_mouse()) {
-      crosvm_cmd.AddVhostUser("input", instance.mouse_socket_path());
-    }
-    crosvm_cmd.AddVhostUser("input", instance.rotary_socket_path());
-    crosvm_cmd.AddVhostUser("input", instance.keyboard_socket_path());
-    crosvm_cmd.AddVhostUser("input", instance.switches_socket_path());
+  const int display_cnt = instance.display_configs().size();
+  const int touchpad_cnt = instance.touchpad_configs().size();
+  const int total_touch_cnt = display_cnt + touchpad_cnt;
+  for (int touch_idx = 0; touch_idx < total_touch_cnt; ++touch_idx) {
+    crosvm_cmd.AddVhostUser("input", instance.touch_socket_path(touch_idx));
   }
+  if (instance.enable_mouse()) {
+    crosvm_cmd.AddVhostUser("input", instance.mouse_socket_path());
+  }
+  crosvm_cmd.AddVhostUser("input", instance.rotary_socket_path());
+  crosvm_cmd.AddVhostUser("input", instance.keyboard_socket_path());
+  crosvm_cmd.AddVhostUser("input", instance.switches_socket_path());
 
   // GPU capture can only support named files and not file descriptors due to
   // having to pass arguments to crosvm via a wrapper script.


### PR DESCRIPTION
Instead make the behavior dependent on the VMM.  webrtc is required to run with crosvm, and nonfunctional with gem5. I'm not sure if there is a dependency on it with qemu, so this leaves it running for qemu.

The flag and config values are left to support some interaction with python acloud.

https://cs.android.com/android/platform/superproject/main/+/main:tools/acloud/internal/lib/cvd_runtime_config.py;l=149;drc=70921dc34d0c06b760159a62f43258ab2ec7fd06

https://cs.android.com/android/platform/superproject/main/+/main:tools/acloud/create/local_image_local_instance.py;l=631;drc=e1d40e5e18750a85a623b15411bd0f72aa6082e2

The current behavior had some complex default logic that ultimately amounted to "enable it by default for crosvm and qemu+swiftshader", unless the user passes a flag value. The new behavior simplifies is it to "always run for crosvm and qemu".

Bug: b/436356145
Test: launch with crosvm
Test: launch with qemu