### PR TITLE
Check for null lights_observer in webrtc connection observer

### DIFF
--- a/base/cvd/cuttlefish/host/frontend/webrtc/connection_observer.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/connection_observer.cpp
@@ -271,12 +271,16 @@ class ConnectionObserverImpl : public webrtc_streaming::ConnectionObserver {
       std::function<bool(const Json::Value &)> lights_message_sender) override {
     VLOG(0) << "Lights channel open";
 
-    lights_subscription_id_ =
-        lights_observer_->Subscribe(lights_message_sender);
+    if (lights_observer_) {
+      lights_subscription_id_ =
+          lights_observer_->Subscribe(lights_message_sender);
+    }
   }
 
   void OnLightsChannelClosed() override {
-    lights_observer_->Unsubscribe(lights_subscription_id_);
+    if (lights_observer_) {
+      lights_observer_->Unsubscribe(lights_subscription_id_);
+    }
   }
 
   void OnLocationChannelOpen(std::function<bool(const uint8_t *, size_t)>


### PR DESCRIPTION
When the lights server is disabled (e.g. on auto_cf targets), lights_observer_ is a null pointer. Check for it in webrtc connection observer to prevent a crash when a WebUI client connects and triggers subscription to the lights channel.

Bug: b/489145090
Test: Disable lights server, build/launch cf, and then verify webUI