### PR TITLE
Refine GH postsubmit workflow to calculate version schema earlier

### DIFF
--- a/.github/actions/build-debian-packages/action.yaml
+++ b/.github/actions/build-debian-packages/action.yaml
@@ -1,49 +1,26 @@
 name: 'Build debian packages for Cuttlefish host'
 inputs:
-  deploy-channel:
-    required: false
-  yyyymmddhhmm:
+  debian-version:
     required: false
 runs:
   using: "composite"
   steps:
   - name: Modify version format
-    if: inputs.deploy-channel != ''
+    if: inputs.debian-version != ''
     run: |
-      case "${INPUTS_DEPLOY_CHANNEL}" in
-        stable)
-          # Stable version format : X.Y.Z
-          SEMVER=$(echo ${GITHUB_REF_NAME} | grep -oE '[0-9]+.[0-9]+.[0-9]+')
-          sed -i "1s/(\([0-9]\+.[0-9]\+.[0-9]\+\))/(${SEMVER})/g" \
-            base/debian/changelog
-          sed -i "1s/(\([0-9]\+.[0-9]\+.[0-9]\+\))/(${SEMVER})/g" \
-            container/debian/changelog
-          sed -i "1s/(\([0-9]\+.[0-9]\+.[0-9]\+\))/(${SEMVER})/g" \
-            frontend/debian/changelog
-          sed -i "1s/(\([0-9]\+.[0-9]\+.[0-9]\+\))/(${SEMVER})/g" \
-            cuttlefish-integration-gigabyte-arm64/debian/changelog
-          ;;
-        unstable|nightly)
-          # Unstable/nightly version format : X.Y.Z~gitYYYYMMDDHHMM.<Github SHA 8 digit>
-          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
-          SUFFIX="~git${INPUTS_YYYYMMDDHHMM}.${SHORT_SHA}"
-          sed -i "1s/(\([0-9]\+.[0-9]\+.[0-9]\+\))/(\1${SUFFIX})/g" \
-            base/debian/changelog
-          sed -i "1s/(\([0-9]\+.[0-9]\+.[0-9]\+\))/(\1${SUFFIX})/g" \
-            container/debian/changelog
-          sed -i "1s/(\([0-9]\+.[0-9]\+.[0-9]\+\))/(\1${SUFFIX})/g" \
-            frontend/debian/changelog
-          sed -i "1s/(\([0-9]\+.[0-9]\+.[0-9]\+\))/(\1${SUFFIX})/g" \
-            cuttlefish-integration-gigabyte-arm64/debian/changelog
-          ;;
-        *)
-          exit 1
-          ;;
-      esac
+      FILES=(
+        "base/debian/changelog"
+        "container/debian/changelog"
+        "frontend/debian/changelog"
+        "cuttlefish-integration-gigabyte-arm64/debian/changelog"
+      )
+
+      for FILE in "${FILES[@]}"; do
+        sed -i "1s/(\([0-9]\+.[0-9]\+.[0-9]\+\))/(${INPUTS_DEBIAN_VERSION})/g" "$FILE"
+      done
     shell: bash
     env:
-      INPUTS_DEPLOY_CHANNEL: ${{ inputs.deploy-channel }}
-      INPUTS_YYYYMMDDHHMM: ${{ inputs.yyyymmddhhmm }}
+      INPUTS_DEBIAN_VERSION: ${{ inputs.debian-version }}
   - name: Build CF debian packages
     run: |
       sudo docker build --file "tools/buildutils/cw/Containerfile" --tag "android-cuttlefish-build" .

--- a/.github/actions/deploy-docker-image/action.yaml
+++ b/.github/actions/deploy-docker-image/action.yaml
@@ -2,42 +2,19 @@ name: 'Deploy docker image cuttlefish-orchestration'
 inputs:
   arch:
     required: true
-  deploy-channel:
+  image-version:
     required: true
-  yyyymmddhhmm:
-    required: false
 runs:
   using: "composite"
   steps:
   - name: Deploy docker image into Artifact Registry
     run: |
