### PR TITLE
libffi: add riscv64 arch support with pre-generated config headers

### DIFF
--- a/base/cvd/build_external/libffi/BUILD.libffi.bazel
+++ b/base/cvd/build_external/libffi/BUILD.libffi.bazel
@@ -33,6 +33,12 @@ SRCS_ARM64 = [
     "src/aarch64/sysv.S",
 ]
 
+SRCS_RISCV64 = [
+    "src/riscv/ffi.c",
+    "src/riscv/ffitarget.h",
+    "src/riscv/sysv.S",
+]
+
 COPTS_X86_64 = [
     "-DHAVE_AS_X86_PCREL",
     "-DHAVE_AS_ASCII_PSEUDO_OP",
@@ -41,12 +47,19 @@ COPTS_X86_64 = [
 COPTS_ARM64 = [
 ]
 
+COPTS_RISCV64 = [
+]
+
 DEPS_X86_64 = [
     "@//build_external/libffi/linux-x86:libffi_linux_x86",
 ]
 
 DEPS_ARM64 = [
     "@//build_external/libffi/linux-arm64:libffi_linux_arm64",
+]
+
+DEPS_RISCV64 = [
+    "@//build_external/libffi/linux-riscv64:libffi_linux_riscv64",
 ]
 
 genrule(
@@ -76,6 +89,7 @@ cc_library(
     srcs = COMMON_SRCS + select({
         "@platforms//cpu:x86_64": SRCS_X86_64,
         "@platforms//cpu:arm64": SRCS_ARM64,
+        "@platforms//cpu:riscv64": SRCS_RISCV64,
         "//conditions:default": [],
     }),
     copts = [
@@ -94,11 +108,13 @@ cc_library(
     ] + select({
         "@platforms//cpu:x86_64": COPTS_X86_64,
         "@platforms//cpu:arm64": COPTS_ARM64,
+        "@platforms//cpu:riscv64": COPTS_RISCV64,
         "//conditions:default": [],
     }),
     deps = [":libffi_include"] + select({
         "@platforms//cpu:x86_64": DEPS_X86_64,
         "@platforms//cpu:arm64": DEPS_ARM64,
+        "@platforms//cpu:riscv64": DEPS_RISCV64,
         "//conditions:default": [],
     }),
 )

--- a/base/cvd/build_external/libffi/linux-riscv64/BUILD.bazel
+++ b/base/cvd/build_external/libffi/linux-riscv64/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "libffi_linux_riscv64",
+    hdrs = [
+        "ffi.h",
+        "fficonfig.h",
+    ],
+    includes = ["."],
+    visibility = ["//visibility:public"],
+)

--- a/base/cvd/build_external/libffi/linux-riscv64/ffi.h
+++ b/base/cvd/build_external/libffi/linux-riscv64/ffi.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef LIBFFI_H
+
+#define RISCV
+#define CONF_HAVE_LONG_DOUBLE 1
+
+#define LIBFFI_H
+#include "../src/riscv/ffitarget.h"
+#undef LIBFFI_H
+
+#include "ffi_gen.h"
+
+#endif

--- a/base/cvd/build_external/libffi/linux-riscv64/fficonfig.h
+++ b/base/cvd/build_external/libffi/linux-riscv64/fficonfig.h
@@ -1,0 +1,164 @@
+/* fficonfig.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define to one of `_getb67', `GETB67', `getb67' for Cray-2 and Cray-YMP
+   systems. This function is required for `alloca.c' support on those systems.
+   */
+#undef CRAY_STACKSEG_END
+
+/* Define to 1 if using `alloca.c'. */
+#undef C_ALLOCA
+
+/* Define to the flags needed for the .section .eh_frame directive. */
+#define EH_FRAME_FLAGS "aw"
+
+/* Define this if you want extra debugging. */
+#undef FFI_DEBUG
+
+/* Define this is you do not want support for the raw API. */
+#undef FFI_NO_RAW_API
+
+/* Define this is you do not want support for aggregate types. */
+#undef FFI_NO_STRUCTS
+
+/* Define to 1 if you have `alloca', as a function or macro. */
+#define HAVE_ALLOCA 1
+
+/* Define to 1 if you have <alloca.h> and it should be used (not on Ultrix).
+   */
+#define HAVE_ALLOCA_H 1
+
+/* Define if your assembler supports .cfi_* directives. */
+#undef HAVE_AS_CFI_PSEUDO_OP
+
+/* Define if your assembler supports .register. */
+#undef HAVE_AS_REGISTER_PSEUDO_OP
+
+/* Define if your assembler and linker support unaligned PC relative relocs.
+   */
+#undef HAVE_AS_SPARC_UA_PCREL
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define if __attribute__((visibility("hidden"))) is supported. */
+#define HAVE_HIDDEN_VISIBILITY_ATTRIBUTE 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define if you have the long double type and it is bigger than a double */
+#undef HAVE_LONG_DOUBLE
+
+/* Define to 1 if you have the `memcpy' function. */
+#define HAVE_MEMCPY 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the `mmap' function. */
+#define HAVE_MMAP 1
+
+/* Define if mmap with MAP_ANON(YMOUS) works. */
+#define HAVE_MMAP_ANON 1
+
+/* Define if mmap of /dev/zero works. */
+#define HAVE_MMAP_DEV_ZERO 1
+
+/* Define if read-only mmap of a plain file works. */
+#define HAVE_MMAP_FILE 1
+
+/* Define if .eh_frame sections should be read-only. */
+#undef HAVE_RO_EH_FRAME
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#undef HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/mman.h> header file. */
+#define HAVE_SYS_MMAN_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to 1 if your C compiler doesn't accept -c and -o together. */
+#undef NO_MINUS_C_MINUS_O
+
+/* Name of package */
+#define PACKAGE "libffi"
+
+/* Define to the address where bug reports for this package should be sent. */
+#undef PACKAGE_BUGREPORT
+
+/* Define to the full name of this package. */
+#undef PACKAGE_NAME
+
+/* Define to the full name and version of this package. */
+#undef PACKAGE_STRING
+
+/* Define to the one symbol short name of this package. */
+#undef PACKAGE_TARNAME
+
+/* Define to the version of this package. */
+#undef PACKAGE_VERSION
+
+/* The size of `double', as computed by sizeof. */
+#define SIZEOF_DOUBLE 8
+
+/* The size of `long double', as computed by sizeof. */
+#undef SIZEOF_LONG_DOUBLE
+
+/* If using the C implementation of alloca, define if you know the
+   direction of stack growth for your system; otherwise it will be
+   automatically deduced at runtime.
+	STACK_DIRECTION > 0 => grows toward higher addresses
+	STACK_DIRECTION < 0 => grows toward lower addresses
+	STACK_DIRECTION = 0 => direction of growth unknown */
+#undef STACK_DIRECTION
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Define this if you are using Purify and want to suppress spurious messages.
+   */
+#undef USING_PURIFY
+
+/* Version number of package */
+#undef VERSION
+
+/* Define to 1 if your processor stores words with the most significant byte
+   first (like Motorola and SPARC, unlike Intel and VAX). */
+#undef WORDS_BIGENDIAN
+
+
+#ifdef HAVE_HIDDEN_VISIBILITY_ATTRIBUTE
+#ifdef LIBFFI_ASM
+#ifdef __APPLE__
+#define FFI_HIDDEN(name) .private_extern name
+#else
+#define FFI_HIDDEN(name) .hidden name
+#endif
+#else
+#define FFI_HIDDEN __attribute__ ((visibility ("hidden")))
+#endif
+#else
+#ifdef LIBFFI_ASM
+#define FFI_HIDDEN(name)
+#else
+#define FFI_HIDDEN
+#endif
+#endif
+


### PR DESCRIPTION
Add riscv64 sources, copts, and deps to BUILD.libffi.bazel select()
blocks, mirroring the existing x86_64 and arm64 patterns.  Provide
pre-generated fficonfig.h and ffi.h for linux-riscv64.