### PR TITLE
Refactor to expose cvdalloc launcher.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/cvdalloc.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/cvdalloc.cpp
@@ -30,9 +30,7 @@
 #include <android-base/logging.h>
 #include <fruit/component.h>
 #include <fruit/fruit_forward_decls.h>
-#include <fruit/macro.h>
 
-#include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/result.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"
 #include "cuttlefish/host/commands/cvdalloc/privilege.h"
@@ -44,85 +42,72 @@
 #include "cuttlefish/host/libs/vm_manager/vm_manager.h"
 
 namespace cuttlefish {
-namespace {
 
 constexpr std::chrono::seconds kCvdAllocateTimeout = std::chrono::seconds(30);
 constexpr std::chrono::seconds kCvdTeardownTimeout = std::chrono::seconds(2);
 
-class Cvdalloc : public vm_manager::VmmDependencyCommand {
- public:
-  INJECT(Cvdalloc(const CuttlefishConfig::InstanceSpecific &instance))
-      : instance_(instance) {}
+Cvdalloc::Cvdalloc(const CuttlefishConfig::InstanceSpecific& instance)
+    : instance_(instance) {}
 
-  // CommandSource
-  Result<std::vector<MonitorCommand>> Commands() override {
-    std::string path = CvdallocBinary();
-    CF_EXPECT(BinaryIsValid(path));
-    auto nice_stop = [this]() { return Stop(); };
+Result<std::vector<MonitorCommand>> Cvdalloc::Commands() {
+  std::string path = CvdallocBinary();
+  CF_EXPECT(BinaryIsValid(path));
+  auto nice_stop = [this]() { return Stop(); };
 
-    Command cmd(path, KillSubprocessFallback(nice_stop));
-    cmd.AddParameter("--id=", instance_.id());
-    cmd.AddParameter("--socket=", their_socket_);
-    std::vector<MonitorCommand> commands;
-    commands.emplace_back(std::move(cmd));
-    return commands;
+  Command cmd(path, KillSubprocessFallback(nice_stop));
+  cmd.AddParameter("--id=", instance_.id());
+  cmd.AddParameter("--socket=", their_socket_);
+  std::vector<MonitorCommand> commands;
+  commands.emplace_back(std::move(cmd));
+  return commands;
+}
+
+std::string Cvdalloc::Name() const { return "Cvdalloc"; }
+bool Cvdalloc::Enabled() const { return instance_.use_cvdalloc(); }
+std::unordered_set<SetupFeature *> Cvdalloc::Dependencies() const { return {}; }
+
+Result<void> Cvdalloc::WaitForAvailability() {
+  LOG(INFO) << "cvdalloc (run_cvd): waiting to finish allocation.";
+  CF_EXPECT(cvdalloc::Wait(socket_, kCvdAllocateTimeout),
+            "cvdalloc (run_cvd): Wait failed");
+  LOG(INFO) << "cvdalloc (run_cvd): allocation is done.";
+
+  return {};
+}
+
+Result<void> Cvdalloc::ResultSetup() {
+  std::pair<SharedFD, SharedFD> p =
+      CF_EXPECT(SharedFD::SocketPair(AF_LOCAL, SOCK_STREAM, 0));
+  socket_ = std::move(p.first);
+  their_socket_ = std::move(p.second);
+
+  return {};
+}
+
+Result<void> Cvdalloc::BinaryIsValid(std::string_view path) {
+  struct stat st;
+  int r = stat(path.data(), &st);
+  CF_EXPECT(r == 0, "Could not stat the cvdalloc binary at "
+                        << path << ": " << strerror(errno));
+  CF_EXPECT(ValidateCvdallocBinary(path));
+  return {};
+}
+
+StopperResult Cvdalloc::Stop() {
+  LOG(INFO) << "cvdalloc (run_cvd): stop requested; teardown started";
+  if (!cvdalloc::Post(socket_).ok()) {
+    LOG(INFO) << "cvdalloc (run_cvd): stop failed: couldn't Post";
+    return StopperResult::kStopFailure;
   }
 
-  std::string Name() const override { return "Cvdalloc"; }
-  bool Enabled() const override { return instance_.use_cvdalloc(); }
-  std::unordered_set<SetupFeature *> Dependencies() const override {
-    return {};
+  if (!cvdalloc::Wait(socket_, kCvdTeardownTimeout).ok()) {
+    LOG(INFO) << "cvdalloc (run_cvd): stop failed: couldn't Wait";
+    return StopperResult::kStopFailure;
   }
 
-  // StatusCheckCommandSource
-  Result<void> WaitForAvailability() override {
-    LOG(INFO) << "cvdalloc (run_cvd): waiting to finish allocation.";
-    CF_EXPECT(cvdalloc::Wait(socket_, kCvdAllocateTimeout),
-              "cvdalloc (run_cvd): Wait failed");
-    LOG(INFO) << "cvdalloc (run_cvd): allocation is done.";
-
-    return {};
-  }
-
- private:
-  Result<void> ResultSetup() override {
-    std::pair<SharedFD, SharedFD> p =
-        CF_EXPECT(SharedFD::SocketPair(AF_LOCAL, SOCK_STREAM, 0));
-    socket_ = std::move(p.first);
-    their_socket_ = std::move(p.second);
-    return {};
-  }
-
-  Result<void> BinaryIsValid(std::string_view path) {
-    struct stat st;
-    int r = stat(path.data(), &st);
-    CF_EXPECT(r == 0, "Could not stat the cvdalloc binary at "
-                          << path << ": " << strerror(errno));
-    CF_EXPECT(ValidateCvdallocBinary(path));
-    return {};
-  }
-
-  StopperResult Stop() {
-    LOG(INFO) << "cvdalloc (run_cvd): stop requested; teardown started";
-    if (!cvdalloc::Post(socket_).ok()) {
-      LOG(INFO) << "cvdalloc (run_cvd): stop failed: couldn't Post";
-      return StopperResult::kStopFailure;
-    }
-
-    if (!cvdalloc::Wait(socket_, kCvdTeardownTimeout).ok()) {
-      LOG(INFO) << "cvdalloc (run_cvd): stop failed: couldn't Wait";
-      return StopperResult::kStopFailure;
-    }
-
-    LOG(INFO) << "cvdalloc (run_cvd): teardown completed";
-    return StopperResult::kStopSuccess;
-  }
-
-  const CuttlefishConfig::InstanceSpecific &instance_;
-  SharedFD socket_, their_socket_;
-};
-
-}  // namespace
+  LOG(INFO) << "cvdalloc (run_cvd): teardown completed";
+  return StopperResult::kStopSuccess;
+}
 
 fruit::Component<fruit::Required<const CuttlefishConfig::InstanceSpecific>>
 CvdallocComponent() {

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/cvdalloc.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/cvdalloc.h
@@ -15,11 +15,41 @@
 
 #pragma once
 
+#include <mutex>
+#include <string_view>
+
 #include <fruit/fruit.h>
 
+#include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/common/libs/utils/result.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/feature/command_source.h"
+#include "cuttlefish/host/libs/feature/feature.h"
+#include "cuttlefish/host/libs/vm_manager/vm_manager.h"
 
 namespace cuttlefish {
+
+class Cvdalloc : public vm_manager::VmmDependencyCommand {
+ public:
+  INJECT(Cvdalloc(const CuttlefishConfig::InstanceSpecific &instance));
+
+  // CommandSource
+  Result<std::vector<MonitorCommand>> Commands() override;
+  std::string Name() const override;
+  bool Enabled() const override;
+  std::unordered_set<SetupFeature *> Dependencies() const override;
+
+  // StatusCheckCommandSource
+  Result<void> WaitForAvailability() override;
+
+ private:
+  Result<void> ResultSetup() override;
+  Result<void> BinaryIsValid(std::string_view path);
+  StopperResult Stop();
+
+  const CuttlefishConfig::InstanceSpecific &instance_;
+  SharedFD socket_, their_socket_;
+};
 
 fruit::Component<fruit::Required<const CuttlefishConfig::InstanceSpecific>>
 CvdallocComponent();


### PR DESCRIPTION
We'll soon need to make sure that open_wrt's launcher can refer to cvdalloc's launcher, so it can wait on cvdalloc's availability. Let's get the refactor out of the way first, to focus the later diff.