### PR TITLE
Put locks in CvdDir when invoked as cvd.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -299,9 +299,9 @@ class CvdStartCommandHandler : public CvdCommandHandler {
 Result<void> CvdStartCommandHandler::AcloudCompatActions(
     const LocalInstanceGroup& group, const cvd_common::Envs& envs,
     const CommandRequest& request) {
-  // rm -fr "InstanceLocksPath()/local-instance-<i>"
+  // rm -fr "AcloudInstanceLocksPath()/local-instance-<i>"
   std::string acloud_compat_home_prefix =
-      InstanceLocksPath() + "/local-instance-";
+      AcloudInstanceLocksPath() + "/local-instance-";
   std::vector<std::string> acloud_compat_homes;
   acloud_compat_homes.reserve(group.Instances().size());
   for (const auto& instance : group.Instances()) {

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/lock/instance_lock.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/lock/instance_lock.cpp
@@ -63,11 +63,13 @@ bool InstanceLockFile::operator<(const InstanceLockFile& other) const {
   return lock_file_ < other.lock_file_;
 }
 
-InstanceLockFileManager::InstanceLockFileManager() {}
+InstanceLockFileManager::InstanceLockFileManager(
+    std::string_view instance_locks_path)
+    : instance_locks_path_(instance_locks_path) {};
 
 Result<std::string> InstanceLockFileManager::LockFilePath(int instance_num) {
   std::stringstream path;
-  path << InstanceLocksPath();
+  path << instance_locks_path_;
   CF_EXPECT(EnsureDirectoryExists(path.str()));
   path << "local-instance-" << instance_num << ".lock";
   return path.str();

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/lock/instance_lock.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/lock/instance_lock.h
@@ -47,7 +47,7 @@ class InstanceLockFileManager {
   using LockFileManager = cvd_impl::LockFileManager;
 
  public:
-  InstanceLockFileManager();
+  InstanceLockFileManager(std::string_view instance_locks_path);
 
   Result<InstanceLockFile> AcquireLock(int instance_num);
   Result<std::set<InstanceLockFile>> AcquireLocks(const std::set<int>& nums);
@@ -71,7 +71,8 @@ class InstanceLockFileManager {
    * Generate value to initialize
    */
   Result<std::set<int>> FindPotentialInstanceNumsFromNetDevices();
-  static Result<std::string> LockFilePath(int instance_num);
+  Result<std::string> LockFilePath(int instance_num);
+  std::string_view instance_locks_path_;
   std::optional<std::set<int>> all_instance_nums_;
   LockFileManager lock_file_manager_;
 };

--- a/base/cvd/cuttlefish/host/commands/cvd/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/main.cc
@@ -198,15 +198,20 @@ Result<void> CvdMain(int argc, char** argv, char** envp) {
 
   IncreaseFileLimit();
 
-  InstanceLockFileManager instance_lockfile_manager;
   InstanceDatabase instance_db(InstanceDatabasePath());
-  InstanceManager instance_manager(instance_lockfile_manager, instance_db);
-  Cvd cvd(instance_manager, instance_lockfile_manager);
 
   // TODO(b/206893146): Make this decision inside the server.
   if (android::base::Basename(all_args[0]) == "acloud") {
+    InstanceLockFileManager instance_lockfile_manager(
+        AcloudInstanceLocksPath());
+    InstanceManager instance_manager(instance_lockfile_manager, instance_db);
+    Cvd cvd(instance_manager, instance_lockfile_manager);
     return cvd.HandleAcloud(all_args, env);
   }
+
+  InstanceLockFileManager instance_lockfile_manager(InstanceLocksPath());
+  InstanceManager instance_manager(instance_lockfile_manager, instance_db);
+  Cvd cvd(instance_manager, instance_lockfile_manager);
   if (android::base::Basename(all_args[0]) == "cvd") {
     CF_EXPECT(cvd.HandleCvdCommand(all_args, env));
     return {};

--- a/base/cvd/cuttlefish/host/commands/cvd/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/utils/BUILD.bazel
@@ -17,6 +17,7 @@ cf_cc_library(
         "//cuttlefish/host/commands/cvd/cli:types",
         "//cuttlefish/host/libs/config:config_utils",
         "//libbase",
+        "@abseil-cpp//absl/strings:str_format",
     ],
 )
 

--- a/base/cvd/cuttlefish/host/commands/cvd/utils/common.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/utils/common.cpp
@@ -26,6 +26,7 @@
 #include <android-base/file.h>
 #include <android-base/logging.h>
 #include <android-base/strings.h>
+#include "absl/strings/str_format.h"
 
 #include "cuttlefish/common/libs/utils/contains.h"
 #include "cuttlefish/common/libs/utils/files.h"
@@ -166,7 +167,11 @@ std::string InstanceDatabasePath() {
   return fmt::format("{}/instance_database.binpb", PerUserDir());
 }
 
-std::string InstanceLocksPath() { return "/tmp/acloud_cvd_temp/"; }
+std::string AcloudInstanceLocksPath() { return "/tmp/acloud_cvd_temp/"; }
+
+std::string InstanceLocksPath() {
+  return absl::StrFormat("%s/%s/", CvdDir(), "lock");
+}
 
 Result<std::string> GroupDirFromHome(std::string_view dir) {
   std::string per_user_dir = PerUserDir();

--- a/base/cvd/cuttlefish/host/commands/cvd/utils/common.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/utils/common.h
@@ -84,6 +84,7 @@ std::string PerUserCacheDir();
 
 std::string InstanceDatabasePath();
 
+std::string AcloudInstanceLocksPath();
 std::string InstanceLocksPath();
 
 Result<std::string> GroupDirFromHome(std::string_view group_home_dir);


### PR DESCRIPTION
When invoked as cvd, lock files should be placed in a subdirectory of CvdDir. This means that the InstanceLockFileManager should have the lock directory as a parameter; when invoked as acloud, we use the old subdirectory as the parameter instead.

(This contains the locking changes we had discussed briefly, but I feel like I might be forgetting something. You might also have a better idea if this leads to acloud incompatability or brokenness; please point me in the right direction if so.)