### PR TITLE
Replace usages of android::base::Realpath

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/files.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/files.cpp
@@ -432,10 +432,6 @@ std::string AbsolutePath(std::string_view path) {
   if (path[0] == '/') {
     return std::string(path);
   }
-  if (path[0] == '~') {
-    LOG(WARNING) << "Tilde expansion in path " << path <<" is not supported";
-    return {};
-  }
 
   std::array<char, PATH_MAX> buffer{};
   if (!realpath(".", buffer.data())) {

--- a/base/cvd/cuttlefish/common/libs/utils/files.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/files.cpp
@@ -23,11 +23,15 @@
 #endif
 
 #include <dirent.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <ftw.h>
 #include <libgen.h>
 #include <sched.h>
+#include <stddef.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/ioctl.h>
 #include <sys/select.h>
 #include <sys/socket.h>
@@ -37,12 +41,7 @@
 #include <unistd.h>
 
 #include <array>
-#include <cerrno>
 #include <chrono>
-#include <cstddef>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
 #include <fstream>
 #include <ios>
 #include <iosfwd>

--- a/base/cvd/cuttlefish/common/libs/utils/files.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/files.cpp
@@ -433,13 +433,24 @@ std::string AbsolutePath(std::string_view path) {
     return std::string(path);
   }
 
-  std::array<char, PATH_MAX> buffer{};
-  if (!realpath(".", buffer.data())) {
-    LOG(WARNING) << "Could not get real path for current directory \".\""
-                 << ": " << strerror(errno);
+  Result<std::string> real_cwd = RealPath(".");
+  if (!real_cwd.ok()) {
+    LOG(WARNING) << "Could not get real path for current directory \".\": "
+                 << real_cwd.error();
     return {};
   }
-  return absl::StrCat(buffer.data(), "/", path);
+  return absl::StrCat(*real_cwd, "/", path);
+}
+
+Result<std::string> RealPath(const std::string& path) {
+  std::array<char, PATH_MAX> buffer{};
+  char* res;
+  do {
+    res = realpath(path.c_str(), buffer.data());
+  } while (res == nullptr && errno == EINTR);
+  CF_EXPECTF(res != nullptr, "Could not get real path for path \"{}\": {}",
+             path, StrError(errno));
+  return std::string(buffer.data());
 }
 
 off_t FileSize(const std::string& path) {
@@ -722,12 +733,11 @@ Result<std::string> EmulateAbsolutePath(const InputPathForm& path_info) {
 
   const auto processed_path = "/" + absl::StrJoin(processed_tokens, "/");
 
-  std::string real_path = processed_path;
   if (path_info.follow_symlink && FileExists(processed_path)) {
-    CF_EXPECTF(android::base::Realpath(processed_path, &real_path),
-               "Failed to effectively conduct readpath -f {}", processed_path);
+    return CF_EXPECTF(RealPath(processed_path),
+                           "Failed to effectively conduct readpath -f {}", processed_path);
   }
-  return real_path;
+  return processed_path;
 }
 
 std::vector<std::string> Path(const std::string& env_name) {

--- a/base/cvd/cuttlefish/common/libs/utils/files.h
+++ b/base/cvd/cuttlefish/common/libs/utils/files.h
@@ -84,7 +84,6 @@ Result<uid_t> FileOwner(const std::string& path);
 
 // The returned value may contain .. or . if these are present in the path
 // argument.
-// path must not contain ~
 std::string AbsolutePath(std::string_view path);
 
 std::string CurrentDirectory();

--- a/base/cvd/cuttlefish/common/libs/utils/files.h
+++ b/base/cvd/cuttlefish/common/libs/utils/files.h
@@ -86,6 +86,8 @@ Result<uid_t> FileOwner(const std::string& path);
 // argument.
 std::string AbsolutePath(std::string_view path);
 
+Result<std::string> RealPath(const std::string& path);
+
 std::string CurrentDirectory();
 
 struct FileSizes {

--- a/base/cvd/cuttlefish/common/libs/utils/users.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/users.cpp
@@ -110,11 +110,7 @@ Result<std::string> SystemWideUserHome() {
       return CF_ERRNO("Failed to find the home directory using " << uid);
     }
   }
-  std::string home_realpath;
-  if (!android::base::Realpath(home_dir, &home_realpath)) {
-    return CF_ERRNO("Failed to convert " << home_dir << " to its Realpath");
-  }
-  return home_realpath;
+  return home_dir;
 }
 
 Result<std::string> CurrentUserName() {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/bugreport.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/bugreport.cpp
@@ -120,9 +120,6 @@ Result<void> CvdBugreportCommandHandler::Handle(const CommandRequest& request) {
   std::vector<std::string> cmd_args = request.SubcommandArguments();
   cvd_common::Envs env = request.Env();
 
-  std::string android_host_out;
-  std::string home = CF_EXPECT(SystemWideUserHome());
-
   if (CF_EXPECT(HasHelpFlag(cmd_args))) {
     CF_EXPECT(HandleHelp(env, cmd_args, request));
     return {};
@@ -136,8 +133,8 @@ Result<void> CvdBugreportCommandHandler::Handle(const CommandRequest& request) {
 
   auto instance_group =
       CF_EXPECT(selector::SelectGroup(instance_manager_, request));
-  android_host_out = instance_group.HostArtifactsPath();
-  home = instance_group.HomeDir();
+  std::string android_host_out = instance_group.HostArtifactsPath();
+  std::string home = instance_group.HomeDir();
   env["HOME"] = home;
   env[kAndroidHostOut] = android_host_out;
   const std::string bin_path =

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/bugreport.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/bugreport.cpp
@@ -34,7 +34,6 @@
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/flag_parser.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"
-#include "cuttlefish/common/libs/utils/users.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/interruptible_terminal.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/config_path.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/config_path.cpp
@@ -23,9 +23,8 @@
 namespace cuttlefish {
 
 Result<std::string> GetCuttlefishConfigPath(const std::string& home) {
-  std::string home_realpath;
   CF_EXPECT(DirectoryExists(home), "Invalid Home Directory");
-  CF_EXPECT(android::base::Realpath(home, &home_realpath));
+  std::string home_realpath = CF_EXPECT(RealPath(home));
   static const char kSuffix[] = "/cuttlefish_assembly/cuttlefish_config.json";
   std::string config_path = AbsolutePath(home_realpath + kSuffix);
   CF_EXPECT(FileExists(config_path), "No config file exists");

--- a/base/cvd/cuttlefish/host/libs/command_util/snapshot_utils.cc
+++ b/base/cvd/cuttlefish/host/libs/command_util/snapshot_utils.cc
@@ -142,9 +142,9 @@ Result<void> CopyDirectoryImpl(
  * If emulating absolute path fails, "path" is returned as is.
  */
 std::string RealpathOrSelf(const std::string& path) {
-  std::string output;
-  if (android::base::Realpath(path, &output)) {
-    return output;
+  Result<std::string> output = RealPath(path);
+  if (output.ok()) {
+    return *output;
   }
   struct InputPathForm input_form {
     .path_to_convert = path, .follow_symlink = true,

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -263,7 +263,9 @@ cf_cc_library(
     srcs = ["fetcher_configs.cc"],
     hdrs = ["fetcher_configs.h"],
     deps = [
+        "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/libs/config:fetcher_config",
+        "//cuttlefish/result",
         "//libbase",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/strings",

--- a/base/cvd/cuttlefish/host/libs/config/fetcher_configs.cc
+++ b/base/cvd/cuttlefish/host/libs/config/fetcher_configs.cc
@@ -24,9 +24,10 @@
 #include "absl/log/log.h"
 #include "absl/strings/str_cat.h"
 #include "absl/types/span.h"
-#include "android-base/file.h"
 
+#include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/libs/config/fetcher_config.h"
+#include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
 
@@ -40,9 +41,13 @@ FetcherConfigs FetcherConfigs::ReadFromDirectories(
 
   for (const std::string& dir : directories) {
     std::string real;
-    if (!android::base::Realpath(dir, &real)) {
-      LOG(WARNING) << "Failed to resolve real path for '" << dir << "'";
+    Result<std::string> real_res = cuttlefish::RealPath(dir);
+    if (!real_res.ok()) {
+      LOG(WARNING) << "Failed to resolve real path for '" << dir
+                   << "': " << real_res.error();
       real = dir;
+    } else {
+      real = *real_res;
     }
 
     auto [it, inserted] =

--- a/base/cvd/cuttlefish/host/libs/image_aggregator/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/image_aggregator/BUILD.bazel
@@ -128,6 +128,7 @@ cf_cc_library(
     hdrs = ["sparse_image.h"],
     deps = [
         "//cuttlefish/common/libs/fs",
+        "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:subprocess",
         "//cuttlefish/host/libs/config:known_paths",
         "//cuttlefish/host/libs/image_aggregator:disk_image",

--- a/base/cvd/cuttlefish/host/libs/image_aggregator/sparse_image.cc
+++ b/base/cvd/cuttlefish/host/libs/image_aggregator/sparse_image.cc
@@ -23,10 +23,12 @@
 #include <string_view>
 #include <utility>
 
-#include <android-base/file.h>
+#include <android-base/unique_fd.h>
 #include <sparse/sparse.h>
 
+
 #include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"
 #include "cuttlefish/host/libs/config/known_paths.h"
 #include "cuttlefish/posix/rename.h"
@@ -38,8 +40,7 @@ namespace {
 constexpr std::string_view kAndroidSparseImageMagic = "\x3A\xFF\x26\xED";
 
 Result<SharedFD> AcquireLockForImage(const std::string& image_path) {
-  std::string image_realpath;
-  CF_EXPECT(android::base::Realpath(image_path, &image_realpath));
+  std::string image_realpath = CF_EXPECT(RealPath(image_path));
   std::string tmp_lock_image_path = image_realpath + ".lock";
   SharedFD fd =
       SharedFD::Open(tmp_lock_image_path.c_str(), O_RDWR | O_CREAT, 0666);


### PR DESCRIPTION
* Adds our own implementation of RealPath, returning Result and handling EINTR errors.
* Don't call realpath in SystemWideHome to break a circular dependency and because it's not correct in most situations.
* Adds tilde expansion to cuttlefish::AbsolutePath instead of returning empty string (it still does if SystemWideHome fails, but at least that's less likely)
* 

Bug: b/505481472
Assisted-by: Gemini:Next