### PR TITLE
Add formatted output for the `LauncherResponse` type

### DIFF
--- a/base/cvd/cuttlefish/host/libs/command_util/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/command_util/BUILD.bazel
@@ -17,6 +17,7 @@ cc_proto_library(
 cf_cc_library(
     name = "command_util",
     srcs = [
+        "runner/defs.cc",
         "snapshot_utils.cc",
         "util.cc",
     ],

--- a/base/cvd/cuttlefish/host/libs/command_util/runner/defs.cc
+++ b/base/cvd/cuttlefish/host/libs/command_util/runner/defs.cc
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "cuttlefish/host/libs/command_util/runner/defs.h"
+
+#include <ostream>
+
+namespace cuttlefish {
+
+std::ostream& operator<<(std::ostream& out, LauncherResponse response) {
+  switch (response) {
+    case LauncherResponse::kSuccess:
+      return out << "LauncherResponse::kSuccess";
+    case LauncherResponse::kError:
+      return out << "LauncherResponse::kError";
+    case LauncherResponse::kUnknownAction:
+      return out << "LauncherResponse::kUnknownAction";
+    default:
+      int response_int = static_cast<int>(response);
+      return out << "LauncherResponse::(unknown: " << response_int << ")";
+  }
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/command_util/runner/defs.h
+++ b/base/cvd/cuttlefish/host/libs/command_util/runner/defs.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <ostream>
+
 namespace cuttlefish {
 
 enum RunnerExitCodes : int {
@@ -63,5 +65,7 @@ enum class LauncherResponse : char {
   kError = 'E',
   kUnknownAction = 'U',
 };
+
+std::ostream& operator<<(std::ostream&, LauncherResponse);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/command_util/util.cc
+++ b/base/cvd/cuttlefish/host/libs/command_util/util.cc
@@ -164,7 +164,7 @@ Result<void> RunLauncherAction(SharedFD monitor_socket, LauncherAction action,
   LauncherResponse response;
   CF_EXPECT(ReadExactBinaryResult(monitor_socket, &response),
             "Error reading LauncherResponse");
-  CF_EXPECT_EQ((int)response, (int)LauncherResponse::kSuccess);
+  CF_EXPECT_EQ(response, LauncherResponse::kSuccess);
   return {};
 }
 
@@ -194,7 +194,7 @@ Result<void> RunLauncherAction(
   LauncherResponse response;
   CF_EXPECT(ReadExactBinaryResult(monitor_socket, &response),
             "Error reading LauncherResponse");
-  CF_EXPECT_EQ((int)response, (int)LauncherResponse::kSuccess);
+  CF_EXPECT_EQ(response, LauncherResponse::kSuccess);
   return {};
 }
 


### PR DESCRIPTION
This changes an error message from
```
Expected "(int)response" == "(int)LauncherResponse::kSuccess" but was 69 vs 83.
```
to
```
Expected "response" == "LauncherResponse::kSuccess" but was LauncherResponse::kError vs LauncherResponse::kSuccess.
```

Bug: b/446765997