### PR TITLE
toolchains_llvm: add riscv64 host support via MODULE.bazel patches

### DIFF
--- a/base/cvd/MODULE.bazel
+++ b/base/cvd/MODULE.bazel
@@ -65,3 +65,18 @@ include("//toolchain:bazel.MODULE.bazel")
 include("//toolchain:llvm.MODULE.bazel")
 include("//toolchain:python.MODULE.bazel")
 include("//toolchain:rust.MODULE.bazel")
+
+# riscv64: rules_rust does not support riscv64 host out of the box.
+# Patch triple.bzl to add riscv64gc to the supported linux architectures
+# and map the riscv64 arch string to riscv64gc (Rust's triple prefix).
+# Also patch crate_universe to include riscv64gc-unknown-linux-gnu in the
+# default SUPPORTED_PLATFORM_TRIPLES so generated BUILD files are compatible.
+single_version_override(
+    module_name = "rules_rust",
+    patches = [
+        "//patches/rules_rust:riscv64_triple.patch",
+        "//patches/rules_rust:riscv64_supported_platform.patch",
+    ],
+    patch_strip = 1,
+)
+

--- a/base/cvd/MODULE.bazel
+++ b/base/cvd/MODULE.bazel
@@ -80,3 +80,14 @@ single_version_override(
     patch_strip = 1,
 )
 
+# riscv64: toolchains_llvm does not support riscv64 as a host architecture.
+# Patch to add linux-riscv64 to SUPPORTED_TARGETS and its target system name.
+single_version_override(
+    module_name = "toolchains_llvm",
+    patches = [
+        "//patches/toolchains_llvm:riscv64_common.patch",
+        "//patches/toolchains_llvm:riscv64_configure.patch",
+        "//patches/toolchains_llvm:riscv64_cc_toolchain_config.patch",
+    ],
+    patch_strip = 1,
+)

--- a/base/cvd/patches/rules_rust/BUILD.bazel
+++ b/base/cvd/patches/rules_rust/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["riscv64_triple.patch"])

--- a/base/cvd/patches/rules_rust/riscv64_supported_platform.patch
+++ b/base/cvd/patches/rules_rust/riscv64_supported_platform.patch
@@ -1,0 +1,10 @@
+--- a/crate_universe/private/crates_repository.bzl
++++ b/crate_universe/private/crates_repository.bzl
+@@ -34,6 +34,7 @@
+     "x86_64-pc-windows-msvc",
+     "x86_64-unknown-linux-gnu",
+     "x86_64-unknown-nixos-gnu",
++    "riscv64gc-unknown-linux-gnu",
+ ]
+
+ def _crates_repository_impl(repository_ctx):

--- a/base/cvd/patches/rules_rust/riscv64_triple.patch
+++ b/base/cvd/patches/rules_rust/riscv64_triple.patch
@@ -1,0 +1,21 @@
+--- a/rust/platform/triple.bzl
++++ b/rust/platform/triple.bzl
+@@ -129,7 +129,7 @@
+     # Detect the host's cpu architecture
+ 
+     supported_architectures = {
+-        "linux": ["aarch64", "x86_64", "s390x", "powerpc64le"],
++        "linux": ["aarch64", "x86_64", "s390x", "powerpc64le", "riscv64gc"],
+         "macos": ["aarch64", "x86_64"],
+         "windows": ["aarch64", "x86_64"],
+     }
+@@ -141,6 +141,9 @@
+     if arch == "ppc64le":
+         arch = "powerpc64le"
+ 
++    if arch == "riscv64":
++        arch = "riscv64gc"
++
+     if "linux" in repository_ctx.os.name:
+         _validate_cpu_architecture(arch, supported_architectures["linux"])
+         prefix = "{}-unknown-linux".format(arch)

--- a/base/cvd/patches/toolchains_llvm/BUILD.bazel
+++ b/base/cvd/patches/toolchains_llvm/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(glob(["*.patch"]))

