### PR TITLE
xz: add riscv64 config to disable x86 intrinsics

### DIFF
--- a/base/cvd/build_external/xz/xz.MODULE.bazel
+++ b/base/cvd/build_external/xz/xz.MODULE.bazel
@@ -2,5 +2,12 @@ single_version_override(
     module_name = "xz",
     version = "5.4.5.bcr.5",
     patch_strip = 1,
-    patches = ["@//build_external/xz:bazel9.patch"],
+    patches = [
+        "@//build_external/xz:bazel9.patch",
+        # riscv64: xz BUILD.bazel only has x86_64 and arm64 config settings.
+        # On riscv64 it falls through to //conditions:default (x86_64 config)
+        # which defines HAVE_IMMINTRIN_H — but immintrin.h is x86-only.
+        # Add a linux_riscv64 config that undefs x86 intrinsics (mirrors arm64).
+        "//patches/xz:riscv64_config.patch",
+    ],
 )

--- a/base/cvd/patches/xz/BUILD.bazel
+++ b/base/cvd/patches/xz/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(glob(["*.patch"]))

--- a/base/cvd/patches/xz/riscv64_config.patch
+++ b/base/cvd/patches/xz/riscv64_config.patch
@@ -1,0 +1,41 @@
+--- a/BUILD.bazel	2026-04-03 21:44:20.553444101 +0000
++++ b/BUILD.bazel	2026-04-03 21:44:43.881933926 +0000
+@@ -43,6 +43,14 @@
+ )
+ 
+ config_setting(
++    name = "linux_riscv64",
++    constraint_values = [
++        "@platforms//os:linux",
++        "@platforms//cpu:riscv64",
++    ],
++)
++
++config_setting(
+     name = "wasm32",
+     constraint_values = [
+         "@platforms//os:none",
+@@ -77,11 +85,23 @@
+     template = "config.lzma-linux.h",
+ )
+ 
++expand_template(
++    name = "config_linux_riscv64",
++    out = "config.lzma-linux-riscv64.h",
++    substitutions = {
++        "{HAVE_IMMINTRIN_H}": "#undef HAVE_IMMINTRIN_H",
++        "{HAVE_CPUID_H}": "#undef HAVE_CPUID_H",
++        "{HAVE_USABLE_CLMUL}": "#undef HAVE_USABLE_CLMUL",
++    },
++    template = "config.lzma-linux.h",
++)
++
+ copy_file(
+     name = "copy_config",
+     src = selects.with_or({
+         "@platforms//os:android": "config.lzma-android.h",
+         ":linux_arm64": "config.lzma-linux-arm64.h",
++        ":linux_riscv64": "config.lzma-linux-riscv64.h",
+         ":linux_x86_64": "config.lzma-linux-x86_64.h",
+         ":osx_arm64": "config.lzma-osx-arm64.h",
+         ":osx_x86_64": "config.lzma-osx-x86_64.h",


### PR DESCRIPTION
xz BUILD.bazel only has config settings for x86_64 and arm64.  On
riscv64 it falls through to //conditions:default which uses the x86_64
config defining HAVE_IMMINTRIN_H — but immintrin.h is x86-only.
Add a linux_riscv64 config_setting and expand_template that undefs
x86 intrinsics, mirroring the arm64 approach.