### PR TITLE
Vectorize assemble_cvd's --config flag

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/system_image_dir.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/system_image_dir.h
@@ -32,6 +32,8 @@ class SystemImageDirFlag {
   // flags, it is accessed directly by index instead.
   std::string ForIndex(size_t argument_index) const;
 
+  size_t Size() const { return system_image_dirs_.size(); }
+
  private:
   explicit SystemImageDirFlag(std::vector<std::string> system_image_dirs);
 

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -37,6 +37,7 @@ cf_cc_library(
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/feature",
         "//libbase",
+        "@abseil-cpp//absl/strings",
         "@fmt",
         "@fruit",
         "@gflags",


### PR DESCRIPTION
The --config flag is used to figure out the default values of other flags based on the type of device. When launching multiple devices it needs to support different configs per device instead of applying the first's device's default values to all.

Bug: b/441595948