-      case "${INPUTS_DEPLOY_CHANNEL}" in
-        stable)
-          # Stable version tag : X.Y.Z-<amd64|arm64>
-          SEMVER=$(echo ${GITHUB_REF_NAME} | grep -oE '[0-9]+.[0-9]+.[0-9]+')
-          TAG="${SEMVER}-${INPUTS_ARCH}"
-          ;;
-        unstable)
-          # Unstable version tag : X.Y-<Github SHA 8 digit>-<amd64|arm64>
-          SEMVER=$(echo ${GITHUB_REF_NAME} | grep -oE '[0-9]+.[0-9]+')
-          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
-          TAG="${SEMVER}-${SHORT_SHA}-${INPUTS_ARCH}"
-          ;;
-        nightly)
-          # Nightly version tag : gitYYYYMMDDHHMM-<Github SHA 8 digit>-<amd64|arm64>
-          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
-          TAG="git${INPUTS_YYYYMMDDHHMM}-${SHORT_SHA}-${INPUTS_ARCH}"
-          ;;
-        *)
-          exit 1
-          ;;
-      esac
+      TAG=${INPUTS_IMAGE_VERSION}-${INPUTS_ARCH}
       REMOTE_IMAGE_TAG=us-docker.pkg.dev/android-cuttlefish-artifacts/cuttlefish-orchestration/cuttlefish-orchestration:${TAG}
 
       docker tag cuttlefish-orchestration ${REMOTE_IMAGE_TAG}
       docker push ${REMOTE_IMAGE_TAG}
     shell: bash
     env:
-      INPUTS_DEPLOY_CHANNEL: ${{ inputs.deploy-channel }}
       INPUTS_ARCH: ${{ inputs.arch }}
-      INPUTS_YYYYMMDDHHMM: ${{ inputs.yyyymmddhhmm }}
+      INPUTS_IMAGE_VERSION: ${{ inputs.image-version }}

--- a/.github/actions/deploy-gigabyte-ampere-cuttlefish-installer/action.yaml
+++ b/.github/actions/deploy-gigabyte-ampere-cuttlefish-installer/action.yaml
@@ -2,8 +2,8 @@ name: 'Deploy installer for Gigabyte Ampere server'
 inputs:
   deploy-channel:
     required: true
-  yyyymmddhhmm:
-    required: false
+  image-version:
+    required: true
   path:
     required: true
 runs:
@@ -16,27 +16,6 @@ runs:
   - name: Deploy installer image into Artifact Registry
     run: |
       REPO=gigabyte-ampere-server-installer
-      case "${INPUTS_DEPLOY_CHANNEL}" in
-        stable)
-          # Stable version tag : X.Y.Z
-          SEMVER=$(echo ${GITHUB_REF_NAME} | grep -oE '[0-9]+.[0-9]+.[0-9]+')
-          TAG="${SEMVER}"
-          ;;
-        unstable)
-          # Unstable version tag : X.Y-<Github SHA 8 digit>
-          SEMVER=$(echo ${GITHUB_REF_NAME} | grep -oE '[0-9]+.[0-9]+')
-          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
-          TAG="${SEMVER}-${SHORT_SHA}"
-          ;;
-        nightly)
-          # Nightly version tag : gitYYYYMMDDHHMM-<Github SHA 8 digit>
-          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
-          TAG="git${INPUTS_YYYYMMDDHHMM}-${SHORT_SHA}"
-          ;;
-        *)
-          exit 1
-          ;;
-      esac
       pushd ${INPUTS_PATH}
       gcloud artifacts versions delete ${INPUTS_DEPLOY_CHANNEL} \
         --location=us \
@@ -44,7 +23,7 @@ runs:
         --project="android-cuttlefish-artifacts" \
         --quiet \
         --repository="${REPO}" || true
-      for VERSION in ${TAG} ${INPUTS_DEPLOY_CHANNEL}; do
+      for VERSION in ${INPUTS_IMAGE_VERSION} ${INPUTS_DEPLOY_CHANNEL}; do
         gcloud artifacts generic upload \
           --location=us \
           --package="debian-installer" \
@@ -57,5 +36,5 @@ runs:
     shell: bash
     env:
       INPUTS_DEPLOY_CHANNEL: ${{ inputs.deploy-channel }}
-      INPUTS_YYYYMMDDHHMM: ${{ inputs.yyyymmddhhmm }}
+      INPUTS_IMAGE_VERSION: ${{ inputs.image-version }}
       INPUTS_PATH: ${{ inputs.path }}

