### PR TITLE
Name cvdalloc-managed interfaces differently.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -11,9 +11,11 @@ cf_cc_library(
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:result",
+        "//cuttlefish/host/commands/cvdalloc:interface",
         "//cuttlefish/host/libs/allocd:allocd_utils",
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/strings:str_format",
     ],
 )
 

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/alloc.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/alloc.h
@@ -25,6 +25,8 @@
 
 namespace cuttlefish {
 
+constexpr std::string_view kDefaultInterfacePrefix = "cvd";
+
 struct IfaceData {
   std::string name;
   uint32_t session_id;

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/BUILD.bazel
@@ -1,7 +1,18 @@
-load("//cuttlefish/bazel:rules.bzl", "cf_cc_binary")
+load("//cuttlefish/bazel:rules.bzl", "cf_cc_binary", "cf_cc_library")
 
 package(
     default_visibility = ["//:android_cuttlefish"],
+)
+
+cf_cc_library(
+    name = "interface",
+    srcs = [
+        "interface.cpp",
+    ],
+    hdrs = ["interface.h"],
+    deps = [
+        "@abseil-cpp//absl/strings:str_format",
+    ],
 )
 
 cf_cc_binary(
@@ -10,6 +21,7 @@ cf_cc_binary(
         "cvdalloc.cpp",
     ],
     deps = [
+        ":interface",
         "//allocd:alloc_utils",
         "//cuttlefish/common/libs/fs",
         "//libbase",

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/cvdalloc.h
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/cvdalloc.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+
+namespace cuttlefish {
+
+constexpr std::string_view kCvdallocInterfacePrefix = "cvd-pi";
+
+std::string CvdallocInterfaceName(const std::string &name, int num) {
+  return absl::StrFormat("%s-%s%d", kCvdallocInterfacePrefix, name, num);
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/interface.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/interface.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "cuttlefish/host/commands/cvdalloc/interface.h"
+
+#include "absl/strings/str_format.h"
+
+namespace cuttlefish {
+
+std::string CvdallocInterfaceName(const std::string &name, int num) {
+  return absl::StrFormat("%s-%s%d", kCvdallocInterfacePrefix, name, num);
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/interface.h
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/interface.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+
+namespace cuttlefish {
+
+constexpr std::string_view kCvdallocInterfacePrefix = "cvd-pi";
+
+std::string CvdallocInterfaceName(const std::string &name, int num);
+
+}  // namespace cuttlefish


### PR DESCRIPTION
Tell the vmm to expect cvdalloc-managed tap interfaces to be named differently from preallocated tap interfaces. This way, we avoid conflicts on a host where cuttlefish-host-resources may be running.

While we are doing this, we remove the padding requirements for the interface number in the naming scheme for cvdalloc-managed interfaces. This makes the interface naming more idiomatic and avoids the potential problem in the future if we have more than 99 instances on a host.