### PR TITLE
debian: add riscv64 bazel output paths to dh-exec install files

### DIFF
--- a/base/debian/cuttlefish-base.install
+++ b/base/debian/cuttlefish-base.install
@@ -1,5 +1,6 @@
 #!/usr/bin/dh-exec
 [amd64] cvd/bazel-out/k8-opt/bin/cuttlefish/package/cuttlefish-common /usr/lib
 [arm64] cvd/bazel-out/aarch64-opt/bin/cuttlefish/package/cuttlefish-common /usr/lib
+[riscv64] cvd/bazel-out/riscv64-opt/bin/cuttlefish/package/cuttlefish-common /usr/lib
 host/deploy/capability_query.py /usr/lib/cuttlefish-common/bin/
 host/packages/cuttlefish-base/* /

--- a/base/debian/cuttlefish-integration.install
+++ b/base/debian/cuttlefish-integration.install
@@ -1,4 +1,5 @@
 #!/usr/bin/dh-exec
 [amd64] cvd/bazel-out/k8-opt/bin/cuttlefish/package/cuttlefish-integration/bin/* /usr/bin
 [arm64] cvd/bazel-out/aarch64-opt/bin/cuttlefish/package/cuttlefish-integration/bin/* /usr/bin
+[riscv64] cvd/bazel-out/riscv64-opt/bin/cuttlefish/package/cuttlefish-integration/bin/* /usr/bin
 host/packages/cuttlefish-integration/* /

--- a/base/debian/cuttlefish-metrics.install
+++ b/base/debian/cuttlefish-metrics.install
@@ -1,3 +1,4 @@
 #!/usr/bin/dh-exec
 [amd64] cvd/bazel-out/k8-opt/bin/cuttlefish/package/cuttlefish-metrics /usr/lib
 [arm64] cvd/bazel-out/aarch64-opt/bin/cuttlefish/package/cuttlefish-metrics /usr/lib
+[riscv64] cvd/bazel-out/riscv64-opt/bin/cuttlefish/package/cuttlefish-metrics /usr/lib


### PR DESCRIPTION
Add [riscv64] entries for cuttlefish-base, cuttlefish-integration,
and cuttlefish-metrics pointing to bazel-out/riscv64-opt/, matching
the existing amd64 (k8-opt) and arm64 (aarch64-opt) patterns.