### PR TITLE
alloc_utils and cvdalloc use string_view.

### DIFF
--- a/base/cvd/allocd/BUILD.bazel
+++ b/base/cvd/allocd/BUILD.bazel
@@ -48,5 +48,6 @@ cc_library(
         "//cuttlefish/host/commands/cvd/utils:common",
         "//cuttlefish/host/libs/config:logging",
         "//libbase",
+        "@abseil-cpp//absl/strings:str_format",
     ],
 )

--- a/base/cvd/allocd/alloc_utils.h
+++ b/base/cvd/allocd/alloc_utils.h
@@ -23,6 +23,7 @@
 #include <atomic>
 #include <optional>
 #include <sstream>
+#include <string_view>
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 
@@ -64,62 +65,62 @@ struct GatewayConfig {
 int RunExternalCommand(const std::string& command);
 std::optional<std::string> GetUserName(uid_t uid);
 
-bool AddTapIface(const std::string& name);
-bool CreateTap(const std::string& name);
+bool AddTapIface(std::string_view name);
+bool CreateTap(std::string_view name);
 
-bool BringUpIface(const std::string& name);
-bool ShutdownIface(const std::string& name);
+bool BringUpIface(std::string_view name);
+bool ShutdownIface(std::string_view name);
 
-bool DestroyIface(const std::string& name);
-bool DeleteIface(const std::string& name);
+bool DestroyIface(std::string_view name);
+bool DeleteIface(std::string_view name);
 
-bool CreateBridge(const std::string& name);
-bool DestroyBridge(const std::string& name);
+bool CreateBridge(std::string_view name);
+bool DestroyBridge(std::string_view name);
 
-bool CreateEbtables(const std::string& name, bool use_ipv,
+bool CreateEbtables(std::string_view name, bool use_ipv,
                     bool use_ebtables_legacy);
-bool DestroyEbtables(const std::string& name, bool use_ipv4,
+bool DestroyEbtables(std::string_view name, bool use_ipv4,
                      bool use_ebtables_legacy);
-bool EbtablesBroute(const std::string& name, bool use_ipv4, bool add,
+bool EbtablesBroute(std::string_view name, bool use_ipv4, bool add,
                     bool use_ebtables_legacy);
-bool EbtablesFilter(const std::string& name, bool use_ipv4, bool add,
+bool EbtablesFilter(std::string_view name, bool use_ipv4, bool add,
                     bool use_ebtables_legacy);
 
-bool CreateMobileIface(const std::string& name, uint16_t id,
-                       const std::string& ipaddr);
-bool DestroyMobileIface(const std::string& name, uint16_t id,
-                        const std::string& ipaddr);
+bool CreateMobileIface(std::string_view name, uint16_t id,
+                       std::string_view ipaddr);
+bool DestroyMobileIface(std::string_view name, uint16_t id,
+                        std::string_view ipaddr);
 
-bool CreateEthernetIface(const std::string& name, const std::string& bridge_name,
+bool CreateEthernetIface(std::string_view name, std::string_view bridge_name,
                          bool has_ipv4_bridge, bool has_ipv6_bridge,
                          bool use_ebtables_legacy);
-bool DestroyEthernetIface(const std::string& name,
+bool DestroyEthernetIface(std::string_view name,
                           bool has_ipv4_bridge, bool use_ipv6,
                           bool use_ebtables_legacy);
-void CleanupEthernetIface(const std::string& name,
+void CleanupEthernetIface(std::string_view name,
                           const EthernetNetworkConfig& config);
 
-bool IptableConfig(const std::string& network, bool add);
+bool IptableConfig(std::string_view network, bool add);
 
-bool LinkTapToBridge(const std::string& tap_name,
-                     const std::string& bridge_name);
+bool LinkTapToBridge(std::string_view tap_name,
+                     std::string_view bridge_name);
 
-bool SetupBridgeGateway(const std::string& name, const std::string& ipaddr);
-void CleanupBridgeGateway(const std::string& name, const std::string& ipaddr,
+bool SetupBridgeGateway(std::string_view name, std::string_view ipaddr);
+void CleanupBridgeGateway(std::string_view name, std::string_view ipaddr,
                           const GatewayConfig& config);
 
-bool CreateEthernetBridgeIface(const std::string& name,
-                               const std::string &ipaddr);
-bool DestroyEthernetBridgeIface(const std::string& name,
-                                const std::string &ipaddr);
+bool CreateEthernetBridgeIface(std::string_view name,
+                               std::string_view ipaddr);
+bool DestroyEthernetBridgeIface(std::string_view name,
+                                std::string_view ipaddr);
 
-bool AddGateway(const std::string& name, const std::string& gateway,
-                const std::string& netmask);
-bool DestroyGateway(const std::string& name, const std::string& gateway,
-                    const std::string& netmask);
+bool AddGateway(std::string_view name, std::string_view gateway,
+                std::string_view netmask);
+bool DestroyGateway(std::string_view name, std::string_view gateway,
+                    std::string_view netmask);
 
-bool StartDnsmasq(const std::string& bridge_name, const std::string& gateway,
-                  const std::string& dhcp_range);
-bool StopDnsmasq(const std::string& name);
+bool StartDnsmasq(std::string_view bridge_name, std::string_view gateway,
+                  std::string_view dhcp_range);
+bool StopDnsmasq(std::string_view name);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/cvdalloc.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/cvdalloc.cpp
@@ -16,6 +16,8 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <string_view>
+
 #include <android-base/logging.h>
 #include <android-base/macros.h>
 #include "absl/cleanup/cleanup.h"
@@ -41,8 +43,8 @@ void Usage() {
   LOG(ERROR) << "Should only be invoked from run_cvd.";
 }
 
-Result<void> Allocate(int id, const std::string &ethernet_bridge_name,
-                      const std::string &wireless_bridge_name) {
+Result<void> Allocate(int id, std::string_view ethernet_bridge_name,
+                      std::string_view wireless_bridge_name) {
   LOG(INFO) << "cvdalloc: allocating network resources";
 
   CF_EXPECT(CreateMobileIface(CvdallocInterfaceName("mtap", id), id,
@@ -61,8 +63,8 @@ Result<void> Allocate(int id, const std::string &ethernet_bridge_name,
   return {};
 }
 
-Result<void> Teardown(int id, const std::string &ethernet_bridge_name,
-                      const std::string &wireless_bridge_name) {
+Result<void> Teardown(int id, std::string_view ethernet_bridge_name,
+                      std::string_view wireless_bridge_name) {
   LOG(INFO) << "cvdalloc: tearing down resources";
 
   DestroyMobileIface(CvdallocInterfaceName("mtap", id), id,


### PR DESCRIPTION
Some of the idioms are starting to clash, which suggests a refactor. All uses of `const std::string &` in alloc_utils and cvdalloc are now forklifted wholesale to `std::string_view`, which is the more recent and preferred idiomatic mechanism for passing bits of strings like this.