### PR TITLE
Pass through the path to the iptables binary.

### DIFF
--- a/base/cvd/allocd/alloc_driver.h
+++ b/base/cvd/allocd/alloc_driver.h
@@ -37,6 +37,7 @@ Result<bool> BridgeInUse(std::string_view name);
 Result<bool> BridgeExists(std::string_view name);
 Result<bool> BridgeInUse(std::string_view name);
 Result<void> CreateBridge(std::string_view name);
-Result<void> IptableConfig(std::string_view network, bool add);
+Result<void> IptableConfig(std::string_view iptables_path,
+                           std::string_view network, bool add);
 
 }  // namespace cuttlefish

--- a/base/cvd/allocd/alloc_iproute2.cpp
+++ b/base/cvd/allocd/alloc_iproute2.cpp
@@ -97,9 +97,11 @@ Result<void> CreateBridge(std::string_view name) {
   return {};
 }
 
-Result<void> IptableConfig(std::string_view network, bool add) {
-  CF_EXPECT(Execute({"iptables", "-t", "nat", add ? "-A" : "-D", "POSTROUTING",
-                     "-s", std::string(network), "-j", "MASQUERADE"}) == 0,
+Result<void> IptableConfig(std::string_view iptables_path,
+                           std::string_view network, bool add) {
+  CF_EXPECT(Execute({std::string(iptables_path), "-t", "nat", add ? "-A" : "-D",
+                     "POSTROUTING", "-s", std::string(network), "-j",
+                     "MASQUERADE"}) == 0,
             "IptableConfig");
   return {};
 }

--- a/base/cvd/allocd/alloc_netlink.cpp
+++ b/base/cvd/allocd/alloc_netlink.cpp
@@ -31,6 +31,7 @@
 
 #include <cstdint>
 #include <fstream>
+#include <string>
 #include <string_view>
 
 #include "absl/log/check.h"
@@ -234,10 +235,12 @@ Result<void> CreateBridge(std::string_view name) {
   return {};
 }
 
-Result<void> IptableConfig(std::string_view network, bool add) {
+Result<void> IptableConfig(std::string_view iptables_path,
+                           std::string_view network, bool add) {
   // TODO: Use NETLINK_NETFILTER.
-  CF_EXPECT(Execute({"iptables", "-t", "nat", add ? "-A" : "-D", "POSTROUTING",
-                     "-s", std::string(network), "-j", "MASQUERADE"}) == 0,
+  CF_EXPECT(Execute({std::string(iptables_path), "-t", "nat", add ? "-A" : "-D",
+                     "POSTROUTING", "-s", std::string(network), "-j",
+                     "MASQUERADE"}) == 0,
             "IptableConfig");
   return {};
 }

--- a/base/cvd/allocd/alloc_utils.cpp
+++ b/base/cvd/allocd/alloc_utils.cpp
@@ -85,7 +85,7 @@ bool CreateMobileIface(std::string_view name, uint16_t id,
     DestroyIface(name);
   }
 
-  if (!IptableConfig(network, true).ok()) {
+  if (!IptableConfig("/sbin/iptables", network, true).ok()) {
     DestroyGateway(name, gateway, netmask);
     DestroyIface(name);
     return false;
@@ -105,7 +105,7 @@ bool DestroyMobileIface(std::string_view name, uint16_t id,
   auto gateway = MobileGatewayName(ipaddr, id);
   auto network = MobileNetworkName(ipaddr, netmask, id);
 
-  IptableConfig(network, false);
+  IptableConfig("/sbin/iptables", network, false);
   DestroyGateway(name, gateway, netmask);
   return DestroyIface(name);
 }
@@ -211,7 +211,7 @@ bool SetupBridgeGateway(std::string_view bridge_name,
 
   config.has_dnsmasq = true;
 
-  auto ret = IptableConfig(network, true).ok();
+  auto ret = IptableConfig("/sbin/iptables", network, true).ok();
   if (!ret) {
     CleanupBridgeGateway(bridge_name, ipaddr, config);
     LOG(WARNING) << "Failed to setup ip tables";
@@ -228,7 +228,7 @@ void CleanupBridgeGateway(std::string_view name, std::string_view ipaddr,
   auto dhcp_range = absl::StrFormat("%s.2,%s.255", ipaddr, ipaddr);
 
   if (config.has_iptable) {
-    IptableConfig(network, false);
+    IptableConfig("/sbin/iptables", network, false);
   }
 
   if (config.has_dnsmasq) {


### PR DESCRIPTION
Earlier in #2405 we added some functionality such that we could resolve names against PATH manually. We need to do this for the iptables command specifically, since some environments do not have iptables in PATH unless invoked with sudo, and it is the one utility that both the netlink driver and the iproute2 drivers still shell out to the system for.

Ahead of us using the new utilities to resolve the iptables binary, let us manually specify the path for now. While there is no guarantee that we'll find iptables there outside of Linux, both these drivers are all Linux specific anyway, and if iptables isn't found here, this still wouldn't work, so we aren't regressing in terms of portability or functionality.