### PR TITLE
Talk about bridge names symbolically.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -282,6 +282,7 @@ cf_cc_library(
         "//cuttlefish/host/commands/assemble_cvd/flags:system_image_dir",
         "//cuttlefish/host/commands/assemble_cvd/flags:vendor_boot_image",
         "//cuttlefish/host/commands/assemble_cvd/flags:vm_manager",
+        "//cuttlefish/host/commands/cvdalloc:interface",
         "//cuttlefish/host/libs/config:ap_boot_flow",
         "//cuttlefish/host/libs/config:config_constants",
         "//cuttlefish/host/libs/config:cuttlefish_config",

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -66,6 +66,7 @@
 #include "cuttlefish/host/commands/assemble_cvd/guest_config.h"
 #include "cuttlefish/host/commands/assemble_cvd/network_flags.h"
 #include "cuttlefish/host/commands/assemble_cvd/touchpad.h"
+#include "cuttlefish/host/commands/cvdalloc/interface.h"
 #include "cuttlefish/host/libs/config/ap_boot_flow.h"
 #include "cuttlefish/host/libs/config/config_constants.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
@@ -994,8 +995,9 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
     instance.set_has_wifi_card(enable_wifi_vec[instance_index]);
     instance.set_mobile_bridge_name(StrForInstance("cvd-mbr-", num));
     if (const_instance.use_cvdalloc()) {
-      instance.set_wifi_bridge_name("cvd-pi-wbr");
-      instance.set_ethernet_bridge_name("cvd-pi-ebr");
+      instance.set_wifi_bridge_name(std::string(kCvdallocWirelessBridgeName));
+      instance.set_ethernet_bridge_name(
+          std::string(kCvdallocEthernetBridgeName));
     } else {
       instance.set_wifi_bridge_name("cvd-wbr");
       instance.set_ethernet_bridge_name("cvd-ebr");

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/cvdalloc.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/cvdalloc.cpp
@@ -123,15 +123,12 @@ Result<int> CvdallocMain(int argc, char *argv[]) {
     return CF_ERRNO("Couldn't elevate permissions: " << strerror(errno));
   }
 
-  std::string ethernet_bridge_name = "cvd-pi-ebr";
-  std::string wireless_bridge_name = "cvd-pi-wbr";
-
-  absl::Cleanup teardown = [id, ethernet_bridge_name, wireless_bridge_name]() {
+  absl::Cleanup teardown = [id]() {
     LOG(INFO) << "cvdalloc: teardown started";
-    Teardown(id, ethernet_bridge_name, wireless_bridge_name);
+    Teardown(id, kCvdallocEthernetBridgeName, kCvdallocWirelessBridgeName);
   };
 
-  CF_EXPECT(Allocate(id, ethernet_bridge_name, wireless_bridge_name));
+  CF_EXPECT(Allocate(id, kCvdallocEthernetBridgeName, kCvdallocWirelessBridgeName));
   CF_EXPECT(cvdalloc::Post(sock));
 
   LOG(INFO) << "cvdalloc: waiting to teardown";

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/interface.h
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/interface.h
@@ -20,6 +20,8 @@
 namespace cuttlefish {
 
 constexpr std::string_view kCvdallocInterfacePrefix = "cvd-pi";
+constexpr std::string_view kCvdallocEthernetBridgeName = "cvd-pi-ebr";
+constexpr std::string_view kCvdallocWirelessBridgeName = "cvd-pi-wbr";
 constexpr char kCvdallocMobileIpPrefix[] = "192.168.144";
 constexpr char kCvdallocWirelessIpPrefix[] = "192.168.160";
 constexpr char kCvdallocWirelessApIpPrefix[] = "192.168.176";


### PR DESCRIPTION
Instead of having to keep track of bridge names as strings that should be kept in sync when things are updated, use some constexpr symbols, to make these relationships clearer.