### PR TITLE
Simplify the `Avb` class interface

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_config.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_config.cc
@@ -192,9 +192,8 @@ Result<void> PrepareBootEnvImage(
   const off_t boot_env_size_bytes =
       AlignToPowerOf2(kMaxAvbMetadataSize + 4096, PARTITION_SIZE_SHIFT);
 
-  std::unique_ptr<Avb> avbtool = GetDefaultAvb();
-  CF_EXPECT(avbtool->AddHashFooter(tmp_boot_env_image_path, "uboot_env",
-                                   boot_env_size_bytes));
+  CF_EXPECT(Avb().AddHashFooter(tmp_boot_env_image_path, "uboot_env",
+                                boot_env_size_bytes));
 
   if (!FileExists(image_path) ||
       ReadFile(image_path) != ReadFile(tmp_boot_env_image_path)) {

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_image_utils.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_image_utils.cc
@@ -370,10 +370,14 @@ bool RepackVendorBootImage(const std::string& new_ramdisk,
     return false;
   }
 
-  auto avbtool = Avb(AvbToolBinary());
+  std::unique_ptr<Avb> avbtool = GetDefaultAvb();
+  if (!avbtool) {
+    LOG(ERROR) << "Failed to create avb object";
+    return false;
+  }
   Result<void> result =
-      avbtool.AddHashFooter(tmp_vendor_boot_image_path, "vendor_boot",
-                            FileSize(vendor_boot_image_path));
+      avbtool->AddHashFooter(tmp_vendor_boot_image_path, "vendor_boot",
+                             FileSize(vendor_boot_image_path));
   if (!result.ok()) {
     LOG(ERROR) << result.error().Trace();
     return false;

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_image_utils.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_image_utils.cc
@@ -370,14 +370,9 @@ bool RepackVendorBootImage(const std::string& new_ramdisk,
     return false;
   }
 
-  std::unique_ptr<Avb> avbtool = GetDefaultAvb();
-  if (!avbtool) {
-    LOG(ERROR) << "Failed to create avb object";
-    return false;
-  }
   Result<void> result =
-      avbtool->AddHashFooter(tmp_vendor_boot_image_path, "vendor_boot",
-                             FileSize(vendor_boot_image_path));
+      Avb().AddHashFooter(tmp_vendor_boot_image_path, "vendor_boot",
+                          FileSize(vendor_boot_image_path));
   if (!result.ok()) {
     LOG(ERROR) << result.error().Trace();
     return false;
@@ -476,11 +471,8 @@ void RepackGem5BootImage(
 // https://source.android.com/docs/core/architecture/bootloader/boot-image-header
 Result<std::string> ReadAndroidVersionFromBootImage(
     const std::string& boot_image_path) {
-  std::unique_ptr<Avb> avb = GetDefaultAvb();
-  CF_EXPECT(avb.get());
-
   std::string boot_params =
-      CF_EXPECTF(avb->InfoImage(boot_image_path),
+      CF_EXPECTF(Avb().InfoImage(boot_image_path),
                  "Failed to get avb boot data from '{}'", boot_image_path);
 
   std::string os_version =

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/create_dynamic_disk_files.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/create_dynamic_disk_files.cc
@@ -76,13 +76,10 @@ Result<void> CreateDynamicDiskFiles(
     const FetcherConfig& fetcher_config, const CuttlefishConfig& config,
     const SystemImageDirFlag& system_image_dir) {
   for (const auto& instance : config.Instances()) {
-    std::unique_ptr<Avb> avb = GetDefaultAvb();
-    CF_EXPECT(avb.get());
-
     std::optional<ChromeOsStateImage> chrome_os_state =
         CF_EXPECT(ChromeOsStateImage::CreateIfNecessary(instance));
 
-    CF_EXPECT(RepackKernelRamdisk(config, instance, *avb));
+    CF_EXPECT(RepackKernelRamdisk(config, instance, Avb()));
     CF_EXPECT(VbmetaEnforceMinimumSize(instance));
     CF_EXPECT(BootloaderPresentCheck(instance));
     CF_EXPECT(Gem5ImageUnpacker(config));  // Requires RepackKernelRamdisk

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/generate_persistent_bootconfig.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/generate_persistent_bootconfig.cpp
@@ -84,9 +84,8 @@ Result<std::optional<BootConfigPartition>> BootConfigPartition::CreateIfNeeded(
     const off_t bootconfig_size_bytes = AlignToPowerOf2(
         kMaxAvbMetadataSize + bootconfig.size(), PARTITION_SIZE_SHIFT);
 
-    std::unique_ptr<Avb> avbtool = GetDefaultAvb();
-    CF_EXPECT(avbtool->AddHashFooter(bootconfig_path, "bootconfig",
-                                     bootconfig_size_bytes));
+    CF_EXPECT(Avb().AddHashFooter(bootconfig_path, "bootconfig",
+                                  bootconfig_size_bytes));
   }
 
   return BootConfigPartition(std::move(bootconfig_path));

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/generate_persistent_vbmeta.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/generate_persistent_vbmeta.cpp
@@ -31,7 +31,6 @@ namespace cuttlefish {
 namespace {
 
 Result<void> PrepareVBMetaImage(const std::string& path, bool has_boot_config) {
-  std::unique_ptr<Avb> avbtool = GetDefaultAvb();
   std::vector<ChainPartition> chained_partitions = {ChainPartition{
       .name = "uboot_env",
       .rollback_index = "1",
@@ -44,7 +43,7 @@ Result<void> PrepareVBMetaImage(const std::string& path, bool has_boot_config) {
         .key_path = TestPubKeyRsa4096(),
     });
   }
-  CF_EXPECT(avbtool->MakeVbMetaImage(path, chained_partitions, {}, {}));
+  CF_EXPECT(Avb().MakeVbMetaImage(path, chained_partitions, {}, {}));
   return {};
 }
 

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/vendor_dlkm_utils.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/vendor_dlkm_utils.cc
@@ -412,9 +412,8 @@ Result<void> BuildVbmetaImage(const std::string& image_path,
   CF_EXPECT(!image_path.empty());
   CF_EXPECTF(FileExists(image_path), "'{}' does not exist", image_path);
 
-  std::unique_ptr<Avb> avbtool = GetDefaultAvb();
-  CF_EXPECT(avbtool->MakeVbMetaImage(vbmeta_path, {}, {image_path},
-                                     {"--padding_size", "4096"}));
+  CF_EXPECT(Avb().MakeVbMetaImage(vbmeta_path, {}, {image_path},
+                                  {"--padding_size", "4096"}));
   return {};
 }
 

--- a/base/cvd/cuttlefish/host/libs/avb/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/avb/BUILD.bazel
@@ -19,6 +19,5 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:subprocess",
         "//cuttlefish/common/libs/utils:subprocess_managed_stdio",
         "//cuttlefish/host/libs/config:known_paths",
-        "@fruit",
     ],
 )

--- a/base/cvd/cuttlefish/host/libs/avb/avb.cpp
+++ b/base/cvd/cuttlefish/host/libs/avb/avb.cpp
@@ -44,8 +44,6 @@ constexpr size_t kVbMetaMaxSize = 65536ul;
 
 }  // namespace
 
-Avb::Avb(std::string avbtool_path) : avbtool_path_(std::move(avbtool_path)) {}
-
 Avb::Avb(std::string avbtool_path, std::string algorithm, std::string key)
     : avbtool_path_(std::move(avbtool_path)),
       algorithm_(std::move(algorithm)),

--- a/base/cvd/cuttlefish/host/libs/avb/avb.cpp
+++ b/base/cvd/cuttlefish/host/libs/avb/avb.cpp
@@ -22,8 +22,6 @@
 #include <memory>
 #include <string>
 
-#include <fruit/fruit.h>
-
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/result.h"
@@ -43,6 +41,8 @@ constexpr char kMakeVbmetaImage[] = "make_vbmeta_image";
 constexpr size_t kVbMetaMaxSize = 65536ul;
 
 }  // namespace
+
+Avb::Avb() : Avb(AvbToolBinary(), kDefaultAlgorithm, TestKeyRsa4096()) {}
 
 Avb::Avb(std::string avbtool_path, std::string algorithm, std::string key)
     : avbtool_path_(std::move(avbtool_path)),
@@ -153,16 +153,6 @@ Result<void> EnforceVbMetaSize(const std::string& path) {
                path, vbmeta_fd->StrError());
   }
   return {};
-}
-
-std::unique_ptr<Avb> GetDefaultAvb() {
-  return std::unique_ptr<Avb>(
-      new Avb(AvbToolBinary(), kDefaultAlgorithm, TestKeyRsa4096()));
-}
-
-fruit::Component<Avb> CuttlefishKeyAvbComponent() {
-  return fruit::createComponent().registerProvider(
-      []() -> Avb* { return GetDefaultAvb().release(); });
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/avb/avb.h
+++ b/base/cvd/cuttlefish/host/libs/avb/avb.h
@@ -42,7 +42,6 @@ struct ChainPartition {
 
 class Avb {
  public:
-  Avb(std::string avbtool_path);
   Avb(std::string avbtool_path, std::string algorithm, std::string key);
 
   /**

--- a/base/cvd/cuttlefish/host/libs/avb/avb.h
+++ b/base/cvd/cuttlefish/host/libs/avb/avb.h
@@ -20,11 +20,8 @@
 #include <sys/types.h>
 
 #include <cstdint>
-#include <memory>
 #include <string>
 #include <vector>
-
-#include <fruit/fruit.h>
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"
@@ -42,6 +39,7 @@ struct ChainPartition {
 
 class Avb {
  public:
+  Avb();
   Avb(std::string avbtool_path, std::string algorithm, std::string key);
 
   /**
@@ -54,7 +52,7 @@ class Avb {
   */
   Result<void> AddHashFooter(const std::string& image_path,
                              const std::string& partition_name,
-                             const off_t partition_size_bytes) const;
+                             off_t partition_size_bytes) const;
   Result<std::string> InfoImage(const std::string& image_path) const;
   Result<void> MakeVbMetaImage(
       const std::string& output_path,
@@ -65,7 +63,7 @@ class Avb {
  private:
   Command GenerateAddHashFooter(const std::string& image_path,
                                 const std::string& partition_name,
-                                const off_t partition_size_bytes) const;
+                                off_t partition_size_bytes) const;
   Command GenerateInfoImage(const std::string& image_path,
                             const SharedFD& output_path) const;
   Command GenerateMakeVbMetaImage(
@@ -80,9 +78,5 @@ class Avb {
 };
 
 Result<void> EnforceVbMetaSize(const std::string& path);
-
-std::unique_ptr<Avb> GetDefaultAvb();
-
-fruit::Component<Avb> CuttlefishKeyAvbComponent();
 
 }  // namespace cuttlefish


### PR DESCRIPTION
- Always provide an algorithm and key to the Avb class
- Merge `GetDefaultAvb()` into the default constructor of `Avb`

Bug: b/436367852