### PR TITLE
Append an environment variable to `cvd` cmds

### DIFF
--- a/frontend/src/host_orchestrator/orchestrator/cvd/cvd.go
+++ b/frontend/src/host_orchestrator/orchestrator/cvd/cvd.go
@@ -288,7 +288,13 @@ func (cli *CLI) groupFromCmdOutput(cmdOut []byte) (*Group, error) {
 }
 
 func (cli *CLI) buildCmd(bin string, args ...string) *exec.Cmd {
-	return cli.execContext(context.TODO(), bin, args...)
+	cmd := cli.execContext(context.TODO(), bin, args...)
+	// to be read by `cvd` for metrics
+	cmd.Env = append(cmd.Env, "CVD_INVOKER=host_orchestrator")
+	// setting `Env` to a value other than `nil` overrides using the existing
+	// environment for the command, so copy it along
+	cmd.Env = append(cmd.Env, os.Environ()...)
+	return cmd
 }
 
 func (cli *CLI) runCmd(cmd *exec.Cmd) ([]byte, error) {


### PR DESCRIPTION
The new variable will be read by `cvd` to report host orchestrator invocations for metrics.

Bug: 491973243