### PR TITLE
Wire cvdalloc up to run_cvd.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvdalloc/cvdalloc.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/cvdalloc.cpp
@@ -125,14 +125,13 @@ Result<int> CvdallocMain(int argc, char *argv[]) {
   };
 
   CF_EXPECT(Allocate(id, bridge_name));
-  CF_EXPECT(Post(sock));
+  CF_EXPECT(cvdalloc::Post(sock));
 
   LOG(INFO) << "cvdalloc: waiting to teardown";
 
-  CF_EXPECT(Wait(sock, kSemNoTimeout));
+  CF_EXPECT(cvdalloc::Wait(sock, cvdalloc::kSemNoTimeout));
   std::move(teardown).Invoke();
-  CF_EXPECT(Post(sock));
-
+  CF_EXPECT(cvdalloc::Post(sock));
 
   return 0;
 }

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/sem.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/sem.cpp
@@ -17,7 +17,7 @@
 
 #include "cuttlefish/host/libs/command_util/util.h"
 
-namespace cuttlefish {
+namespace cuttlefish::cvdalloc {
 
 Result<void> Post(const SharedFD socket) {
   char i = 0;
@@ -35,4 +35,4 @@ Result<void> Wait(const SharedFD socket, std::chrono::seconds timeout) {
   return {};
 }
 
-}  // namespace
+}  // namespace cuttlefish::cvdalloc

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/sem.h
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/sem.h
@@ -20,7 +20,7 @@
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/result.h"
 
-namespace cuttlefish {
+namespace cuttlefish::cvdalloc {
 
 constexpr std::chrono::seconds kSemNoTimeout = std::chrono::seconds(0);
 
@@ -40,4 +40,4 @@ Result<void> Post(const SharedFD socket);
  */
 Result<void> Wait(const SharedFD socket, std::chrono::seconds timeout);
 
-}  // namespace
+}  // namespace cuttlefish::cvdalloc

--- a/base/cvd/cuttlefish/host/commands/run_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/BUILD.bazel
@@ -60,6 +60,7 @@ cf_cc_binary(
         "//cuttlefish/host/commands/run_cvd/launch:casimir_control_server",
         "//cuttlefish/host/commands/run_cvd/launch:console_forwarder",
         "//cuttlefish/host/commands/run_cvd/launch:control_env_proxy_server",
+        "//cuttlefish/host/commands/run_cvd/launch:cvdalloc",
         "//cuttlefish/host/commands/run_cvd/launch:echo_server",
         "//cuttlefish/host/commands/run_cvd/launch:gnss_grpc_proxy",
         "//cuttlefish/host/commands/run_cvd/launch:kernel_log_monitor",

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
@@ -102,6 +102,25 @@ cf_cc_library(
 )
 
 cf_cc_library(
+    name = "cvdalloc",
+    srcs = ["cvdalloc.cpp"],
+    hdrs = ["cvdalloc.h"],
+    deps = [
+        "//cuttlefish/common/libs/fs",
+        "//cuttlefish/common/libs/utils:result",
+        "//cuttlefish/common/libs/utils:subprocess",
+        "//cuttlefish/host/commands/cvdalloc:sem",
+        "//cuttlefish/host/libs/command_util",
+        "//cuttlefish/host/libs/config:cuttlefish_config",
+        "//cuttlefish/host/libs/config:known_paths",
+        "//cuttlefish/host/libs/feature",
+        "//cuttlefish/host/libs/vm_manager",
+        "//libbase",
+        "@fruit",
+    ],
+)
+
+cf_cc_library(
     name = "echo_server",
     srcs = ["echo_server.cpp"],
     hdrs = ["echo_server.h"],

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/cvdalloc.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/cvdalloc.cpp
@@ -1,0 +1,118 @@
+//
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cuttlefish/host/commands/run_cvd/launch/cvdalloc.h"
+
+#include <sys/socket.h>
+#include <chrono>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <android-base/logging.h>
+#include <fruit/component.h>
+#include <fruit/fruit_forward_decls.h>
+#include <fruit/macro.h>
+
+#include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/common/libs/utils/subprocess.h"
+#include "cuttlefish/host/commands/cvdalloc/sem.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/known_paths.h"
+#include "cuttlefish/host/libs/feature/command_source.h"
+#include "cuttlefish/host/libs/feature/feature.h"
+#include "cuttlefish/host/libs/vm_manager/vm_manager.h"
+
+namespace cuttlefish {
+namespace {
+
+constexpr std::chrono::seconds kCvdAllocateTimeout = std::chrono::seconds(30);
+constexpr std::chrono::seconds kCvdTeardownTimeout = std::chrono::seconds(2);
+
+class Cvdalloc : public vm_manager::VmmDependencyCommand {
+ public:
+  INJECT(Cvdalloc(const CuttlefishConfig::InstanceSpecific &instance))
+      : instance_(instance) {}
+
+  // CommandSource
+  Result<std::vector<MonitorCommand>> Commands() override {
+    auto nice_stop = [this]() { return Stop(); };
+
+    Command cmd(CvdallocBinary(), KillSubprocessFallback(nice_stop));
+    cmd.AddParameter("--id=", instance_.id());
+    cmd.AddParameter("--socket=", their_socket_);
+    std::vector<MonitorCommand> commands;
+    commands.emplace_back(std::move(cmd));
+    return commands;
+  }
+
+  std::string Name() const override { return "Cvdalloc"; }
+  bool Enabled() const override { return instance_.use_cvdalloc(); }
+  std::unordered_set<SetupFeature *> Dependencies() const override {
+    return {};
+  }
+
+  // StatusCheckCommandSource
+  Result<void> WaitForAvailability() const override {
+    LOG(INFO) << "cvdalloc (run_cvd): waiting to finish allocation.";
+    CF_EXPECT(cvdalloc::Wait(socket_, kCvdAllocateTimeout),
+              "cvdalloc (run_cvd): Wait failed");
+    LOG(INFO) << "cvdalloc (run_cvd): allocation is done.";
+
+    return {};
+  }
+
+ private:
+  Result<void> ResultSetup() override {
+    std::pair<SharedFD, SharedFD> p =
+        CF_EXPECT(SharedFD::SocketPair(AF_LOCAL, SOCK_STREAM, 0));
+    socket_ = std::move(p.first);
+    their_socket_ = std::move(p.second);
+    return {};
+  }
+
+  StopperResult Stop() {
+    LOG(INFO) << "cvdalloc (run_cvd): stop requested; teardown started";
+    if (!cvdalloc::Post(socket_).ok()) {
+      LOG(INFO) << "cvdalloc (run_cvd): stop failed: couldn't Post";
+      return StopperResult::kStopFailure;
+    }
+
+    if (!cvdalloc::Wait(socket_, kCvdTeardownTimeout).ok()) {
+      LOG(INFO) << "cvdalloc (run_cvd): stop failed: couldn't Wait";
+      return StopperResult::kStopFailure;
+    }
+
+    LOG(INFO) << "cvdalloc (run_cvd): teardown completed";
+    return StopperResult::kStopSuccess;
+  }
+
+  const CuttlefishConfig::InstanceSpecific &instance_;
+  SharedFD socket_, their_socket_;
+};
+
+}  // namespace
+
+fruit::Component<fruit::Required<const CuttlefishConfig::InstanceSpecific>>
+CvdallocComponent() {
+  return fruit::createComponent()
+      .addMultibinding<vm_manager::VmmDependencyCommand, Cvdalloc>()
+      .addMultibinding<CommandSource, Cvdalloc>()
+      .addMultibinding<SetupFeature, Cvdalloc>();
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/cvdalloc.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/cvdalloc.h
@@ -1,0 +1,27 @@
+//
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <fruit/fruit.h>
+
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
+
+namespace cuttlefish {
+
+fruit::Component<fruit::Required<const CuttlefishConfig::InstanceSpecific>>
+CvdallocComponent();
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/run_cvd/main.cc
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/main.cc
@@ -42,6 +42,7 @@
 #include "cuttlefish/host/commands/run_cvd/launch/casimir_control_server.h"
 #include "cuttlefish/host/commands/run_cvd/launch/console_forwarder.h"
 #include "cuttlefish/host/commands/run_cvd/launch/control_env_proxy_server.h"
+#include "cuttlefish/host/commands/run_cvd/launch/cvdalloc.h"
 #include "cuttlefish/host/commands/run_cvd/launch/echo_server.h"
 #include "cuttlefish/host/commands/run_cvd/launch/gnss_grpc_proxy.h"
 #include "cuttlefish/host/commands/run_cvd/launch/input_connections_provider.h"
@@ -174,6 +175,7 @@ fruit::Component<> runCvdComponent(
       .install(AutoCmd<VhalProxyServer>::Component)
       .install(Ti50EmulatorComponent)
 #endif
+      .install(CvdallocComponent)
       .install(AdbConfigComponent)
       .install(AdbConfigFragmentComponent)
       .install(FastbootConfigComponent)

--- a/base/cvd/cuttlefish/host/libs/config/known_paths.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/known_paths.cpp
@@ -46,6 +46,8 @@ std::string ControlEnvProxyServerBinary() {
 
 std::string CpioBinary() { return HostBinaryPath("cpio"); }
 
+std::string CvdallocBinary() { return HostBinaryPath("cvdalloc"); }
+
 std::string DefaultKeyboardSpec() {
   return DefaultHostArtifactsPath("etc/default_input_devices/keyboard.json");
 }

--- a/base/cvd/cuttlefish/host/libs/config/known_paths.h
+++ b/base/cvd/cuttlefish/host/libs/config/known_paths.h
@@ -27,6 +27,7 @@ std::string CasimirControlServerBinary();
 std::string ConsoleForwarderBinary();
 std::string ControlEnvProxyServerBinary();
 std::string CpioBinary();
+std::string CvdallocBinary();
 std::string DefaultKeyboardSpec();
 std::string DefaultMouseSpec();
 std::string DefaultGamepadSpec();


### PR DESCRIPTION
The instance id is passed to cvdalloc here so that cvdalloc can just simply trust that it is the appropriate instance ID and let that be managed elsewhere.

Recall that we need run_cvd to invoke socketpair(2) for acting on key events with the cvdalloc process: when allocation has completed, when the instance is stopping and resources should be torn down, and when teardown is complete.

We must wait on allocation completion so that we know we can start up the vmm without issue. To do that we need to override the WaitForAvailability method provided through VmmDependencyCommand; all classes implementing VmmDependencyCommand will have their WaitForAvailability methods called synchronously before the vmm is started, which achieves the intended result.

When run_cvd is shutting down cleanly, we could potentially just have run_cvd close its end of the socket, let cvdalloc invoke its teardown sequence, and have run_cvd abandon the cvdalloc process (letting init(1) or equivalent adopt it), but this loses the ability to see cvdalloc's log messages. Instead, we wait explicitly on teardown completion for a clean shutdown.