### PR TITLE
Remove default for -arch and make it mandatory.

### DIFF
--- a/tools/baseimage/cmd/create_gce_base_image/main.go
+++ b/tools/baseimage/cmd/create_gce_base_image/main.go
@@ -46,6 +46,9 @@ func init() {
 func main() {
 	flag.Parse()
 
+	if arch.String() == "" {
+		log.Fatal("usage: `-arch` must not be empty")
+	}
 	if project == "" {
 		log.Fatal("usage: `-project` must not be empty")
 	}


### PR DESCRIPTION
The -arch flag is typed as cli.Arch. When this is empty, it defaults unconditionally to "x86_64", even when using a source image that doesn't match that architecture. We should probably change this default in cli.Arch, but that would increase the scope of the change. For now, it is more logical to make the arch flag mandatory.

Bug: 505513391