### PR TITLE
Fix 9 ClangTidyReadability findings:

### DIFF
--- a/base/cvd/cuttlefish/host/commands/modem_simulator/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/main.cpp
@@ -105,7 +105,7 @@ int ModemSimulatorMain(int argc, char** argv) {
 
     auto modem_simulator = std::make_unique<ModemSimulator>(modem_id);
     auto channel_monitor =
-        std::make_unique<ChannelMonitor>(*modem_simulator.get(), fd);
+        std::make_unique<ChannelMonitor>(*modem_simulator, fd);
 
     modem_simulator->Initialize(std::move(channel_monitor));
 

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/network_service.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/network_service.cpp
@@ -178,7 +178,7 @@ void NetworkService::InitializeSimOperator() {
     return;
   }
   auto sim_operator_numeric = sim_service_->GetSimOperator();
-  if (sim_operator_numeric == "") {
+  if (sim_operator_numeric.empty()) {
     return;
   }
 

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/sim_service.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/sim_service.cpp
@@ -778,10 +778,10 @@ bool SimService::SetPhoneNumber(std::string_view number) {
   std::string bcd_number = PDUParser::StringToBCD(number);
   int newLength = 0;
   // Skip Type(91) and Country Code(68)
-  if (number.size() == 12 && number.compare("68") == 0) {
+  if (number.size() == 12 && number == "68") {
     record.replace(footerOffset + 6, bcd_number.size(), bcd_number);
     newLength = 8;
-  } else { // Skip Type(81)
+  } else {  // Skip Type(81)
     record.replace(footerOffset + 4, bcd_number.size(), bcd_number);
     newLength = (bcd_number.size() + 2) / 2;
   }
@@ -957,7 +957,7 @@ void SimService::HandleSIM_IO(const Client& client,
   }
 
   SimFileSystem::EFId fileid = (SimFileSystem::EFId)std::stoi(id, nullptr, 16);
-  if (path == "") {
+  if (path.empty()) {
     path = SimFileSystem::GetUsimEFPath(fileid);
   }
   // EF_ADN under DF_PHONEBOOK is mapped to EF_ADN under DF_TELECOM per

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/sms_service.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/sms_service.cpp
@@ -286,7 +286,7 @@ void SmsService::HandleSendSMSPDU(const Client& client, std::string& command) {
     port = std::stoi(phone_number);
   }
 
-  if (phone_number == "") {  /* Phone number unknown */
+  if (phone_number.empty()) {  /* Phone number unknown */
     LOG(ERROR) << "Failed to get phone number form address";
     client.SendCommandResponse(kCmsErrorSCAddressUnknown);
     return;
@@ -330,7 +330,7 @@ void SmsService::HandleSendSMSPDU(const Client& client, std::string& command) {
 /* AT+CMGS callback function */
 void SmsService::HandleReceiveSMS(PDUParser sms_pdu) {
   std::string pdu = sms_pdu.CreatePDU();
-  if (pdu != "") {
+  if (!pdu.empty()) {
     SendUnsolicitedCommand("+CMT: 0");
     SendUnsolicitedCommand(pdu);
   }
@@ -361,7 +361,7 @@ void SmsService::HandleSMSStatuReport(PDUParser sms_pdu, int message_reference) 
 
   auto pdu = sms_pdu.CreateStatuReport(message_reference);
   auto pdu_length = (pdu.size() - 2) / 2;  // Not Including SMSC Address
-  if (pdu != "" && pdu_length > 0) {
+  if (!pdu.empty() && pdu_length > 0) {
     ss << "+CDS: " << pdu_length;
     SendUnsolicitedCommand(ss.str());
     SendUnsolicitedCommand(pdu);
@@ -380,7 +380,7 @@ void SmsService::HandleReceiveRemoteSMS(const Client& /*client*/, std::string& c
     return;
   }
   pdu = sms_pdu.CreatePDU();
-  if (pdu != "") {
+  if (!pdu.empty()) {
     SendUnsolicitedCommand("+CMT: 0");
     SendUnsolicitedCommand(pdu);
   }

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/stk_service.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/stk_service.cpp
@@ -247,7 +247,7 @@ void StkService::OnUnsolicitedCommandForTR(std::string& command) {
 
   if (menu_id == "11") {  // BACKWARD_MOVE_BY_USER
     current_select_item_menu_ids_.pop_back();
-    if (current_select_item_menu_ids_.size() >= 1) {
+    if (!current_select_item_menu_ids_.empty()) {
       select_item = GetCurrentSelectItem();
       auto text = select_item->FindAttribute("text");
       if (text) {


### PR DESCRIPTION
* the 'empty' method should be used to check for emptiness instead of comparing to an empty object.
* do not use 'compare' to test equality of strings; use the string equality operator instead.
* redundant get() call on smart pointer.
* the 'empty' method should be used to check for emptiness instead of 'size'.