### PR TITLE
Apply `--test_output=errors` by default

### DIFF
--- a/base/cvd/.bazelrc
+++ b/base/cvd/.bazelrc
@@ -1,4 +1,5 @@
 build --build_tag_filters=-clang_tidy,-clang-tidy
 build --copt=-fdiagnostics-color=always
-build --test_summary=terse
 build --output_filter='^//((?!(external/libarchive|external/libevent|external/rules_flex|external/rules_m4):).)*$'
+build --test_output=errors
+build --test_summary=terse


### PR DESCRIPTION
CI uses `--test_output=errors` to make sure errors are surfaced in failing action output: https://github.com/google/android-cuttlefish/blob/686693afeecc702c5b40dc3926a02c78b828bda2/.github/actions/run-cvd-unit-tests/action.yaml#L18

This would also be convenient in local runs.

Bug: b/446013487