### PR TITLE
Add WebRTC command to control LLOB sensor

### DIFF
--- a/base/cvd/cuttlefish/common/libs/sensors/sensors.h
+++ b/base/cvd/cuttlefish/common/libs/sensors/sensors.h
@@ -57,6 +57,7 @@ inline constexpr char OUTER_DELIM = ' ';
 inline constexpr int kUpdateRotationVec = 0;
 inline constexpr int kGetSensorsData = 1;
 inline constexpr int kUpdateHal = 2;
+inline constexpr int kUpdateLowLatencyOffBodyDetect = 3;
 
 using SensorsCmd = int;
 

--- a/base/cvd/cuttlefish/host/commands/sensors_simulator/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/sensors_simulator/main.cpp
@@ -78,6 +78,12 @@ Result<void> ProcessWebrtcRequest(transport::SharedFdChannel& channel,
                 "Can't send request for cmd: " << cmd);
       break;
     }
+    case kUpdateLowLatencyOffBodyDetect: {
+      double value;
+      CF_EXPECT(static_cast<bool>(ss >> value), kReqMisFormatted);
+      sensors_simulator.UpdateLowLatencyOffBodyDetect(value);
+      break;
+    }
     default: {
       return CF_ERR("Unsupported cmd: " << cmd);
     }

--- a/base/cvd/cuttlefish/host/commands/sensors_simulator/sensors_hal_proxy.cpp
+++ b/base/cvd/cuttlefish/host/commands/sensors_simulator/sensors_hal_proxy.cpp
@@ -33,7 +33,8 @@ static constexpr uint32_t kIntervalMs = 1000;
 static constexpr SensorsMask kContinuousModeSensors =
     (1 << kAccelerationId) | (1 << kGyroscopeId) | (1 << kMagneticId) |
     (1 << kPressureId) | (1 << kUncalibGyroscopeId) |
