### PR TITLE
Set default file attributes for fetches

### DIFF
--- a/base/cvd/cuttlefish/host/libs/zip/zip_file.cc
+++ b/base/cvd/cuttlefish/host/libs/zip/zip_file.cc
@@ -72,6 +72,12 @@ Result<void> ExtractFile(ReadableZip& zip, std::string_view zip_path,
   CF_EXPECT(SparseCopy(*reader, *writer));
 
   if (Result<uint32_t> attr = zip.FileAttributes(zip_path); attr.ok()) {
+    // The fetcher must occasionally download archives from Android 10 or 11
+    // which incorrectly had the file attributes set to 0. To remedy this
+    // set them to a safe 0640.
+    if(*attr == 0) {
+      *attr = 0640;
+    }
     CF_EXPECT_EQ(chmod(host_path.c_str(), *attr), 0, StrError(errno));
   }
   return {};


### PR DESCRIPTION
Older Android archives (A11 and A10) contain images with incorrect file attributes set to 0. If these are detected on a download, set them to 0640 - a minimally permissive default.

Bug: b/499569737