### PR TITLE
Use standard runner to build CF debian packages for ARM on Github workflow

### DIFF
--- a/.github/actions/run-cw-sharded-e2e-test/action.yaml
+++ b/.github/actions/run-cw-sharded-e2e-test/action.yaml
@@ -8,7 +8,7 @@ runs:
   using: "composite"
   steps:
     - name: Free disk space
-      uses: jlumbroso/free-disk-space@v1.3.1
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # aka v1.3.1
       with:
         tool-cache: true
     - name: Download image

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -232,6 +232,46 @@ jobs:
       with:
         name: debs_x86
         path: debs_x86.tar
+  build-debian-package-arm:
+    runs-on: ubuntu-22.04-arm
+    steps:
+    - name: Free disk space
+      uses: jlumbroso/free-disk-space@v1.3.1
+      with:
+        docker-images: false
+        swap-storage: false
+    - name: checkout repository
+      uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
+      with:
+        path: "android-cuttlefish"
+    - name: Load cache config
+      run: |
+        cat android-cuttlefish/.config/cache-config.env >> $GITHUB_ENV
+        echo "JOB_HASH=$(yq .jobs[\"build-debian-package-arm\"] android-cuttlefish/.github/workflows/presubmit.yaml | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
+    - name: Generate cache key prefix
+      run: echo "CACHE_KEY_PREFIX=${{ runner.os }}-${{ runner.arch }}-bazel-disk-cache-${{ env.CACHE_VERSION }}-debian-package-${{ env.JOB_HASH }}" >> $GITHUB_ENV
+    - name: Mount Bazel cache
+      uses: actions/cache/restore@v4
+      with:
+        path: "~/bazel-disk-cache"
+        key: ${{ format('{0}-{1}-{2}-{3}', env.CACHE_KEY_PREFIX, github.ref_name, github.sha, github.event_name) }}
+        restore-keys: |
+          ${{ format('{0}-{1}-', env.CACHE_KEY_PREFIX, github.ref_name) }}
+          ${{ format('{0}-main-', env.CACHE_KEY_PREFIX) }}
+          ${{ format('{0}-', env.CACHE_KEY_PREFIX) }}
+    - name: Build CF debian packages
+      run: |
+        cd android-cuttlefish
+        sudo docker build --file "tools/buildutils/cw/Containerfile" --tag "android-cuttlefish-build" .
+        sudo docker run -v=$PWD:/mnt/build -w /mnt/build -v=$HOME/bazel-disk-cache:/root/bazel-disk-cache android-cuttlefish-build base -d /root/bazel-disk-cache
+        sudo docker run -v=$PWD:/mnt/build -w /mnt/build android-cuttlefish-build frontend
+    - name: Build debs_arm.tar
+      run: find . -name 'cuttlefish-*.deb' -print0 | tar -cvf debs_arm.tar --null --files-from -
+    - name: Publish debs_arm.tar
+      uses: actions/upload-artifact@v4
+      with:
+        name: debs_arm
+        path: debs_arm.tar
   e2e-tests-orchestration-build-image:
     runs-on: ubuntu-24.04
     needs: [build-debian-package-x86]

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -196,7 +196,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Free disk space
-      uses: jlumbroso/free-disk-space@v1.3.1
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # aka v1.3.1
       with:
         docker-images: false
         swap-storage: false
@@ -236,7 +236,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
     steps:
     - name: Free disk space
-      uses: jlumbroso/free-disk-space@v1.3.1
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # aka v1.3.1
       with:
         docker-images: false
         swap-storage: false
@@ -332,7 +332,7 @@ jobs:
     needs: [e2e-tests-orchestration-build-image]
     steps:
     - name: Free disk space
-      uses: jlumbroso/free-disk-space@v1.3.1
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # aka v1.3.1
       with:
         tool-cache: true
     - name: checkout repository
@@ -377,7 +377,7 @@ jobs:
     needs: [build-debian-package-x86]
     steps:
     - name: Free disk space
