### PR TITLE
Allow for locks to be acquired incrementally.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/instances/lock/instance_lock.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/lock/instance_lock.cpp
@@ -250,4 +250,16 @@ Result<void> InstanceLockFileManager::RemoveLockFile(int instance_num) {
   return {};
 }
 
+Result<std::set<InstanceLockFile>> InstanceLockFileManager::AcquireUnusedLocks(
+    unsigned int number) {
+  std::set<InstanceLockFile> more;
+  for (int i = 1; more.size() < number; i++) {
+    auto lock = CF_EXPECT(TryAcquireLock(i));
+    if (lock && CF_EXPECT(lock->Status()) == InUseState::kNotInUse) {
+      more.emplace(std::move(*lock));
+    }
+  }
+  return more;
+}
+
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/lock/instance_lock.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/lock/instance_lock.h
@@ -51,6 +51,7 @@ class InstanceLockFileManager {
 
   Result<InstanceLockFile> AcquireLock(int instance_num);
   Result<std::set<InstanceLockFile>> AcquireLocks(const std::set<int>& nums);
+  Result<std::set<InstanceLockFile>> AcquireUnusedLocks(unsigned int number);
 
   Result<std::optional<InstanceLockFile>> TryAcquireLock(int instance_num);
   Result<std::set<InstanceLockFile>> TryAcquireLocks(const std::set<int>& nums);


### PR DESCRIPTION
Since we currently statically allocate tap interfaces for the maximum number of instances we anticipate running, the current code tries to acquire a number of instance locks for the number of tap interfaces currently on the system.

If we want to only acquire tap interfaces when instances are created, this scheme has to be modified. Here, we provide some functionality to examine what locks have been acquired and to acquire additional locks.