### PR TITLE
Add a handler to the WebRTC operator for context.

### DIFF
--- a/frontend/src/liboperator/operator/operator.go
+++ b/frontend/src/liboperator/operator/operator.go
@@ -174,7 +174,21 @@ func CreateHttpHandlers(
 	router.HandleFunc("/infra_config", func(w http.ResponseWriter, r *http.Request) {
 		ReplyJSONOK(w, config)
 	}).Methods("GET")
+	router.HandleFunc("/context", func(w http.ResponseWriter, r *http.Request) {
+		getContext(w, r)
+	}).Methods("GET")
 	return router
+}
+
+func getContext(w http.ResponseWriter, r *http.Request) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	ctx := make(map[string]interface{})
+	ctx["hostname"] = hostname
+	ReplyJSONOK(w, ctx)
 }
 
 // Control endpoint


### PR DESCRIPTION
We may be running in environments where only the WebRTC operator is exposed. This can make it difficult to verify information about that environment; for example, is the operator (and cvd, etc.) running in a container, or not? One simple way to do this is to expose an endpoint on the operator for debugging purposes, and one simple way to get information about the environment is to expose the hostname.

For now, we just expose the hostname, but it may be worthwhile adding extra fields in the future.

Bug: 503333785