### PR TITLE
Enable launching legacy Cuttlefish builds

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
@@ -265,13 +265,23 @@ Result<void> CvdCreateCommandHandler::CreateSymlinks(
   for (const auto& instance : group.Instances()) {
     // later on, we link cuttlefish_runtime to cuttlefish_runtime.smallest_id
     smallest_id = std::min(smallest_id, instance.id());
-    const std::string instance_home_dir = fmt::format(
+    std::string instance_home_dir = fmt::format(
         "{}/cuttlefish/instances/cvd-{}", group.HomeDir(), instance.id());
+    if(!FileExists(instance_home_dir)) {
+      // Legacy launchers create cuttlefish_runtime.{$ID}
+      instance_home_dir = fmt::format(
+          "{}/cuttlefish_runtime.{}", group.HomeDir(), instance.id());
+    }
     CF_EXPECT(EnsureSymlink(instance_home_dir,
                             fmt::format("{}/cuttlefish_runtime.{}",
                                         system_wide_home, instance.id())));
-    CF_EXPECT(EnsureSymlink(group.HomeDir() + "/cuttlefish",
-                            system_wide_home + "/cuttlefish"));
+    std::string cuttlefish_home_dir = group.HomeDir() + "/cuttlefish";
+    if(FileExists(cuttlefish_home_dir)) {
+      // Legacy Cuttlefish launchers don't create this directory so no need to
+      // create a corresponding symlink in that case.
+      CF_EXPECT(EnsureSymlink(cuttlefish_home_dir,
+                              system_wide_home + "/cuttlefish"));
+    }
   }
   // create cuttlefish_runtime to cuttlefish_runtime.id
   CF_EXPECT_NE(std::numeric_limits<unsigned>::max(), smallest_id,

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_manager.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_manager.cpp
@@ -259,7 +259,7 @@ Result<void> InstanceManager::Clear() {
     if (Result<void> res = RemoveFile(runtime_link);!res.ok()) {
       LOG(ERROR) << res.error();
     }
-    std::string config_link = group.HomeDir() + config_json_name;
+    std::string config_link = group.HomeDir() + "/" + config_json_name;
     if (Result<void> res = RemoveFile(config_link);!res.ok()) {
       LOG(ERROR) << res.error();
     }

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/local_instance.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/local_instance.cpp
@@ -60,8 +60,14 @@ void LocalInstance::set_state(cvd::InstanceState state) {
 }
 
 std::string LocalInstance::instance_dir() const {
-  return fmt::format("{}/cuttlefish/instances/cvd-{}",
-                     group_proto_->home_directory(), id());
+  std::string to_ret = fmt::format("{}/cuttlefish/instances/cvd-{}",
+                                   group_proto_->home_directory(), id());
+  if(!FileExists(to_ret)) {
+    // Legacy launchers create cuttlefish_runtime.{$ID}
+    to_ret = fmt::format("{}/cuttlefish_runtime.{}",
+                         group_proto_->home_directory(), id());
+  }
+  return to_ret;
 }
 
 int LocalInstance::adb_port() const {

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/status_fetcher.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/status_fetcher.cpp
@@ -126,8 +126,30 @@ Result<Json::Value> FetchInstanceStatus(LocalInstance& instance,
   envs["HOME"] = home;
   // old cvd_internal_status expects CUTTLEFISH_INSTANCE=<k>
   envs[kCuttlefishInstanceEnvVarName] = std::to_string(instance.id());
-  std::vector<std::string> args{"--print", "--wait_for_launcher",
+
+  ConstructCommandParam help_cmd_param{
+      .bin_path = bin_path,
+      .home = home,
+      .args = {"--help"},
+      .envs = envs,
+      .working_dir = working_dir,
+      .command_name = bin,
+  };
+  Command help_cmd = CF_EXPECT(ConstructCommand(help_cmd_param));
+
+  std::string stdout_str, stderr_str;
+  RunWithManagedStdio(std::move(help_cmd), nullptr, &stdout_str, &stderr_str);
+
+  bool has_print = stdout_str.find("--print") != std::string::npos ||
+                   stderr_str.find("--print") != std::string::npos;
+
+  std::vector<std::string> args{"--wait_for_launcher",
                                 std::to_string(timeout.count())};
+  if (has_print) {
+    args.push_back("--print");
+  } else {
+    LOG(INFO) << bin << " does not support --print. Omitting flag.";
+  }
 
   ConstructCommandParam construct_cmd_param{
       .bin_path = bin_path,

--- a/base/cvd/cuttlefish/host/commands/cvd/utils/common.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/utils/common.cpp
@@ -138,7 +138,12 @@ Result<std::string> GroupDirFromHome(std::string_view dir) {
 }
 
 std::string AssemblyDirFromHome(const std::string& group_home_dir) {
-  return group_home_dir + "/cuttlefish/assembly";
+  std::string to_ret = group_home_dir + "/cuttlefish/assembly";
+  if(!FileExists(to_ret)) {
+    // Legacy launchers create cuttlefish_assembly instead
+    to_ret = group_home_dir + "/cuttlefish_assembly";
+  }
+  return to_ret;
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/config/config_utils.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/config_utils.cpp
@@ -158,8 +158,9 @@ std::string DefaultEnvironmentPath(const std::string& environment_key,
 }
 
 bool IsValidAndroidHostOutPath(const std::string& path) {
-  std::string start_bin_path = path + "/bin/cvd_internal_start";
-  return FileExists(start_bin_path);
+  std::string internal_start_bin_path = path + "/bin/cvd_internal_start";
+  std::string launch_cvd_bin_path = path + "/bin/launch_cvd";
+  return FileExists(internal_start_bin_path) || FileExists(launch_cvd_bin_path);
 }
 
 // In practice this is mostly validating that the `cuttlefish-base` debian


### PR DESCRIPTION
Older versions of the launcher have a few notable differences that modern cvd has to support. This patch adds the support for these quirks.

1. the instance directory is named cuttlefish_runtime.{$ID}
2. the assembly directory is cuttlefish_assembly
3. older cvd status didn't support the print flag
4. the cuttlefish dir in the cvd home directory didn't exist
5. the android host dir had launch_cvd instead of cvd_internal_start

Also fixed a small bug in the deletion of the hidden copy of the config.json file. The path was missing a "/" between the dir and file.

Tested with the following
$ bazel build cuttlefish/package:cvd
$ /.../cvd fetch \
    --default_build=aosp-android11-gsi/aosp_cf_x86_64_phone-userdebug
$ /.../cvd create
$ /.../cvd stop
$ /.../cvd reset -y