### PR TITLE
Fix host orchestrator screenshot endpoint

### DIFF
--- a/frontend/src/host_orchestrator/orchestrator/cvd/cvd.go
+++ b/frontend/src/host_orchestrator/orchestrator/cvd/cvd.go
@@ -409,7 +409,7 @@ func (i *Instance) Screenshot(displayNumber int, path string) error {
 	args := i.selectorArgs()
 	args = append(args, "display")
 	args = append(args, "screenshot")
-	args = append(args, fmt.Sprintf("--display_number=%d", displayNumber))
+	args = append(args, fmt.Sprintf("--display=%d", displayNumber))
 	args = append(args, "--screenshot_path="+path)
 	_, err := i.cli.exec(CVDBin, args...)
 	return err

--- a/frontend/src/host_orchestrator/orchestrator/displayscreenshotaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/displayscreenshotaction.go
@@ -38,7 +38,6 @@ type DisplayScreenshotActionOpts struct {
 type DisplayScreenshotAction struct {
 	req      *apiv1.DisplayScreenshotRequest
 	selector cvd.InstanceSelector
-	paths    IMPaths
 	om       OperationManager
 	cvdCLI   *cvd.CLI
 }
@@ -47,7 +46,6 @@ func NewDisplayScreenshotAction(opts DisplayScreenshotActionOpts) *DisplayScreen
 	return &DisplayScreenshotAction{
 		req:      opts.Request,
 		selector: opts.Selector,
-		paths:    opts.Paths,
 		om:       opts.OperationManager,
 		cvdCLI:   cvd.NewCLI(opts.ExecContext),
 	}
@@ -75,7 +73,7 @@ func (a *DisplayScreenshotAction) createScreenshot(op apiv1.Operation) (*apiv1.D
 
 	screenshotPath := filepath.Join(tempdir, "screenshot.png")
 
-	if err := a.cvdCLI.LazySelectInstance(a.selector).Screenshot(0, screenshotPath); err != nil {
+	if err := a.cvdCLI.LazySelectInstance(a.selector).Screenshot(a.req.DisplayNumber, screenshotPath); err != nil {
 		return nil, operator.NewInternalError("cvd display screenshot failed", err)
 	}
 


### PR DESCRIPTION
- Use the correct flag for display number (`--display`)
- Actually use the provided display number instead of always `0`