### PR TITLE
gigabyte-ampere-cuttlefish-installer: preseed.cfg: make dhcp timeout …

### DIFF
--- a/gigabyte-ampere-cuttlefish-installer/preseed/preseed.cfg
+++ b/gigabyte-ampere-cuttlefish-installer/preseed/preseed.cfg
@@ -12,6 +12,15 @@ d-i keyboard-configuration/xkb-keymap select us
 # skip displaying a list if there is more than one interface.
 d-i netcfg/choose_interface select auto
 
+# To set a different link detection timeout (default is 3 seconds).
+# Values are interpreted as seconds.
+d-i netcfg/link_wait_timeout string 30
+
+# If you have a slow dhcp server and the installer times out waiting for
+# it, this might be useful.
+d-i netcfg/dhcp_timeout string 90
+d-i netcfg/dhcpv6_timeout string 90
+
 # Any hostname and domain names assigned from dhcp take precedence over
 # values set here. However, setting the values still prevents the questions
 # from being shown, even if values come from dhcp.


### PR DESCRIPTION
gigabyte-ampere-cuttlefish-installer: preseed.cfg: make dhcp timeout longer

We met an issue that the installer failed with
"Your network is probably not using the DHCP protocol. Alternatively, the DHCP server may be slow or some network hardware is not working properly."

We make the dhcp timeout longer for fixing this issue.