### PR TITLE
Introduce bsdtar wrapper to fix bsdtar issue on podcvd fetch

### DIFF
--- a/container/image/Containerfile
+++ b/container/image/Containerfile
@@ -60,6 +60,13 @@ RUN apt install -y --no-install-recommends \
 
 FROM runner-${BUILD_OPTION} AS runner
 
+# TODO(b/491256959): Seek better option than introducing wrapper of bsdtar.
+# Add bsdtar wrapper, to avoid owner user/group issue when fetching artifacts.
+RUN dpkg-divert --add --rename --divert /usr/bin/bsdtar.real /usr/bin/bsdtar && \
+    echo '#!/bin/bash' > /usr/bin/bsdtar && \
+    echo '/usr/bin/bsdtar.real --no-same-owner "$@"' >> /usr/bin/bsdtar && \
+    chmod +x /usr/bin/bsdtar
+
 RUN usermod -aG kvm root
 RUN usermod -aG cvdnetwork root
 ENTRYPOINT ["/root/run_services.sh"]


### PR DESCRIPTION
As https://github.com/google/android-cuttlefish/pull/2463 is merged which reverts https://github.com/google/android-cuttlefish/pull/2286, `podcvd fetch` is not working as intended. However, `podcvd fetch` is necessary to enable E2E tests of `podcvd`. Until enabling E2E tests, we cannot detect any breakages under `podcvd` immediately from CI.

Context: b/491256959, b/408497913
