### PR TITLE
libwebrtc: add generic DSP implementations for riscv64

### DIFF
--- a/base/cvd/build_external/libwebrtc/BUILD.libwebrtc.bazel
+++ b/base/cvd/build_external/libwebrtc/BUILD.libwebrtc.bazel
@@ -1206,6 +1206,11 @@ cc_library(
             "modules/audio_processing/aec3/vector_math_avx2.cc",
             "modules/audio_processing/agc2/rnn_vad/vector_math_avx2.cc",
         ],
+        "@platforms//cpu:riscv64": [
+            "common_audio/signal_processing/complex_bit_reverse.c",
+            "common_audio/signal_processing/filter_ar_fast_q12.c",
+            "common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor.c",
+        ],
         "//conditions:default": [],
     }),
     hdrs = [


### PR DESCRIPTION
The arch-specific select() defaults to empty sources on riscv64,
leaving WebRtcSpl_SqrtFloor, WebRtcSpl_ComplexBitReverse, and
WebRtcSpl_FilterARFastQ12 undefined.  Add the generic C
implementations, same as arm64 and x86_64 use.