--- a/.github/workflows/update-cache-and-deployment.yaml
+++ b/.github/workflows/update-cache-and-deployment.yaml
@@ -111,6 +111,7 @@ jobs:
         deploy-channel: ${{ inputs.deploy-channel }}
         path: .
   deploy-gigabyte-ampere-installer-arm64:
+    if: inputs.deploy-channel != ''
     needs: [set-variables]
     environment: deployment
     runs-on: ubuntu-22.04
@@ -122,12 +123,10 @@ jobs:
     - name: Build Gigabyte Ampere installer
       uses: ./.github/actions/build-gigabyte-ampere-cuttlefish-installer
     - name: Authentication on GCP project android-cuttlefish-artifacts
-      if: inputs.deploy-channel != ''
       uses: 'google-github-actions/auth@v3'
       with:
         credentials_json: '${{ secrets.artifact-registry-uploader-json-creds }}'
     - name: Deploy Gigabyte Ampere server iso installer image.
-      if: inputs.deploy-channel != ''
       uses: ./.github/actions/deploy-gigabyte-ampere-cuttlefish-installer
       with:
         deploy-channel: ${{ inputs.deploy-channel }}

--- a/.github/workflows/update-cache-and-deployment.yaml
+++ b/.github/workflows/update-cache-and-deployment.yaml
@@ -17,15 +17,14 @@ jobs:
   set-variables:
     runs-on: ubuntu-22.04
     outputs:
-      yyyymmddhhmm: ${{ steps.yyyymmddhhmm.outputs.time }}
+      yyyymmddhhmm: ${{ steps.define-version.outputs.time }}
     steps:
-    - name: Set YYYYMMDDHHMM
-      id: yyyymmddhhmm
-      run: echo "time=$(date -u +'%Y%m%d%H%M')" >> $GITHUB_OUTPUT
-    - name: Echo YYYYMMDDHHMM
-      run: echo ${STEPS_YYYYMMDDHHMM_OUTPUTS_TIME}
-      env:
-        STEPS_YYYYMMDDHHMM_OUTPUTS_TIME: ${{ steps.yyyymmddhhmm.outputs.time }}
+    - name: Define version
+      id: define-version
+      run: |
+        TIME=$(date -u +'%Y%m%d%H%M')
+        echo "time=$TIME" >> $GITHUB_OUTPUT
+        echo "time is $TIME"
   update-cvd-test-bazel-cache:
     if: inputs.update-cache
     runs-on: ubuntu-24.04

--- a/.github/workflows/update-cache-and-deployment.yaml
+++ b/.github/workflows/update-cache-and-deployment.yaml
@@ -18,13 +18,38 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       yyyymmddhhmm: ${{ steps.define-version.outputs.time }}
+      image-version: ${{ steps.define-version.outputs.image_version }}
     steps:
     - name: Define version
       id: define-version
       run: |
         TIME=$(date -u +'%Y%m%d%H%M')
+        case "${INPUTS_DEPLOY_CHANNEL}" in
+          stable)
+            # Stable version tag : X.Y.Z
+            SEMVER=$(echo ${GITHUB_REF_NAME} | grep -oE '[0-9]+.[0-9]+.[0-9]+')
+            IMAGE_VERSION="${SEMVER}"
+            ;;
+          unstable)
+            # Unstable version tag : X.Y-<Github SHA 8 digit>
+            SEMVER=$(echo ${GITHUB_REF_NAME} | grep -oE '[0-9]+.[0-9]+')
+            SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
+            IMAGE_VERSION="${SEMVER}-${SHORT_SHA}"
+            ;;
+          nightly)
+            # Nightly version tag : gitYYYYMMDDHHMM-<Github SHA 8 digit>
+            SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
+            IMAGE_VERSION="git${TIME}-${SHORT_SHA}"
+            ;;
+          *)
+            IMAGE_VERSION=
+        esac
         echo "time=$TIME" >> $GITHUB_OUTPUT
         echo "time is $TIME"
+        echo "image_version=$IMAGE_VERSION" >> $GITHUB_OUTPUT
+        echo "image_version is $IMAGE_VERSION"
+      env:
+        INPUTS_DEPLOY_CHANNEL: ${{ inputs.deploy-channel }}
   update-cvd-test-bazel-cache:
     if: inputs.update-cache
     runs-on: ubuntu-24.04
