### PR TITLE
Do not advertise TIMESTAMP_MONOTONIC for buffer timestamps.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/vhost_user_media/emulated_camera_splane/src/device.rs
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_media/emulated_camera_splane/src/device.rs
@@ -109,10 +109,6 @@ impl Buffer {
             }
             BufferState::Outgoing { sequence } => {
                 self.v4l2_buffer.set_sequence(sequence);
-                self.v4l2_buffer.set_timestamp(bindings::timeval {
-                    tv_sec: (sequence + 1) as bindings::__time_t / 1000,
-                    tv_usec: (sequence + 1) as bindings::__time_t % 1000,
-                });
                 Self::unset_flag(&mut flags, BufferFlags::QUEUED);
             }
         }
@@ -582,7 +578,6 @@ where
                             panic!()
                         }
                         v4l2_buffer.set_field(BufferField::None);
-                        v4l2_buffer.set_flags(BufferFlags::TIMESTAMP_MONOTONIC);
 
                         Ok(Buffer::new(v4l2_buffer, fd, offset))
                     })


### PR DESCRIPTION
- This behavior was taken from virtio-media reference device, however it's not relevant to this device implementation.

Bug: b/502639876