### PR TITLE
Ensure the instance RIL is set up properly.

### DIFF
--- a/base/cvd/allocd/alloc_utils.cpp
+++ b/base/cvd/allocd/alloc_utils.cpp
@@ -117,14 +117,14 @@ bool CreateEthernetIface(const std::string& name, const std::string& bridge_name
 
 std::string MobileGatewayName(const std::string& ipaddr, uint16_t id) {
   std::stringstream ss;
-  ss << ipaddr << "." << (4 * id + 1);
+  ss << ipaddr << "." << (4 * id - 3);
   return ss.str();
 }
 
 std::string MobileNetworkName(const std::string& ipaddr,
                               const std::string& netmask, uint16_t id) {
   std::stringstream ss;
-  ss << ipaddr << "." << (4 * id) << netmask;
+  ss << ipaddr << "." << (4 * id - 4) << netmask;
   return ss.str();
 }
 

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -398,8 +398,11 @@ cf_cc_library(
     hdrs = ["network_flags.h"],
     deps = [
         "//cuttlefish/common/libs/utils:result",
+        "//cuttlefish/host/commands/cvdalloc:interface",
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//libbase",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/strings:str_format",
     ],
 )
 

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/cvdalloc.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/cvdalloc.cpp
@@ -44,10 +44,10 @@ Result<void> Allocate(int id, const std::string &bridge_name) {
   LOG(INFO) << "cvdalloc: allocating network resources";
 
   CreateBridge(bridge_name);
-  CF_EXPECT(
-      CreateMobileIface(CvdallocInterfaceName("mtap", id), id, kMobileIp));
-  CF_EXPECT(
-      CreateMobileIface(CvdallocInterfaceName("wtap", id), id, kWirelessIp));
+  CF_EXPECT(CreateMobileIface(CvdallocInterfaceName("mtap", id), id,
+                              kCvdallocMobileIp));
+  CF_EXPECT(CreateMobileIface(CvdallocInterfaceName("wtap", id), id,
+                              kCvdallocWirelessIp));
   CF_EXPECT(CreateEthernetIface(CvdallocInterfaceName("etap", id), bridge_name,
                                 true, true, false));
 
@@ -57,8 +57,9 @@ Result<void> Allocate(int id, const std::string &bridge_name) {
 Result<void> Teardown(int id, const std::string &bridge_name) {
   LOG(INFO) << "cvdalloc: tearing down resources";
 
-  DestroyMobileIface(CvdallocInterfaceName("mtap", id), id, kMobileIp);
-  DestroyMobileIface(CvdallocInterfaceName("wtap", id), id, kWirelessIp);
+  DestroyMobileIface(CvdallocInterfaceName("mtap", id), id, kCvdallocMobileIp);
+  DestroyMobileIface(CvdallocInterfaceName("wtap", id), id,
+                     kCvdallocWirelessIp);
   DestroyEthernetIface(CvdallocInterfaceName("etap", id), true, true, false);
   DestroyBridge(bridge_name);
 

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/interface.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/interface.cpp
@@ -23,4 +23,16 @@ std::string CvdallocInterfaceName(const std::string &name, int num) {
   return absl::StrFormat("%s-%s%d", kCvdallocInterfacePrefix, name, num);
 }
 
+std::string InstanceToMobileGatewayAddress(int num) {
+  return absl::StrFormat("%s.%d", kCvdallocMobileIp, 4 * num - 3);
+}
+
+std::string InstanceToMobileAddress(int num) {
+  return absl::StrFormat("%s.%d", kCvdallocMobileIp, 4 * num - 2);
+}
+
+std::string InstanceToMobileBroadcast(int num) {
+  return absl::StrFormat("%s.%d", kCvdallocMobileIp, 4 * num - 1);
+}
+
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/interface.h
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/interface.h
@@ -20,7 +20,13 @@
 namespace cuttlefish {
 
 constexpr std::string_view kCvdallocInterfacePrefix = "cvd-pi";
+constexpr char kCvdallocMobileIp[] = "192.168.144";
+constexpr char kCvdallocWirelessIp[] = "192.168.160";
+constexpr char kCvdallocthernetIp[] = "192.168.176";
 
 std::string CvdallocInterfaceName(const std::string &name, int num);
+std::string InstanceToMobileGatewayAddress(int num);
+std::string InstanceToMobileAddress(int num);
+std::string InstanceToMobileBroadcast(int num);
 
 }  // namespace cuttlefish


### PR DESCRIPTION
assemble_cvd introspects the on-device tap interfaces to populate flags so that the instance RIL gets the right network information. However, when using cvdalloc, the tap devices aren't available at assemble_cvd time, so defaults are used.

Unfortunately, these defaults aren't correct. Instead, we do the same thing that cuttlefish-host-resources does: allocates subnetwork parameters based on instance ID. The RIL flags are populated anticipating the network parameters we will give to the tap device when cvdalloc runs.

While we are here, we introduce new address ranges to assign to cvdalloc's interfaces, so they can't conflict with addresses assigned to interfaces created by cuttlefish-host-resources. Additionally, alloc_utils now maps instance number to the relevant address in the same way that cuttlefish-host-resources does.