### PR TITLE
swiftshader: add riscv64 default condition to select() blocks

### DIFF
--- a/base/cvd/build_external/swiftshader/BUILD.swiftshader.bazel
+++ b/base/cvd/build_external/swiftshader/BUILD.swiftshader.bazel
@@ -1447,6 +1447,10 @@ cc_library(
             "third_party/llvm-16.0/llvm/lib/Target/X86/X86VZeroUpper.cpp",
             "third_party/llvm-16.0/llvm/lib/Target/X86/X86WinEHState.cpp",
         ],
+        "@platforms//cpu:riscv64": [
+            # No arch-specific LLVM JIT backend sources for riscv64.
+            # SwiftShader will build but JIT compilation will not be available.
+        ],
     }),
     hdrs = glob([
         "third_party/llvm-16.0/configs/common/include/**/*.h",


### PR DESCRIPTION
The LLVM backend sources select() in BUILD.swiftshader.bazel only lists
x86_64 and aarch64 entries. On riscv64 Bazel fails with 'no matching
condition'. Add //conditions:default: [] so riscv64 falls through to
pure C/software rendering (SwiftShader's CPU renderer works without
arch-specific LLVM backends).