### PR TITLE
Arm64 Server 1.51 hotfix

### DIFF
--- a/.github/actions/gigabyte-ampere-cuttlefish-installer-check-preseed-after-install-script/action.yaml
+++ b/.github/actions/gigabyte-ampere-cuttlefish-installer-check-preseed-after-install-script/action.yaml
@@ -1,0 +1,56 @@
+name: 'Gigabyte Cuttlefish installer check preseed after install script'
+
+inputs:
+  emulate-nvidia:
+    required: false
+    default: "false"
+  emulate-amd:
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+  - name: Prepare test environment
+    shell: bash
+    run: |
+      apt-get update
+      apt-get upgrade -y
+      apt-get install -y sudo
+      apt-get install -y initramfs-tools
+      apt-get install -y grub-efi-arm64
+      apt-get install -y lsb-release
+      apt-get install -y pciutils
+      apt-get install -y apt-show-versions
+      apt-get install -y linux-image-arm64 linux-headers-arm64
+  - name: Setup non-free repository
+    shell: bash
+    run: |
+      echo "deb http://deb.debian.org/debian $(lsb_release -c -s) contrib non-free non-free-firmware" | tee /etc/apt/sources.list.d/debian-nonfree-1.list
+      apt -o Apt::Get::Assume-Yes=true -o APT::Color=0 -o DPkgPM::Progress-Fancy=0 update
+  - name: Setup backports repository
+    shell: bash
+    run: |
+      if grep "apt-setup/services-select" preseed/preseed.cfg  | grep backports  | egrep '^[^#]'; then
+        echo "deb http://deb.debian.org/debian $(lsb_release -c -s)-backports main contrib non-free non-free-firmware" | tee /etc/apt/sources.list.d/debian-backports-1.list
+        apt -o Apt::Get::Assume-Yes=true -o APT::Color=0 -o DPkgPM::Progress-Fancy=0 update
+      fi
+  - name: Check nVidia GPU emulation
+    shell: bash
+    run: echo "EMULATE_NVIDIA_GPU=${{ inputs.emulate-nvidia }}" >> $GITHUB_ENV
+  - name: Check AMD GPU emulation
+    shell: bash
+    run: echo "EMULATE_AMD_GPU=${{ inputs.emulate-amd }}" >> $GITHUB_ENV
+  - name: Running tests
+    working-directory: ./gigabyte-ampere-cuttlefish-installer
+    shell: bash
+    run: |
+      ./tests/test-after-install-script-kernel.sh
+      sh after_install_1_kernel.sh
+      apt-show-versions linux-image-arm64
+      apt-show-versions linux-headers-arm64
+      apt-show-versions firmware-amd-graphics
+      apt-show-versions nvidia-open-kernel-dkms
+      apt-show-versions nvidia-kernel-dkms
+      apt-show-versions nvidia-driver
+      apt-show-versions firmware-misc-nonfree

--- a/.github/workflows/gigabyte-ampere-cuttlefish-installer.yaml
+++ b/.github/workflows/gigabyte-ampere-cuttlefish-installer.yaml
@@ -10,7 +10,60 @@ on:
       - '**'
 
 jobs:
+  check-install-gigabyte-package-deb-job:
+    runs-on: ubuntu-22.04-arm
+    container:
+      image: debian@sha256:2c91e484d93f0830a7e05a2b9d92a7b102be7cab562198b984a84fdbc7806d91 # debian:trixie-20260202
+    steps:
+    - name: Prepare test environment
+      run: |
+        apt-get update
+        apt-get upgrade -y
+        apt-get install -y sudo
+        apt-get install -y curl ca-certificates
+    - name: Setup repository
+      run: |
+        curl -fsSL https://us-apt.pkg.dev/doc/repo-signing-key.gpg -o /etc/apt/trusted.gpg.d/artifact-registry.asc
+        chmod a+r /etc/apt/trusted.gpg.d/artifact-registry.asc
+        echo "deb https://us-apt.pkg.dev/projects/android-cuttlefish-artifacts android-cuttlefish main" | tee -a /etc/apt/sources.list.d/artifact-registry.list
+        apt-get update
+    - name: Install meta package
+      run: apt -o Apt::Get::Assume-Yes=true -o APT::Color=0 -o DPkgPM::Progress-Fancy=0 install cuttlefish-integration-gigabyte-arm64
+    - name: ulimit config test
+      run: |
+        test -e /etc/security/limits.d/95-cuttlefish-integration-gigabyte-arm64-nofile.conf
+        ulimit -n
+    - name: NTP config test
+      run: test -e /etc/ntpsec/ntp.d/google-time-server.conf
+    - name: Package purge test
+      run: |
+        apt -o Apt::Get::Assume-Yes=true -o APT::Color=0 -o DPkgPM::Progress-Fancy=0 purge cuttlefish-integration-gigabyte-arm64
+        test ! -e /etc/ntpsec/ntp.d/google-time-server.conf
+
+  check-preseed-after-install-script-gpu-job:
+    runs-on: ubuntu-22.04-arm
+    container:
+      image: debian@sha256:2c91e484d93f0830a7e05a2b9d92a7b102be7cab562198b984a84fdbc7806d91 # debian:trixie-20260202
+    defaults:
+      run:
+        working-directory: ./gigabyte-ampere-cuttlefish-installer
+    strategy:
+      matrix:
+        amd_gpu: ["true", "false"]
+        nvidia_gpu: ["true", "false"]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Check preseed after install script
+      uses: ./.github/actions/gigabyte-ampere-cuttlefish-installer-check-preseed-after-install-script
+      with:
+        emulate-nvidia: ${{ matrix.nvidia_gpu }}
+        emulate-amd: ${{ matrix.amd_gpu }}
+
   build-installer-iso-job:
