### PR TITLE
Use standard runner to build CF debian packages for x86 on Github workflow

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -192,29 +192,22 @@ jobs:
       with:
         name: cvd-unit-tests-logs
         path: base/cvd/bazel-out/k8-fastbuild/testlogs
-  build-debian-package:
-    runs-on: ubuntu-22.04-4core
-    container:
-      image: debian@sha256:9258a75a7e4323c9e5562b361effc84ee747920116d8adfc98a465a5cdc9150e # debian:bookworm-20250407 (amd64)
+  build-debian-package-x86:
+    runs-on: ubuntu-22.04
     steps:
-    - name: Check for dockerenv file
-      run: (ls /.dockerenv && echo 'Found dockerenv') || (echo 'No dockerenv')
-    - name: setup apt
-      run: apt update -y && apt upgrade -y
-    - name: install dependencies
-      run: apt install -y git devscripts config-package-dev debhelper-compat golang protobuf-compiler yq
-    - name: go version
-      run: go version
+    - name: Free disk space
+      uses: jlumbroso/free-disk-space@v1.3.1
+      with:
+        docker-images: false
+        swap-storage: false
     - name: checkout repository
       uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
       with:
         path: "android-cuttlefish"
-    - name: install bazel
-      run: bash android-cuttlefish/tools/buildutils/installbazel.sh
     - name: Load cache config
       run: |
         cat android-cuttlefish/.config/cache-config.env >> $GITHUB_ENV
-        echo "JOB_HASH=$(yq .jobs[\"build-debian-package\"] android-cuttlefish/.github/workflows/presubmit.yaml | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
+        echo "JOB_HASH=$(yq .jobs[\"build-debian-package-x86\"] android-cuttlefish/.github/workflows/presubmit.yaml | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
     - name: Generate cache key prefix
       run: echo "CACHE_KEY_PREFIX=${{ runner.os }}-${{ runner.arch }}-bazel-disk-cache-${{ env.CACHE_VERSION }}-debian-package-${{ env.JOB_HASH }}" >> $GITHUB_ENV
     - name: Mount Bazel cache
@@ -226,37 +219,33 @@ jobs:
           ${{ format('{0}-{1}-', env.CACHE_KEY_PREFIX, github.ref_name) }}
           ${{ format('{0}-main-', env.CACHE_KEY_PREFIX) }}
           ${{ format('{0}-', env.CACHE_KEY_PREFIX) }}
-    - name: install package build dependencies
-      run: cd android-cuttlefish/base && mk-build-deps -i -t 'apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y'
-    - name: build base debian package
-      run: cd android-cuttlefish/base && debuild -e BAZEL_DISK_CACHE_DIR=$HOME/bazel-disk-cache -i -us -uc -b
-    - name: install base debian package
-      run: dpkg -i android-cuttlefish/cuttlefish-base_*_*64.deb || apt-get install -f -y
-    - name: build frontend debian packages
-      run: cd android-cuttlefish/frontend && debuild -i -us -uc -b
-    - name: install user debian package
-      run: dpkg -i android-cuttlefish/cuttlefish-user_*_*64.deb || apt-get install -f -y
-    - name: Build debs.tar
-      run: find . -name 'cuttlefish-*.deb' -print0 | tar -cvf debs.tar --null --files-from -
-    - name: Publish debs.tar
+    - name: Build CF debian packages
+      run: |
+        cd android-cuttlefish
+        sudo docker build --file "tools/buildutils/cw/Containerfile" --tag "android-cuttlefish-build" .
+        sudo docker run -v=$PWD:/mnt/build -w /mnt/build -v=$HOME/bazel-disk-cache:/root/bazel-disk-cache android-cuttlefish-build base -d /root/bazel-disk-cache
+        sudo docker run -v=$PWD:/mnt/build -w /mnt/build android-cuttlefish-build frontend
+    - name: Build debs_x86.tar
+      run: find . -name 'cuttlefish-*.deb' -print0 | tar -cvf debs_x86.tar --null --files-from -
+    - name: Publish debs_x86.tar
       uses: actions/upload-artifact@v4
       with:
-        name: debs
-        path: debs.tar
+        name: debs_x86
+        path: debs_x86.tar
   e2e-tests-orchestration-build-image:
     runs-on: ubuntu-24.04
-    needs: [build-debian-package]
+    needs: [build-debian-package-x86]
     steps:
     - name: Checkout repository
       uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
     - name: Download cuttlefish debs
       uses: actions/download-artifact@v4
       with:
-        name: debs
+        name: debs_x86
         github-token: ${{ github.token }}
     - name: Build image
       run: |
-        tar -xvf debs.tar && mv android-cuttlefish/cuttlefish*.deb .
+        tar -xvf debs_x86.tar && mv android-cuttlefish/cuttlefish*.deb .
         sudo podman info
         sudo podman build -f "tools/testutils/cw/Containerfile" --tag "android-cuttlefish-e2etest:latest" .
         sudo podman save --quiet -o android-cuttlefish-e2etest.tar localhost/android-cuttlefish-e2etest
@@ -345,7 +334,7 @@ jobs:
         df -h
   docker-image-check:
     runs-on: ubuntu-22.04
-    needs: [build-debian-package]
+    needs: [build-debian-package-x86]
     steps:
     - name: Free disk space
       uses: jlumbroso/free-disk-space@v1.3.1
@@ -356,12 +345,12 @@ jobs:
     - name: Download cuttlefish debs
       uses: actions/download-artifact@v4
       with:
-        name: debs
+        name: debs_x86
         github-token: ${{ github.token }}
     - name: Run check
       shell: bash
       run: |
