### PR TITLE
Metrics gathering for cvd invocation sources

### DIFF
--- a/base/cvd/cuttlefish/host/libs/metrics/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/metrics/BUILD.bazel
@@ -128,6 +128,10 @@ cf_cc_library(
     ],
     deps = [
         "//cuttlefish/common/libs/utils:host_info",
+        "//cuttlefish/host/libs/metrics:gce_environment",
+        "//cuttlefish/host/libs/metrics:github_environment",
+        "//cuttlefish/host/libs/metrics:invoker",
+        "//cuttlefish/result",
     ],
 )
 

--- a/base/cvd/cuttlefish/host/libs/metrics/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/metrics/BUILD.bazel
@@ -69,6 +69,19 @@ cf_cc_library(
 )
 
 cf_cc_library(
+    name = "github_environment",
+    srcs = [
+        "github_environment.cc",
+    ],
+    hdrs = [
+        "github_environment.h",
+    ],
+    deps = [
+        "//cuttlefish/common/libs/utils:environment",
+    ],
+)
+
+cf_cc_library(
     name = "guest_metrics",
     srcs = [
         "guest_metrics.cc",

--- a/base/cvd/cuttlefish/host/libs/metrics/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/metrics/BUILD.bazel
@@ -69,6 +69,25 @@ cf_cc_library(
 )
 
 cf_cc_library(
+    name = "gce_environment",
+    srcs = [
+        "gce_environment.cc",
+    ],
+    hdrs = [
+        "gce_environment.h",
+    ],
+    deps = [
+        "//cuttlefish/host/libs/web/http_client",
+        "//cuttlefish/host/libs/web/http_client:curl_global_init",
+        "//cuttlefish/host/libs/web/http_client:curl_http_client",
+        "//cuttlefish/host/libs/web/http_client:http_string",
+        "//cuttlefish/result",
+        "@abseil-cpp//absl/strings",
+        "@fmt",
+    ],
+)
+
+cf_cc_library(
     name = "github_environment",
     srcs = [
         "github_environment.cc",

--- a/base/cvd/cuttlefish/host/libs/metrics/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/metrics/BUILD.bazel
@@ -119,6 +119,19 @@ cf_cc_library(
 )
 
 cf_cc_library(
+    name = "host_metrics",
+    srcs = [
+        "host_metrics.cc",
+    ],
+    hdrs = [
+        "host_metrics.h",
+    ],
+    deps = [
+        "//cuttlefish/common/libs/utils:host_info",
+    ],
+)
+
+cf_cc_library(
     name = "invoker",
     srcs = [
         "invoker.cc",
@@ -168,6 +181,7 @@ cf_cc_library(
         "//cuttlefish/host/libs/metrics:device_event_type",
         "//cuttlefish/host/libs/metrics:flag_metrics",
         "//cuttlefish/host/libs/metrics:guest_metrics",
+        "//cuttlefish/host/libs/metrics:host_metrics",
         "//external_proto:cf_flags_cc_proto",
         "//external_proto:cf_guest_cc_proto",
         "//external_proto:cf_host_cc_proto",
@@ -206,13 +220,13 @@ cf_cc_library(
     ],
     deps = [
         "//cuttlefish/common/libs/utils:files",
-        "//cuttlefish/common/libs/utils:host_info",
         "//cuttlefish/common/libs/utils:tee_logging",
         "//cuttlefish/host/commands/cvd/version",
         "//cuttlefish/host/libs/metrics:device_event_type",
         "//cuttlefish/host/libs/metrics:enabled",
         "//cuttlefish/host/libs/metrics:flag_metrics",
         "//cuttlefish/host/libs/metrics:guest_metrics",
+        "//cuttlefish/host/libs/metrics:host_metrics",
         "//cuttlefish/host/libs/metrics:metrics_conversion",
         "//cuttlefish/host/libs/metrics:metrics_transmitter",
         "//cuttlefish/host/libs/metrics:metrics_writer",

--- a/base/cvd/cuttlefish/host/libs/metrics/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/metrics/BUILD.bazel
@@ -119,6 +119,19 @@ cf_cc_library(
 )
 
 cf_cc_library(
+    name = "invoker",
+    srcs = [
+        "invoker.cc",
+    ],
+    hdrs = [
+        "invoker.h",
+    ],
+    deps = [
+        "//cuttlefish/common/libs/utils:environment",
+    ],
+)
+
+cf_cc_library(
     name = "metrics",
     srcs = [
         "metrics_receiver.cc",

--- a/base/cvd/cuttlefish/host/libs/metrics/gce_environment.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/gce_environment.cc
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/host/libs/metrics/gce_environment.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <fmt/format.h>
+#include "absl/strings/str_split.h"
+
+#include "cuttlefish/host/libs/web/http_client/curl_global_init.h"
+#include "cuttlefish/host/libs/web/http_client/curl_http_client.h"
+#include "cuttlefish/host/libs/web/http_client/http_client.h"
+#include "cuttlefish/host/libs/web/http_client/http_string.h"
+#include "cuttlefish/result/result.h"
+
+namespace cuttlefish {
+namespace {
+
+constexpr std::string_view kDetectUrl = "metadata.google.internal";
+constexpr std::string_view kDetectHeader = "Metadata-Flavor";
+constexpr std::string_view kExpectedDetectHeaderValue = "Google";
+
+// https://docs.cloud.google.com/compute/docs/metadata/predefined-metadata-keys
+constexpr std::string_view kGceMetadataUrlBase =
+    "http://metadata.google.internal/computeMetadata/v1";
+constexpr std::string_view kNumericProjectId = "project/numeric-project-id";
+constexpr std::string_view kZone = "instance/zone";
+
+// https://docs.cloud.google.com/compute/docs/instances/detect-compute-engine
+Result<bool> IsGceEnvironment(HttpClient& http_client) {
+  const HttpResponse<std::string> response =
+      CF_EXPECT(HttpGetToString(http_client, std::string(kDetectUrl)));
+  return HeaderValue(response.headers, kDetectHeader) ==
+         kExpectedDetectHeaderValue;
+}
+
+// https://docs.cloud.google.com/compute/docs/metadata/querying-metadata
+Result<std::string> QueryGceMetadata(HttpClient& http_client,
+                                     std::string_view metadata_key) {
+  const std::vector<std::string> required_metadata_query_header = {
+      fmt::format("{}: {}", kDetectHeader, kExpectedDetectHeaderValue)};
+  const std::string url =
+      fmt::format("{}/{}", kGceMetadataUrlBase, metadata_key);
+  HttpResponse<std::string> response = CF_EXPECT(
+      HttpGetToString(http_client, url, required_metadata_query_header));
+  return response.data;
+}
+
+Result<std::string> GetZoneValue(std::string_view response_string) {
+  std::vector<std::string> components = absl::StrSplit(response_string, "/");
+  CF_EXPECTF(
+      components.size() == 4 && components[2] == "zones",
+      "Unexpected format in response string for zone metadata, expected "
+      "the form \"projects/<project_num>/zones/<zone>\" and received: {}",
+      response_string);
+  return components[3];
+}
+
+}  // namespace
+
+Result<std::optional<GceEnvironment>> DetectGceEnvironment() {
+  CurlGlobalInit curl_init;
+  std::unique_ptr<HttpClient> http_client = CurlHttpClient();
+  if (!CF_EXPECT(IsGceEnvironment(*http_client))) {
+    return std::nullopt;
+  }
+  const std::string zone_response =
+      CF_EXPECT(QueryGceMetadata(*http_client, kZone));
+  return GceEnvironment{
+      .numeric_project_id =
+          CF_EXPECT(QueryGceMetadata(*http_client, kNumericProjectId)),
+      .zone = CF_EXPECT(GetZoneValue(zone_response)),
+  };
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/metrics/gce_environment.h
+++ b/base/cvd/cuttlefish/host/libs/metrics/gce_environment.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "cuttlefish/result/result.h"
+
+namespace cuttlefish {
+
+struct GceEnvironment {
+  std::string numeric_project_id;
+  std::string zone;
+};
+
+Result<std::optional<GceEnvironment>> DetectGceEnvironment();
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/metrics/github_environment.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/github_environment.cc
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/host/libs/metrics/github_environment.h"
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "cuttlefish/common/libs/utils/environment.h"
+
+namespace cuttlefish {
+namespace {
+
+// https://docs.github.com/en/actions/reference/workflows-and-actions/variables
+// set to "true" when GitHub Actions is running the workflow
+constexpr std::string_view kGitHubActions = "GITHUB_ACTIONS";
+// holds the owner and repository name
+constexpr std::string_view kGitHubRepository = "GITHUB_REPOSITORY";
+
+constexpr std::string_view kAndroidCuttlefish = "google/android-cuttlefish";
+constexpr std::string_view kCloudAndroidOrchestration =
+    "google/cloud-android-orchestration";
+
+GitHubRepository ToGitHubRepository(std::string_view gh_env_str) {
+  if (gh_env_str == kAndroidCuttlefish) {
+    return GitHubRepository::AndroidCuttlefish;
+  } else if (gh_env_str == kCloudAndroidOrchestration) {
+    return GitHubRepository::CloudAndroidOrchestration;
+  } else {
+    return GitHubRepository::Unknown;
+  }
+}
+
+}  // namespace
+
+std::optional<GitHubRepository> DetectGitHubRepository() {
+  if (StringFromEnv(std::string(kGitHubActions)) != "true") {
+    return std::nullopt;
+  }
+  return ToGitHubRepository(
+      StringFromEnv(std::string(kGitHubRepository), "unknown"));
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/metrics/github_environment.h
+++ b/base/cvd/cuttlefish/host/libs/metrics/github_environment.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <optional>
+
+namespace cuttlefish {
+
+enum class GitHubRepository {
+  AndroidCuttlefish,
+  CloudAndroidOrchestration,
+  Unknown,
+};
+
+std::optional<GitHubRepository> DetectGitHubRepository();
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/metrics/host_metrics.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/host_metrics.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Android Open Source Project
+ * Copyright (C) 2026 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,27 +14,16 @@
  * limitations under the License.
  */
 
-#pragma once
-
-#include <chrono>
-#include <string>
-#include <vector>
-
-#include "cuttlefish/host/libs/metrics/guest_metrics.h"
 #include "cuttlefish/host/libs/metrics/host_metrics.h"
-#include "external_proto/cf_log.pb.h"
+
+#include "cuttlefish/common/libs/utils/host_info.h"
 
 namespace cuttlefish {
 
-struct MetricsData {
-  std::string session_id;
-  std::string cf_common_version;
-  std::chrono::milliseconds now;
-  HostMetrics host_metrics;
-  std::vector<GuestMetrics> guest_metrics;
-};
-
-logs::proto::wireless::android::cuttlefish::CuttlefishLogEvent
-BuildCuttlefishLogEvent(const MetricsData& metrics_data);
+HostMetrics GetHostMetrics() {
+  return HostMetrics{
+      .os = GetHostInfo(),
+  };
+}
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/metrics/host_metrics.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/host_metrics.cc
@@ -16,13 +16,39 @@
 
 #include "cuttlefish/host/libs/metrics/host_metrics.h"
 
+#include <optional>
+
 #include "cuttlefish/common/libs/utils/host_info.h"
+#include "cuttlefish/host/libs/metrics/gce_environment.h"
+#include "cuttlefish/host/libs/metrics/github_environment.h"
+#include "cuttlefish/host/libs/metrics/invoker.h"
+#include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
+namespace {
 
-HostMetrics GetHostMetrics() {
+Result<std::optional<Environment>> GetEnvironment() {
+  const std::optional<GitHubRepository> github_environment =
+      DetectGitHubRepository();
+  if (github_environment) {
+    return github_environment;
+  }
+
+  const std::optional gce_environment = CF_EXPECT(DetectGceEnvironment());
+  if (gce_environment) {
+    return gce_environment;
+  }
+
+  return std::nullopt;
+}
+
+}  // namespace
+
+Result<HostMetrics> GetHostMetrics() {
   return HostMetrics{
       .os = GetHostInfo(),
+      .invoker = GetInvoker(),
+      .environment = CF_EXPECT(GetEnvironment()),
   };
 }
 

--- a/base/cvd/cuttlefish/host/libs/metrics/host_metrics.h
+++ b/base/cvd/cuttlefish/host/libs/metrics/host_metrics.h
@@ -16,14 +16,25 @@
 
 #pragma once
 
+#include <optional>
+#include <variant>
+
 #include "cuttlefish/common/libs/utils/host_info.h"
+#include "cuttlefish/host/libs/metrics/gce_environment.h"
+#include "cuttlefish/host/libs/metrics/github_environment.h"
+#include "cuttlefish/host/libs/metrics/invoker.h"
+#include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
 
+using Environment = std::variant<GceEnvironment, GitHubRepository>;
+
 struct HostMetrics {
   HostInfo os;
+  Invoker invoker;
+  std::optional<Environment> environment;
 };
 
-HostMetrics GetHostMetrics();
+Result<HostMetrics> GetHostMetrics();
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/metrics/host_metrics.h
+++ b/base/cvd/cuttlefish/host/libs/metrics/host_metrics.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Android Open Source Project
+ * Copyright (C) 2026 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,25 +16,14 @@
 
 #pragma once
 
-#include <chrono>
-#include <string>
-#include <vector>
-
-#include "cuttlefish/host/libs/metrics/guest_metrics.h"
-#include "cuttlefish/host/libs/metrics/host_metrics.h"
-#include "external_proto/cf_log.pb.h"
+#include "cuttlefish/common/libs/utils/host_info.h"
 
 namespace cuttlefish {
 
-struct MetricsData {
-  std::string session_id;
-  std::string cf_common_version;
-  std::chrono::milliseconds now;
-  HostMetrics host_metrics;
-  std::vector<GuestMetrics> guest_metrics;
+struct HostMetrics {
+  HostInfo os;
 };
 
-logs::proto::wireless::android::cuttlefish::CuttlefishLogEvent
-BuildCuttlefishLogEvent(const MetricsData& metrics_data);
+HostMetrics GetHostMetrics();
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/metrics/invoker.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/invoker.cc
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/host/libs/metrics/invoker.h"
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "cuttlefish/common/libs/utils/environment.h"
+
+namespace cuttlefish {
+namespace {
+
+constexpr std::string_view kAcloud = "acloud";
+constexpr std::string_view kHostOrchestrator = "host_orchestrator";
+constexpr std::string_view kInvokerVariable = "CVD_INVOKER";
+
+}  // namespace
+
+Invoker GetInvoker() {
+  const std::optional<std::string> invoker_value =
+      StringFromEnv(std::string(kInvokerVariable));
+  if (!invoker_value) {
+    return Invoker::None;
+  } else if (invoker_value == kAcloud) {
+    return Invoker::Acloud;
+  } else if (invoker_value == kHostOrchestrator) {
+    return Invoker::HostOrchestrator;
+  } else {
+    return Invoker::Unknown;
+  }
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/metrics/invoker.h
+++ b/base/cvd/cuttlefish/host/libs/metrics/invoker.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace cuttlefish {
+
+enum class Invoker {
+  Acloud,
+  HostOrchestrator,
+  None,
+  Unknown,
+};
+
+Invoker GetInvoker();
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/metrics/metrics_conversion.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/metrics_conversion.cc
@@ -189,8 +189,8 @@ CuttlefishLogEvent BuildCuttlefishLogEvent(const MetricsData& metrics_data) {
   }
 
   CuttlefishHost& host = *metrics_event.mutable_host();
-  host.set_host_os(ConvertHostOs(metrics_data.host_metrics));
-  host.set_host_os_version(metrics_data.host_metrics.release);
+  host.set_host_os(ConvertHostOs(metrics_data.host_metrics.os));
+  host.set_host_os_version(metrics_data.host_metrics.os.release);
 
   return cf_log_event;
 }

--- a/base/cvd/cuttlefish/host/libs/metrics/metrics_orchestration.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/metrics_orchestration.cc
@@ -77,7 +77,7 @@ Result<MetricsData> GatherMetrics(const MetricsInput& metrics_input) {
           CF_EXPECT(ReadSessionIdFile(metrics_input.metrics_directory)),
       .cf_common_version = GetVersionIds().ToString(),
       .now = GetEpochTime(),
-      .host_metrics = GetHostMetrics(),
+      .host_metrics = CF_EXPECT(GetHostMetrics()),
   };
 
   if (metrics_input.guests) {

--- a/base/cvd/cuttlefish/host/libs/metrics/metrics_orchestration.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/metrics_orchestration.cc
@@ -27,13 +27,13 @@
 #include "absl/log/log.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
-#include "cuttlefish/common/libs/utils/host_info.h"
 #include "cuttlefish/common/libs/utils/tee_logging.h"
 #include "cuttlefish/host/commands/cvd/version/version.h"
 #include "cuttlefish/host/libs/metrics/device_event_type.h"
 #include "cuttlefish/host/libs/metrics/enabled.h"
 #include "cuttlefish/host/libs/metrics/flag_metrics.h"
 #include "cuttlefish/host/libs/metrics/guest_metrics.h"
+#include "cuttlefish/host/libs/metrics/host_metrics.h"
 #include "cuttlefish/host/libs/metrics/metrics_conversion.h"
 #include "cuttlefish/host/libs/metrics/metrics_transmitter.h"
 #include "cuttlefish/host/libs/metrics/metrics_writer.h"
@@ -77,7 +77,7 @@ Result<MetricsData> GatherMetrics(const MetricsInput& metrics_input) {
           CF_EXPECT(ReadSessionIdFile(metrics_input.metrics_directory)),
       .cf_common_version = GetVersionIds().ToString(),
       .now = GetEpochTime(),
-      .host_metrics = GetHostInfo(),
+      .host_metrics = GetHostMetrics(),
   };
 
   if (metrics_input.guests) {


### PR DESCRIPTION
Gathering, but not yet converting and transmitting, metrics field for `cvd` invocation sources and environments devices are run in.

Bug: 456483667