@@ -130,7 +155,7 @@ jobs:
       uses: ./.github/actions/deploy-gigabyte-ampere-cuttlefish-installer
       with:
         deploy-channel: ${{ inputs.deploy-channel }}
-        yyyymmddhhmm: ${{ needs.set-variables.outputs.yyyymmddhhmm }}
+        image-version: ${{ needs.set-variables.outputs.image-version }}
         path: ./gigabyte-ampere-cuttlefish-installer
 
   deploy-docker-image-amd64:
@@ -159,8 +184,7 @@ jobs:
       uses: ./.github/actions/deploy-docker-image
       with:
         arch: amd64
-        deploy-channel: ${{ inputs.deploy-channel }}
-        yyyymmddhhmm: ${{ needs.set-variables.outputs.yyyymmddhhmm }}
+        image-version: ${{ needs.set-variables.outputs.image-version }}
   deploy-docker-image-arm64:
     if: inputs.deploy-channel != ''
     needs: [set-variables, update-bazel-cache-and-deploy-debian-package-arm64]
@@ -187,8 +211,7 @@ jobs:
       uses: ./.github/actions/deploy-docker-image
       with:
         arch: arm64
-        deploy-channel: ${{ inputs.deploy-channel }}
-        yyyymmddhhmm: ${{ needs.set-variables.outputs.yyyymmddhhmm }}
+        image-version: ${{ needs.set-variables.outputs.image-version }}
   deploy-docker-manifest:
     if: inputs.deploy-channel != ''
     needs: [set-variables, deploy-docker-image-amd64, deploy-docker-image-arm64]
@@ -209,28 +232,8 @@ jobs:
         password: '${{ secrets.artifact-registry-uploader-json-creds }}'
     - name: Deploy manifests
       run: |
-        case "${INPUTS_DEPLOY_CHANNEL}" in
-          stable)
-            # Stable version tag : X.Y.Z
-            SEMVER=$(echo ${GITHUB_REF_NAME} | grep -oE '[0-9]+.[0-9]+.[0-9]+')
-            TAG="${SEMVER}"
-            ;;
-          unstable)
-            # Unstable version tag : X.Y-<Github SHA 8 digit>
-            SEMVER=$(echo ${GITHUB_REF_NAME} | grep -oE '[0-9]+.[0-9]+')
-            SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
-            TAG="${SEMVER}-${SHORT_SHA}"
-            ;;
-          nightly)
-            # Nightly version tag : gitYYYYMMDDHHMM-<Github SHA 8 digit>
-            SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
-            TAG="git${NEEDS_SET_VARIABLES_OUTPUTS_YYYYMMDDHHMM}-${SHORT_SHA}"
-            ;;
-          *)
-            exit 1
-            ;;
-        esac
         IMAGE=us-docker.pkg.dev/android-cuttlefish-artifacts/cuttlefish-orchestration/cuttlefish-orchestration
+        TAG=${NEEDS_SET_VARIABLES_OUTPUTS_IMAGE_VERSION}
 
         for MANIFEST_TAG in ${TAG} ${INPUTS_DEPLOY_CHANNEL}; do
           docker manifest create ${IMAGE}:${MANIFEST_TAG} \
@@ -240,4 +243,4 @@ jobs:
         done
       env:
         INPUTS_DEPLOY_CHANNEL: ${{ inputs.deploy-channel }}
-        NEEDS_SET_VARIABLES_OUTPUTS_YYYYMMDDHHMM: ${{ needs.set-variables.outputs.yyyymmddhhmm }}
+        NEEDS_SET_VARIABLES_OUTPUTS_IMAGE_VERSION: ${{ needs.set-variables.outputs.image_version }}

--- a/.github/workflows/update-cache-and-deployment.yaml
+++ b/.github/workflows/update-cache-and-deployment.yaml
@@ -17,37 +17,47 @@ jobs:
   set-variables:
     runs-on: ubuntu-22.04
     outputs:
