### PR TITLE
Add const char* and std::string_view overloads for StringFromEnv

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
@@ -96,6 +96,15 @@ cf_cc_library(
     ],
 )
 
+cf_cc_test(
+    name = "environment_test",
+    srcs = ["environment_test.cpp"],
+    deps = [
+        ":environment",
+        "@abseil-cpp//absl/cleanup",
+    ],
+)
+
 cf_cc_library(
     name = "files",
     srcs = ["files.cpp"],

--- a/base/cvd/cuttlefish/common/libs/utils/environment.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/environment.cpp
@@ -18,21 +18,37 @@
 
 #include <cstdlib>
 #include <string>
+#include <string_view>
 
 namespace cuttlefish {
 
-std::optional<std::string> StringFromEnv(const std::string& varname) {
-
-  const char* const valstr = getenv(varname.c_str());
+std::optional<std::string> StringFromEnv(const char* varname) {
+  const char* const valstr = getenv(varname);
   if (!valstr) {
     return std::nullopt;
   }
   return valstr;
 }
 
+std::optional<std::string> StringFromEnv(const std::string& varname) {
+  return StringFromEnv(varname.c_str());
+}
+
+std::optional<std::string> StringFromEnv(std::string_view varname) {
+  return StringFromEnv(std::string(varname).c_str());
+}
+
+std::string StringFromEnv(const char* varname, const std::string& defval) {
+  return StringFromEnv(varname).value_or(defval);
+}
+
 std::string StringFromEnv(const std::string& varname,
                           const std::string& defval) {
-  return StringFromEnv(varname).value_or(defval);
+  return StringFromEnv(varname.c_str(), defval);
+}
+
+std::string StringFromEnv(std::string_view varname, const std::string& defval) {
+  return StringFromEnv(std::string(varname).c_str(), defval);
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/environment.h
+++ b/base/cvd/cuttlefish/common/libs/utils/environment.h
@@ -17,12 +17,17 @@
 
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace cuttlefish {
 
 std::optional<std::string> StringFromEnv(const std::string& varname);
+std::optional<std::string> StringFromEnv(const char* varname);
+std::optional<std::string> StringFromEnv(std::string_view varname);
 
 std::string StringFromEnv(const std::string& varname,
                           const std::string& defval);
+std::string StringFromEnv(const char* varname, const std::string& defval);
+std::string StringFromEnv(std::string_view varname, const std::string& defval);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/environment_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/environment_test.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/common/libs/utils/environment.h"
+
+#include <cstdlib>
+#include <string>
+#include <string_view>
+
+#include <gtest/gtest.h>
+#include "absl/cleanup/cleanup.h"
+
+namespace cuttlefish {
+
+TEST(EnvironmentTest, StringFromEnvString) {
+  const std::string env_name = "TEST_ENV_VAR_STRING";
+  const std::string env_value = "test_value";
+
+  setenv(env_name.c_str(), env_value.c_str(), 1);
+  absl::Cleanup cleanup = [&env_name]() { unsetenv(env_name.c_str()); };
+
+  std::optional<std::string> result = StringFromEnv(env_name);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, env_value);
+}
+
+TEST(EnvironmentTest, StringFromEnvStringDefault) {
+  const std::string env_name = "TEST_ENV_VAR_STRING_DEFAULT";
+  const std::string env_value = "test_value";
+  const std::string def_value = "default_value";
+
+  setenv(env_name.c_str(), env_value.c_str(), 1);
+  absl::Cleanup cleanup = [&env_name]() { unsetenv(env_name.c_str()); };
+
+  EXPECT_EQ(StringFromEnv(env_name, def_value), env_value);
+}
+
+TEST(EnvironmentTest, StringFromEnvStringDefaultFallback) {
+  const std::string env_name = "TEST_ENV_VAR_STRING_DEFAULT_FALLBACK";
+  const std::string def_value = "default_value";
+
+  EXPECT_EQ(StringFromEnv(env_name, def_value), def_value);
+}
+
+TEST(EnvironmentTest, StringFromEnvCharPtr) {
+  const char* env_name = "TEST_ENV_VAR_CHAR_PTR";
+  const char* env_value = "test_value";
+
+  setenv(env_name, env_value, 1);
+  absl::Cleanup cleanup = [env_name]() { unsetenv(env_name); };
+
+  std::optional<std::string> result = StringFromEnv(env_name);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, env_value);
+}
+
+TEST(EnvironmentTest, StringFromEnvCharPtrDefault) {
+  const char* env_name = "TEST_ENV_VAR_CHAR_PTR_DEFAULT";
+  const char* env_value = "test_value";
+  const std::string def_value = "default_value";
+
+  setenv(env_name, env_value, 1);
+  absl::Cleanup cleanup = [env_name]() { unsetenv(env_name); };
+
+  EXPECT_EQ(StringFromEnv(env_name, def_value), env_value);
+}
+
+TEST(EnvironmentTest, StringFromEnvCharPtrDefaultFallback) {
+  const char* env_name = "TEST_ENV_VAR_CHAR_PTR_DEFAULT_FALLBACK";
+  const std::string def_value = "default_value";
+
+  EXPECT_EQ(StringFromEnv(env_name, def_value), def_value);
+}
+
+TEST(EnvironmentTest, StringFromEnvStringView) {
+  const std::string env_name_str = "TEST_ENV_VAR_STRING_VIEW";
+  const std::string env_value = "test_value";
+  std::string_view env_name = env_name_str;
+
+  setenv(env_name_str.c_str(), env_value.c_str(), 1);
+  absl::Cleanup cleanup = [&env_name_str]() { unsetenv(env_name_str.c_str()); };
+
+  std::optional<std::string> result = StringFromEnv(env_name);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, env_value);
+}
+
+TEST(EnvironmentTest, StringFromEnvStringViewDefault) {
+  const std::string env_name_str = "TEST_ENV_VAR_STRING_VIEW_DEFAULT";
+  const std::string env_value = "test_value";
+  const std::string def_value = "default_value";
+  std::string_view env_name = env_name_str;
+
+  setenv(env_name_str.c_str(), env_value.c_str(), 1);
+  absl::Cleanup cleanup = [&env_name_str]() { unsetenv(env_name_str.c_str()); };
+
+  EXPECT_EQ(StringFromEnv(env_name, def_value), env_value);
+}
+
+TEST(EnvironmentTest, StringFromEnvStringViewDefaultFallback) {
+  const std::string env_name_str = "TEST_ENV_VAR_STRING_VIEW_DEFAULT_FALLBACK";
+  const std::string def_value = "default_value";
+  std::string_view env_name = env_name_str;
+
+  EXPECT_EQ(StringFromEnv(env_name, def_value), def_value);
+}
+
+}  // namespace cuttlefish


### PR DESCRIPTION
Assisted-by: Antigravity:Gemini Next
Bug: b/507161864