### PR TITLE
Do not filter containers when allContainers is set

### DIFF
--- a/container/src/podcvd/internal/util.go
+++ b/container/src/podcvd/internal/util.go
@@ -48,7 +48,7 @@ func Ipv4AddressesByGroupNames(ccm libcfcontainer.CuttlefishContainerManager, al
 	groupNameIpAddrMap := make(map[string]string)
 	clientID := os.Getenv(envClientID)
 	for _, container := range containers {
-		if clientID != "" {
+		if !allContainers && clientID != "" {
 			if val, exists := container.Labels[labelClientID]; exists && val != clientID {
 				continue
 			}


### PR DESCRIPTION
Cuttlefish MCP server had an issue that cannot retrieve information that which containers are existing. This is a fix for creating CF instances from two or more AI(e.g. Gemini CLI) sessions.