### PR TITLE
cvdalloc supports non-bridged Wi-Fi.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -999,8 +999,11 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
     CF_EXPECT(ConfigureNetworkSettings(ril_dns_vec[instance_index],
                                        const_instance, instance));
 
-    if (NetworkInterfaceExists(iface_config.non_bridged_wireless_tap.name) &&
-        tmp_config_obj.virtio_mac80211_hwsim()) {
+    bool use_non_bridged_wireless =
+        (NetworkInterfaceExists(iface_config.non_bridged_wireless_tap.name) ||
+         const_instance.use_cvdalloc()) &&
+        tmp_config_obj.virtio_mac80211_hwsim();
+    if (use_non_bridged_wireless) {
       instance.set_use_bridged_wifi_tap(false);
       instance.set_wifi_tap_name(iface_config.non_bridged_wireless_tap.name);
     } else {

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/cvdalloc.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/cvdalloc.cpp
@@ -49,6 +49,8 @@ Result<void> Allocate(int id, const std::string &bridge_name) {
                               kCvdallocMobileIpPrefix));
   CF_EXPECT(CreateMobileIface(CvdallocInterfaceName("wtap", id), id,
                               kCvdallocWirelessIpPrefix));
+  CF_EXPECT(CreateMobileIface(CvdallocInterfaceName("wifiap", id), id,
+                              kCvdallocWirelessApIpPrefix));
   CF_EXPECT(CreateEthernetIface(CvdallocInterfaceName("etap", id), bridge_name,
                                 true, true, false));
 
@@ -62,6 +64,8 @@ Result<void> Teardown(int id, const std::string &bridge_name) {
                      kCvdallocMobileIpPrefix);
   DestroyMobileIface(CvdallocInterfaceName("wtap", id), id,
                      kCvdallocWirelessIpPrefix);
+  DestroyMobileIface(CvdallocInterfaceName("wifiap", id), id,
+                     kCvdallocWirelessApIpPrefix);
   DestroyEthernetIface(CvdallocInterfaceName("etap", id), true, true, false);
   DestroyBridge(bridge_name);
 

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/interface.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/interface.cpp
@@ -35,4 +35,15 @@ std::string InstanceToMobileBroadcast(int num) {
   return absl::StrFormat("%s.%d", kCvdallocMobileIpPrefix, 4 * num - 1);
 }
 
+std::string InstanceToWifiGatewayAddress(int num) {
+  return absl::StrFormat("%s.%d", kCvdallocWirelessApIpPrefix, 4 * num - 3);
+}
+
+std::string InstanceToWifiAddress(int num) {
+  return absl::StrFormat("%s.%d", kCvdallocWirelessApIpPrefix, 4 * num - 2);
+}
+
+std::string InstanceToWifiBroadcast(int num) {
+  return absl::StrFormat("%s.%d", kCvdallocWirelessApIpPrefix, 4 * num - 1);
+}
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/interface.h
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/interface.h
@@ -29,5 +29,8 @@ std::string CvdallocInterfaceName(const std::string &name, int num);
 std::string InstanceToMobileGatewayAddress(int num);
 std::string InstanceToMobileAddress(int num);
 std::string InstanceToMobileBroadcast(int num);
+std::string InstanceToWifiGatewayAddress(int num);
+std::string InstanceToWifiAddress(int num);
+std::string InstanceToWifiBroadcast(int num);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -283,6 +283,7 @@ cf_cc_library(
     srcs = ["openwrt_args.cpp"],
     hdrs = ["openwrt_args.h"],
     deps = [
+        "//cuttlefish/host/commands/cvdalloc:interface",
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//libbase",
     ],

--- a/base/cvd/cuttlefish/host/libs/config/openwrt_args.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/openwrt_args.cpp
@@ -21,6 +21,7 @@
 
 #include <android-base/parseint.h>
 
+#include "cuttlefish/host/commands/cvdalloc/interface.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 namespace cuttlefish {
@@ -64,12 +65,19 @@ std::unordered_map<std::string, std::string> OpenwrtArgsFromConfig(
 
   } else {
     openwrt_args["bridged_wifi_tap"] = "false";
-    openwrt_args["wan_gateway"] =
-        getIpAddress(94 + c_class_base, d_class_base + 1);
-    openwrt_args["wan_ipaddr"] =
-        getIpAddress(94 + c_class_base, d_class_base + 2);
-    openwrt_args["wan_broadcast"] =
-        getIpAddress(94 + c_class_base, d_class_base + 3);
+
+    if (instance.use_cvdalloc()) {
+      openwrt_args["wan_gateway"] = InstanceToWifiGatewayAddress(instance_num);
+      openwrt_args["wan_ipaddr"] = InstanceToWifiAddress(instance_num);
+      openwrt_args["wan_broadcast"] = InstanceToWifiBroadcast(instance_num);
+    } else {
+      openwrt_args["wan_gateway"] =
+          getIpAddress(94 + c_class_base, d_class_base + 1);
+      openwrt_args["wan_ipaddr"] =
+          getIpAddress(94 + c_class_base, d_class_base + 2);
+      openwrt_args["wan_broadcast"] =
+          getIpAddress(94 + c_class_base, d_class_base + 3);
+    }
   }
 
   return openwrt_args;


### PR DESCRIPTION
Most of this is plumbing the right arguments to OpenWRT to specify a network for the instance, as well as creating the non-bridged tap interfaces.

The existing behavior is to use non-bridged Wi-Fi if the tap device exists and the 802.11 simulator is enabled; since the tap device doesn't exist by default for cvdalloc, we just use the use_cvdalloc flag as a proxy for that condition.