### PR TITLE
Add udev rules for reverse ncm device interface service

### DIFF
--- a/base/debian/cuttlefish-base.udev
+++ b/base/debian/cuttlefish-base.udev
@@ -1,2 +1,5 @@
 ACTION=="add", KERNEL=="vhost-net", SUBSYSTEM=="misc", MODE="0660", GROUP="cvdnetwork"
 ACTION=="add", KERNEL=="vhost-vsock", SUBSYSTEM=="misc", MODE="0660", GROUP="cvdnetwork"
+
+ACTION=="add", SUBSYSTEM=="net", ENV{ID_NET_DRIVER}=="cdc_ncm", ENV{ID_VENDOR_ID}=="18d1", ENV{ID_MODEL_ID}=="4ef2", ENV{NM_UNMANAGED}="1", RUN+="/sbin/ip link set dev $env{ID_NET_NAME} master cvd-ebr up"
+ACTION=="add", SUBSYSTEM=="net", ENV{ID_NET_DRIVER}=="cdc_ncm", ENV{ID_VENDOR_ID}=="18d1", ENV{ID_MODEL_ID}=="4ef3", ENV{NM_UNMANAGED}="1", RUN+="/sbin/ip link set dev $env{ID_NET_NAME} master cvd-ebr up"


### PR DESCRIPTION
Pixel 6+ phones in "Reverse Ncm Device Interface Service" mode (without/with adb debug interface) show up with USB VID:PID 18d1:4ef{2,3}.

This is effectively the reverse of ncm tethering.
In normal tethering the phone provides a DHCPv4 server (and broadcasts IPv6 RAs). In reverse tethering the phone runs a DHCP client, and expects the other end of the connection to operate the DHCP server (and/or provide IPv6 RAs).

Cuttlefish already provides the required services (cvd-ebr bridge, dnsmasq, iptables MASQUERADE rules), so all we actually need to do is add the appropriate usb cdc ncm interface into the bridge and things magically just work.

This mode can be enabled via:
  adb shell svc usb setFunctions 'rndis'
and disabled via:
  adb shell svc usb setFunctions ''

Bug: 500283166