+    needs:
+      - check-install-gigabyte-package-deb-job
+      - check-preseed-after-install-script-gpu-job
     runs-on: ubuntu-22.04
     container:
       image: debian@sha256:13f29b6806e531c3ff3b565bb6eed73f2132506c8c9d41bb996065ca20fb27f2 # debian:trixie-20260223 (amd64)

--- a/base/debian/changelog
+++ b/base/debian/changelog
@@ -1,3 +1,9 @@
+cuttlefish-common (1.51.1) unstable; urgency=medium
+
+  * N/A
+
+ -- Ram Muthiah <rammuthiah@google.com>  Wed, 22 Apr 2026 11:29:15 +0000
+
 cuttlefish-common (1.51.0) stable; urgency=medium
 
   * Add a powerwash e2etest by @jmacnak in https://github.com/google/android-cuttlefish/pull/2311

--- a/container/debian/changelog
+++ b/container/debian/changelog
@@ -1,3 +1,9 @@
+cuttlefish-container (1.51.1) unstable; urgency=medium
+
+  * N/A
+
+ -- Ram Muthiah <rammuthiah@google.com>  Wed, 22 Apr 2026 11:29:15 +0000
+
 cuttlefish-container (1.51.0) stable; urgency=medium
 
   * Add tools on cuttlefish_mcp_server, but executing podcvd directly by @0405ysj in https://github.com/google/android-cuttlefish/pull/2338

--- a/cuttlefish-integration-gigabyte-arm64/debian/changelog
+++ b/cuttlefish-integration-gigabyte-arm64/debian/changelog
@@ -1,3 +1,9 @@
+cuttlefish-integration-gigabyte-arm64 (1.51.1) unstable; urgency=medium
+
+  * gigabyte-ampere-cuttlefish-installer: preseed.cfg: disable backports by @grandpaul in https://github.com/google/android-cuttlefish/pull/2394
+
+ -- Ram Muthiah <rammuthiah@google.com>  Wed, 22 Apr 2026 11:29:15 +0000
+
 cuttlefish-integration-gigabyte-arm64 (1.51.0) stable; urgency=medium
 
   * Add cloud image installer for Gigabyte Ampere server. by @grandpaul in https://github.com/google/android-cuttlefish/pull/2303

--- a/frontend/debian/changelog
+++ b/frontend/debian/changelog
@@ -1,3 +1,9 @@
+cuttlefish-frontend (1.51.1) unstable; urgency=medium
+
+  * N/A
+
+ -- Ram Muthiah <rammuthiah@google.com>  Wed, 22 Apr 2026 11:29:15 +0000
+
 cuttlefish-frontend (1.51.0) stable; urgency=medium
 
   * N/A

--- a/gigabyte-ampere-cuttlefish-installer/preseed/preseed.cfg
+++ b/gigabyte-ampere-cuttlefish-installer/preseed/preseed.cfg
@@ -299,7 +299,7 @@ d-i partman-partitioning/default_label string gpt
 # (default: false).
 d-i apt-setup/cdrom/set-first boolean false
 # Backport selection
-d-i apt-setup/services-select multiselect backports
+# d-i apt-setup/services-select multiselect backports
 # You can choose to install non-free firmware.
 d-i apt-setup/non-free-firmware boolean true
 # You can choose to install non-free and contrib software.

--- a/gigabyte-ampere-cuttlefish-installer/tests/test-after-install-script-kernel.sh
+++ b/gigabyte-ampere-cuttlefish-installer/tests/test-after-install-script-kernel.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+awk '/# Install kernel/,/# End of Install kernel/' preseed/after_install_1.sh > after_install_1_kernel.sh
+
+if [ x"${EMULATE_NVIDIA_GPU}" = x"true" ]; then
+    sed -i 's/^nvidia_gpu=.*/nvidia_gpu="nVidia"/' after_install_1_kernel.sh
+fi
+if [ x"${EMULATE_AMD_GPU}" = x"true" ]; then
+    sed -i 's/^amd_gpu=.*/amd_gpu="VGA_AMD"/' after_install_1_kernel.sh
+fi


### PR DESCRIPTION
The arm64 servers don't boot with the GPU enabled if Nvidia backports are used. Disable backports.