### PR TITLE
rules_rust: add riscv64 host support

### DIFF
--- a/base/cvd/MODULE.bazel
+++ b/base/cvd/MODULE.bazel
@@ -65,3 +65,18 @@ include("//toolchain:bazel.MODULE.bazel")
 include("//toolchain:llvm.MODULE.bazel")
 include("//toolchain:python.MODULE.bazel")
 include("//toolchain:rust.MODULE.bazel")
+
+# riscv64: rules_rust does not support riscv64 host out of the box.
+# Patch triple.bzl to add riscv64gc to the supported linux architectures
+# and map the riscv64 arch string to riscv64gc (Rust's triple prefix).
+# Also patch crate_universe to include riscv64gc-unknown-linux-gnu in the
+# default SUPPORTED_PLATFORM_TRIPLES so generated BUILD files are compatible.
+single_version_override(
+    module_name = "rules_rust",
+    patches = [
+        "//patches/rules_rust:riscv64_triple.patch",
+        "//patches/rules_rust:riscv64_supported_platform.patch",
+    ],
+    patch_strip = 1,
+)
+

--- a/base/cvd/patches/rules_rust/BUILD.bazel
+++ b/base/cvd/patches/rules_rust/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(glob(["*.patch"]))

--- a/base/cvd/patches/rules_rust/riscv64_supported_platform.patch
+++ b/base/cvd/patches/rules_rust/riscv64_supported_platform.patch
@@ -1,0 +1,10 @@
+--- a/crate_universe/private/crates_repository.bzl
++++ b/crate_universe/private/crates_repository.bzl
+@@ -34,6 +34,7 @@
+     "x86_64-pc-windows-msvc",
+     "x86_64-unknown-linux-gnu",
+     "x86_64-unknown-nixos-gnu",
++    "riscv64gc-unknown-linux-gnu",
+ ]
+
+ def _crates_repository_impl(repository_ctx):

--- a/base/cvd/patches/rules_rust/riscv64_triple.patch
+++ b/base/cvd/patches/rules_rust/riscv64_triple.patch
@@ -1,0 +1,21 @@
+--- a/rust/platform/triple.bzl
++++ b/rust/platform/triple.bzl
+@@ -129,7 +129,7 @@
+     # Detect the host's cpu architecture
+ 
+     supported_architectures = {
+-        "linux": ["aarch64", "x86_64", "s390x", "powerpc64le"],
++        "linux": ["aarch64", "x86_64", "s390x", "powerpc64le", "riscv64gc"],
+         "macos": ["aarch64", "x86_64"],
+         "windows": ["aarch64", "x86_64"],
+     }
+@@ -141,6 +141,9 @@
+     if arch == "ppc64le":
+         arch = "powerpc64le"
+ 
++    if arch == "riscv64":
++        arch = "riscv64gc"
++
+     if "linux" in repository_ctx.os.name:
+         _validate_cpu_architecture(arch, supported_architectures["linux"])
+         prefix = "{}-unknown-linux".format(arch)

--- a/base/cvd/toolchain/rust.MODULE.bazel
+++ b/base/cvd/toolchain/rust.MODULE.bazel
@@ -1,3 +1,22 @@
+rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
+
+# Add an explicit riscv64gc Linux repository_set, because rules_rust 0.68.1's
+# default toolchain triple table does not include riscv64gc-unknown-linux-gnu.
+rust.repository_set(
+    name = "rust_linux_riscv64gc",
+    edition = "2021",
+    exec_triple = "riscv64gc-unknown-linux-gnu",
+    target_triple = "riscv64gc-unknown-linux-gnu",
+    versions = ["1.86.0"],
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:riscv64",
+    ],
+)
+
+use_repo(rust, "rust_toolchains")
+register_toolchains("@rust_toolchains//:all")
+
 rust_host_tools = use_extension("@rules_rust//rust:extensions.bzl", "rust_host_tools")
 rust_host_tools.host_tools(
     name = "rust_host_tools_nightly",


### PR DESCRIPTION
Patch rules_rust 0.68.1 to support riscv64 as a host architecture:
- Add riscv64gc to supported linux architectures in triple.bzl
- Add riscv64gc-unknown-linux-gnu to SUPPORTED_PLATFORM_TRIPLES in crate_universe for generated BUILD files
- Register riscv64gc Rust toolchain with Rust 1.86.0