### PR TITLE
Add and use flag wrapper template class

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/flag_parser.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/flag_parser.cpp
@@ -155,7 +155,7 @@ static bool LikelyFlag(const std::string& next_arg) {
   return android::base::StartsWith(next_arg, "-");
 }
 
-Result<bool> ParseBool(const std::string& value, const std::string& name) {
+Result<bool> ParseBool(std::string_view value, std::string_view name) {
   auto result = android::base::ParseBool(value);
   CF_EXPECT(result != android::base::ParseBoolResult::kError,
             "Failed to parse value \"" << value << "\" for " << name);

--- a/base/cvd/cuttlefish/common/libs/utils/flag_parser.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/flag_parser.cpp
@@ -165,6 +165,14 @@ Result<bool> ParseBool(std::string_view value, std::string_view name) {
   return false;
 }
 
+Result<int> ParseInt(const std::string& value, std::string_view name) {
+  int result;
+  CF_EXPECTF(android::base::ParseInt(value, &result),
+             "Failed to parse value \"{}\" as integer for \"{}\"",
+             value, name);
+  return result;
+}
+
 Result<Flag::FlagProcessResult> Flag::Process(
     const std::string& arg, const std::optional<std::string>& next_arg) const {
   using android::base::StringReplace;

--- a/base/cvd/cuttlefish/common/libs/utils/flag_parser.h
+++ b/base/cvd/cuttlefish/common/libs/utils/flag_parser.h
@@ -133,7 +133,7 @@ std::ostream& operator<<(std::ostream&, const Flag&);
 
 std::vector<std::string> ArgsToVec(int argc, char** argv);
 
-Result<bool> ParseBool(const std::string& value, const std::string& name);
+Result<bool> ParseBool(std::string_view value, std::string_view name);
 
 /* Handles a list of flags. Flags are matched in the order given in case two
  * flags match the same argument. Matched flags are removed, leaving only

--- a/base/cvd/cuttlefish/common/libs/utils/flag_parser.h
+++ b/base/cvd/cuttlefish/common/libs/utils/flag_parser.h
@@ -134,6 +134,7 @@ std::ostream& operator<<(std::ostream&, const Flag&);
 std::vector<std::string> ArgsToVec(int argc, char** argv);
 
 Result<bool> ParseBool(std::string_view value, std::string_view name);
+Result<int> ParseInt(const std::string& value, std::string_view name);
 
 /* Handles a list of flags. Flags are matched in the order given in case two
  * flags match the same argument. Matched flags are removed, leaving only

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -273,6 +273,7 @@ cf_cc_library(
         "//cuttlefish/host/commands/assemble_cvd/flags:boot_image",
         "//cuttlefish/host/commands/assemble_cvd/flags:bootloader",
         "//cuttlefish/host/commands/assemble_cvd/flags:cpus",
+        "//cuttlefish/host/commands/assemble_cvd/flags:daemon",
         "//cuttlefish/host/commands/assemble_cvd/flags:display_proto",
         "//cuttlefish/host/commands/assemble_cvd/flags:initramfs_path",
         "//cuttlefish/host/commands/assemble_cvd/flags:kernel_path",

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
@@ -230,9 +230,6 @@ DEFINE_vec(
 
 DEFINE_vec(uuid, CF_DEFAULTS_UUID,
            "UUID to use for the device. Random if not specified");
-DEFINE_vec(daemon, CF_DEFAULTS_DAEMON?"true":"false",
-            "Run cuttlefish in background, the launcher exits on boot "
-            "completed/failed");
 
 DEFINE_vec(setupwizard_mode, CF_DEFAULTS_SETUPWIZARD_MODE,
               "One of DISABLED,OPTIONAL,REQUIRED");

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.h
@@ -105,7 +105,6 @@ DECLARE_vec(udp_port_range);
 DECLARE_vec(webrtc_device_id);
 
 DECLARE_vec(uuid);
-DECLARE_vec(daemon);
 
 DECLARE_vec(setupwizard_mode);
 DECLARE_vec(enable_bootanimation);

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -54,6 +54,7 @@
 #include "cuttlefish/host/commands/assemble_cvd/flags/boot_image.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags/bootloader.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags/cpus.h"
+#include "cuttlefish/host/commands/assemble_cvd/flags/daemon.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags/display_proto.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags/initramfs_path.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags/kernel_path.h"
@@ -495,7 +496,7 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
   std::vector<bool> pause_in_bootloader_vec = CF_EXPECT(GET_FLAG_BOOL_VALUE(
       pause_in_bootloader));
   std::vector<std::string> uuid_vec = CF_EXPECT(GET_FLAG_STR_VALUE(uuid));
-  std::vector<bool> daemon_vec = CF_EXPECT(GET_FLAG_BOOL_VALUE(daemon));
+  DaemonFlag daemon_values = CF_EXPECT(DaemonFlag::FromGlobalGflags());
   std::vector<bool> enable_minimal_mode_vec = CF_EXPECT(GET_FLAG_BOOL_VALUE(
       enable_minimal_mode));
   std::vector<bool> enable_modem_simulator_vec = CF_EXPECT(GET_FLAG_BOOL_VALUE(
@@ -978,7 +979,7 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
     instance.set_userdata_format(userdata_format_vec[instance_index]);
     instance.set_guest_enforce_security(guest_enforce_security_vec[instance_index]);
     instance.set_pause_in_bootloader(pause_in_bootloader_vec[instance_index]);
-    instance.set_run_as_daemon(daemon_vec[instance_index]);
+    instance.set_run_as_daemon(daemon_values.ForIndex(instance_index));
     instance.set_enable_modem_simulator(enable_modem_simulator_vec[instance_index] &&
                                         !enable_minimal_mode_vec[instance_index]);
     instance.set_modem_simulator_instance_number(modem_simulator_count_vec[instance_index]);

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/BUILD.bazel
@@ -84,6 +84,8 @@ cf_cc_library(
     deps = [
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/commands/assemble_cvd:flags_defaults",
+        "//cuttlefish/host/commands/assemble_cvd/flags:flag_base",
+        "//cuttlefish/host/commands/assemble_cvd/flags:from_gflags",
         "//libbase",
         "@gflags",
     ],

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/BUILD.bazel
@@ -106,6 +106,30 @@ cf_cc_library(
 )
 
 cf_cc_library(
+    name = "flag_base",
+    srcs = ["flag_base.cc"],
+    hdrs = ["flag_base.h"],
+    deps = [
+        "//cuttlefish/common/libs/utils:result",
+        "//libbase",
+        "@gflags",
+    ],
+)
+
+cf_cc_library(
+    name = "from_gflags",
+    srcs = ["from_gflags.cc"],
+    hdrs = ["from_gflags.h"],
+    deps = [
+        "//cuttlefish/common/libs/utils:flag_parser",
+        "//cuttlefish/common/libs/utils:result",
+        "//cuttlefish/host/commands/assemble_cvd/flags:flag_base",
+        "//libbase",
+        "@gflags",
+    ],
+)
+
+cf_cc_library(
     name = "initramfs_path",
     srcs = ["initramfs_path.cc"],
     hdrs = ["initramfs_path.h"],

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/BUILD.bazel
@@ -90,6 +90,20 @@ cf_cc_library(
 )
 
 cf_cc_library(
+    name = "daemon",
+    srcs = ["daemon.cc"],
+    hdrs = ["daemon.h"],
+    deps = [
+        "//cuttlefish/common/libs/utils:result",
+        "//cuttlefish/host/commands/assemble_cvd:flags_defaults",
+        "//cuttlefish/host/commands/assemble_cvd/flags:flag_base",
+        "//cuttlefish/host/commands/assemble_cvd/flags:from_gflags",
+        "//libbase",
+        "@gflags",
+    ],
+)
+
+cf_cc_library(
     name = "display_proto",
     srcs = ["display_proto.cc"],
     hdrs = ["display_proto.h"],

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/BUILD.bazel
@@ -41,6 +41,8 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:result",
         "//cuttlefish/host/commands/assemble_cvd:flags_defaults",
         "//cuttlefish/host/commands/assemble_cvd:guest_config",
+        "//cuttlefish/host/commands/assemble_cvd/flags:flag_base",
+        "//cuttlefish/host/commands/assemble_cvd/flags:from_gflags",
         "//libbase",
         "@gflags",
     ],

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/blank_data_image_mb.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/blank_data_image_mb.h
@@ -16,26 +16,22 @@
 
 #pragma once
 
-#include <cstdlib>
 #include <vector>
 
 #include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/commands/assemble_cvd/flags/flag_base.h"
 #include "cuttlefish/host/commands/assemble_cvd/guest_config.h"
 
 namespace cuttlefish {
 
-class BlankDataImageMbFlag {
+class BlankDataImageMbFlag : public FlagBase<int> {
  public:
   static Result<BlankDataImageMbFlag> FromGlobalGflags(
       const std::vector<GuestConfig>& guest_configs);
-
-  int ForIndex(std::size_t index) const;
+  ~BlankDataImageMbFlag() override = default;
 
  private:
-  BlankDataImageMbFlag(const int, std::vector<int>);
-
-  int default_value_ = 0;
-  std::vector<int> blank_data_image_mb_values_;
+  BlankDataImageMbFlag(std::vector<int>);
 };
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/cpus.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/cpus.h
@@ -16,24 +16,20 @@
 
 #pragma once
 
-#include <cstdlib>
 #include <vector>
 
 #include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/commands/assemble_cvd/flags/flag_base.h"
 
 namespace cuttlefish {
 
-class CpusFlag {
+class CpusFlag : public FlagBase<int> {
  public:
   static Result<CpusFlag> FromGlobalGflags();
-
-  int ForIndex(std::size_t index) const;
+  ~CpusFlag() override = default;
 
  private:
-  CpusFlag(const int, std::vector<int>);
-
-  int default_value_ = 0;
-  std::vector<int> cpus_values_;
+  CpusFlag(std::vector<int>);
 };
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/daemon.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/daemon.cc
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/host/commands/assemble_cvd/flags/daemon.h"
+
+#include <utility>
+#include <vector>
+
+#include <gflags/gflags.h>
+
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/commands/assemble_cvd/flags/flag_base.h"
+#include "cuttlefish/host/commands/assemble_cvd/flags/from_gflags.h"
+#include "cuttlefish/host/commands/assemble_cvd/flags_defaults.h"
+
+DEFINE_string(daemon, CF_DEFAULTS_DAEMON ? "true" : "false",
+              "Run cuttlefish in background, the launcher exits on boot "
+              "completed/failed");
+
+namespace cuttlefish {
+namespace {
+
+constexpr char kFlagName[] = "daemon";
+
+}  // namespace
+
+Result<DaemonFlag> DaemonFlag::FromGlobalGflags() {
+  const auto flag_info = gflags::GetCommandLineFlagInfoOrDie(kFlagName);
+  std::vector<bool> flag_values =
+      CF_EXPECT(BoolFromGlobalGflags(flag_info, kFlagName));
+  return DaemonFlag(std::move(flag_values));
+}
+
+DaemonFlag::DaemonFlag(std::vector<bool> flag_values)
+    : FlagBase<bool>(std::move(flag_values)) {}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/daemon.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/daemon.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <vector>
+
+#include "cuttlefish/common/libs/utils/result.h"
+#include "cuttlefish/host/commands/assemble_cvd/flags/flag_base.h"
+
+namespace cuttlefish {
+
+class DaemonFlag : public FlagBase<bool> {
+ public:
+  static Result<DaemonFlag> FromGlobalGflags();
+  ~DaemonFlag() override = default;
+
+ private:
+  DaemonFlag(std::vector<bool>);
+};
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/flag_base.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/flag_base.cc
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/host/commands/assemble_cvd/flags/flag_base.h"
+
+#include <cstdlib>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace cuttlefish {
+
+template <typename T>
+T FlagBase<T>::ForIndex(const std::size_t index) const {
+  if (index < values_.size()) {
+    return values_[index];
+  } else {
+    return values_[0];
+  }
+}
+
+template <typename T>
+FlagBase<T>::FlagBase(std::vector<T> flag_values)
+    : values_(std::move(flag_values)) {}
+
+template <typename T>
+FlagBase<T>::~FlagBase() {}
+
+template class FlagBase<bool>;
+template class FlagBase<int>;
+template class FlagBase<std::string>;
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/flag_base.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/flag_base.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdlib>
+#include <vector>
+
+namespace cuttlefish {
+
+template <typename T>
+class FlagBase {
+ public:
+  T ForIndex(const std::size_t index) const;
+
+ protected:
+  FlagBase(std::vector<T> flag_values);
+  virtual ~FlagBase() = 0;
+
+ private:
+  std::vector<T> values_;
+};
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/from_gflags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/from_gflags.cc
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/host/commands/assemble_cvd/flags/from_gflags.h"
+
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <android-base/strings.h>
+#include <gflags/gflags.h>
+
+#include "cuttlefish/common/libs/utils/flag_parser.h"
+#include "cuttlefish/common/libs/utils/result.h"
+
+namespace cuttlefish {
+
+namespace {
+
+// identity function, to match other type parsers
+Result<std::string> ParseString(const std::string& value, const std::string&) {
+  return value;
+}
+
+template <typename T>
+Result<std::vector<T>> FromGlobalGflags(
+    const gflags::CommandLineFlagInfo& flag_info, const std::string& flag_name,
+    std::function<Result<T>(const std::string& value, const std::string& name)>
+        parse_func) {
+  T default_value = CF_EXPECT(parse_func(flag_info.default_value, flag_name));
+
+  std::vector<std::string> string_values =
+      android::base::Split(flag_info.current_value, ",");
+  std::vector<T> values(string_values.size());
+
+  for (int i = 0; i < string_values.size(); i++) {
+    if (string_values[i] == "unset" || string_values[i] == "\"unset\"") {
+      values[i] = default_value;
+    } else {
+      values[i] = CF_EXPECT(parse_func(string_values[i], flag_name));
+    }
+  }
+  return std::move(values);
+}
+
+}  // namespace
+
+Result<std::vector<bool>> BoolFromGlobalGflags(
+    const gflags::CommandLineFlagInfo& flag_info,
+    const std::string& flag_name) {
+  return CF_EXPECT(FromGlobalGflags<bool>(flag_info, flag_name, ParseBool));
+}
+
+Result<std::vector<int>> IntFromGlobalGflags(
+    const gflags::CommandLineFlagInfo& flag_info,
+    const std::string& flag_name) {
+  return CF_EXPECT(FromGlobalGflags<int>(flag_info, flag_name, ParseInt));
+}
+
+Result<std::vector<std::string>> StringFromGlobalGflags(
+    const gflags::CommandLineFlagInfo& flag_info,
+    const std::string& flag_name) {
+  return CF_EXPECT(
+      FromGlobalGflags<std::string>(flag_info, flag_name, ParseString));
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/from_gflags.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/from_gflags.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <gflags/gflags.h>
+
+#include "cuttlefish/common/libs/utils/result.h"
+
+namespace cuttlefish {
+
+Result<std::vector<bool>> BoolFromGlobalGflags(
+    const gflags::CommandLineFlagInfo& flag_info, const std::string& flag_name);
+Result<std::vector<int>> IntFromGlobalGflags(
+    const gflags::CommandLineFlagInfo& flag_info, const std::string& flag_name);
+Result<std::vector<std::string>> StringFromGlobalGflags(
+    const gflags::CommandLineFlagInfo& flag_info, const std::string& flag_name);
+
+}  // namespace cuttlefish


### PR DESCRIPTION
This PR is a new branch based on feedback from #1604.

The goal of the new `FlagBase` is to speed the conversion of flags into a form where the parsing can be re-used in different locations within the codebases.