### PR TITLE
cargo-bazel: add riscv64 support for CARGO_BAZEL_GENERATOR

### DIFF
--- a/base/debian/rules
+++ b/base/debian/rules
@@ -9,6 +9,20 @@
 
 include /usr/share/dpkg/buildflags.mk
 
+# for riscv64 host, we rely on environment vars for cargo-bazel
+ifeq ($(DEB_HOST_ARCH),riscv64)
+  ifndef CARGO_BAZEL_GENERATOR_URL
+    $(error riscv64 requires CARGO_BAZEL_GENERATOR_URL to be set. \
+      cargo-bazel must be built from source and the URL provided. \
+      Example: export CARGO_BAZEL_GENERATOR_URL=file:///usr/local/bin/cargo-bazel \
+      See docs/riscv64-setup.md for full instructions.)
+  endif
+  export CARGO_BAZEL_GENERATOR_URL
+  ifdef CARGO_BAZEL_GENERATOR_SHA256
+    export CARGO_BAZEL_GENERATOR_SHA256
+  endif
+endif
+
 # Retrieve bazel's view of the current compilation_mode
 compilation_mode :=
 default_compilation_mode := \

--- a/tools/buildutils/build_package.sh
+++ b/tools/buildutils/build_package.sh
@@ -64,6 +64,12 @@ fi
 if [ -n "${https_proxy:-}" ]; then
   preserve_envvar+=" -e https_proxy=${https_proxy}"
 fi
+if [ -n "${CARGO_BAZEL_GENERATOR_URL:-}" ]; then
+  preserve_envvar+=" -e CARGO_BAZEL_GENERATOR_URL=${CARGO_BAZEL_GENERATOR_URL}"
+fi
+if [ -n "${CARGO_BAZEL_GENERATOR_SHA256:-}" ]; then
+  preserve_envvar+=" -e CARGO_BAZEL_GENERATOR_SHA256=${CARGO_BAZEL_GENERATOR_SHA256}"
+fi
 
 pushd "${PKGDIR}"
 echo "Installing package dependencies"


### PR DESCRIPTION
On riscv64 no prebuilt cargo-bazel binary exists; require
CARGO_BAZEL_GENERATOR_URL to be set in debian/rules and pass
it through to the build container in build_package.sh.