-    (1 << kUncalibAccelerationId) | (1 << kLightId);
+    (1 << kUncalibAccelerationId) | (1 << kLightId) |
+    (1 << kSensorHandleLowLatencyOffBodyDetect);
 
 Result<std::string> SensorIdToName(int id) {
   switch (id) {

--- a/base/cvd/cuttlefish/host/commands/sensors_simulator/sensors_simulator.cpp
+++ b/base/cvd/cuttlefish/host/commands/sensors_simulator/sensors_simulator.cpp
@@ -35,7 +35,8 @@ inline double ToRadians(double x) { return x * M_PI / 180; }
 // Check if a given sensor id provides scalar data
 static bool IsScalarSensor(int id) {
   return (id == kTemperatureId) || (id == kProximityId) || (id == kLightId) ||
-         (id == kPressureId) || (id == kHumidityId) || (id == kHingeAngle0Id);
+         (id == kPressureId) || (id == kHumidityId) || (id == kHingeAngle0Id) ||
+         (id == kSensorHandleLowLatencyOffBodyDetect);
 }
 
 // Calculate the rotation matrix of the pitch, roll, and yaw angles.
@@ -130,6 +131,10 @@ void SensorsSimulator::RefreshSensors(double x, double y, double z) {
   sensors_data_[kUncalibAccelerationId].v = acc_update;
   sensors_data_[kUncalibGyroscopeId].v = gyro_update;
   sensors_data_[kUncalibMagneticId].v = mgn_update;
+}
+
+void SensorsSimulator::UpdateLowLatencyOffBodyDetect(double value) {
+  sensors_data_[kSensorHandleLowLatencyOffBodyDetect].f = value;
 }
 
 std::string SensorsSimulator::GetSensorsData(const SensorsMask mask) {

--- a/base/cvd/cuttlefish/host/commands/sensors_simulator/sensors_simulator.h
+++ b/base/cvd/cuttlefish/host/commands/sensors_simulator/sensors_simulator.h
@@ -39,6 +39,7 @@ class SensorsSimulator {
   SensorsSimulator(bool is_auto);
   // Update sensor values based on new rotation status.
   void RefreshSensors(double x, double y, double z);
+  void UpdateLowLatencyOffBodyDetect(double value);
 
   // Return a string with serialized sensors data in ascending order of
   // sensor id. A bitmask is used to specify which sensors to include.

--- a/base/cvd/cuttlefish/host/frontend/webrtc/connection_observer.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/connection_observer.cpp
@@ -249,22 +249,13 @@ class ConnectionObserverImpl : public webrtc_streaming::ConnectionObserver {
 
   void OnSensorsMessage(const uint8_t *msg, size_t size) override {
     std::string msgstr(msg, msg + size);
-    std::vector<std::string_view> xyz = absl::StrSplit(msgstr, ' ');
 
-    if (xyz.size() != 3) {
-      LOG(WARNING) << "Invalid rotation angles: Expected 3, received "
-                   << xyz.size();
-      return;
+    if (msgstr.rfind(kOnSensorLowLatencyOffBodyDetectCmd, 0) == 0) {
+      auto payload = msgstr.substr(kOnSensorLowLatencyOffBodyDetectCmd.size());
+      HandleLowLatencyOffBodySensorMessage(payload);
+    } else {
+      HandleRotationSensorMessage(msgstr);
     }
-
-    double x, y, z;
-    CHECK(absl::SimpleAtod(xyz.at(0), &x))
-        << "X rotation value must be a double";
-    CHECK(absl::SimpleAtod(xyz.at(1), &y))
-        << "Y rotation value must be a double";
-    CHECK(absl::SimpleAtod(xyz.at(2), &z))
-        << "Z rotation value must be a double";
-    sensors_handler_.HandleMessage(x, y, z);
   }
 
   void OnLightsChannelOpen(
@@ -433,6 +424,32 @@ class ConnectionObserverImpl : public webrtc_streaming::ConnectionObserver {
     }
   }
 
+  void HandleRotationSensorMessage(const std::string &msg) {
+    std::vector<std::string_view> xyz = absl::StrSplit(msg, ' ');
+
+    if (xyz.size() != 3) {
+      LOG(WARNING) << "Invalid rotation angles: Expected 3, received "
+                   << xyz.size();
+      return;
+    }
+
+    double x, y, z;
+    CHECK(absl::SimpleAtod(xyz.at(0), &x))
+        << "X rotation value must be a double";
+    CHECK(absl::SimpleAtod(xyz.at(1), &y))
+        << "Y rotation value must be a double";
+    CHECK(absl::SimpleAtod(xyz.at(2), &z))
+        << "Z rotation value must be a double";
+    sensors_handler_.HandleMessage(x, y, z);
+  }
+
+  void HandleLowLatencyOffBodySensorMessage(const std::string &msg) {
+    double value;
+    CHECK(absl::SimpleAtod(msg, &value))
+        << "Low latency off body value must be a double";
+    sensors_handler_.HandleLowLatencyOffBodyDetectMessage(value);
+  }
+
   std::unique_ptr<InputConnector::EventSink> input_events_sink_;
   KernelLogEventsHandler &kernel_log_events_handler_;
   int kernel_log_subscription_id_ = -1;
@@ -448,6 +465,8 @@ class ConnectionObserverImpl : public webrtc_streaming::ConnectionObserver {
   std::shared_ptr<webrtc_streaming::LightsObserver> lights_observer_;
   int sensors_subscription_id = -1;
   int lights_subscription_id_ = -1;
+  static constexpr std::string_view kOnSensorLowLatencyOffBodyDetectCmd =
+      "low-latency-off-body-detect:";
 };
 
 CfConnectionObserverFactory::CfConnectionObserverFactory(

--- a/base/cvd/cuttlefish/host/frontend/webrtc/sensors_handler.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/sensors_handler.cpp
@@ -61,6 +61,20 @@ Result<void> SensorsHandler::RefreshSensors(const double x, const double y,
   return {};
 }
 
+Result<void> SensorsHandler::RefreshLowLatencyOffBodyDetect(
+    const double value) {
+  auto msg = std::to_string(value);
+  auto size = msg.size();
+  auto cmd = sensors::kUpdateLowLatencyOffBodyDetect;
+  auto request = CF_EXPECT(transport::CreateMessage(cmd, size),
+                           "Failed to allocate message for cmd: "
+                               << cmd << " with size: " << size << " bytes. ");
+  std::memcpy(request->payload, msg.data(), size);
+  CF_EXPECT(channel_.SendRequest(*request),
+            "Can't send request for cmd: " << cmd);
+  return {};
+}
+
 Result<std::string> SensorsHandler::GetSensorsData() {
   auto msg = std::to_string(kUiSupportedSensors);
   auto size = msg.size();
@@ -86,6 +100,16 @@ void SensorsHandler::HandleMessage(const double x, const double y, const double 
   auto refresh_result = RefreshSensors(x, y, z);
   if (!refresh_result.ok()) {
     LOG(ERROR) << "Failed to refresh sensors: " << refresh_result.error();
+    return;
+  }
+  UpdateSensorsUi();
+}
+
+void SensorsHandler::HandleLowLatencyOffBodyDetectMessage(double value) {
+  auto refresh_result = RefreshLowLatencyOffBodyDetect(value);
+  if (!refresh_result.ok()) {
+    LOG(ERROR) << "Failed to refresh low latency off body detect: "
+               << refresh_result.error().FormatForEnv();
     return;
   }
   UpdateSensorsUi();

--- a/base/cvd/cuttlefish/host/frontend/webrtc/sensors_handler.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/sensors_handler.h
@@ -31,11 +31,13 @@ class SensorsHandler {
   ~SensorsHandler();
 
   void HandleMessage(double x, double y, double z);
+  void HandleLowLatencyOffBodyDetectMessage(double value);
   int Subscribe(std::function<void(const uint8_t*, size_t)> send_to_client);
   void UnSubscribe(int subscriber_id);
 
  private:
   Result<void> RefreshSensors(double x, double y, double z);
+  Result<void> RefreshLowLatencyOffBodyDetect(double value);
   Result<std::string> GetSensorsData();
   void UpdateSensorsUi();
 


### PR DESCRIPTION
Update the sensor_simulator and the WebRTC protocol to support a new command which can update the value of LLOB (low latency off body) sensor.

BUG: 428611649
Test: Send "low-latency-off-body-detect:1" command via sensors-channel.
Change-Id: Ib967c3c8bd42d53f666c7356d4164083ce87498f