### PR TITLE
Vectorize --enable_vhal_proxy_server

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
@@ -171,8 +171,9 @@ DEFINE_string(netsim_args, CF_DEFAULTS_NETSIM_ARGS,
 DEFINE_bool(enable_automotive_proxy, CF_DEFAULTS_ENABLE_AUTOMOTIVE_PROXY,
             "Enable the automotive proxy service on the host.");
 
-DEFINE_bool(enable_vhal_proxy_server, CF_DEFAULTS_ENABLE_VHAL_PROXY_SERVER,
-            "Enable the vhal proxy service on the host.");
+DEFINE_vec(enable_vhal_proxy_server,
+           fmt::format("{}", CF_DEFAULTS_ENABLE_VHAL_PROXY_SERVER),
+           "Enable the vhal proxy service on the host.");
 DEFINE_int32(vhal_proxy_server_instance_num,
              CF_DEFAULTS_VHAL_PROXY_SERVER_INSTANCE_NUM,
              "If it is greater than 0, use an existing vhal proxy server "

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.h
@@ -79,7 +79,7 @@ DECLARE_string(netsim_args);
 
 DECLARE_bool(enable_automotive_proxy);
 
-DECLARE_bool(enable_vhal_proxy_server);
+DECLARE_vec(enable_vhal_proxy_server);
 DECLARE_int32(vhal_proxy_server_instance_num);
 
 /**

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -665,8 +665,13 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
   tmp_config_obj.set_vhal_proxy_server_port(
       cuttlefish::vhal_proxy_server::kDefaultEthPort +
       vhal_proxy_server_instance_num);
+  std::vector<bool> enable_vhal_proxy_server_vec =
+      CF_EXPECT(GET_FLAG_BOOL_VALUE(enable_vhal_proxy_server));
+  bool enable_vhal_proxy_server =
+      std::any_of(enable_vhal_proxy_server_vec.begin(),
+                  enable_vhal_proxy_server_vec.end(), [](bool e) { return e; });
   LOG(DEBUG) << "launch vhal proxy server: "
-             << (FLAGS_enable_vhal_proxy_server &&
+             << (enable_vhal_proxy_server &&
                  vhal_proxy_server_instance_num <= 0);
 
   tmp_config_obj.set_kvm_path(FLAGS_kvm_path);
@@ -1162,7 +1167,7 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
     instance.set_start_pica(is_first_instance && !is_uwb_netsim &&
                             FLAGS_pica_instance_num <= 0);
     instance.set_start_vhal_proxy_server(
-        is_first_instance && FLAGS_enable_vhal_proxy_server &&
+        is_first_instance && enable_vhal_proxy_server &&
         FLAGS_vhal_proxy_server_instance_num <= 0);
 
     // TODO(b/288987294) Remove this when separating environment is done


### PR DESCRIPTION
While the vhal proxy server seems to be started at environment level (first instance only) the value for this flag is typically set in the cvd configs, which are instance-specififc, so that flags needs to be instance specific as a result and therefore accept a list of values.

Equivalent to ag/35448534

Bug: b/441907863