--- a/base/cvd/patches/toolchains_llvm/riscv64_cc_toolchain_config.patch
+++ b/base/cvd/patches/toolchains_llvm/riscv64_cc_toolchain_config.patch
@@ -1,0 +1,17 @@
+--- a/toolchain/cc_toolchain_config.bzl
++++ b/toolchain/cc_toolchain_config.bzl
+@@ -82,6 +82,14 @@ def cc_toolchain_config(
+             "clang",
+             "glibc_unknown",
+         ),
++        "linux-riscv64": (
++            "clang-riscv64-linux",
++            "riscv64",
++            "glibc_unknown",
++            "clang",
++            "clang",
++            "glibc_unknown",
++        ),
+         "linux-armv7": (
+             "clang-armv7-linux",
+             "armv7",

--- a/base/cvd/patches/toolchains_llvm/riscv64_common.patch
+++ b/base/cvd/patches/toolchains_llvm/riscv64_common.patch
@@ -1,0 +1,10 @@
+--- a/toolchain/internal/common.bzl
++++ b/toolchain/internal/common.bzl
+@@ -16,6 +16,7 @@ SUPPORTED_TARGETS = [
+     ("linux", "x86_64"),
+     ("linux", "aarch64"),
+     ("linux", "armv7"),
++    ("linux", "riscv64"),
+     ("darwin", "x86_64"),
+     ("darwin", "aarch64"),
+     ("none", "riscv32"),

--- a/base/cvd/patches/toolchains_llvm/riscv64_configure.patch
+++ b/base/cvd/patches/toolchains_llvm/riscv64_configure.patch
@@ -1,0 +1,10 @@
+--- a/toolchain/internal/configure.bzl
++++ b/toolchain/internal/configure.bzl
+@@ -347,6 +347,7 @@ def _cc_toolchain_str(
+         "darwin-aarch64": "aarch64-apple-macosx",
+         "linux-aarch64": "aarch64-unknown-linux-gnu",
+         "linux-armv7": "armv7-unknown-linux-gnueabihf",
++        "linux-riscv64": "riscv64-unknown-linux-gnu",
+         "linux-x86_64": "x86_64-unknown-linux-gnu",
+         "none-riscv32": "riscv32-unknown-none-elf",
+         "none-x86_64": "x86_64-unknown-none",

--- a/base/cvd/toolchain/llvm.MODULE.bazel
+++ b/base/cvd/toolchain/llvm.MODULE.bazel
@@ -3,6 +3,14 @@ llvm.toolchain(
     llvm_version = "19.1.7",
 )
 
+# riscv64: no prebuilt LLVM toolchain is available for riscv64 host.
+# Use the system-installed clang-19 from /usr/lib/llvm-19.
+llvm.toolchain_root(
+    name = "llvm_toolchain",
+    targets = ["linux-riscv64"],
+    path = "/usr/lib/llvm-19",
+)
+
 use_repo(llvm, "llvm_toolchain")
 
 register_toolchains(

--- a/base/cvd/toolchain/rust.MODULE.bazel
+++ b/base/cvd/toolchain/rust.MODULE.bazel
@@ -1,3 +1,22 @@
+rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
+
+# Add an explicit riscv64gc Linux repository_set, because rules_rust 0.68.1's
+# default toolchain triple table does not include riscv64gc-unknown-linux-gnu.
+rust.repository_set(
+    name = "rust_linux_riscv64gc",
+    edition = "2021",
+    exec_triple = "riscv64gc-unknown-linux-gnu",
+    target_triple = "riscv64gc-unknown-linux-gnu",
+    versions = ["1.86.0"],
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:riscv64",
+    ],
+)
+
+use_repo(rust, "rust_toolchains")
+register_toolchains("@rust_toolchains//:all")
+
 rust_host_tools = use_extension("@rules_rust//rust:extensions.bzl", "rust_host_tools")
 rust_host_tools.host_tools(
     name = "rust_host_tools_nightly",


### PR DESCRIPTION
toolchains_llvm 1.6.0 does not support riscv64 as a host architecture.
Patch three files to add linux-riscv64:
    - toolchain/internal/common.bzl: add (linux, riscv64) to SUPPORTED_TARGETS
    - toolchain/internal/configure.bzl: add riscv64-unknown-linux-gnu target
      system name mapping
    - toolchain/cc_toolchain_config.bzl: add linux-riscv64 toolchain config
      entry mirroring linux-aarch64
    
Also configure llvm.MODULE.bazel to use the system-installed clang-19
as the toolchain root for riscv64, since no prebuilt LLVM distribution exists 
for riscv64 Linux host.
