### PR TITLE
Revert "Do not preserve owner user/group when extracting tar archive"

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/archive.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/archive.cpp
@@ -67,8 +67,7 @@ Result<std::vector<std::string>> ExtractFiles(
                            .AddParameter(target_directory)
                            .AddParameter("-f")
                            .AddParameter(archive)
-                           .AddParameter("-S")
-                           .AddParameter("--no-same-owner");
+                           .AddParameter("-S");
   for (const auto& extract : to_extract) {
     bsdtar_cmd.AddParameter(extract);
   }
@@ -140,7 +139,6 @@ std::string ExtractArchiveToMemory(const std::string& archive_filepath,
   bsdtar_cmd.AddParameter(archive_filepath);
   bsdtar_cmd.AddParameter("-O");
   bsdtar_cmd.AddParameter(archive_member);
-  bsdtar_cmd.AddParameter("--no-same-owner");
   Result<std::string> stdout_str = RunAndCaptureStdout(std::move(bsdtar_cmd));
 
   if (!stdout_str.ok()) {


### PR DESCRIPTION
This reverts commit 75e592d4171a0dac176f77640234f017f7fccb12.

This fixes mixed build boot tests:
```
$ cvd fetch --default_build=15280243/cf_x86_64_only_phone-trunk_staging-userdebug --host_package_build=15280243/cf_x86_64_only_phone-trunk_staging-userdebug --system_build=15280243/gsi_x86_64-trunk_staging-userdebug
$ cvd create --product_path=$PWD --host_path=$PWD
```

The reverted commit added a new flag `--no-same-owner` to a `bsdtar` invocation. The implementation of `bsdtar` used in Android CI does not support this flag and a mixed build test that invokes `bsdtar` fails.

Bug: b/506159631 and b/408497913
Test: repro given above