### PR TITLE
Make a copy of `fetch.log` instead of symlinking

### DIFF
--- a/base/cvd/cuttlefish/host/commands/start/main.cc
+++ b/base/cvd/cuttlefish/host/commands/start/main.cc
@@ -192,8 +192,7 @@ Result<void> LinkLogs2InstanceDir(
         fmt::format("{}/{}", android::base::Dirname(images_dir), "fetch.log");
   }
   if (FileExists(fetch_log)) {
-    CF_EXPECT(
-        CreateSymLink(fetch_log, instance.PerInstanceLogPath("fetch.log")));
+    CF_EXPECT(Copy(fetch_log, instance.PerInstanceLogPath("fetch.log")));
   }
 
   return {};


### PR DESCRIPTION
This fixes the error:
```
$ bazel run //cuttlefish/package:cvd -- create --host_path=$HOME/dl4 --product_path=$HOME/dl4 --enable_virtiofs=false --gpu_mode=guest_swiftshader --snapshot_path=$HOME/snapshot --base_instance_num=1
...
failed to open /tmp/cvd/270178/1758589050846141/home/cuttlefish/instances/cvd-1/logs/fetch.log: No such file or directory
```

Bug: b/446758371