### PR TITLE
Create abstraction for cvdalloc socket signaling.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvdalloc/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/BUILD.bazel
@@ -15,6 +15,19 @@ cf_cc_library(
     ],
 )
 
+cf_cc_library(
+    name = "sem",
+    srcs = [
+        "sem.cpp",
+    ],
+    hdrs = ["sem.h"],
+    deps = [
+        "//cuttlefish/common/libs/fs",
+        "//cuttlefish/common/libs/utils:result",
+        "//cuttlefish/host/libs/command_util",
+    ],
+)
+
 cf_cc_binary(
     name = "cvdalloc",
     srcs = [
@@ -22,6 +35,7 @@ cf_cc_binary(
     ],
     deps = [
         ":interface",
+        ":sem",
         "//allocd:alloc_utils",
         "//cuttlefish/common/libs/fs",
         "//libbase",

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/cvdalloc.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/cvdalloc.cpp
@@ -27,6 +27,7 @@
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/fs/shared_select.h"
 #include "cuttlefish/host/commands/cvdalloc/interface.h"
+#include "cuttlefish/host/commands/cvdalloc/sem.h"
 
 ABSL_FLAG(int, id, 0, "Id");
 ABSL_FLAG(int, socket, 0, "Socket");
@@ -123,17 +124,11 @@ Result<int> CvdallocMain(int argc, char *argv[]) {
 
   CF_EXPECT(Allocate(id, bridge_name));
 
-  int i = 0;
-  r = sock->Write(&i, sizeof(int));
-  if (r == -1) {
-    return CF_ERRNO("Write: " << strerror(errno));
-  }
+  CF_EXPECT(Post(sock));
 
   LOG(INFO) << "cvdalloc: waiting to teardown";
 
-  if (sock->Read(&i, sizeof(i)) < 0) {
-    return CF_ERRNO("Read: " << strerror(errno));
-  }
+  CF_EXPECT(Wait(sock, kSemNoTimeout));
 
   /* Teardown invoked by scopeguard above. */
 

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/sem.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/sem.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "cuttlefish/host/commands/cvdalloc/sem.h"
+
+#include "cuttlefish/host/libs/command_util/util.h"
+
+namespace cuttlefish {
+
+Result<void> Post(const SharedFD socket) {
+  char i = 0;
+  CF_EXPECT(socket->Write(&i, sizeof(char)) != -1);
+  return {};
+}
+
+Result<void> Wait(const SharedFD socket, std::chrono::seconds timeout) {
+  CF_EXPECT(socket->IsOpen(), "IsOpen: " << socket->StrError());
+  CF_EXPECT(WaitForRead(socket, timeout.count()), "WaitForRead");
+  char i = -1;
+  int r = socket->Read(&i, sizeof(i));
+  CF_EXPECT_GT(r, 0, socket->StrError());
+  CF_EXPECT(i == 0, "Unexpected read");
+  return {};
+}
+
+}  // namespace

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/sem.h
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/sem.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <chrono>
+
+#include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/common/libs/utils/result.h"
+
+namespace cuttlefish {
+
+constexpr std::chrono::seconds kSemNoTimeout = std::chrono::seconds(0);
+
+/*
+ * Write into the socket.
+ *
+ * Any other processes Wait'ing to read on the socket will be unblocked.
+ */
+Result<void> Post(const SharedFD socket);
+
+/*
+ * Wait on the socket.
+ *
+ * The process wil block until the socket can be read from, the socket is
+ * shut down, or the timeout is reached. The Result is ok if the socket
+ * can be successfully read from.
+ */
+Result<void> Wait(const SharedFD socket, std::chrono::seconds timeout);
+
+}  // namespace


### PR DESCRIPTION
Soon, run_cvd will need to also unblock and block on cvdalloc's socket. To do this reliably, we should have some stronger checks and some formalizations around the signaling that we're doing with the socket. Since we're treating these like semaphores, introduce a Post and Wait to do to this.