### PR TITLE
Use `androidboot.cuttlefish_service_bluetooth_checker` in launcher.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/bootconfig_args.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/bootconfig_args.cpp
@@ -259,6 +259,13 @@ Result<std::unordered_map<std::string, std::string>> BootconfigArgsFromConfig(
             : "com.google.emulated.camera.provider.hal.v4l2";
   }
 
+  if (instance.device_type() == cuttlefish::DeviceType::Auto) {
+    if (!builtin_bootconfig_args.count("androidboot.cuttlefish_service_bluetooth_checker")) {
+      // # TODO (b/405655265) Remove once the BT issue is fixed
+      bootconfig_args["androidboot.cuttlefish_service_bluetooth_checker"] = "false";
+    }
+  }
+
   if (!instance.vcpu_config_path().empty()) {
     auto vcpu_config_json =
         CF_EXPECT(LoadFromFile(instance.vcpu_config_path()));


### PR DESCRIPTION
Bug: b/495490297