### PR TITLE
Introduce E2E tests on podcvd

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -520,7 +520,10 @@ jobs:
         # Grant permission on devices as it's hard to grant on test env
         sudo chmod 666 /dev/kvm /dev/vhost-net /dev/vhost-vsock
         cd e2etests
-        bazel test //cvd/display_tests \
+        bazel test \
+          //cvd/cvd_powerwash_tests \
+          //cvd/display_tests \
+          //cvd/env_tests \
           --test_env=HOME=$HOME \
           --test_env=USE_PODCVD=true \
           --test_env=XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR \

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -482,3 +482,46 @@ jobs:
         # Run create_from_images_zip_test e2e tests
         cd e2etests
         bazel test orchestration/create_from_images_zip_test:create_from_images_zip_test_test
+  e2etests-podcvd:
+    runs-on: ubuntu-24.04
+    needs: [build-debian-package-amd64, build-docker-image-amd64]
+    steps:
+    - name: Free disk space
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # aka v1.3.1
+      with:
+        docker-images: false
+        swap-storage: false
+        tool-cache: true
+    - name: Checkout repository
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+    - name: Download cuttlefish debs
+      uses: actions/download-artifact@v7
+      with:
+        name: debs_amd64
+    - name: Install cuttlefish-podcvd
+      run: |
+        tar -xvf debs_amd64.tar
+        sudo apt install -y ./cuttlefish-podcvd_*.deb
+        /usr/lib/cuttlefish-podcvd/bin/cuttlefish-podcvd-prerequisites.sh
+    - name: Download docker image
+      uses: actions/download-artifact@v7
+      with:
+        name: cuttlefish-orchestration-amd64
+    - name: Load docker image as podman image
+      run: |
+        sudo sysctl -w kernel.unprivileged_userns_clone=1
+        sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+        sudo apt install -y skopeo
+        skopeo copy \
+          docker-archive:cuttlefish-orchestration.tar \
+          containers-storage:localhost/cuttlefish-orchestration:latest
+    - name: Run cvd e2e test for podcvd
+      run: |
+        # Grant permission on devices as it's hard to grant on test env
+        sudo chmod 666 /dev/kvm /dev/vhost-net /dev/vhost-vsock
+        cd e2etests
+        bazel test //cvd/display_tests \
+          --test_env=HOME=$HOME \
+          --test_env=USE_PODCVD=true \
+          --test_env=XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR \
+          --test_output=errors

