### PR TITLE
Cleanup disk if it can't be attached.

### DIFF
--- a/tools/baseimage/pkg/gce/gce.go
+++ b/tools/baseimage/pkg/gce/gce.go
@@ -255,7 +255,7 @@ func (h *GceHelper) BuildImage(project, zone string, opts BuildImageOpts) error 
 
 	log.Println("attaching disk...")
 	if err := h.AttachDisk(insName, attachedDiskName); err != nil {
-		log.Fatalf("failed to attach disk %q to instance %q: %v", attachedDiskName, insName, err)
+		return fmt.Errorf("failed to attach disk %q to instance %q: %v", attachedDiskName, insName, err)
 	}
 	defer h.cleanupDetachDisk(insName, attachedDiskName)
 	log.Println("disk attached")


### PR DESCRIPTION
We use log.Fatalf to report attachment failures, then exit immediately. However, defer doesn't happen in this case, and so we don't clean up the disk resource we just created.

We could just return an error here and let callers handle this, but here we preserve behavior, keep the overall change scope small, remind ourselves to address this behavior with a TODO, and clean up the disk manually.

Bug: 505513391