### PR TITLE
Post before shutdown on clean termination.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvdalloc/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/BUILD.bazel
@@ -39,6 +39,7 @@ cf_cc_binary(
         "//allocd:alloc_utils",
         "//cuttlefish/common/libs/fs",
         "//libbase",
+        "@abseil-cpp//absl/cleanup:cleanup",
         "@abseil-cpp//absl/flags:flag",
         "@abseil-cpp//absl/flags:parse",
         "@abseil-cpp//absl/strings:str_format",


### PR DESCRIPTION
The semantics of shutdown on our semaphores have changed to better signify abnormal termination cases. This will eventually allow run_cvd to determine if the notification it receives is because the allocation process has completed successfully or whether cvdalloc has died and should propagate the error to prevent the vmm from starting.