### PR TITLE
Install linux-headers/linux-image although not having backports.

### DIFF
--- a/gigabyte-ampere-cuttlefish-installer/preseed/after_install_1.sh
+++ b/gigabyte-ampere-cuttlefish-installer/preseed/after_install_1.sh
@@ -34,6 +34,9 @@ has_backports=$(apt-cache policy | grep "${DEBIAN_DISTRIBUTION}-backports")
 if [ x"$has_backports" != x"" ]; then
     apt install -y -t "${DEBIAN_DISTRIBUTION}-backports" linux-headers-arm64
     apt install -y -t "${DEBIAN_DISTRIBUTION}-backports" linux-image-arm64
+else
+    apt install -y linux-headers-arm64
+    apt install -y linux-image-arm64
 fi
 
 # Install nVidia or AMD GPU driver


### PR DESCRIPTION
As there was no `linux-headers-arm64`, I observed nvidia drivers weren't installed as intended, on the on-permise server. I expect `linux-image-arm64` would be installed as default though, I added it into `after_install_1.sh` to match parity between whether having backports or not.