### PR TITLE
Don't wait on disabled dependencies.

### DIFF
--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
@@ -512,6 +512,9 @@ Result<std::vector<MonitorCommand>> CrosvmManager::StartCommands(
   CrosvmBuilder crosvm_cmd;
   crosvm_cmd.Cmd().AddPrerequisite([&dependencyCommands]() -> Result<void> {
     for (auto dependencyCommand : dependencyCommands) {
+      if (!dependencyCommand->Enabled()) {
+        continue;
+      }
       CF_EXPECT(dependencyCommand->WaitForAvailability());
     }
 

--- a/base/cvd/cuttlefish/host/libs/vm_manager/qemu_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/qemu_manager.cpp
@@ -251,6 +251,9 @@ Result<std::vector<MonitorCommand>> QemuManager::StartCommands(
 
   qemu_cmd.AddPrerequisite([&dependency_commands]() -> Result<void> {
     for (auto dependencyCommand : dependency_commands) {
+      if (!dependencyCommand->Enabled()) {
+        continue;
+      }
       CF_EXPECT(dependencyCommand->WaitForAvailability());
     }
 


### PR DESCRIPTION
When not using cvdalloc, the launcher will be disabled, but since cvdalloc is a VmmDependency, crosvm will attempt to wait on it. This fails immediately so there isn't an actual problem except for logspam, but we shouldn't bother to wait on disabled dependencies in the first place.