### PR TITLE
cvdalloc supports bridged Wi-Fi.

### DIFF
--- a/base/cvd/allocd/BUILD.bazel
+++ b/base/cvd/allocd/BUILD.bazel
@@ -45,6 +45,7 @@ cc_library(
     ],
     deps = [
         "//cuttlefish/common/libs/fs",
+        "//cuttlefish/host/commands/cvd/utils:common",
         "//cuttlefish/host/libs/config:logging",
         "//libbase",
     ],

--- a/base/cvd/allocd/alloc_utils.cpp
+++ b/base/cvd/allocd/alloc_utils.cpp
@@ -20,6 +20,8 @@
 
 #include "android-base/logging.h"
 
+#include "cuttlefish/host/commands/cvd/utils/common.h"
+
 namespace cuttlefish {
 
 int RunExternalCommand(const std::string& command) {
@@ -364,7 +366,7 @@ bool SetupBridgeGateway(const std::string& bridge_name,
 
   config.has_gateway = true;
 
-  if (StartDnsmasq(bridge_name, gateway, dhcp_range)) {
+  if (!StartDnsmasq(bridge_name, gateway, dhcp_range)) {
     CleanupBridgeGateway(bridge_name, ipaddr, config);
     return false;
   }
@@ -419,8 +421,10 @@ bool StartDnsmasq(const std::string& bridge_name, const std::string& gateway,
     " --dhcp-option=\"option:dns-server," << dns_servers << "\""
     " --dhcp-option=\"option6:dns-server," << dns6_servers << "\""
     " --conf-file=\"\""
-    " --pid-file=/var/run/cuttlefish-dnsmasq-" << bridge_name << ".pid"
-    " --dhcp-leasefile=/var/run/cuttlefish-dnsmasq-" << bridge_name << ".leases"
+    " --pid-file=" << CvdDir()
+         << "/cuttlefish-dnsmasq-" << bridge_name << ".pid"
+    " --dhcp-leasefile=" << CvdDir()
+         << "/cuttlefish-dnsmasq-" << bridge_name << ".leases"
     " --dhcp-no-override ";
   // clang-format on
 

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/interface.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/interface.cpp
@@ -46,4 +46,17 @@ std::string InstanceToWifiAddress(int num) {
 std::string InstanceToWifiBroadcast(int num) {
   return absl::StrFormat("%s.%d", kCvdallocWirelessApIpPrefix, 4 * num - 1);
 }
+
+std::string InstanceToBridgedWifiGatewayAddress(int num) {
+  return absl::StrFormat("%s.%d", kCvdallocWirelessIpPrefix, 1);
+}
+
+std::string InstanceToBridgedWifiAddress(int num) {
+  return absl::StrFormat("%s.%d", kCvdallocWirelessIpPrefix, 4 * num - 2);
+}
+
+std::string InstanceToBridgedWifiBroadcast(int num) {
+  return absl::StrFormat("%s.%d", kCvdallocWirelessIpPrefix, 4 * num - 1);
+}
+
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/interface.h
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/interface.h
@@ -32,5 +32,8 @@ std::string InstanceToMobileBroadcast(int num);
 std::string InstanceToWifiGatewayAddress(int num);
 std::string InstanceToWifiAddress(int num);
 std::string InstanceToWifiBroadcast(int num);
+std::string InstanceToBridgedWifiGatewayAddress(int num);
+std::string InstanceToBridgedWifiAddress(int num);
+std::string InstanceToBridgedWifiBroadcast(int num);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/privilege.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/privilege.cpp
@@ -68,6 +68,18 @@ static int SetAmbientCapabilities() {
     return -1;
   }
 
+  r = prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, CAP_NET_BIND_SERVICE, 0, 0);
+  if (r == -1) {
+    PLOG(INFO) << "prctl";
+    return -1;
+  }
+
+  r = prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, CAP_NET_RAW, 0, 0);
+  if (r == -1) {
+    PLOG(INFO) << "prctl";
+    return -1;
+  }
+
   return 1;
 }
 #endif
@@ -84,7 +96,8 @@ Result<void> ValidateCvdallocBinary(std::string_view path) {
   CF_EXPECTF(
       s != 1 && (cap.data[0].permitted & (1 << CAP_NET_ADMIN)) != 0,
       "cvdalloc binary does not have permissions to allocate resources.\n"
-      "As root, please\n\n    setcap cap_net_admin=+ep `realpath {}`",
+      "As root, please\n\n    setcap cap_net_admin,cap_net_bind_service,"
+      "cap_net_raw=+ep `realpath {}`",
       path);
 #else
   CF_EXPECTF(

--- a/base/cvd/cuttlefish/host/libs/config/openwrt_args.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/openwrt_args.cpp
@@ -57,12 +57,20 @@ std::unordered_map<std::string, std::string> OpenwrtArgsFromConfig(
   // (AOSP) external/openwrt-prebuilts/shared/uci-defaults/0_default_config
   if (instance.use_bridged_wifi_tap()) {
     openwrt_args["bridged_wifi_tap"] = "true";
-    openwrt_args["wan_gateway"] = getIpAddress(96, 1);
-    // TODO(seungjaeyoo) : Remove config after using DHCP server outside OpenWRT
-    // instead.
-    openwrt_args["wan_ipaddr"] = getIpAddress(96, d_class_base + 2);
-    openwrt_args["wan_broadcast"] = getIpAddress(96, d_class_base + 3);
 
+    if (instance.use_cvdalloc()) {
+      openwrt_args["wan_gateway"] =
+          InstanceToBridgedWifiGatewayAddress(instance_num);
+      openwrt_args["wan_ipaddr"] = InstanceToBridgedWifiAddress(instance_num);
+      openwrt_args["wan_broadcast"] =
+          InstanceToBridgedWifiBroadcast(instance_num);
+    } else {
+      openwrt_args["wan_gateway"] = getIpAddress(96, 1);
+      // TODO(seungjaeyoo) : Remove config after using DHCP server outside
+      // OpenWRT instead.
+      openwrt_args["wan_ipaddr"] = getIpAddress(96, d_class_base + 2);
+      openwrt_args["wan_broadcast"] = getIpAddress(96, d_class_base + 3);
+    }
   } else {
     openwrt_args["bridged_wifi_tap"] = "false";
 


### PR DESCRIPTION
Bridged Wi-Fi necessitates ensuring cvdalloc can handle setting up bridges and dnsmasq(8) properly. The existing alloc_utils does this, but assumes it gets run as root. If cvdalloc were setuid root, then this isn't an issue. However, we use capabilities and thus need more permissions: one to set up the raw DHCP socket, another to allow binding to low ports, again for DHCP.

alloc_utils also defaults to putting the logs and lease files in /var/run which would otherwise require root, but we can just put those in CvdDir instead.

The rest of the support necessary for bridged Wi-Fi is much like non-bridged Wi-Fi.