### PR TITLE
Improvements to the HO's cvd command wrapper

### DIFF
--- a/frontend/src/host_orchestrator/orchestrator/BUILD.bazel
+++ b/frontend/src/host_orchestrator/orchestrator/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//api/v1:api",
         "//orchestrator/artifacts",
         "//orchestrator/cvd",
+        "//orchestrator/cvd/output",
         "//orchestrator/debug",
         "//orchestrator/exec",
         "@com_github_google_android_cuttlefish_frontend_src_liboperator//operator",

--- a/frontend/src/host_orchestrator/orchestrator/createcvdbugreportaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/createcvdbugreportaction.go
@@ -70,7 +70,7 @@ func (a *CreateCVDBugReportAction) Run() (apiv1.Operation, error) {
 	go func(uuid string, op apiv1.Operation) {
 		dst := filepath.Join(a.paths.CVDBugReportsDir, uuid, BugReportZipFileName)
 		result := &OperationResult{}
-		if err := a.cvdCLI.BugReport(cvd.Selector{Group: a.group}, a.includeADBBugreport, dst); err != nil {
+		if err := a.cvdCLI.LazySelectGroup(cvd.GroupSelector{Name: a.group}).BugReport(a.includeADBBugreport, dst); err != nil {
 			result.Error = operator.NewInternalError("`cvd host_bugreport` failed: ", err)
 		} else {
 			result.Value = uuid

--- a/frontend/src/host_orchestrator/orchestrator/cvd/BUILD.bazel
+++ b/frontend/src/host_orchestrator/orchestrator/cvd/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//orchestrator/exec",
+        "//orchestrator/cvd/output",
     ],
 )
 

--- a/frontend/src/host_orchestrator/orchestrator/cvd/output/BUILD.bazel
+++ b/frontend/src/host_orchestrator/orchestrator/cvd/output/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "output",
+    srcs = ["output.go"],
+    importpath = "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/cvd/output",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//orchestrator/exec",
+    ],
+)

--- a/frontend/src/host_orchestrator/orchestrator/cvd/output/output.go
+++ b/frontend/src/host_orchestrator/orchestrator/cvd/output/output.go
@@ -1,0 +1,53 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package output
+
+// The types in this file are used to parse the JSON output of cvd commands.
+
+// A CVD instance group
+type Group struct {
+	Name      string      `json:"group_name"`
+	Instances []*Instance `json:"instances"`
+}
+
+// A CVD instance
+type Instance struct {
+	InstanceName   string   `json:"instance_name"`
+	Status         string   `json:"status"`
+	Displays       []string `json:"displays"`
+	InstanceDir    string   `json:"instance_dir"`
+	WebRTCDeviceID string   `json:"webrtc_device_id"`
+	ADBSerial      string   `json:"adb_serial"`
+}
+
+// The output of the cvd fleet command
+type Fleet struct {
+	Groups []*Group `json:"groups"`
+}
+
+type DisplayMode struct {
+	Windowed []int `json:"windowed"`
+}
+
+type Display struct {
+	DPI           []int       `json:"dpi"`
+	Mode          DisplayMode `json:"mode"`
+	RefreshRateHZ int         `json:"refresh-rate"`
+}
+
+// The output of the `cvd displays` command
+type Displays struct {
+	Displays map[int]*Display `json:"displays"`
+}

