### PR TITLE
netsim: update out_dir name.

### DIFF
--- a/base/cvd/BUILD.android_tools_netsim.bazel
+++ b/base/cvd/BUILD.android_tools_netsim.bazel
@@ -50,7 +50,7 @@ collect_files_in_dir(
         ":netsim_netlink_rust_gen",
         "@rootcanal//packets:link_layer_packets_rs",
     ],
-    out = "link_layer_packets.rs",
+    out = "libnetsim_packets_out_dir",
 )
 
 rust_library(


### PR DESCRIPTION
link_layer_packets.rs was a confusing name for the output directory. Change it to libnetsim_packets_out_dir.