### PR TITLE
Enable clang-tidy for `//cuttlefish/host/libs/location`

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd_import_locations/unittest/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd_import_locations/unittest/BUILD.bazel
@@ -12,6 +12,7 @@ cf_cc_test(
     ],
     deps = [
         "//cuttlefish/host/libs/location",
+        "//cuttlefish/host/libs/location:string_parse",
         "//libbase",
         "@googletest//:gtest",
         "@googletest//:gtest_main",

--- a/base/cvd/cuttlefish/host/libs/location/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/location/BUILD.bazel
@@ -10,16 +10,13 @@ cf_cc_library(
         "GnssClient.cpp",
         "GpxParser.cpp",
         "KmlParser.cpp",
-        "StringParse.cpp",
     ],
     hdrs = [
         "GnssClient.h",
         "GpsFix.h",
         "GpxParser.h",
         "KmlParser.h",
-        "StringParse.h",
     ],
-    clang_tidy_enabled = False,  # TODO: 403655105 - revisit `vsscanf` clang-tidy warning in `StringParse.cpp`
     # `layering_check` conflicts with the combination of the clang prebuilt and
     # the cmake build rules used for @libxml2.
     features = ["-layering_check"],
@@ -28,6 +25,7 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:environment",
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/commands/gnss_grpc_proxy:libcvd_gnss_grpc_proxy",
+        "//cuttlefish/host/libs/location:string_parse",
         "//libbase",
         "@grpc",
         "@grpc//:grpc++",
@@ -36,4 +34,10 @@ cf_cc_library(
         "@libxml2",
         "@protobuf",
     ],
+)
+
+cf_cc_library(
+    name = "string_parse",
+    srcs = ["StringParse.cpp"],
+    hdrs = ["StringParse.h"],
 )


### PR DESCRIPTION
There is a bug in clang_tidy that it can incorrectly identify a va_list type as being uninitialized in a scenario where it lints multiple files.

https://bugs.llvm.org/show_bug.cgi?id=41311

Having it lint the file alone works around the issue.

Bug: b/403655105