--- a/frontend/src/host_orchestrator/orchestrator/displayaddaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/displayaddaction.go
@@ -19,13 +19,14 @@ import (
 
 	apiv1 "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
 	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/cvd"
+	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/cvd/output"
 	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/exec"
 	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
 )
 
 type DisplayAddActionOpts struct {
 	Request          *apiv1.DisplayAddRequest
-	Selector         cvd.Selector
+	Selector         cvd.InstanceSelector
 	Paths            IMPaths
 	OperationManager OperationManager
 	ExecContext      exec.ExecContext
@@ -33,7 +34,7 @@ type DisplayAddActionOpts struct {
 
 type DisplayAddAction struct {
 	req      *apiv1.DisplayAddRequest
-	selector cvd.Selector
+	selector cvd.InstanceSelector
 	paths    IMPaths
 	om       OperationManager
 	cvdCLI   *cvd.CLI
@@ -63,7 +64,7 @@ func toCvdDisplayAddOpts(req *apiv1.DisplayAddRequest) cvd.DisplayAddOpts {
 	return opts
 }
 
-func findNewDisplayNumber(oldDisplays *cvd.Displays, newDisplays *cvd.Displays) (int, error) {
+func findNewDisplayNumber(oldDisplays *output.Displays, newDisplays *output.Displays) (int, error) {
 	oldDisplaysLen := len(oldDisplays.Displays)
 	newDisplaysLen := len(newDisplays.Displays)
 	if newDisplaysLen-oldDisplaysLen != 1 {
@@ -80,16 +81,17 @@ func findNewDisplayNumber(oldDisplays *cvd.Displays, newDisplays *cvd.Displays) 
 }
 
 func (a *DisplayAddAction) Run() (*apiv1.DisplayAddResponse, error) {
-	oldDisplays, err := a.cvdCLI.DisplayList(a.selector)
+	instance := a.cvdCLI.LazySelectInstance(a.selector)
+	oldDisplays, err := instance.ListDisplays()
 	if err != nil {
 		return nil, operator.NewInternalError("cvd display add: failed to list old displays:", err)
 	}
 
-	if err := a.cvdCLI.DisplayAdd(a.selector, toCvdDisplayAddOpts(a.req)); err != nil {
+	if err := instance.AddDisplay(toCvdDisplayAddOpts(a.req)); err != nil {
 		return nil, operator.NewInternalError("cvd display add failed", err)
 	}
 
-	newDisplays, err := a.cvdCLI.DisplayList(a.selector)
+	newDisplays, err := instance.ListDisplays()
 	if err != nil {
 		return nil, operator.NewInternalError("cvd display add: failed to list new displays:", err)
 	}

--- a/frontend/src/host_orchestrator/orchestrator/displaylistaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/displaylistaction.go
@@ -17,19 +17,20 @@ package orchestrator
 import (
 	apiv1 "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
 	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/cvd"
+	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/cvd/output"
 	"github.com/google/android-cuttlefish/frontend/src/host_orchestrator/orchestrator/exec"
 	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
 )
 
 type DisplayListActionOpts struct {
-	Selector         cvd.Selector
+	Selector         cvd.InstanceSelector
 	Paths            IMPaths
 	OperationManager OperationManager
 	ExecContext      exec.ExecContext
 }
 
 type DisplayListAction struct {
-	selector cvd.Selector
+	selector cvd.InstanceSelector
 	paths    IMPaths
 	om       OperationManager
 	cvdCLI   *cvd.CLI
@@ -44,13 +45,13 @@ func NewDisplayListAction(opts DisplayListActionOpts) *DisplayListAction {
 	}
 }
 
-func toApiv1DisplayMode(m cvd.DisplayMode) apiv1.DisplayMode {
+func toApiv1DisplayMode(m output.DisplayMode) apiv1.DisplayMode {
 	return apiv1.DisplayMode{
 		Windowed: m.Windowed,
 	}
 }
 
-func toApiv1Display(d *cvd.Display) apiv1.Display {
+func toApiv1Display(d *output.Display) apiv1.Display {
 	return apiv1.Display{
 		DPI:           d.DPI,
 		RefreshRateHZ: d.RefreshRateHZ,
@@ -58,7 +59,7 @@ func toApiv1Display(d *cvd.Display) apiv1.Display {
 	}
 }
 
-func toApiv1DisplayResponse(d *cvd.Displays) *apiv1.DisplayListResponse {
+func toApiv1DisplayResponse(d *output.Displays) *apiv1.DisplayListResponse {
 	resp := &apiv1.DisplayListResponse{
 		Displays: make(map[int]apiv1.Display),
 	}
@@ -69,7 +70,7 @@ func toApiv1DisplayResponse(d *cvd.Displays) *apiv1.DisplayListResponse {
 }
 
 func (a *DisplayListAction) Run() (*apiv1.DisplayListResponse, error) {
-	displays, err := a.cvdCLI.DisplayList(a.selector)
+	displays, err := a.cvdCLI.LazySelectInstance(a.selector).ListDisplays()
 	if err != nil {
 		return nil, operator.NewInternalError("cvd display list failed", err)
 	}

--- a/frontend/src/host_orchestrator/orchestrator/displayremoveaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/displayremoveaction.go
@@ -23,7 +23,7 @@ import (
 
 type DisplayRemoveActionOpts struct {
 	DisplayNumber    int
-	Selector         cvd.Selector
+	Selector         cvd.InstanceSelector
 	Paths            IMPaths
 	OperationManager OperationManager
 	ExecContext      exec.ExecContext
@@ -31,7 +31,7 @@ type DisplayRemoveActionOpts struct {
 
 type DisplayRemoveAction struct {
 	displayNumber int
-	selector      cvd.Selector
+	selector      cvd.InstanceSelector
 	paths         IMPaths
 	om            OperationManager
 	cvdCLI        *cvd.CLI
@@ -48,7 +48,7 @@ func NewDisplayRemoveAction(opts DisplayRemoveActionOpts) *DisplayRemoveAction {
 }
 
 func (a *DisplayRemoveAction) Run() (*apiv1.DisplayRemoveResponse, error) {
-	if err := a.cvdCLI.DisplayRemove(a.selector, a.displayNumber); err != nil {
+	if err := a.cvdCLI.LazySelectInstance(a.selector).RemoveDisplay(a.displayNumber); err != nil {
 		return nil, operator.NewInternalError("cvd display remove failed:", err)
 	}
 

--- a/frontend/src/host_orchestrator/orchestrator/displayscreenshotaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/displayscreenshotaction.go
@@ -29,7 +29,7 @@ import (
 
 type DisplayScreenshotActionOpts struct {
 	Request          *apiv1.DisplayScreenshotRequest
-	Selector         cvd.Selector
+	Selector         cvd.InstanceSelector
 	Paths            IMPaths
 	OperationManager OperationManager
 	ExecContext      exec.ExecContext
@@ -37,7 +37,7 @@ type DisplayScreenshotActionOpts struct {
 
 type DisplayScreenshotAction struct {
 	req      *apiv1.DisplayScreenshotRequest
-	selector cvd.Selector
+	selector cvd.InstanceSelector
 	paths    IMPaths
 	om       OperationManager
 	cvdCLI   *cvd.CLI
@@ -75,7 +75,7 @@ func (a *DisplayScreenshotAction) createScreenshot(op apiv1.Operation) (*apiv1.D
 
 	screenshotPath := filepath.Join(tempdir, "screenshot.png")
 
-	if err := a.cvdCLI.DisplayScreenshot(a.selector, 0, screenshotPath); err != nil {
+	if err := a.cvdCLI.LazySelectInstance(a.selector).Screenshot(0, screenshotPath); err != nil {
 		return nil, operator.NewInternalError("cvd display screenshot failed", err)
 	}
 

--- a/frontend/src/host_orchestrator/orchestrator/instancemanager.go
+++ b/frontend/src/host_orchestrator/orchestrator/instancemanager.go
@@ -60,18 +60,18 @@ func CvdGroupToAPIObject(group *cvd.Group) []*apiv1.CVD {
 func CvdInstanceToAPIObject(instance *cvd.Instance, group string) *apiv1.CVD {
 	return &apiv1.CVD{
 		Group: group,
-		Name:  instance.InstanceName,
+		Name:  instance.Name,
 		// TODO(b/259725479): Update when `cvd fleet` prints out build information.
 		BuildSource:    &apiv1.BuildSource{},
-		Status:         instance.Status,
-		Displays:       instance.Displays,
-		WebRTCDeviceID: instance.WebRTCDeviceID,
-		ADBSerial:      instance.ADBSerial,
+		Status:         instance.Status(),
+		Displays:       instance.Displays(),
+		WebRTCDeviceID: instance.WebRTCDeviceID(),
+		ADBSerial:      instance.ADBSerial(),
 	}
 }
 
-func findGroup(fleet *cvd.Fleet, name string) (bool, *cvd.Group) {
-	for _, e := range fleet.Groups {
+func findGroup(groups []*cvd.Group, name string) (bool, *cvd.Group) {
+	for _, e := range groups {
 		if e.Name == name {
 			return true, e
 		}
@@ -81,7 +81,7 @@ func findGroup(fleet *cvd.Fleet, name string) (bool, *cvd.Group) {
 
 func findInstance(group *cvd.Group, name string) (bool, *cvd.Instance) {
 	for _, e := range group.Instances {
-		if e.InstanceName == name {
+		if e.Name == name {
 			return true, e
 		}
 	}
@@ -102,7 +102,7 @@ func CVDLogsDir(ctx hoexec.ExecContext, groupName, name string) (string, error) 
 	if !ok {
 		return "", operator.NewNotFoundError(fmt.Sprintf("Instance %q not found", name), nil)
 	}
-	return ins.InstanceDir + "/logs", nil
+	return ins.InstanceDir() + "/logs", nil
 }
 
 type fetchCVDCommandArtifactsFetcher struct {
@@ -182,7 +182,7 @@ func CreateCVD(ctx hoexec.ExecContext, p startCVDParams) (*cvd.Group, error) {
 	}
 
 	cvdCLI := cvd.NewCLI(ctx)
-	group, err := cvdCLI.Create(cvd.Selector{Group: groupName}, createOpts, startOpts)
+	group, err := cvdCLI.Create(cvd.GroupSelector{Name: groupName}, createOpts, startOpts)
 	if err != nil {
 		return nil, fmt.Errorf("launch cvd stage failed: %w", err)
 	}

--- a/frontend/src/host_orchestrator/orchestrator/listcvdsaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/listcvdsaction.go
@@ -44,13 +44,12 @@ func NewListCVDsAction(opts ListCVDsActionOpts) *ListCVDsAction {
 }
 
 func (a *ListCVDsAction) Run() (*apiv1.ListCVDsResponse, error) {
-	fleet, err := a.cvdCLI.Fleet()
+	groups, err := a.cvdCLI.Fleet()
 	if err != nil {
 		return nil, err
 	}
-	groups := fleet.Groups
 	if a.group != "" {
-		ok, g := findGroup(fleet, a.group)
+		ok, g := findGroup(groups, a.group)
 		if !ok {
 			return nil, operator.NewNotFoundError(fmt.Sprintf("Group %q not found", a.group), nil)
 		}

--- a/frontend/src/host_orchestrator/orchestrator/startcvdaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/startcvdaction.go
@@ -27,7 +27,7 @@ import (
 
 type StartCVDActionOpts struct {
 	Request          *apiv1.StartCVDRequest
-	Selector         cvd.Selector
+	Selector         cvd.GroupSelector
 	Paths            IMPaths
 	OperationManager OperationManager
 	ExecContext      exec.ExecContext
@@ -35,7 +35,7 @@ type StartCVDActionOpts struct {
 
 type StartCVDAction struct {
 	req      *apiv1.StartCVDRequest
-	selector cvd.Selector
+	selector cvd.GroupSelector
 	paths    IMPaths
 	om       OperationManager
 	cvdCLI   *cvd.CLI
@@ -78,7 +78,7 @@ func (a *StartCVDAction) Run() (apiv1.Operation, error) {
 }
 
 func (a *StartCVDAction) exec(op apiv1.Operation, opts cvd.StartOptions) (*apiv1.EmptyResponse, error) {
-	if err := a.cvdCLI.Start(a.selector, opts); err != nil {
+	if err := a.cvdCLI.LazySelectGroup(a.selector).Start(opts); err != nil {
 		return nil, operator.NewInternalError("cvd start failed", err)
 	}
 	return &apiv1.EmptyResponse{}, nil


### PR DESCRIPTION
Clearly separate what operations act on a group vs on an instance or are global.
Use different selector types to find instances vs groups.