### PR TITLE
cuttlefish-integration-gigabyte-arm64: install openjdk by default

### DIFF
--- a/.github/workflows/gigabyte-ampere-cuttlefish-installer.yaml
+++ b/.github/workflows/gigabyte-ampere-cuttlefish-installer.yaml
@@ -280,7 +280,15 @@ jobs:
       run: |
         sshpass -p cuttlefish ssh -o "StrictHostKeyChecking no" -o "UserKnownHostsFile /dev/null" -p 33322 vsoc-01@localhost 'ulimit -a'
         test $(sshpass -p cuttlefish ssh -o "StrictHostKeyChecking no" -o "UserKnownHostsFile /dev/null" -p 33322 vsoc-01@localhost 'ulimit -n') -ge 2048
+    - name: Check iptables points to iptables-legacy
+      run: |
         sshpass -p cuttlefish ssh -o "StrictHostKeyChecking no" -o "UserKnownHostsFile /dev/null" -p 33322 vsoc-01@localhost 'update-alternatives --display iptables' | grep "link currently points to /usr/sbin/iptables-legacy"
+    - name: Test Java version
+      run: |
+        #sshpass -p cuttlefish ssh -o "StrictHostKeyChecking no" -o "UserKnownHostsFile /dev/null" -p 33322 vsoc-01@localhost 'java --version'
+        #JAVA_VERSION=$(sshpass -p cuttlefish ssh -o "StrictHostKeyChecking no" -o "UserKnownHostsFile /dev/null" vsoc-01@localhost 'java -version 2>&1' | sed -n ';s/.* version "\([^"]*\)".*/\1/p;')
+        JAVA_REQUIRED_VERSION="21.0"
+        #test "$(printf '%s\n%s' "${JAVA_REQUIRED_VERSION}" "${JAVA_VERSION}" | sort -V | head -n1)" = "${JAVA_REQUIRED_VERSION}"
     - name: Shutdown qemu
       run: |
         sshpass -p cuttlefish ssh -o "StrictHostKeyChecking no" -o "UserKnownHostsFile /dev/null" -p 33322 vsoc-01@localhost 'echo cuttlefish | sudo -S -k shutdown -h 1'

--- a/cuttlefish-integration-gigabyte-arm64/debian/control
+++ b/cuttlefish-integration-gigabyte-arm64/debian/control
@@ -14,11 +14,13 @@ Homepage: https://github.com/google/android-cuttlefish
 Package: cuttlefish-integration-gigabyte-arm64
 Architecture: any
 Multi-Arch: foreign
-Depends: dkms,
+Depends: default-jdk (>= 2:1.21),
+         dkms,
          libc6-dev,
          libglvnd-dev,
          lzop,
          ntpsec,
+         openjdk-25-jdk,
          pkgconf,
          ${misc:Depends},
          ${shlibs:Depends}


### PR DESCRIPTION
We've already migrate Gigabyte Ampere server installer to Trixie. Thus we can install openjdk-21 from the repo. Install it by default.

We also add modify the tests to check that the openjdk is installed and is the version we want.