### PR TITLE
Minor improvements to the host orchestrator

### DIFF
--- a/frontend/src/host_orchestrator/orchestrator/cvd/cvd.go
+++ b/frontend/src/host_orchestrator/orchestrator/cvd/cvd.go
@@ -31,8 +31,7 @@ import (
 )
 
 const (
-	CVDBin      = "/usr/bin/cvd"
-	FetchCVDBin = "/usr/bin/fetch_cvd"
+	CVDBin = "/usr/bin/cvd"
 )
 
 // A CVD instance group
@@ -415,6 +414,7 @@ func (cli *CLI) Fetch(mainBuild AndroidBuild, targetDir string, opts FetchOpts) 
 		return fmt.Errorf("invalid main build: %w", err)
 	}
 	args := []string{
+		"fetch",
 		fmt.Sprintf("--directory=%s", targetDir),
 		fmt.Sprintf("--default_build=%s", cliFormat(mainBuild)),
 	}
@@ -443,7 +443,7 @@ func (cli *CLI) Fetch(mainBuild AndroidBuild, targetDir string, opts FetchOpts) 
 		args = append(args, fmt.Sprintf("--api_base_url=%s", opts.BuildAPIBaseURL))
 	}
 
-	cmd := cli.buildCmd(FetchCVDBin, args...)
+	cmd := cli.buildCmd(CVDBin, args...)
 
 	if opts.Credentials.UseGCEServiceAccountCredentials {
 		cmd.Args = append(cmd.Args, "--credential_source=gce")
@@ -462,7 +462,7 @@ func (cli *CLI) Fetch(mainBuild AndroidBuild, targetDir string, opts FetchOpts) 
 	}
 
 	if _, err := cli.runCmd(cmd); err != nil {
-		return fmt.Errorf("`fetch_cvd` failed: %w", err)
+		return fmt.Errorf("`cvd fetch` failed: %w", err)
 	}
 	// TODO(b/286466643): Remove this hack once cuttlefish is capable of booting from read-only artifacts again.
 	if _, err := cli.exec("chmod", "-R", "g+rw", targetDir); err != nil {

--- a/frontend/src/host_orchestrator/orchestrator/cvd/cvd.go
+++ b/frontend/src/host_orchestrator/orchestrator/cvd/cvd.go
@@ -169,9 +169,9 @@ func (cli *CLI) Load(configPath string, opts LoadOpts) (*Group, error) {
 }
 
 type CreateOptions struct {
-	HostPath     string
-	ProductPath  string
-	InstanceNums []uint32
+	HostPath      string
+	ProductPath   string
+	InstanceCount uint32
 }
 
 func (o *CreateOptions) toArgs() []string {
@@ -182,10 +182,7 @@ func (o *CreateOptions) toArgs() []string {
 	if o.ProductPath != "" {
 		args = append(args, "--product_path", o.ProductPath)
 	}
-	if len(o.InstanceNums) > 0 {
-		args = append(args, "--instance_nums", strings.Join(sliceItoa(o.InstanceNums), ","))
-		args = append(args, "--num_instances", fmt.Sprintf("%d", len(o.InstanceNums)))
-	}
+	args = append(args, "--num_instances", fmt.Sprintf("%d", o.InstanceCount))
 	return args
 }
 

--- a/frontend/src/host_orchestrator/orchestrator/instancemanager.go
+++ b/frontend/src/host_orchestrator/orchestrator/instancemanager.go
@@ -152,7 +152,7 @@ const (
 )
 
 type startCVDParams struct {
-	InstanceNumbers  []uint32
+	InstanceCount    uint32
 	MainArtifactsDir string
 	// OPTIONAL. If set, kernel relevant artifacts will be pulled from this dir.
 	KernelDir string
@@ -165,9 +165,7 @@ func CreateCVD(ctx hoexec.ExecContext, p startCVDParams) (*cvd.Group, error) {
 		HostPath:    p.MainArtifactsDir,
 		ProductPath: p.MainArtifactsDir,
 	}
-	if len(p.InstanceNumbers) > 1 {
-		createOpts.InstanceNums = p.InstanceNumbers
-	}
+	createOpts.InstanceCount = p.InstanceCount
 
 	startOpts := cvd.StartOptions{
 		ReportUsageStats: reportAnonymousUsageStats,
@@ -243,15 +241,6 @@ func runAcloudSetup(execContext hoexec.ExecContext, artifactsRootDir, artifactsD
 	}
 	// Creates symbolic link `acloud_link` which points to the passed device artifacts directory.
 	go run(execContext(context.TODO(), "ln", "-s", artifactsDir, artifactsRootDir+"/acloud_link"))
-}
-
-func contains(s []uint32, e uint32) bool {
-	for _, a := range s {
-		if a == e {
-			return true
-		}
-	}
-	return false
 }
 
 func isRunningOnGCE() bool {


### PR DESCRIPTION
Use `cvd fetch` instead of `fetch_cvd`.

Delete unnecessary handling of instance numbers when creating a new cvd(s). It was always creating instances with ids starting at 1, which is the default for `cvd create` anyways, but would fail if there are already instances with those ids in the host. Now it doesn't pick instance numbers directly, but lets cvd pick them instead, which succeeds even if the first instance numbers are already in use. It will still try to create the symlink for acloud compatibility on every create request, which will fail, but that's ok as that failure is not fatal.