### PR TITLE
gfxstream: include sys/syscall.h for memfd_create on riscv64

### DIFF
--- a/base/cvd/build_external/gfxstream/gfxstream.MODULE.bazel
+++ b/base/cvd/build_external/gfxstream/gfxstream.MODULE.bazel
@@ -8,5 +8,6 @@ git_repository(
     patches = [
         "@//build_external/gfxstream:PATCH.gfxstream.build_variables.patch",
         "@//build_external/gfxstream:bazel9.patch",
+        "@//build_external/gfxstream:riscv64_memfd_create.patch",
     ],
 )

--- a/base/cvd/build_external/gfxstream/riscv64_memfd_create.patch
+++ b/base/cvd/build_external/gfxstream/riscv64_memfd_create.patch
@@ -1,0 +1,10 @@
+--- a/common/base/SharedMemory_posix.cpp
++++ b/common/base/SharedMemory_posix.cpp
+@@ -16,6 +16,7 @@
+ #include <sys/stat.h>
+ #include <unistd.h>
+
++#include <sys/syscall.h>
+ #include "gfxstream/EintrWrapper.h"
+ #include "gfxstream/Macros.h"
+ #include "gfxstream/files/PathUtils.h"


### PR DESCRIPTION
SharedMemory_posix.cpp has hardcoded __NR_memfd_create syscall numbers
for x86/arm but not riscv64.  Including sys/syscall.h provides the
correct kernel-defined value, so the hardcoded fallback is skipped.