### PR TITLE
Add some utilities for PATH searching.

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
@@ -104,6 +104,7 @@ cf_cc_library(
         "@platforms//os:linux",  # SEEK_DATA
     ],
     deps = [
+        ":environment",
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:in_sandbox",
@@ -140,6 +141,8 @@ cf_cc_test(
         "//cuttlefish/result",
         "//cuttlefish/result:result_matchers",
         "//libbase",
+        "@abseil-cpp//absl/cleanup",
+        "@abseil-cpp//absl/strings",
     ],
 )
 

--- a/base/cvd/cuttlefish/common/libs/utils/files.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/files.cpp
@@ -61,11 +61,13 @@
 #include "absl/log/log.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
 #include "fmt/format.h"
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/contains.h"
+#include "cuttlefish/common/libs/utils/environment.h"
 #include "cuttlefish/common/libs/utils/in_sandbox.h"
 #include "cuttlefish/common/libs/utils/users.h"
 #include "cuttlefish/posix/rename.h"
@@ -718,6 +720,25 @@ Result<std::string> EmulateAbsolutePath(const InputPathForm& path_info) {
                "Failed to effectively conduct readpath -f {}", processed_path);
   }
   return real_path;
+}
+
+std::vector<std::string> Path(const std::string& env_name) {
+  // TODO: Assumes a SUS system. Elsewhere we may need to change the delimiter.
+  // https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html
+  return absl::StrSplit(StringFromEnv(env_name).value_or(""), ':');
+}
+
+Result<std::string> Search(const std::vector<std::string>& path,
+                           std::string_view name) {
+  // TODO: Assumes a SUS system. Elsewhere we may need to change the delimiter.
+  // https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html
+  for (const auto& dir : path) {
+    std::string abs_path = absl::StrCat(dir, "/", name);
+    if (FileExists(abs_path)) {
+      return abs_path;
+    }
+  }
+  return CF_ERR("Not found: ") << name << ", path " << absl::StrJoin(path, ":");
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/files.h
+++ b/base/cvd/cuttlefish/common/libs/utils/files.h
@@ -131,4 +131,9 @@ struct InputPathForm {
  */
 Result<std::string> EmulateAbsolutePath(const InputPathForm& path_info);
 
+std::vector<std::string> Path(const std::string& env_name = "PATH");
+
+Result<std::string> Search(const std::vector<std::string>& path,
+                           std::string_view name);
+
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/files_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/files_test.cpp
@@ -21,6 +21,8 @@
 #include <android-base/file.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "absl/cleanup/cleanup.h"
+#include "absl/strings/str_cat.h"
 
 #include "cuttlefish/common/libs/utils/files_test_helper.h"
 #include "cuttlefish/result/result.h"
@@ -179,5 +181,50 @@ INSTANTIATE_TEST_SUITE_P(
                     InputOutput{.path_to_convert_ = "~/k/../../t/./q",
                                 .home_dir_ = "/x/y/z",
                                 .expected_ = "/x/y/t/q"}));
+
+TEST(FilesTest, PathWithCustomEnv) {
+  const std::string env_name = "TEST_PATH";
+  const std::string dir1 = "/foo/bar";
+  const std::string dir2 = "/baz";
+  const std::string env_value = absl::StrCat(dir1, ":", dir2);
+  setenv(env_name.c_str(), env_value.c_str(), 1);
+  absl::Cleanup cleanup = [&env_name]() { unsetenv(env_name.c_str()); };
+
+  std::vector<std::string> result = Path(env_name);
+  ASSERT_EQ(result.size(), 2);
+  EXPECT_EQ(result[0], dir1);
+  EXPECT_EQ(result[1], dir2);
+}
+
+TEST(FilesTest, PathWithSecondCustomEnv) {
+  const std::string env_name = "TEST_PATH";
+  const std::string dir = "/foo";
+  setenv(env_name.c_str(), dir.c_str(), 1);
+  absl::Cleanup cleanup = [&env_name]() { unsetenv(env_name.c_str()); };
+
+  auto result = Path(env_name);
+  ASSERT_EQ(result.size(), 1);
+  EXPECT_EQ(result[0], dir);
+}
+
+TEST(FilesTest, SearchFindsFile) {
+  const std::string temp_dir = testing::TempDir();
+  const std::string file_name = "search_test_file";
+  const std::string full_path = absl::StrCat(temp_dir, "/", file_name);
+
+  EXPECT_TRUE(android::base::WriteStringToFile("", full_path));
+  absl::Cleanup cleanup = [full_path]() { unlink(full_path.c_str()); };
+
+  auto result = Search({temp_dir}, file_name);
+  EXPECT_THAT(result, IsOkAndValue(full_path));
+}
+
+TEST(FilesTest, SearchFileNotFoundReturnsError) {
+  const std::string temp_dir = testing::TempDir();
+  EXPECT_FALSE(FileExists(absl::StrCat(temp_dir, "/search_non_existent_file")));
+
+  auto result = Search({temp_dir}, "search_non_existent_file");
+  EXPECT_FALSE(result.ok());
+}
 
 }  // namespace cuttlefish


### PR DESCRIPTION
A lot of our tooling relies on executing binaries found on the host system. The subprocess library ends up calling execvpe on Linux, which means that PATH resolution happens for the executable.

Two issues present themselves. Firstly, execvpe is a Linuxism -- it is not in the SUS; our tentative non-Linux (macOS) implementation calles execve instead.

Secondly and more importantly, if the executable that we expect to be able to run is not in PATH, then we will fail to exec it, even if the actual executable is installed; this can happen on some distributions where nonprivileged users are configured by default to not have executables where root privileges are required in PATH.

Therefore, we need to be able to perform PATH resolution ourselves, so that we can do things like test if a binary truly isn't available or whether it merely isn't in the current PATH.

We add a reminder for ourselves too that while the usual colon-separated PATH splitting makes perfect sense for SUS systems, it is not the case on platforms like Windows -- if in the future we want to go down that direction.

(Also, perhaps we should just migrate to using posix_spawn, but that's not important right now.)

Bug: 488432653