### PR TITLE
Fix a lifetime issue.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/instances/lock/instance_lock.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/lock/instance_lock.cpp
@@ -64,8 +64,8 @@ bool InstanceLockFile::operator<(const InstanceLockFile& other) const {
 }
 
 InstanceLockFileManager::InstanceLockFileManager(
-    std::string_view instance_locks_path)
-    : instance_locks_path_(instance_locks_path) {};
+    std::string instance_locks_path)
+    : instance_locks_path_(std::move(instance_locks_path)) {};
 
 Result<std::string> InstanceLockFileManager::LockFilePath(int instance_num) {
   std::stringstream path;

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/lock/instance_lock.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/lock/instance_lock.h
@@ -47,7 +47,7 @@ class InstanceLockFileManager {
   using LockFileManager = cvd_impl::LockFileManager;
 
  public:
-  InstanceLockFileManager(std::string_view instance_locks_path);
+  InstanceLockFileManager(std::string instance_locks_path);
 
   Result<InstanceLockFile> AcquireLock(int instance_num);
   Result<std::set<InstanceLockFile>> AcquireLocks(const std::set<int>& nums);
@@ -72,7 +72,7 @@ class InstanceLockFileManager {
    */
   Result<std::set<int>> FindPotentialInstanceNumsFromNetDevices();
   Result<std::string> LockFilePath(int instance_num);
-  std::string_view instance_locks_path_;
+  std::string instance_locks_path_;
   std::optional<std::set<int>> all_instance_nums_;
   LockFileManager lock_file_manager_;
 };


### PR DESCRIPTION
The lock parameter path may not outlive the InstanceLockFileManager, so we shouldn't use a string_view at all here.

(Split from #1697, will also remove there.)