### PR TITLE
Allow omitting connection to light server

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -1081,7 +1081,9 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
     instance.set_tombstone_receiver_port(calc_vsock_port(6600));
     instance.set_audiocontrol_server_port(
         9410); /* OK to use the same port number across instances */
-    instance.set_lights_server_port(calc_vsock_port(6900));
+    if (guest_configs[instance_index].lights_server_enabled) {
+      instance.set_lights_server_port(calc_vsock_port(6900));
+    }
 
     // gpu related settings
     const GpuMode gpu_mode = CF_EXPECT(ConfigureGpuSettings(

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/guest_config.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/guest_config.cc
@@ -137,6 +137,10 @@ Result<void> ParseGuestConfigTextProto(const std::string& guest_config_path,
     guest_config.ti50_emulator = virtualization_config.ti50_emulator_path();
   }
 
+  // Unlike with android-info.txt, this defaults to false if not provided in the
+  // proto file.
+  guest_config.lights_server_enabled = proto_config.has_lights();
+
   return {};
 }
 
@@ -221,6 +225,15 @@ Result<void> ParseGuestConfigTxt(const std::string& guest_config_path,
                "Failed to parse value '{}' for blank data image size", *res);
   }
 
+  if (const Result<std::string> res =
+          MapGetResult(info, "lights_server_enabled");
+      res.ok()) {
+    bool value;
+    if (absl::SimpleAtob(*res, &value)) {
+      guest_config.lights_server_enabled = value;
+    }
+  }
+
   return {};
 }
 
@@ -248,7 +261,8 @@ PrettyStruct Pretty(const GuestConfig& config, PrettyAdlPlaceholder) {
       .Member("output_audio_streams_count", config.output_audio_streams_count)
       .Member("audio_settings", config.audio_settings)
       .Member("enforce_mac80211_hwsim", config.enforce_mac80211_hwsim)
-      .Member("blank_data_image_mb", config.blank_data_image_mb);
+      .Member("blank_data_image_mb", config.blank_data_image_mb)
+      .Member("lights_server_enabled", config.lights_server_enabled);
 }
 
 Result<std::vector<GuestConfig>> ReadGuestConfig(

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/guest_config.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/guest_config.h
@@ -50,6 +50,7 @@ struct GuestConfig {
   std::optional<::cuttlefish::config::Audio> audio_settings;
   std::optional<bool> enforce_mac80211_hwsim;
   int blank_data_image_mb = 0;
+  bool lights_server_enabled = true; // true for backwards compatibility
 };
 
 PrettyStruct Pretty(const GuestConfig&,

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/proto/guest_config.proto
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/proto/guest_config.proto
@@ -119,6 +119,9 @@ enum DeviceType {
   Unknown = 7;
 }
 
+// The presence of this field in the proto indicates the lights HAL is enabled.
+message Lights {}
+
 // GuestConfigFile represents the configuration for a Cuttlefish guest device,
 // typically parsed from an cuttlefish-guest-config.txtpb file. It defines the
 // device's hardware capabilities, software features, and virtualization
@@ -137,4 +140,6 @@ message GuestConfigFile {
   Storage storage = 6;
 
   Virtualization virtualization = 7;
+
+  Lights lights = 8;
 }


### PR DESCRIPTION
The light server runs guest side and listens on a vsock port. The webRTC process connects to this server. This change makes this connection optional, configurable via the android-info.txt or cuttlefish-guest-config.txtpb file. This allows android targets that don't have a lights HAL (like some auto targets) to indicate so and avoid spurious error messages in the logs.

Bug: b/489145090