### PR TITLE
Add default styles for button elements

### DIFF
--- a/base/cvd/cuttlefish/host/frontend/webrtc/html_client/client.html
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/html_client/client.html
@@ -27,7 +27,7 @@
       <div id="loader"></div>
       <div id="error-message-div">
         <h3 id="error-message" class="hidden">
-          <span class="material-icons close-btn">close</span>
+          <button class="material-icons close-btn">close</button>
         </h3>
       </div>
       <section id="device-connection">

--- a/base/cvd/cuttlefish/host/frontend/webrtc/html_client/style.css
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/html_client/style.css
@@ -132,7 +132,6 @@ body {
 }
 #error-message .close-btn {
   float: right;
-  cursor: pointer;
 }
 #error-message.hidden {
   display: none;
@@ -147,6 +146,14 @@ body {
   background-color: var(--error-bg);
 }
 /* Control panel buttons and device screen(s). */
+
+button{
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  outline: none;
+  appearance: none;
+}
 
 #controls-and-displays {
   height: 100%;
@@ -181,9 +188,6 @@ body {
 }
 .modal-close {
   color: var(--main-fg);
-  border: none;
-  outline: none;
-  background-color: transparent;
 }
 .modal-button, .modal-button-highlight {
   border-radius: 10px;
@@ -193,7 +197,6 @@ body {
   display:       inline-block;
   font:          normal bold 14px/1 "Open Sans", sans-serif;
   text-align:    center;
-  cursor:        pointer;
 }
 .modal-button {
   background: var(--modal-button-bg);
@@ -281,9 +284,7 @@ body {
   height: 40px;
   font-size: 32px;
   color: var(--button-fg);
-  border: none;
   border-radius: 10px;
-  outline: none;
   background-color: var(--button-bg);
 }
 #display-add-modal-button.modal-button-opened {
@@ -336,9 +337,7 @@ body {
   font-size: 32px;
 
   color: var(--button-fg);
-  border: none;
   border-radius: 10px;
-  outline: none;
   background-color: var(--button-bg);
 }
 
@@ -349,10 +348,6 @@ body {
 .control-panel-column button:disabled {
   color: var(--button-disabled-fg);
   cursor: not-allowed;
-}
-
-.control-panel-column button:enabled {
-  cursor: pointer;
 }
 
 .control-panel-column button:active {
@@ -412,11 +407,6 @@ body {
 
 .device-display-remove-button {
   color: var(--main-fg);
-  background: none;
-  border: none;
-  outline: none;
-  padding: 0;
-  cursor: pointer;
 }
 
 /* The actual <video> element for each display. */
@@ -475,10 +465,6 @@ body {
 
 #touchpad-list .selectors button {
   color: var(--main-fg);
-  background: transparent;
-  border: none;
-  outline: none;
-  cursor: pointer;
 }
 
 #touchpad-list .selectors button:hover {


### PR DESCRIPTION
### Refactor: Add base styles for buttons

Bug ID: 435333747

This PR introduces default base styles for all `<button>` elements to ensure consistency and reduce code duplication. It also updates the error message close element to use a semantically correct `<button>`.

**Changes:**

1.  **Base Button Styles (`style.css`):**
    *   Introduced a base stylesheet for all `<button>` elements, applying a common set of reset styles.
    *   **Benefit:** Previously, styles had to be set on individual buttons. Now, global styles for `<button>` elements reduce code duplication and ensure a consistent look and feel.

2.  **Semantic Close Button (`client.html`):**
    *   Changed the close control button for error messages from a `<span>` to a `<button>` element.