### PR TITLE
Always show all help commands

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/help.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/help.cpp
@@ -120,14 +120,12 @@ class CvdHelpHandler : public CvdCommandHandler {
       }
     }
 
-    if (CF_EXPECT(instance_manager_.HasInstanceGroups())) {
-      help_message << kSelectorOptionsText;
-      help_message << "\nDevice-Specific Commands (cvd help <command> for more "
-                      "information):\n";
-      for (const auto& handler : request_handlers_) {
-        if (handler->RequiresDeviceExists()) {
-          CF_EXPECT(PrintHandler(help_message, *handler));
-        }
+    help_message << kSelectorOptionsText;
+    help_message << "\nDevice-Specific Commands (cvd help <command> for more "
+                    "information):\n";
+    for (const auto& handler : request_handlers_) {
+      if (handler->RequiresDeviceExists()) {
+        CF_EXPECT(PrintHandler(help_message, *handler));
       }
     }
 


### PR DESCRIPTION
Follow-up to PR #2429 to keep the bulk of the changes, like grouping commands, but not hide commands from the user.

Bug: 504758273