### PR TITLE
Replace usage of android::base::Readlink

### DIFF
--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd.cpp
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd.cpp
@@ -37,7 +37,6 @@
 #include <utility>
 #include <vector>
 
-#include <android-base/file.h>
 #include <fmt/format.h>
 #include "absl/log/check.h"
 #include "absl/log/log.h"
@@ -1059,19 +1058,6 @@ int FileInstance::Futimens(const struct timespec times[2]) {
 
   return TEMP_FAILURE_RETRY(futimens(fd_, times));
 }
-
-#ifdef __linux__
-Result<std::string> FileInstance::ProcFdLinkTarget() const {
-  std::stringstream output_composer;
-  output_composer << "/proc/" << getpid() << "/fd/" << fd_;
-  const std::string mem_fd_link = output_composer.str();
-  std::string mem_fd_target;
-  CF_EXPECT(
-      android::base::Readlink(mem_fd_link, &mem_fd_target),
-      "Getting link for the memory file \"" << mem_fd_link << "\" failed");
-  return mem_fd_target;
-}
-#endif
 
 // inotify related functions
 int FileInstance::InotifyAddWatch(const std::string& pathname, uint32_t mask) {

--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd.h
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd.h
@@ -399,10 +399,6 @@ class FileInstance {
 
   int Futimens(const struct timespec times[2]);
 
-  // Returns the target of "/proc/getpid()/fd/" + std::to_string(fd_)
-  // if appropriate
-  Result<std::string> ProcFdLinkTarget() const;
-
   // inotify related functions
   int InotifyAddWatch(const std::string& pathname, uint32_t mask);
   void InotifyRmWatch(int watch);

--- a/base/cvd/cuttlefish/common/libs/utils/files.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/files.cpp
@@ -534,6 +534,19 @@ Result<std::string> ReadFileContents(const std::string& filepath) {
   return file_content;
 }
 
+Result<std::string> ReadLink(const std::string& path) {
+  std::vector<char> buf(4096);
+  while (true) {
+    ssize_t size = readlink(path.c_str(), buf.data(), buf.size());
+    CF_EXPECTF(size != -1, "readlink(\"{}\") failed: {}", path,
+               StrError(errno));
+    if (static_cast<size_t>(size) < buf.size()) {
+      return std::string(buf.data(), size);
+    }
+    buf.resize(buf.size() * 2);
+  }
+}
+
 Result<void> WriteNewFile(const std::string& filepath, std::string_view content,
                           mode_t mode) {
   CF_EXPECTF(!FileExists(filepath), "File already exists: {}", filepath);

--- a/base/cvd/cuttlefish/common/libs/utils/files.h
+++ b/base/cvd/cuttlefish/common/libs/utils/files.h
@@ -72,6 +72,7 @@ Result<std::string> RenameFile(const std::string& current_filepath,
                                const std::string& target_filepath);
 std::string ReadFile(const std::string& file);
 Result<std::string> ReadFileContents(const std::string& filepath);
+Result<std::string> ReadLink(const std::string& path);
 Result<void> WriteNewFile(const std::string& filepath, std::string_view content,
                           mode_t mode = S_IRWXU | S_IRGRP | S_IROTH);
 bool MakeFileExecutable(const std::string& path);

--- a/base/cvd/cuttlefish/common/libs/utils/proc_file_utils.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/proc_file_utils.cpp
@@ -146,11 +146,9 @@ Result<std::vector<std::string>> GetCmdArgs(const pid_t pid) {
 }
 
 Result<std::string> GetExecutablePath(const pid_t pid) {
-  std::string exec_target_path;
   std::string proc_exe_path = fmt::format("/proc/{}/exe", pid);
-  CF_EXPECT(
-      android::base::Readlink(proc_exe_path, std::addressof(exec_target_path)),
-      proc_exe_path << " Should be a symbolic link but it is not.");
+  std::string exec_target_path = CF_EXPECTF(
+      ReadLink(proc_exe_path), "Unable to read link at \"{}\".", proc_exe_path);
   std::string suffix(" (deleted)");
   if (absl::EndsWith(exec_target_path, suffix)) {
     return exec_target_path.substr(0, exec_target_path.size() - suffix.size());

--- a/base/cvd/cuttlefish/host/libs/command_util/snapshot_utils.cc
+++ b/base/cvd/cuttlefish/host/libs/command_util/snapshot_utils.cc
@@ -81,9 +81,8 @@ Result<void> CopyDirectoryImpl(
     CF_EXPECTF(lstat(src_path.data(), &src_stat) != -1, "Failed in lstat({})",
                src_path);
     if (IsSymlink(src_stat)) {
-      std::string target;
-      CF_EXPECTF(android::base::Readlink(src_path, &target),
-                 "Readlink failed for {}", src_path);
+      std::string target =
+          CF_EXPECTF(ReadLink(src_path), "Readlink failed for {}", src_path);
       VLOG(0) << "Creating link from " << dest_path << " to " << target;
       if (FileExists(dest_path, /* follow_symlink */ false)) {
         CF_EXPECTF(RemoveFile(dest_path), "Failed to unlink/remove file \"{}\"",


### PR DESCRIPTION
Added ReadLink to `//cuttlefish/common/libs/files`, returning `Result<std::string>` instead of `bool`.
Deleted unused function that would otherwise cause a circular dependency.

Bug: b/505849423