-        tar -xvf debs.tar && mv android-cuttlefish/cuttlefish*.deb .
+        tar -xvf debs_x86.tar && mv android-cuttlefish/cuttlefish*.deb .
         ./docker/image-builder.sh -m dev
         docker images
         sudo docker run --privileged -d -p 2080:2080 cuttlefish-orchestration:latest

--- a/.github/workflows/update-bazel-cache.yaml
+++ b/.github/workflows/update-bazel-cache.yaml
@@ -39,30 +39,23 @@ jobs:
           ${{ github.event_name == 'push' && format('{0}-', env.CACHE_KEY_PREFIX) || '' }}
     - name: Run unit tests
       run: cd base/cvd && bazel test --disk_cache=$HOME/bazel-disk-cache --sandbox_writable_path=$HOME --test_output=errors ...
-  update-debian-package-bazel-cache:
+  update-debian-package-x86-bazel-cache:
     if: ${{ github.repository_owner == 'google' }}
-    runs-on: ubuntu-22.04-4core
-    container:
-      image: debian@sha256:9258a75a7e4323c9e5562b361effc84ee747920116d8adfc98a465a5cdc9150e # debian:bookworm-20250407 (amd64)
+    runs-on: ubuntu-22.04
     steps:
-    - name: Check for dockerenv file
-      run: (ls /.dockerenv && echo 'Found dockerenv') || (echo 'No dockerenv')
-    - name: setup apt
-      run: apt update -y && apt upgrade -y
-    - name: install dependencies
-      run: apt install -y git devscripts config-package-dev debhelper-compat golang protobuf-compiler yq
-    - name: go version
-      run: go version
+    - name: Free disk space
+      uses: jlumbroso/free-disk-space@v1.3.1
+      with:
+        docker-images: false
+        swap-storage: false
     - name: checkout repository
       uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
       with:
         path: "android-cuttlefish"
-    - name: install bazel
-      run: bash android-cuttlefish/tools/buildutils/installbazel.sh
     - name: Load cache config
       run: |
         cat android-cuttlefish/.config/cache-config.env >> $GITHUB_ENV
-        echo "JOB_HASH=$(yq .jobs[\"build-debian-package\"] android-cuttlefish/.github/workflows/presubmit.yaml | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
+        echo "JOB_HASH=$(yq .jobs[\"build-debian-package-x86\"] android-cuttlefish/.github/workflows/presubmit.yaml | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
     - name: Generate cache key prefix
       run: echo "CACHE_KEY_PREFIX=${{ runner.os }}-${{ runner.arch }}-bazel-disk-cache-${{ env.CACHE_VERSION }}-debian-package-${{ env.JOB_HASH }}" >> $GITHUB_ENV
     - name: Mount Bazel cache
@@ -74,7 +67,8 @@ jobs:
           ${{ github.event_name == 'push' && format('{0}-{1}-', env.CACHE_KEY_PREFIX, github.ref_name) || '' }}
           ${{ github.event_name == 'push' && format('{0}-main-', env.CACHE_KEY_PREFIX) || '' }}
           ${{ github.event_name == 'push' && format('{0}-', env.CACHE_KEY_PREFIX) || '' }}
-    - name: install package build dependencies
-      run: cd android-cuttlefish/base && mk-build-deps -i -t 'apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y'
-    - name: build base debian package
-      run: cd android-cuttlefish/base && debuild -e BAZEL_DISK_CACHE_DIR=$HOME/bazel-disk-cache -i -us -uc -b
+    - name: Build CF debian packages
+      run: |
+        cd android-cuttlefish
+        sudo docker build --file "tools/buildutils/cw/Containerfile" --tag "android-cuttlefish-build" .
+        sudo docker run -v=$PWD:/mnt/build -w /mnt/build -v=$HOME/bazel-disk-cache:/root/bazel-disk-cache android-cuttlefish-build base -d /root/bazel-disk-cache

--- a/tools/buildutils/build_package.sh
+++ b/tools/buildutils/build_package.sh
@@ -31,14 +31,18 @@ shift
 
 remote_cache_arg=""
 cache_version_arg=""
+disk_cache_arg=""
 
-while getopts ":r:c:" opt; do
+while getopts ":r:c:d:" opt; do
   case "${opt}" in
     r)
       remote_cache_arg="-e BAZEL_REMOTE_CACHE=${OPTARG}"
       ;;
     c)
       cache_version_arg="-e BAZEL_CACHE_VERSION=${OPTARG}"
+      ;;
+    d)
+      disk_cache_arg="-e BAZEL_DISK_CACHE_DIR=${OPTARG}"
       ;;
     \?)
       echo "Invalid option: ${OPTARG}" >&2
@@ -65,5 +69,5 @@ pushd "${PKGDIR}"
 echo "Installing package dependencies"
 sudo mk-build-deps -i -t 'apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y'
 echo "Building packages"
-debuild ${remote_cache_arg} ${cache_version_arg} ${preserve_envvar} --prepend-path /usr/local/bin -i -uc -us -b
+debuild ${remote_cache_arg} ${cache_version_arg} ${disk_cache_arg} ${preserve_envvar} --prepend-path /usr/local/bin -i -uc -us -b
 popd


### PR DESCRIPTION
Currently `run-cvd-unit-tests`, `build-debian-package`, and their corresponding workflows for updating cache respectively are using `ubuntu-22.04-4core` which isn't a standard runner and costs.

The reason for using `ubuntu-22.04-4core` was to retrieve enough disk space, and I've found the action `jlumbroso/free-disk-space@v1.3.1` is used from another job(`e2e-tests-orchestration-runner-special`). However, we cannot utilize that action when the whole steps in the job are running on the container, though we need to build debian packages on debian, not on ubuntu. So I brought `tools/buildutils/cw/Containerfile` to build debian packages from debian environment.
