### PR TITLE
Fixed mtools build.

### DIFF
--- a/base/cvd/build_external/mtools/config.h
+++ b/base/cvd/build_external/mtools/config.h
@@ -323,7 +323,7 @@
 #define HAVE_TERMIOS_H 1
 
 /* Define to 1 if you have the <termio.h> header file. */
-#define HAVE_TERMIO_H 1
+/* #undef HAVE_TERMIO_H */
 
 /* Define to 1 if you have the <time.h> header file. */
 #define HAVE_TIME_H 1


### PR DESCRIPTION
termio.h was dropped on the latest glibc update to 2.42. Remove it from the build as well.

Bug: b/490465522