### PR TITLE
Don't fail if the artifact is already extracted

### DIFF
--- a/frontend/src/host_orchestrator/orchestrator/userartifacts.go
+++ b/frontend/src/host_orchestrator/orchestrator/userartifacts.go
@@ -150,7 +150,7 @@ func (m *UserArtifactsManagerImpl) ExtractArtifact(checksum string) error {
 	if exists, err := dirExists(dir); err != nil {
 		return fmt.Errorf("failed to check existence of directory: %w", err)
 	} else if exists {
-		return operator.NewConflictError(fmt.Sprintf("user artifact(checksum:%q) already extracted", checksum), nil)
+		return nil
 	}
 	file, err := m.getFilePath(checksum)
 	if err != nil {


### PR DESCRIPTION
If the artifact was already extracted successfully once the current request should succeed immediately instead of failing.

Bug: b/439670070