### PR TITLE
openwrt's vmm waits for cvdalloc.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
@@ -288,6 +288,7 @@ cf_cc_library(
     deps = [
         "//cuttlefish/common/libs/utils:json",
         "//cuttlefish/common/libs/utils:result",
+        "//cuttlefish/host/commands/run_cvd/launch:cvdalloc",
         "//cuttlefish/host/commands/run_cvd/launch:log_tee_creator",
         "//cuttlefish/host/commands/run_cvd/launch:wmediumd_server",
         "//cuttlefish/host/libs/command_util",

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/cvdalloc.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/cvdalloc.h
@@ -29,6 +29,8 @@
 
 namespace cuttlefish {
 
+enum class CvdallocStatus;
+
 class Cvdalloc : public vm_manager::VmmDependencyCommand {
  public:
   INJECT(Cvdalloc(const CuttlefishConfig::InstanceSpecific &instance));
@@ -49,6 +51,8 @@ class Cvdalloc : public vm_manager::VmmDependencyCommand {
 
   const CuttlefishConfig::InstanceSpecific &instance_;
   SharedFD socket_, their_socket_;
+  std::mutex availability_mutex_;
+  CvdallocStatus status_;
 };
 
 fruit::Component<fruit::Required<const CuttlefishConfig::InstanceSpecific>>

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/open_wrt.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/open_wrt.h
@@ -17,15 +17,17 @@
 
 #include <fruit/fruit.h>
 
+#include "cuttlefish/host/commands/run_cvd/launch/cvdalloc.h"
 #include "cuttlefish/host/commands/run_cvd/launch/log_tee_creator.h"
 #include "cuttlefish/host/commands/run_cvd/launch/wmediumd_server.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 namespace cuttlefish {
 
-fruit::Component<fruit::Required<
-    const CuttlefishConfig, const CuttlefishConfig::EnvironmentSpecific,
-    const CuttlefishConfig::InstanceSpecific, LogTeeCreator, WmediumdServer>>
+fruit::Component<fruit::Required<const CuttlefishConfig,
+                                 const CuttlefishConfig::EnvironmentSpecific,
+                                 const CuttlefishConfig::InstanceSpecific,
+                                 LogTeeCreator, WmediumdServer, Cvdalloc>>
 OpenWrtComponent();
 
 }  // namespace cuttlefish


### PR DESCRIPTION
openwrt uses a vmm to run a Wi-Fi access point, using a 802.11 hardware simulator connected to a tap device. Without cvdalloc, it assumes this device was already created by cuttlefish-host-resources. With cvdalloc, openwrt's vmm will need to wait for cvdalloc to complete in order to use the tap device it creates.

The obvious way to do this is to use WaitForAvailability on cvdalloc's launcher. However, cvdalloc's launcher is already a VmmDependencyCommand for the instance's vmm, and if both openwrt's and cvdalloc's launcher are executing at the same time, we have two contending reads on cvdalloc's socketpair, which complicates matters.

We could Wait and Post twice on the socket for notification, but that is rather ugly since that means we couple the number of socket Wait'ers to the cvdalloc binary unnecessarily. Instead, we guard WaitForAvailability by a mutex, so that there is always only one Wait'er at a time, and make WaitForAvailability idempotent, so that the second Wait need not actually attempt to read on the underlying socket.