### PR TITLE
Make WaitForAvailability non-const.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/cvdalloc.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/cvdalloc.cpp
@@ -75,7 +75,7 @@ class Cvdalloc : public vm_manager::VmmDependencyCommand {
   }
 
   // StatusCheckCommandSource
-  Result<void> WaitForAvailability() const override {
+  Result<void> WaitForAvailability() override {
     LOG(INFO) << "cvdalloc (run_cvd): waiting to finish allocation.";
     CF_EXPECT(cvdalloc::Wait(socket_, kCvdAllocateTimeout),
               "cvdalloc (run_cvd): Wait failed");

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/mcu.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/mcu.cpp
@@ -93,7 +93,7 @@ class Mcu : public vm_manager::VmmDependencyCommand {
   }
 
   // StatusCheckCommandSource
-  Result<void> WaitForAvailability() const override {
+  Result<void> WaitForAvailability() override {
     if (!Enabled()) {
       return {};
     }

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/ti50_emulator.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/ti50_emulator.cpp
@@ -80,7 +80,7 @@ class Ti50Emulator : public vm_manager::VmmDependencyCommand {
   bool Enabled() const override { return !instance_.ti50_emulator().empty(); }
 
   // StatusCheckCommandSource
-  Result<void> WaitForAvailability() const override {
+  Result<void> WaitForAvailability() override {
     if (!Enabled()) {
       return {};
     }

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/vhost_device_vsock.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/vhost_device_vsock.cpp
@@ -56,7 +56,7 @@ class VhostDeviceVsock : public vm_manager::VmmDependencyCommand {
   std::string Name() const override;
   bool Enabled() const override;
 
-  Result<void> WaitForAvailability() const override;
+  Result<void> WaitForAvailability() override;
 
  private:
   std::unordered_set<SetupFeature*> Dependencies() const override { return {}; }
@@ -113,7 +113,7 @@ std::string VhostDeviceVsock::Name() const { return "VhostDeviceVsock"; }
 
 bool VhostDeviceVsock::Enabled() const { return instance_.vhost_user_vsock(); }
 
-Result<void> VhostDeviceVsock::WaitForAvailability() const {
+Result<void> VhostDeviceVsock::WaitForAvailability() {
   if (Enabled()) {
     CF_EXPECT(WaitForUnixSocket(
         fmt::format("{}/vsock_{}_{}/vm.vsock", TempDir(),

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/wmediumd_server.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/wmediumd_server.cpp
@@ -103,7 +103,7 @@ bool WmediumdServer::Enabled() const {
   return instance_.start_wmediumd_instance();
 }
 
-Result<void> WmediumdServer::WaitForAvailability() const {
+Result<void> WmediumdServer::WaitForAvailability() {
   if (Enabled()) {
     if (!environment_.wmediumd_api_server_socket().empty()) {
       CF_EXPECT(

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/wmediumd_server.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/wmediumd_server.h
@@ -44,7 +44,7 @@ class WmediumdServer : public vm_manager::VmmDependencyCommand {
   std::string Name() const override;
   bool Enabled() const override;
 
-  Result<void> WaitForAvailability() const override;
+  Result<void> WaitForAvailability() override;
 
  private:
   std::unordered_set<SetupFeature*> Dependencies() const override;

--- a/base/cvd/cuttlefish/host/libs/feature/command_source.h
+++ b/base/cvd/cuttlefish/host/libs/feature/command_source.h
@@ -43,7 +43,7 @@ class CommandSource : public virtual SetupFeature {
 
 class StatusCheckCommandSource : public virtual CommandSource {
  public:
-  virtual Result<void> WaitForAvailability() const = 0;
+  virtual Result<void> WaitForAvailability() = 0;
 };
 
 }  // namespace cuttlefish


### PR DESCRIPTION
This allows for protecting the bodies of WaitForAvailability with mutexes without having to mark them as mutable, and adding extra variables to track the state of availability so calls can be idempotent.