### PR TITLE
Gather initial metrics for remaining events

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
@@ -425,6 +425,7 @@ cf_cc_library(
         "//cuttlefish/host/libs/config:config_constants",
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/metrics:metrics_headers",
+        "//cuttlefish/host/libs/metrics:metrics_orchestration",
         "//external_proto:cf_log_cc_proto",
         "//external_proto:clientanalytics_cc_proto",
         "//libbase",
@@ -471,6 +472,7 @@ cf_cc_library(
         "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/commands/cvd/instances:cvd_persistent_data",
         "//cuttlefish/host/commands/cvd/utils",
+        "//cuttlefish/host/libs/metrics:metrics_orchestration",
         "//libbase",
     ],
 )

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -73,6 +73,7 @@
 #include "cuttlefish/host/libs/config/config_constants.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 #include "cuttlefish/host/libs/metrics/metrics_defs.h"
+#include "cuttlefish/host/libs/metrics/metrics_orchestration.h"
 #include "external_proto/cf_log.pb.h"
 #include "external_proto/clientanalytics.pb.h"
 
@@ -639,6 +640,7 @@ Result<void> CvdStartCommandHandler::LaunchDevice(
     LOG(INFO) << "This will automatically send diagnostic information to "
                  "Google, such as crash reports and usage data from the host "
                  "machine managing the Android Virtual Device.";
+    GatherVmStartMetrics(group);
     uint64_t now_ms = metrics::GetEpochTimeMs();
     CuttlefishLogEvent cf_log_event = metrics::BuildCfLogEvent(now_ms);
     cf_log_event.mutable_metrics_event_v2();
@@ -668,6 +670,7 @@ Result<void> CvdStartCommandHandler::LaunchDevice(
     CF_EXPECT(CvdResetGroup(group));
   }
   CF_EXPECT(CheckProcessExitedNormally(infop));
+  GatherVmBootCompleteMetrics(group);
   return {};
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/stop.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/stop.cpp
@@ -39,6 +39,7 @@
 #include "cuttlefish/host/commands/cvd/instances/cvd_persistent_data.pb.h"
 #include "cuttlefish/host/commands/cvd/instances/instance_manager.h"
 #include "cuttlefish/host/commands/cvd/utils/common.h"
+#include "cuttlefish/host/libs/metrics/metrics_orchestration.h"
 
 namespace cuttlefish {
 namespace {
@@ -137,6 +138,8 @@ Result<void> CvdStopCommandHandler::Handle(const CommandRequest& request) {
     group.SetAllStates(cvd::INSTANCE_STATE_STOPPED);
     CF_EXPECT(instance_manager_.UpdateInstanceGroup(group));
   }
+
+  GatherVmStopMetrics(group);
 
   CF_EXPECT(std::move(stop_outcome));
   return {};

--- a/base/cvd/cuttlefish/host/libs/metrics/metrics_orchestration.h
+++ b/base/cvd/cuttlefish/host/libs/metrics/metrics_orchestration.h
@@ -22,4 +22,10 @@ namespace cuttlefish {
 
 void GatherVmInstantiationMetrics(const LocalInstanceGroup& instance_group);
 
+void GatherVmStartMetrics(const LocalInstanceGroup& instance_group);
+
+void GatherVmBootCompleteMetrics(const LocalInstanceGroup& instance_group);
+
+void GatherVmStopMetrics(const LocalInstanceGroup& instance_group);
+
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/metrics/metrics_writer.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/metrics_writer.cc
@@ -37,11 +37,12 @@ std::string GenerateFilenameSuffix() {
 
 }  // namespace
 
-Result<void> WriteMetricsEvent(const std::string& metrics_directory,
+Result<void> WriteMetricsEvent(std::string_view event_type,
+                               const std::string& metrics_directory,
                                std::string_view session_id,
                                const HostInfo& host_metrics) {
   const std::string event_filepath =
-      fmt::format("{}/vm-instantiation_{}_{}", metrics_directory,
+      fmt::format("{}/{}_{}_{}", metrics_directory, event_type,
                   std::chrono::system_clock::now(), GenerateFilenameSuffix());
   // TODO: chadreynolds - convert (what will be a proto) to text
   CF_EXPECT(WriteNewFile(

--- a/base/cvd/cuttlefish/host/libs/metrics/metrics_writer.h
+++ b/base/cvd/cuttlefish/host/libs/metrics/metrics_writer.h
@@ -25,7 +25,8 @@
 namespace cuttlefish {
 
 // TODO: chadreynolds - add support for more fields than HostInfo
-Result<void> WriteMetricsEvent(const std::string& metrics_directory,
+Result<void> WriteMetricsEvent(std::string_view event_type,
+                               const std::string& metrics_directory,
                                std::string_view session_id,
                                const HostInfo& host_metrics);
 


### PR DESCRIPTION
`cvd start`, `VIRTUAL_DEVICE_BOOT_COMPLETE`, `cvd stop`

Bug: 448398451