### PR TITLE
Add a use_cvdalloc flag to the config.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
@@ -120,8 +120,13 @@ DEFINE_vec(
     "Frame socket path to use when launching a VM "
     "For example, \"--frames_socket_path=${XDG_RUNTIME_DIR}/wayland-0\"");
 
+
 DEFINE_vec(use_allocd, CF_DEFAULTS_USE_ALLOCD?"true":"false",
             "Acquire static resources from the resource allocator daemon.");
+
+DEFINE_vec(use_cvdalloc, CF_DEFAULTS_USE_CVDALLOC? "true": "false",
+            "Acquire static resources with cvdalloc.");
+
 DEFINE_vec(
     enable_minimal_mode, CF_DEFAULTS_ENABLE_MINIMAL_MODE ? "true" : "false",
     "Only enable the minimum features to boot a cuttlefish device and "

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.h
@@ -61,6 +61,7 @@ DECLARE_vec(guest_vulkan_driver);
 DECLARE_vec(frames_socket_path);
 
 DECLARE_vec(use_allocd);
+DECLARE_vec(use_cvdalloc);
 DECLARE_vec(enable_minimal_mode);
 DECLARE_vec(pause_in_bootloader);
 DECLARE_bool(enable_host_bluetooth);

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -517,6 +517,7 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
   std::vector<bool> use_random_serial_vec = CF_EXPECT(GET_FLAG_BOOL_VALUE(
       use_random_serial));
   std::vector<bool> use_allocd_vec = CF_EXPECT(GET_FLAG_BOOL_VALUE(use_allocd));
+  std::vector<bool> use_cvdalloc_vec = CF_EXPECT(GET_FLAG_BOOL_VALUE(use_cvdalloc));
   std::vector<bool> use_sdcard_vec = CF_EXPECT(GET_FLAG_BOOL_VALUE(use_sdcard));
   std::vector<bool> pause_in_bootloader_vec = CF_EXPECT(GET_FLAG_BOOL_VALUE(
       pause_in_bootloader));
@@ -784,6 +785,7 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
     auto const_instance =
         const_cast<const CuttlefishConfig&>(tmp_config_obj).ForInstance(num);
 
+    instance.set_use_cvdalloc(use_cvdalloc_vec[instance_index]);
     instance.set_crosvm_use_balloon(use_balloon_vec[instance_index]);
     instance.set_crosvm_use_rng(use_rng_vec[instance_index]);
     instance.set_crosvm_simple_media_device(simple_media_device_vec[instance_index]);

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags_defaults.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags_defaults.h
@@ -55,6 +55,7 @@
 #define CF_DEFAULTS_SETUPWIZARD_MODE "DISABLED"
 #define CF_DEFAULTS_SMT false
 #define CF_DEFAULTS_USE_ALLOCD false
+#define CF_DEFAULTS_USE_CVDALLOC false
 #define CF_DEFAULTS_USE_SDCARD true
 #define CF_DEFAULTS_UUID \
   cuttlefish::ForCurrentInstance(cuttlefish::kDefaultUuidPrefix)

--- a/base/cvd/cuttlefish/host/commands/start/main.cc
+++ b/base/cvd/cuttlefish/host/commands/start/main.cc
@@ -158,6 +158,7 @@ const std::unordered_set<std::string>& BoolFlags() {
       "start_gnss_proxy",
       "start_webrtc",
       "use_allocd",
+      "use_cvdalloc",
       "use_random_serial",
       "use_sdcard",
       "vhost_net",

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
@@ -324,6 +324,7 @@ class CuttlefishConfig {
     std::string ethernet_ipv6() const;
     uint32_t session_id() const;
     bool use_allocd() const;
+    bool use_cvdalloc() const;
     int vsock_guest_cid() const;
     std::string vsock_guest_group() const;
     std::string uuid() const;
@@ -673,6 +674,7 @@ class CuttlefishConfig {
     void set_ethernet_ipv6(const std::string& ip);
     void set_session_id(uint32_t session_id);
     void set_use_allocd(bool use_allocd);
+    void set_use_cvdalloc(bool use_cvdalloc);
     void set_vsock_guest_cid(int vsock_guest_cid);
     void set_vsock_guest_group(const std::string& vsock_guest_group);
     void set_uuid(const std::string& uuid);

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
@@ -1596,6 +1596,15 @@ void CuttlefishConfig::MutableInstanceSpecific::set_use_allocd(
   (*Dictionary())[kUseAllocd] = use_allocd;
 }
 
+static constexpr char kUseCvdalloc[] = "use_cvdalloc";
+bool CuttlefishConfig::InstanceSpecific::use_cvdalloc() const {
+  return (*Dictionary())[kUseCvdalloc].asBool();
+}
+void CuttlefishConfig::MutableInstanceSpecific::set_use_cvdalloc(
+    bool use_cvdalloc) {
+  (*Dictionary())[kUseCvdalloc] = use_cvdalloc;
+}
+
 static constexpr char kSessionId[] = "session_id";
 uint32_t CuttlefishConfig::InstanceSpecific::session_id() const {
   return (*Dictionary())[kSessionId].asUInt();


### PR DESCRIPTION
To ensure that we can manage changes without disruption, we should have a feature flag to isolate new behavior from old. We could just repurpose the allocd flag, but it might be more readable to add a flag here and remove the allocd flag later in a different commit.