### PR TITLE
The server loop ends if the process monitor does.

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/subprocess.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/subprocess.cpp
@@ -418,6 +418,7 @@ Subprocess Command::Start(SubprocessOptions options) const {
     if (!prerequisiteResult.ok()) {
       LOG(ERROR) << "Failed to check prerequisites: "
                  << prerequisiteResult.error().FormatForEnv();
+      return Subprocess(-1, {});
     }
   }
 

--- a/base/cvd/cuttlefish/host/libs/process_monitor/process_monitor.h
+++ b/base/cvd/cuttlefish/host/libs/process_monitor/process_monitor.h
@@ -72,6 +72,9 @@ class ProcessMonitor {
   // Resume all host subprocesses
   Result<void> ResumeMonitoredProcesses();
 
+  /* Reads on this SharedFD will block while subprocesses are running, */
+  SharedFD status() { return status_; };
+
  private:
   Result<void> StartSubprocesses(Properties& properties);
   Result<void> MonitorRoutine();
@@ -86,6 +89,7 @@ class ProcessMonitor {
   Result<void> ResumeHostProcessesImpl();
 
   Properties properties_;
+  SharedFD status_;
   const SharedFD channel_to_secure_env_;
   pid_t monitor_;
   std::optional<transport::SharedFdChannel> parent_channel_;


### PR DESCRIPTION
The server loop runs StartAndMonitorProcesses, which then forks a routine to wait on the monitored processes. StartAndMonitorProcesses returns success immediately to the parent server loop, which then goes on to immediately accept on a socket which a monitored processes will connect on.

The problem occurs if the one of the monitored processes dies, causing the process monitor itself to die. This leaves the parent blocked on the accept indefinitely, which has the end-user effect of the cvd start operation hanging indefinitely.

To alleviate this effect, use the pipe trick between the process monitor's parent and child routines, then select between one end of the pipe and the server socket. If the process monitor dies, then the pipe becomes readable, and we can get out of the server loop and terminate. Otherwise, the accept can happen normally.