### PR TITLE
Pass sve=[auto=true] option for crosvm under arm64

### DIFF
--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_builder.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_builder.cpp
@@ -95,7 +95,11 @@ Result<void> CrosvmBuilder::AddCpus(const Json::Value& vcpu_config_json) {
 }
 
 void CrosvmBuilder::AddCpus(size_t cpus) {
-  command_.AddParameter("--cpus=", cpus);
+  if (HostArch() == Arch::Arm64) {
+    command_.AddParameter("--cpus=", cpus, ",sve=[auto=true]");
+  } else {
+    command_.AddParameter("--cpus=", cpus);
+  }
 }
 
 void CrosvmBuilder::AddHvcSink() {


### PR DESCRIPTION
While running image that uses sve instruction, boot failed with error about handling sve instruction even the CPU supports sve instruction.

It needs to enable sve instruction at crosvm side.

b/438945282

change for testing: ag/35226572