### PR TITLE
Fix redundant get() call on smart pointer in oauth2_consent.cpp

### DIFF
--- a/base/cvd/cuttlefish/host/libs/web/oauth2_consent.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/oauth2_consent.cpp
@@ -295,7 +295,7 @@ Result<std::unique_ptr<CredentialSource>> CredentialForScopes(
     }
     Result<std::unique_ptr<CredentialSource>> credential =
         CredentialForScopes(http_client, scopes, credential_path);
-    if (credential.ok() && credential->get() != nullptr) {
+    if (credential.ok() && *credential != nullptr) {
       return std::move(*credential);
     }
   }


### PR DESCRIPTION
Remove redundant get() call on smart pointer, as recommended by ClangTidyReadability.

Port of cl/898040821

 #gemini