### PR TITLE
Use better version/tag format for debian packages & docker images

### DIFF
--- a/.github/actions/build-debian-packages/action.yaml
+++ b/.github/actions/build-debian-packages/action.yaml
@@ -11,10 +11,10 @@ runs:
       # Modify debian/changelog to build debian package with desired version
       # format.
       # Stable version format           : X.Y.Z
-      # Unstable/nightly version format : X.Y.Z~gitYYYYMMDD.<Github SHA 8 digit>
-      DATE=$(date -u +'%Y%m%d')
+      # Unstable/nightly version format : X.Y.Z~gitYYYYMMDDHHMM.<Github SHA 8 digit>
+      DATETIME=$(date -u +'%Y%m%d%H%M')
       SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
-      SUFFIX="~git${DATE}.${SHORT_SHA}"
+      SUFFIX="~git${DATETIME}.${SHORT_SHA}"
       sed -i "1s/(\([0-9]\+.[0-9]\+.[0-9]\+\))/(\1${SUFFIX})/g" \
         base/debian/changelog
       sed -i "1s/(\([0-9]\+.[0-9]\+.[0-9]\+\))/(\1${SUFFIX})/g" \

--- a/.github/actions/deploy-docker-image/action.yaml
+++ b/.github/actions/deploy-docker-image/action.yaml
@@ -2,19 +2,34 @@ name: 'Deploy docker image cuttlefish-orchestration'
 inputs:
   arch:
     required: true
+  deploy-channel:
+    required: true
 runs:
   using: "composite"
   steps:
   - name: Deploy docker image into Artifact Registry
     run: |
-      # TODO(b/440196950): Setup condition on this step when we build
-      # stable/unstable versions here too.
-
-      # Stable/Unstable version tag : X.Y.Z
-      # Nightly version tag         : gitYYYYMMDD-<Github SHA 8 digit>
-      DATE=$(date -u +'%Y%m%d')
-      SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
-      TAG="git${DATE}-${SHORT_SHA}-${{ inputs.arch }}"
+      case "${{ inputs.deploy-channel }}" in
+        stable)
+          # Stable version tag : X.Y.Z-<amd64|arm64>
+          SEMVER=$(echo ${{ github.ref_name }} | grep -oE '[0-9]+.[0-9]+.[0-9]+'
+          TAG="${SEMVER}-${{ inputs.arch }}"
+          ;;
+        unstable)
+          # Unstable version tag : X.Y-<Github SHA 8 digit>-<amd64|arm64>
+          SEMVER=$(echo ${{ github.ref_name }} | grep -oE '[0-9]+.[0-9]+'
+          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
+          TAG="${SEMVER}-${SHORT_SHA}-${{ inputs.arch }}"
+          ;;
+        nightly)
+          # Nightly version tag : gitYYYYMMDDHHMM-<Github SHA 8 digit>-<amd64|arm64>
+          DATE=$(date -u +'%Y%m%d%H%M')
+          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
+          TAG="git${DATE}-${SHORT_SHA}-${{ inputs.arch }}"
+        *)
+          exit 1
+          ;;
+      esac
       REMOTE_IMAGE_TAG=us-docker.pkg.dev/android-cuttlefish-artifacts/cuttlefish-orchestration/cuttlefish-orchestration:${TAG}
 
       docker tag cuttlefish-orchestration ${REMOTE_IMAGE_TAG}

--- a/.github/workflows/update-cache-and-deployment.yaml
+++ b/.github/workflows/update-cache-and-deployment.yaml
@@ -119,6 +119,7 @@ jobs:
       uses: ./.github/actions/deploy-docker-image
       with:
         arch: amd64
+        deploy-channel: ${{ inputs.deploy-channel }}
   deploy-docker-image-arm64:
     if: inputs.deploy-channel != ''
     needs: [update-bazel-cache-and-deploy-debian-package-arm64]
@@ -143,6 +144,7 @@ jobs:
       uses: ./.github/actions/deploy-docker-image
       with:
         arch: arm64
+        deploy-channel: ${{ inputs.deploy-channel }}
   deploy-docker-manifest:
     if: inputs.deploy-channel != ''
     needs: [deploy-docker-image-amd64, deploy-docker-image-arm64]
@@ -163,14 +165,27 @@ jobs:
         password: '${{ secrets.artifact-registry-uploader-json-creds }}'
     - name: Deploy manifests
       run: |
-        # TODO(b/440196950): Setup condition on this step when we build
-        # stable/unstable versions here too.
-
-        # Stable/Unstable version tag : X.Y.Z
-        # Nightly version tag         : gitYYYYMMDD-<Github SHA 8 digit>
-        DATE=$(date -u +'%Y%m%d')
-        SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
-        TAG="git${DATE}-${SHORT_SHA}"
+        case "${{ inputs.deploy-channel }}" in
+          stable)
+            # Stable version tag : X.Y.Z
+            SEMVER=$(echo ${{ github.ref_name }} | grep -oE '[0-9]+.[0-9]+.[0-9]+'
+            TAG="${SEMVER}"
+            ;;
+          unstable)
+            # Unstable version tag : X.Y-<Github SHA 8 digit>
+            SEMVER=$(echo ${{ github.ref_name }} | grep -oE '[0-9]+.[0-9]+'
+            SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
+            TAG="${SEMVER}-${SHORT_SHA}"
+            ;;
+          nightly)
+            # Nightly version tag : gitYYYYMMDDHHMM-<Github SHA 8 digit>
+            DATE=$(date -u +'%Y%m%d%H%M')
+            SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
+            TAG="git${DATE}-${SHORT_SHA}"
+          *)
+            exit 1
+            ;;
+        esac
         IMAGE=us-docker.pkg.dev/android-cuttlefish-artifacts/cuttlefish-orchestration/cuttlefish-orchestration
 
         for MANIFEST_TAG in ${TAG} ${{ inputs.deploy-channel }}; do


### PR DESCRIPTION
For debian packages, I added hour & minute information for better comparison between artifacts created at same date and deployed to the same apt repository.

For docker images, I distinguished tag format between stable, unstable, and nightly artifacts not to share tag name though Github SHA is same. (Channel of installed deb packages inside docker image is different.)