### PR TITLE
Fix Debian version of container image

### DIFF
--- a/tools/buildutils/cw/Containerfile
+++ b/tools/buildutils/cw/Containerfile
@@ -1,4 +1,4 @@
-FROM debian:stable AS base
+FROM debian:12 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
As Debian 13 is newly introduced, this container image began to use it but haven't fitted with the new version. This commit is for fixing Debian version as 12(bookworm) which we used before, and we can upgrade into Debian 13 later.