-      yyyymmddhhmm: ${{ steps.define-version.outputs.time }}
+      debian-version: ${{ steps.define-version.outputs.debian_version }}
       image-version: ${{ steps.define-version.outputs.image_version }}
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
     - name: Define version
       id: define-version
       run: |
         TIME=$(date -u +'%Y%m%d%H%M')
         case "${INPUTS_DEPLOY_CHANNEL}" in
           stable)
-            # Stable version tag : X.Y.Z
+            # Debian package format                : X.Y.Z
+            # Docker tag / os image version format : X.Y.Z
             SEMVER=$(echo ${GITHUB_REF_NAME} | grep -oE '[0-9]+.[0-9]+.[0-9]+')
+            DEBIAN_VERSION="${SEMVER}"
             IMAGE_VERSION="${SEMVER}"
             ;;
           unstable)
-            # Unstable version tag : X.Y-<Github SHA 8 digit>
+            # Debian package format                : X.Y~gitYYYYMMDDHHMM-<Github SHA 8 digit>
+            # Docker tag / os image version format : X.Y-<Github SHA 8 digit>
             SEMVER=$(echo ${GITHUB_REF_NAME} | grep -oE '[0-9]+.[0-9]+')
             SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
+            DEBIAN_VERSION="${SEMVER}~git${TIME}.${SHORT_SHA}"
             IMAGE_VERSION="${SEMVER}-${SHORT_SHA}"
             ;;
           nightly)
-            # Nightly version tag : gitYYYYMMDDHHMM-<Github SHA 8 digit>
+            # Debian package format                : X.Y.Z~gitYYYYMMDDHHMM-<Github SHA 8 digit>
+            # Docker tag / os image version format : gitYYYYMMDDHHMM-<Github SHA 8 digit>
             SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
+            BASE_VERSION=$(sed -n '1s/.*(\([0-9]\+\.[0-9]\+\.[0-9]\+\)).*/\1/p' base/debian/changelog)
+            DEBIAN_VERSION="${BASE_VERSION}~git${TIME}.${SHORT_SHA}"
             IMAGE_VERSION="git${TIME}-${SHORT_SHA}"
             ;;
           *)
-            IMAGE_VERSION=
+            DEBIAN_VERSION=""
+            IMAGE_VERSION=""
         esac
-        echo "time=$TIME" >> $GITHUB_OUTPUT
-        echo "time is $TIME"
         echo "image_version=$IMAGE_VERSION" >> $GITHUB_OUTPUT
         echo "image_version is $IMAGE_VERSION"
+        echo "debian_version=$DEBIAN_VERSION" >> $GITHUB_OUTPUT
+        echo "debian_version is $DEBIAN_VERSION"
       env:
         INPUTS_DEPLOY_CHANNEL: ${{ inputs.deploy-channel }}
   update-cvd-test-bazel-cache:
@@ -89,8 +99,7 @@ jobs:
     - name: Build CF host debian packages
       uses: ./.github/actions/build-debian-packages
       with:
-        deploy-channel: ${{ inputs.deploy-channel }}
-        yyyymmddhhmm: ${{ needs.set-variables.outputs.yyyymmddhhmm }}
+        debian-version: ${{ needs.set-variables.outputs.debian-version }}
     - name: Authentication on GCP project android-cuttlefish-artifacts
       if: inputs.deploy-channel != ''
       uses: 'google-github-actions/auth@v3'
@@ -122,8 +131,7 @@ jobs:
     - name: Build CF host debian packages
       uses: ./.github/actions/build-debian-packages
       with:
-        deploy-channel: ${{ inputs.deploy-channel }}
-        yyyymmddhhmm: ${{ needs.set-variables.outputs.yyyymmddhhmm }}
+        debian-version: ${{ needs.set-variables.outputs.debian-version }}
     - name: Authentication on GCP project android-cuttlefish-artifacts
       if: inputs.deploy-channel != ''
       uses: 'google-github-actions/auth@v3'


### PR DESCRIPTION
Currently podcvd is relying on the tag `nightly`, where underlying container image is mutable. GH postsubmit check should pass information around proper image/tag name of fixed container image when building `cuttlefish-podcvd` deb package. However, its calculation is handled by each job or action today. This PR aims for calculating it earlier, so that GH postsubmit workflow is getting more clear and also being usable by more jobs in the workflow

Context: b/504803548