### PR TITLE
Add type to represent `--cpus`

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -271,6 +271,7 @@ cf_cc_library(
         "//cuttlefish/host/commands/assemble_cvd/flags:android_efi_loader",
         "//cuttlefish/host/commands/assemble_cvd/flags:boot_image",
         "//cuttlefish/host/commands/assemble_cvd/flags:bootloader",
+        "//cuttlefish/host/commands/assemble_cvd/flags:cpus",
         "//cuttlefish/host/commands/assemble_cvd/flags:display_proto",
         "//cuttlefish/host/commands/assemble_cvd/flags:initramfs_path",
         "//cuttlefish/host/commands/assemble_cvd/flags:kernel_path",

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
@@ -27,8 +27,6 @@
 
 #define DEFINE_vec DEFINE_string
 
-DEFINE_vec(cpus, std::to_string(CF_DEFAULTS_CPUS),
-              "Virtual CPU count.");
 DEFINE_vec(data_policy, CF_DEFAULTS_DATA_POLICY,
               "How to handle userdata partition."
               " Either 'use_existing', 'create_if_missing', 'resize_up_to', or "

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.h
@@ -20,7 +20,6 @@
 
 #define DECLARE_vec DECLARE_string
 
-DECLARE_vec(cpus);
 DECLARE_vec(data_policy);
 DECLARE_vec(blank_data_image_mb);
 DECLARE_vec(gdb_port);

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -51,6 +51,7 @@
 #include "cuttlefish/host/commands/assemble_cvd/flags/android_efi_loader.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags/boot_image.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags/bootloader.h"
+#include "cuttlefish/host/commands/assemble_cvd/flags/cpus.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags/display_proto.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags/initramfs_path.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags/kernel_path.h"
@@ -504,7 +505,8 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
       vsock_guest_cid));
   std::vector<std::string> vsock_guest_group_vec =
       CF_EXPECT(GET_FLAG_STR_VALUE(vsock_guest_group));
-  std::vector<int> cpus_vec = CF_EXPECT(GET_FLAG_INT_VALUE(cpus));
+  CpusFlag cpus_values =
+      CF_EXPECT(CpusFlag::FromGlobalGflags(name_to_default_value));
   std::vector<int> blank_data_image_mb_vec =
       CF_EXPECT(GetDataImageFlagOrGuestIntValueForInstances(
           FLAGS_blank_data_image_mb, guest_configs, instances_size,
@@ -912,10 +914,11 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
 
     instance.set_session_id(iface_config.mobile_tap.session_id);
 
-    instance.set_cpus(cpus_vec[instance_index]);
+    instance.set_cpus(cpus_values.ForIndex(instance_index));
     // make sure all instances have multiple of 2 then SMT mode
     // if any of instance doesn't have multiple of 2 then NOT SMT
-    CF_EXPECT(!smt_vec[instance_index] || cpus_vec[instance_index] % 2 == 0,
+    CF_EXPECT(!smt_vec[instance_index] ||
+                  cpus_values.ForIndex(instance_index) % 2 == 0,
               "CPUs must be a multiple of 2 in SMT mode");
     instance.set_smt(smt_vec[instance_index]);
 

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/BUILD.bazel
@@ -65,6 +65,18 @@ cf_cc_library(
 )
 
 cf_cc_library(
+    name = "cpus",
+    srcs = ["cpus.cc"],
+    hdrs = ["cpus.h"],
+    deps = [
+        "//cuttlefish/common/libs/utils:result",
+        "//cuttlefish/host/commands/assemble_cvd:flags_defaults",
+        "//libbase",
+        "@gflags",
+    ],
+)
+
+cf_cc_library(
     name = "display_proto",
     srcs = ["display_proto.cc"],
     hdrs = ["display_proto.h"],

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/cpus.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/cpus.cc
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/host/commands/assemble_cvd/flags/cpus.h"
+
+#include <cstdlib>
+#include <map>
+#include <string>
+#include <vector>
+
+#include <android-base/parseint.h>
+#include <android-base/strings.h>
+#include <gflags/gflags.h>
+
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/commands/assemble_cvd/flags_defaults.h"
+
+DEFINE_string(cpus, std::to_string(CF_DEFAULTS_CPUS), "Virtual CPU count.");
+
+namespace cuttlefish {
+namespace {
+
+constexpr char kFlagName[] = "cpus";
+
+Result<int> GetDefaultValue(
+    const std::map<std::string, std::string>& default_value_lookup) {
+  auto lookup = default_value_lookup.find(kFlagName);
+  CF_EXPECT(lookup != default_value_lookup.end());
+  int result;
+  CF_EXPECTF(android::base::ParseInt(lookup->second, &result),
+             "Failed to parse value as integer: \"{}\"", lookup->second);
+  return result;
+}
+
+}  // namespace
+
+Result<CpusFlag> CpusFlag::FromGlobalGflags(
+    const std::map<std::string, std::string>& default_value_lookup) {
+  const int default_value = CF_EXPECT(GetDefaultValue(default_value_lookup));
+
+  gflags::CommandLineFlagInfo flag_info =
+      gflags::GetCommandLineFlagInfoOrDie(kFlagName);
+  std::vector<std::string> string_values =
+      android::base::Split(flag_info.current_value, ",");
+  std::vector<int> values(string_values.size());
+
+  for (int i = 0; i < string_values.size(); i++) {
+    if (string_values[i] != "unset" && string_values[i] != "\"unset\"") {
+      int result;
+      CF_EXPECTF(android::base::ParseInt(string_values[i], &result),
+                 "Failed to parse value as integer: \"{}\"", string_values[i]);
+      values[i] = result;
+    } else {
+      values[i] = default_value;
+    }
+  }
+
+  return CpusFlag(default_value, std::move(values));
+}
+
+int CpusFlag::ForIndex(std::size_t index) const {
+  if (index < cpus_values_.size()) {
+    return cpus_values_[index];
+  } else {
+    return default_value_;
+  }
+}
+
+CpusFlag::CpusFlag(const int default_value, std::vector<int> cpus_values)
+    : default_value_(default_value), cpus_values_(cpus_values) {}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/cpus.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/cpus.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdlib>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "cuttlefish/common/libs/utils/result.h"
+
+namespace cuttlefish {
+
+class CpusFlag {
+ public:
+  static Result<CpusFlag> FromGlobalGflags(
+      const std::map<std::string, std::string>& default_value_lookup);
+
+  int ForIndex(std::size_t index) const;
+
+ private:
+  CpusFlag(const int, std::vector<int>);
+
+  int default_value_ = 0;
+  std::vector<int> cpus_values_;
+};
+
+}  // namespace cuttlefish


### PR DESCRIPTION
To reuse parsing for metrics gathering.

Bug: 442026647