--- a/e2etests/cvd/bugreport_tests/main_test.go
+++ b/e2etests/cvd/bugreport_tests/main_test.go
@@ -35,7 +35,7 @@ func TestTakeBugreport(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := c.RunCmd("cvd", "host_bugreport"); err != nil {
+	if _, err := c.RunCmd(c.TargetBin(), "host_bugreport"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/e2etests/cvd/common/common.go
+++ b/e2etests/cvd/common/common.go
@@ -196,7 +196,7 @@ func (tc *TestContext) CVDCreate(args CreateArgs) error {
 		"HOME": tc.tempdir,
 	}
 
-	createCmd := []string{tc.TargetBin(), "create"};
+	createCmd := []string{tc.TargetBin(), "--verbosity=DEBUG", "create"};
 	createCmd = append(createCmd, "--report_anonymous_usage_stats=y")
 	createCmd = append(createCmd, "--undefok=report_anonymous_usage_stats")
 	if len(args.Args) > 0 {

--- a/e2etests/cvd/common/common.go
+++ b/e2etests/cvd/common/common.go
@@ -75,6 +75,8 @@ type TestContext struct {
 
 	context context.Context
 	cancelled bool
+
+	usePodcvd bool
 }
 
 func runCmdWithContextEnv(ctx context.Context, command []string, envvars map[string]string) (string, error) {
@@ -128,6 +130,14 @@ func (tc *TestContext) RunCmd(args... string) (string, error) {
 	return tc.RunCmdWithEnv(command, map[string]string{})
 }
 
+// Returns the binary name to test.
+func (tc *TestContext) TargetBin() string {
+	if tc.usePodcvd {
+		return "podcvd"
+	}
+	return "cvd"
+}
+
 // Common parameters passed to `cvd fetch`.
 type FetchArgs struct {
     DefaultBuildBranch string
@@ -151,7 +161,7 @@ type FetchAndCreateArgs struct {
 func (tc *TestContext) CVDFetch(args FetchArgs) error {
 	log.Printf("Fetching...")
 	fetchCmd := []string{
-		"cvd",
+		tc.TargetBin(),
 		"fetch",
 		fmt.Sprintf("--default_build=%s/%s", args.DefaultBuildBranch, args.DefaultBuildTarget),
 		fmt.Sprintf("--target_directory=%s", tc.tempdir),
@@ -186,7 +196,7 @@ func (tc *TestContext) CVDCreate(args CreateArgs) error {
 		"HOME": tc.tempdir,
 	}
 
-	createCmd := []string{"cvd", "create"};
+	createCmd := []string{tc.TargetBin(), "create"};
 	createCmd = append(createCmd, "--report_anonymous_usage_stats=y")
 	createCmd = append(createCmd, "--undefok=report_anonymous_usage_stats")
 	if len(args.Args) > 0 {
@@ -207,7 +217,7 @@ func (tc *TestContext) CVDStop() error {
 		"HOME": tc.tempdir,
 	}
 
-	stopCmd := []string{"cvd", "stop"};
+	stopCmd := []string{tc.TargetBin(), "stop"};
 	if _, err := tc.RunCmdWithEnv(stopCmd, tempdirEnv); err != nil {
 		log.Printf("Failed to stop instance(s): %w", err)
 		return err
@@ -259,7 +269,7 @@ func (tc *TestContext) CVDPowerwash() error {
 		"HOME": tc.tempdir,
 	}
 
-	createCmd := []string{"cvd", "powerwash"};
+	createCmd := []string{tc.TargetBin(), "powerwash"};
 	if _, err := tc.RunCmdWithEnv(createCmd, tempdirEnv); err != nil {
 		log.Printf("Failed to powerwash instance(s): %w", err)
 		return err
@@ -287,7 +297,7 @@ func  (tc *TestContext) CVDLoad(load LoadArgs) error {
 
 	log.Printf("Creating instance(s) via `cvd load`...")
 	loadCmd := []string{
-		"cvd",
+		tc.TargetBin(),
 		"load",
 		configpath,
 	};
@@ -330,11 +340,12 @@ func (tc *TestContext) SetUp(t *testing.T) {
 	tc.teardownCalled = false
 	cancellableContext, cancel := context.WithCancel(t.Context())
 	tc.context = cancellableContext
+	tc.usePodcvd = os.Getenv("USE_PODCVD") == "true"
 
 	log.Printf("Initializing %s test...", tc.t.Name())
 
 	log.Printf("Cleaning up any pre-existing instances...")
-	if _, err := tc.RunCmd("cvd", "reset", "-y"); err != nil {
+	if _, err := tc.RunCmd(tc.TargetBin(), "reset", "-y"); err != nil {
 		log.Printf("Failed to cleanup any pre-existing instances: %w", err)
 	}
 	log.Printf("Finished cleaning up any pre-existing instances!")
@@ -464,7 +475,7 @@ func (tc *TestContext) TearDown() {
 		}
 	}
 
-	runCmdWithContextEnv(context.TODO(), []string{"cvd", "reset", "-y"}, map[string]string{})
+	runCmdWithContextEnv(context.TODO(), []string{tc.TargetBin(), "reset", "-y"}, map[string]string{})
 
 	log.Printf("Finished cleaning up after test!")
 }

--- a/e2etests/cvd/display_tests/main_test.go
+++ b/e2etests/cvd/display_tests/main_test.go
@@ -35,7 +35,7 @@ func addDisplay(c e2etests.TestContext, t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := c.RunCmd("cvd", "display", "add", "--display=width=500,height=500",); err != nil {
+	if _, err := c.RunCmd(c.TargetBin(), "display", "add", "--display=width=500,height=500",); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -55,7 +55,7 @@ func listDisplays(c e2etests.TestContext, t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := c.RunCmd("cvd", "display", "list",); err != nil {
+	if _, err := c.RunCmd(c.TargetBin(), "display", "list",); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/e2etests/cvd/env_tests/main_test.go
+++ b/e2etests/cvd/env_tests/main_test.go
@@ -36,7 +36,7 @@ func TestListEnvServices(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := c.RunCmd("cvd", "env", "ls",); err != nil {
+	if _, err := c.RunCmd(c.TargetBin(), "env", "ls",); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/e2etests/cvd/metrics_tests/main_test.go
+++ b/e2etests/cvd/metrics_tests/main_test.go
@@ -50,7 +50,7 @@ func TestMetrics(t *testing.T) {
 
 	var metricsdir string
 	err := func() error {
-		output, err := c.RunCmd("cvd", "fleet")
+		output, err := c.RunCmd(c.TargetBin(), "fleet")
 		if err != nil {
 			return fmt.Errorf("failed to run `cvd fleet`")
 		}


### PR DESCRIPTION
`podcvd` aims to provide identical interface as `cvd` though, it doesn't ensure its functionality as `cvd` ensures as of today. `podcvd` has a lot of unimplemented features still, and there's a risk to break working features while implementing new. To improve `podcvd` more, leaning on E2E test is necessary and E2E test of `cvd` is reusable for validating `podcvd`, as their interface should be identical.

Today, `podcvd` only passes a part of `cvd` E2E tests. I set `display_test` as a minimal set of testing `podcvd` in advance though, I'd enlarge the test coverage of `podcvd` with enabling more tests on it.

On the other hand, I chose GitHub workflow rather than Kokoro for `podcvd` E2E testing because Kokoro check is already a critical path of the presubmit check, and I believe adding `podcvd` on it could be burdening on our DevX. And I expect adding `podcvd` E2E test won't charge more as it uses GitHub standard(free tier) runner. Probably we can switch `podcvd` E2E tests into Kokoro instances afterwards, when we desires.

Context: b/495601167