### PR TITLE
gigabyte-ampere-cuttlefish-installer: modify actions and workflow to support pinned version

### DIFF
--- a/.github/actions/build-gigabyte-ampere-cuttlefish-installer/action.yaml
+++ b/.github/actions/build-gigabyte-ampere-cuttlefish-installer/action.yaml
@@ -1,4 +1,9 @@
 name: 'Build iso installer for Gigabyte Ampere server'
+inputs:
+  deploy-channel:
+    required: false
+  debian-version:
+    required: false
 runs:
   using: "composite"
   steps:
@@ -17,11 +22,17 @@ runs:
       DEBIAN_ISO_URL: "https://deb.debian.org/debian/dists/trixie/main/installer-arm64/current/images/netboot/mini.iso"
       CI_PROJECT_NAME: ${{ github.event.repository.name }}
       CI_PIPELINE_ID: ${{ github.run_id }}
+      INPUTS_DEPLOY_CHANNEL: ${{ inputs.deploy-channel }}
+      INPUTS_DEBIAN_VERSION: ${{ inputs.debian-version }}
     shell: bash
     working-directory: ./gigabyte-ampere-cuttlefish-installer
     run: |
       sed -i "2i CI_PROJECT_NAME=${CI_PROJECT_NAME}" preseed/after_install_1.sh
       sed -i "3i CI_PIPELINE_ID=${CI_PIPELINE_ID}" preseed/after_install_1.sh
+      if [ x"${INPUTS_DEPLOY_CHANNEL}" != x"" ]; then
+        sed -i "s/^#DEPLOY_CHANNEL=/DEPLOY_CHANNEL=${INPUTS_DEPLOY_CHANNEL}/" preseed/after_install_1.sh
+        sed -i "s/^#DEPLOY_VERSION=/DEPLOY_VERSION=${INPUTS_DEBIAN_VERSION}/" preseed/after_install_1.sh
+      fi
       wget -nv -c ${DEBIAN_ISO_URL}
       ./addpreseed.sh
       xz -9e preseed-mini.iso

--- a/.github/workflows/update-cache-and-deployment.yaml
+++ b/.github/workflows/update-cache-and-deployment.yaml
@@ -155,6 +155,9 @@ jobs:
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
     - name: Build Gigabyte Ampere installer
       uses: ./.github/actions/build-gigabyte-ampere-cuttlefish-installer
+      with:
+        deploy-channel: ${{ inputs.deploy-channel }}
+        debian-version: ${{ needs.set-variables.outputs.debian-version }}
     - name: Authentication on GCP project android-cuttlefish-artifacts
       uses: 'google-github-actions/auth@v3'
       with:

--- a/gigabyte-ampere-cuttlefish-installer/preseed/after_install_1.sh
+++ b/gigabyte-ampere-cuttlefish-installer/preseed/after_install_1.sh
@@ -64,16 +64,42 @@ fi
 # End of Install kernel
 
 # Install android cuttlefish packages
+#DEPLOY_CHANNEL=
+#DEPLOY_VERSION=
 curl -fsSL --retry 7 --retry-all-errors https://us-apt.pkg.dev/doc/repo-signing-key.gpg -o /etc/apt/trusted.gpg.d/artifact-registry.asc
 chmod a+r /etc/apt/trusted.gpg.d/artifact-registry.asc
-echo "deb https://us-apt.pkg.dev/projects/android-cuttlefish-artifacts android-cuttlefish main" \
-    | tee -a /etc/apt/sources.list.d/artifact-registry.list
+if [ x"${DEPLOY_CHANNEL}" = x"nightly" ]; then
+    echo "deb https://us-apt.pkg.dev/projects/android-cuttlefish-artifacts android-cuttlefish-nightly main" \
+        | tee -a /etc/apt/sources.list.d/artifact-registry.list
+elif [ x"${DEPLOY_CHANNEL}" = x"unstable" ]; then
+    echo "deb https://us-apt.pkg.dev/projects/android-cuttlefish-artifacts android-cuttlefish-unstable main" \
+        | tee -a /etc/apt/sources.list.d/artifact-registry.list
+else
+    echo "deb https://us-apt.pkg.dev/projects/android-cuttlefish-artifacts android-cuttlefish main" \
+        | tee -a /etc/apt/sources.list.d/artifact-registry.list
+fi
+
 apt-get update
-apt-get install -y cuttlefish-base cuttlefish-user cuttlefish-orchestration -t android-cuttlefish
+
+if [ x"${DEPLOY_CHANNEL}" = x"stable" ]; then
+    apt-get install -y cuttlefish-base="${DEPLOY_VERSION}" cuttlefish-user="${DEPLOY_VERSION}" cuttlefish-orchestration="${DEPLOY_VERSION}" -t android-cuttlefish
+    apt-mark hold cuttlefish-base cuttlefish-user cuttlefish-orchestration
+elif [ x"${DEPLOY_CHANNEL}" != x"" ]; then
+    apt-get install -y cuttlefish-base="${DEPLOY_VERSION}" cuttlefish-user="${DEPLOY_VERSION}" cuttlefish-orchestration="${DEPLOY_VERSION}" -t android-cuttlefish-"${DEPLOY_CHANNEL}"
+    apt-mark hold cuttlefish-base cuttlefish-user cuttlefish-orchestration
+else
+    apt-get install -y cuttlefish-base cuttlefish-user cuttlefish-orchestration -t android-cuttlefish
+fi
+
 adduser vsoc-01 cvdnetwork
 
 # Install gigabyte package
-apt -o Apt::Get::Assume-Yes=true -o APT::Color=0 -o DPkgPM::Progress-Fancy=0 -o Acquire::Retries=5 install cuttlefish-integration-gigabyte-arm64
+if [ x"${DEPLOY_CHANNEL}" != x"" ]; then
+    apt -o Apt::Get::Assume-Yes=true -o APT::Color=0 -o DPkgPM::Progress-Fancy=0 -o Acquire::Retries=5 install cuttlefish-integration-gigabyte-arm64="${DEPLOY_VERSION}"
+    apt-mark hold cuttlefish-integration-gigabyte-arm64
+else
+    apt -o Apt::Get::Assume-Yes=true -o APT::Color=0 -o DPkgPM::Progress-Fancy=0 -o Acquire::Retries=5 install cuttlefish-integration-gigabyte-arm64
+fi
 
 # Extra tools
 cd /root


### PR DESCRIPTION
Let the installer reproducible. Previously the installer always install
the latest stable version. We change it to only install the version
when the image is being built. This makes the image reproducible if
the newer image has issues.
