### PR TITLE
Revert "Refer timestamp of last push for versioning artifacts"

### DIFF
--- a/.github/actions/build-debian-packages/action.yaml
+++ b/.github/actions/build-debian-packages/action.yaml
@@ -12,7 +12,7 @@ runs:
       # format.
       # Stable version format           : X.Y.Z
       # Unstable/nightly version format : X.Y.Z~gitYYYYMMDDHHMM.<Github SHA 8 digit>
-      DATETIME=$(date -d '${{ github.event.repository.pushed_at }}' -u +'%Y%m%d%H%M')
+      DATETIME=$(date -u +'%Y%m%d%H%M')
       SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
       SUFFIX="~git${DATETIME}.${SHORT_SHA}"
       sed -i "1s/(\([0-9]\+.[0-9]\+.[0-9]\+\))/(\1${SUFFIX})/g" \

--- a/.github/actions/deploy-docker-image/action.yaml
+++ b/.github/actions/deploy-docker-image/action.yaml
@@ -23,7 +23,7 @@ runs:
           ;;
         nightly)
           # Nightly version tag : gitYYYYMMDDHHMM-<Github SHA 8 digit>-<amd64|arm64>
-          DATE=$(date -d '${{ github.event.repository.pushed_at }}' -u +'%Y%m%d%H%M')
+          DATE=$(date -u +'%Y%m%d%H%M')
           SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
           TAG="git${DATE}-${SHORT_SHA}-${{ inputs.arch }}"
           ;;

--- a/.github/workflows/update-cache-and-deployment.yaml
+++ b/.github/workflows/update-cache-and-deployment.yaml
@@ -179,7 +179,7 @@ jobs:
             ;;
           nightly)
             # Nightly version tag : gitYYYYMMDDHHMM-<Github SHA 8 digit>
-            DATE=$(date -d '${{ github.event.repository.pushed_at }}' -u +'%Y%m%d%H%M')
+            DATE=$(date -u +'%Y%m%d%H%M')
             SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
             TAG="git${DATE}-${SHORT_SHA}"
             ;;


### PR DESCRIPTION
Reverts google/android-cuttlefish#1629, since the format of `github.event.repository.pushed_at` is different between pull request and push events. Reverting this PR first rather than landing fix PR, because this PR modifies `build-debian-packages` which can lose the way to mount bazel cache for a while.