### PR TITLE
Use ubuntu-22.04-arm as Github workflow runner

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -29,7 +29,7 @@ jobs:
         name: docker-image-x86_64
         path: ${{ env.x86_64_image_path }}
   export-docker-image-arm64:
-    runs-on: arm-ubuntu-arm-22.04-4core
+    runs-on: ubuntu-22.04-arm
     steps:
     - name: Checkout repository
       uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2


### PR DESCRIPTION
Context: https://docs.github.com/en/enterprise-cloud@latest/actions/concepts/runners/github-hosted-runners#runner-images

Now ARM64 runners are in standard Github-hosted runners.