### PR TITLE
Do not deal with cache path as parameter for GH actions

### DIFF
--- a/.github/actions/build-debian-packages/action.yaml
+++ b/.github/actions/build-debian-packages/action.yaml
@@ -1,7 +1,4 @@
 name: 'Build debian packages for Cuttlefish host'
-inputs:
-  cache-path:
-    required: true
 runs:
   using: "composite"
   steps:
@@ -25,6 +22,6 @@ runs:
   - name: Build CF debian packages
     run: |
       sudo docker build --file "tools/buildutils/cw/Containerfile" --tag "android-cuttlefish-build" .
-      sudo docker run -v=$PWD:/mnt/build -w /mnt/build -v=${{ inputs.cache-path }}:/root/bazel-disk-cache android-cuttlefish-build base -d /root/bazel-disk-cache
+      sudo docker run -v=$PWD:/mnt/build -w /mnt/build -v=$HOME/bazel-disk-cache:/root/bazel-disk-cache android-cuttlefish-build base -d /root/bazel-disk-cache
       sudo docker run -v=$PWD:/mnt/build -w /mnt/build android-cuttlefish-build frontend
     shell: bash

--- a/.github/actions/mount-bazel-cache/action.yaml
+++ b/.github/actions/mount-bazel-cache/action.yaml
@@ -2,8 +2,6 @@ name: 'Mount Bazel cache'
 inputs:
   action-name:
     required: true
-  cache-path:
-    required: true
   writable:
     required: false
     default: "false"
@@ -22,7 +20,7 @@ runs:
     if: inputs.writable != 'true'
     uses: actions/cache/restore@v4
     with:
-      path: "${{ inputs.cache-path }}"
+      path: ~/bazel-disk-cache
       key: ${{ format('{0}-{1}-{2}-{3}', env.CACHE_KEY_PREFIX, github.ref_name, github.sha, github.event_name) }}
       restore-keys: |
         ${{ format('{0}-{1}-', env.CACHE_KEY_PREFIX, github.ref_name) }}
@@ -32,7 +30,7 @@ runs:
     if: inputs.writable == 'true'
     uses: actions/cache@v4
     with:
-      path: "${{ inputs.cache-path }}"
+      path: ~/bazel-disk-cache
       key: ${{ format('{0}-{1}-{2}-{3}', env.CACHE_KEY_PREFIX, github.ref_name, github.sha, github.event_name) }}
       restore-keys: |
         ${{ github.event_name == 'push' && format('{0}-{1}-', env.CACHE_KEY_PREFIX, github.ref_name) || '' }}

--- a/.github/actions/run-cvd-unit-tests/action.yaml
+++ b/.github/actions/run-cvd-unit-tests/action.yaml
@@ -1,7 +1,4 @@
 name: 'Run cvd unit tests'
-inputs:
-  cache-path:
-    required: true
 runs:
   using: "composite"
   steps:
@@ -18,5 +15,5 @@ runs:
     run: sudo tools/buildutils/installbazel.sh
     shell: bash
   - name: Run unit tests
-    run: cd base/cvd && bazel test --disk_cache=${{ inputs.cache-path }} --sandbox_writable_path=$HOME --test_output=errors ...
+    run: cd base/cvd && bazel test --disk_cache=$HOME/bazel-disk-cache --sandbox_writable_path=$HOME --test_output=errors ...
     shell: bash

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -170,11 +170,8 @@ jobs:
       uses: ./.github/actions/mount-bazel-cache
       with:
         action-name: "run-cvd-unit-tests"
-        cache-path: "$HOME/bazel-disk-cache"
     - name: Run cvd unit tests
       uses: ./.github/actions/run-cvd-unit-tests
-      with:
-        cache-path: "$HOME/bazel-disk-cache"
     - name: Upload test logs
       if: always()
       uses: actions/upload-artifact@v4
@@ -195,11 +192,8 @@ jobs:
       uses: ./.github/actions/mount-bazel-cache
       with:
         action-name: "build-debian-packages"
-        cache-path: "$HOME/bazel-disk-cache"
     - name: Build CF host debian packages
       uses: ./.github/actions/build-debian-packages
-      with:
-        cache-path: "$HOME/bazel-disk-cache"
     - name: Build debs_amd64.tar
       run: find . -name 'cuttlefish-*.deb' -print0 | tar -cvf debs_amd64.tar --null --files-from -
     - name: Publish debs_amd64.tar
@@ -221,11 +215,8 @@ jobs:
       uses: ./.github/actions/mount-bazel-cache
       with:
         action-name: "build-debian-packages"
-        cache-path: "$HOME/bazel-disk-cache"
     - name: Build CF host debian packages
       uses: ./.github/actions/build-debian-packages
-      with:
-        cache-path: "$HOME/bazel-disk-cache"
     - name: Build debs_arm64.tar
       run: find . -name 'cuttlefish-*.deb' -print0 | tar -cvf debs_arm64.tar --null --files-from -
     - name: Publish debs_arm64.tar

--- a/.github/workflows/update-cache-and-deployment.yaml
+++ b/.github/workflows/update-cache-and-deployment.yaml
@@ -23,12 +23,9 @@ jobs:
       uses: ./.github/actions/mount-bazel-cache
       with:
         action-name: "run-cvd-unit-tests"
-        cache-path: "$HOME/bazel-disk-cache"
         writable: "true"
     - name: Run cvd unit tests
       uses: ./.github/actions/run-cvd-unit-tests
-      with:
-        cache-path: "$HOME/bazel-disk-cache"
   update-bazel-cache-and-deploy-debian-package-amd64:
     if: github.repository_owner == 'google'
     environment: deployment
@@ -45,12 +42,9 @@ jobs:
       uses: ./.github/actions/mount-bazel-cache
       with:
         action-name: "build-debian-packages"
-        cache-path: "$HOME/bazel-disk-cache"
         writable: "true"
     - name: Build CF host debian packages
       uses: ./.github/actions/build-debian-packages
-      with:
-        cache-path: "$HOME/bazel-disk-cache"
     - name: Authentication on GCP project android-cuttlefish-artifacts
       if: github.event_name == 'push'
       uses: 'google-github-actions/auth@v2'
@@ -77,12 +71,9 @@ jobs:
       uses: ./.github/actions/mount-bazel-cache
       with:
         action-name: "build-debian-packages"
-        cache-path: "$HOME/bazel-disk-cache"
         writable: "true"
     - name: Build CF host debian packages
       uses: ./.github/actions/build-debian-packages
-      with:
-        cache-path: "$HOME/bazel-disk-cache"
     - name: Authentication on GCP project android-cuttlefish-artifacts
       if: github.event_name == 'push'
       uses: 'google-github-actions/auth@v2'


### PR DESCRIPTION
From https://github.com/google/android-cuttlefish/pull/1583, there was an error around saving bazel cache. This PR is for doing hotfix.