-      uses: jlumbroso/free-disk-space@v1.3.1
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # aka v1.3.1
       with:
         tool-cache: true
     - name: Checkout repository

--- a/.github/workflows/update-bazel-cache.yaml
+++ b/.github/workflows/update-bazel-cache.yaml
@@ -72,3 +72,36 @@ jobs:
         cd android-cuttlefish
         sudo docker build --file "tools/buildutils/cw/Containerfile" --tag "android-cuttlefish-build" .
         sudo docker run -v=$PWD:/mnt/build -w /mnt/build -v=$HOME/bazel-disk-cache:/root/bazel-disk-cache android-cuttlefish-build base -d /root/bazel-disk-cache
+  update-debian-package-arm-bazel-cache:
+    if: ${{ github.repository_owner == 'google' }}
+    runs-on: ubuntu-22.04-arm
+    steps:
+    - name: Free disk space
+      uses: jlumbroso/free-disk-space@v1.3.1
+      with:
+        docker-images: false
+        swap-storage: false
+    - name: checkout repository
+      uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
+      with:
+        path: "android-cuttlefish"
+    - name: Load cache config
+      run: |
+        cat android-cuttlefish/.config/cache-config.env >> $GITHUB_ENV
+        echo "JOB_HASH=$(yq .jobs[\"build-debian-package-arm\"] android-cuttlefish/.github/workflows/presubmit.yaml | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
+    - name: Generate cache key prefix
+      run: echo "CACHE_KEY_PREFIX=${{ runner.os }}-${{ runner.arch }}-bazel-disk-cache-${{ env.CACHE_VERSION }}-debian-package-${{ env.JOB_HASH }}" >> $GITHUB_ENV
+    - name: Mount Bazel cache
+      uses: actions/cache@v4
+      with:
+        path: "~/bazel-disk-cache"
+        key: ${{ format('{0}-{1}-{2}-{3}', env.CACHE_KEY_PREFIX, github.ref_name, github.sha, github.event_name) }}
+        restore-keys: |
+          ${{ github.event_name == 'push' && format('{0}-{1}-', env.CACHE_KEY_PREFIX, github.ref_name) || '' }}
+          ${{ github.event_name == 'push' && format('{0}-main-', env.CACHE_KEY_PREFIX) || '' }}
+          ${{ github.event_name == 'push' && format('{0}-', env.CACHE_KEY_PREFIX) || '' }}
+    - name: Build CF debian packages
+      run: |
+        cd android-cuttlefish
+        sudo docker build --file "tools/buildutils/cw/Containerfile" --tag "android-cuttlefish-build" .
+        sudo docker run -v=$PWD:/mnt/build -w /mnt/build -v=$HOME/bazel-disk-cache:/root/bazel-disk-cache android-cuttlefish-build base -d /root/bazel-disk-cache

--- a/.github/workflows/update-bazel-cache.yaml
+++ b/.github/workflows/update-bazel-cache.yaml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Free disk space
-      uses: jlumbroso/free-disk-space@v1.3.1
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # aka v1.3.1
       with:
         docker-images: false
         swap-storage: false
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
     steps:
     - name: Free disk space
-      uses: jlumbroso/free-disk-space@v1.3.1
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # aka v1.3.1
       with:
         docker-images: false
         swap-storage: false


### PR DESCRIPTION
Note: This PR contains commits suggested at https://github.com/google/android-cuttlefish/pull/1559. I would rebase this PR before submission, after merging https://github.com/google/android-cuttlefish/pull/1559.

Primary reason for building CF debian packages for ARM is to upload debian packages into Artifact Registry. To achieve that, I want to introduce a presubmit or postsubmit check for building them.

- Estimated time to run job: 10 minutes after caching is applied.
- Estimated time change to complete workflow: No change, as this job won't be in the critical path to complete.
- Cost for running job: Free-tier as it's using `ubuntu-22.04-arm`, which is the standard runner.