### PR TITLE
Minor code formatting for display-remove modal

### DIFF
--- a/base/cvd/cuttlefish/host/frontend/webrtc/html_client/client.html
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/html_client/client.html
@@ -298,8 +298,8 @@
           <h2 id='display-remove-text'></h2>
         </div>
         <div class='display-remove-buttons'>
-          <button id='display-remove-modal-confirm' title='Confirm' class='modal-button'>confirm</button>
-          <button id='display-remove-modal-cancel' title='Cancel' class='modal-button '>cancel</button>
+          <button id='display-remove-modal-confirm' title='Confirm' class='modal-button'>Confirm</button>
+          <button id='display-remove-modal-cancel' title='Cancel' class='modal-button '>Cancel</button>
         </div>
       </div>
       <script src="js/adb.js"></script>

--- a/base/cvd/cuttlefish/host/frontend/webrtc/html_client/js/app.js
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/html_client/js/app.js
@@ -334,8 +334,8 @@ class DeviceControlApp {
     createSelectListener('display-spec-preset-select', () => this.#updateDisplaySpecFrom());
     createButtonListener('display-add-confirm', null, this.#deviceConnection, evt => this.#onDisplayAdditionConfirm(evt));
 
-    createButtonListener('display-remove-modal-confirm',null,this.#deviceConnection, () => this.#handleDisplayRemovalModalAction('confirm'));
-    createButtonListener('display-remove-modal-cancel',null,this.#deviceConnection, () => this.#handleDisplayRemovalModalAction('cancel'));
+    createButtonListener('display-remove-modal-confirm', null, this.#deviceConnection, () => this.#handleDisplayRemovalModalAction('confirm'));
+    createButtonListener('display-remove-modal-cancel', null, this.#deviceConnection, () => this.#handleDisplayRemovalModalAction('cancel'));
 
     if (this.#deviceConnection.description.custom_control_panel_buttons.length >
         0) {
@@ -680,11 +680,11 @@ class DeviceControlApp {
     this.#deviceConnection.sendControlMessage(JSON.stringify(message));
   }
 
-  #handleDisplayRemovalModalAction(action){
+  #handleDisplayRemovalModalAction(action) {
     const removeModalElement = document.getElementById('display-remove-modal');
     const removeDisplayId = removeModalElement.dataset.removal_display_id;
     let removeButtonId = removeDisplayId + '_remove_button';
-    if(action === 'confirm'){
+    if (action === 'confirm') {
       this.#removeDisplay(removeDisplayId);
     } else {
       // Clear the dataset on cancel.

--- a/base/cvd/cuttlefish/host/frontend/webrtc/html_client/js/controls.js
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/html_client/js/controls.js
@@ -260,7 +260,7 @@ function positionModal(button_id, modal_id) {
   modalDiv.style.left = modalButton.offsetWidth + 30;
 }
 
-function showModal(button_id,modal_id) {
+function showModal(button_id, modal_id) {
   const modalButton = document.getElementById(button_id);
   const modalDiv = document.getElementById(modal_id);
 
@@ -268,7 +268,7 @@ function showModal(button_id,modal_id) {
   modalDiv.style.display = 'block';
 }
 
-function hideModal(button_id,hide_id){
+function hideModal(button_id, hide_id) {
   const modalButton = document.getElementById(button_id);
   const modalDivHide = document.getElementById(hide_id);
 
@@ -286,20 +286,20 @@ function createModalButton(button_id, modal_id, close_id, hide_id) {
 
   // Allow the show modal button to toggle the modal,
   modalButton.addEventListener('click', evt => {
-    if(modalDiv.style.display != 'block'){
-      showModal(button_id,modal_id);
-    }else{
-      hideModal(button_id,modal_id);
+    if (modalDiv.style.display != 'block') {
+      showModal(button_id, modal_id);
+    } else {
+      hideModal(button_id, modal_id);
     }
 
     if (hide_id != null) {
-      hideModal(button_id,hide_id);
+      hideModal(button_id, hide_id);
     }
   });
 
   // but the close button always closes.
-  if(modalClose){
-    modalClose.addEventListener('click', evt => hideModal(button_id,modal_id));
+  if (modalClose) {
+    modalClose.addEventListener('click', evt => hideModal(button_id, modal_id));
   }
 
   // Allow the modal to be dragged by the header.


### PR DESCRIPTION
Minor code formatting for display-remove modal
- Adds a missing space for code readability.
- Changes modal button labels to sentence case ("Confirm", "Cancel").


The initial implementation was introduced in  "Add a remove-display modal to confirm the removal"   https://github.com/google/android-cuttlefish/pull/1624



