### PR TITLE
Remove unused include

### DIFF
--- a/base/cvd/cuttlefish/host/libs/metrics/session_id.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/session_id.cc
@@ -17,7 +17,6 @@
 #include "cuttlefish/host/libs/metrics/session_id.h"
 
 #include <string>
-#include <string_view>
 
 #include <uuid/uuid.h>
 


### PR DESCRIPTION
Fixes `clang-tidy` warning.