### PR TITLE
Install image with docker pull as well as load.

### DIFF
--- a/tools/baseimage/cmd/gce_install_cuttlefish_container/main.go
+++ b/tools/baseimage/cmd/gce_install_cuttlefish_container/main.go
@@ -34,6 +34,7 @@ var (
 	sourceImage        string
 	imageName          string
 	containerImageSrc  string
+	containerImageRef  string
 )
 
 func init() {
@@ -44,6 +45,7 @@ func init() {
 	flag.StringVar(&sourceImage, "source-image", "", "Source image name")
 	flag.StringVar(&imageName, "image-name", "", "output GCE image name")
 	flag.StringVar(&containerImageSrc, "container-image-src", "", "local path to container image")
+	flag.StringVar(&containerImageRef, "container-image-ref", "", "docker pull reference (e.g. user/image:tag)")
 }
 
 func main() {
@@ -65,8 +67,11 @@ func main() {
 	if imageName == "" {
 		log.Fatal("usage: `-image-name` must not be empty")
 	}
-	if containerImageSrc == "" {
-		log.Fatal("usage: `-container-image-src` must not be empty")
+	if containerImageSrc != "" && containerImageRef != "" {
+		log.Fatal("usage: specify either `-container-image-src` or `-container-image-ref`, not both")
+	}
+	if containerImageSrc == "" && containerImageRef == "" {
+		log.Fatal("usage: either `-container-image-src` or `-container-image-ref` must be specified")
 	}
 
 	buildImageOpts := gce.BuildImageOpts{
@@ -78,11 +83,14 @@ func main() {
 			if err := gce.UploadBashScript(project, zone, insName, "load_cuttlefish_container_image.sh", scripts.LoadCuttlefishContainerImage); err != nil {
 				return fmt.Errorf("error uploading bash script: %v", err)
 			}
+			if containerImageRef != "" {
+				return gce.RunCmd(project, zone, insName, "./load_cuttlefish_container_image.sh pull "+containerImageRef)
+			}
 			dst := "/tmp/" + filepath.Base(containerImageSrc)
 			if err := gce.UploadFile(project, zone, insName, containerImageSrc, dst); err != nil {
 				return fmt.Errorf("error uploading %s: %v", containerImageSrc, err)
 			}
-			return gce.RunCmd(project, zone, insName, "./load_cuttlefish_container_image.sh "+dst)
+			return gce.RunCmd(project, zone, insName, "./load_cuttlefish_container_image.sh file "+dst)
 		},
 	}
 

--- a/tools/baseimage/pkg/gce/scripts/load_cuttlefish_container_image.sh
+++ b/tools/baseimage/pkg/gce/scripts/load_cuttlefish_container_image.sh
@@ -16,11 +16,12 @@
 
 set -o errexit -o nounset -o pipefail
 
-if [[ $# -eq 0 ]] ; then
-  echo "usage: $0 /path/to/container_image"
+if [[ $# -lt 2 ]] ; then
+  echo "usage: $0 [file|pull] reference"
   exit 1
 fi
-container_image=$1
+mode=$1
+reference=$2
 
 # Load docker image. Internally, it modifies data-root configuration of
 # /etc/docker/daemon.json to load image under default data-root location of
@@ -37,7 +38,14 @@ else
     | sudo tee /etc/docker/daemon.json > /dev/null
 fi
 sudo systemctl start docker.socket docker.service
-sudo docker load --input "$container_image"
+if [ "$mode" == "file" ]; then
+  sudo docker load --input "$reference"
+elif [ "$mode" == "pull" ]; then
+  sudo docker pull "$reference"
+else
+  echo "Unknown mode: $mode"
+  exit 1
+fi
 sudo systemctl stop docker.socket docker.service
 
 sudo chroot /mnt/image /usr/bin/apt install -y docker.io


### PR DESCRIPTION
The docker documentation doesn't suggest that, for example, docker load can accept an OCI container image which may be emitted by podman push. The implication is that only a tarball emitted by docker save can be used in a subsequent docker load. This requires docker to be installed.

Even if we can construct a tarball that can be loaded without docker, it is a tedious part of the workflow considering we could just docker pull the image. Allow the possibility.

Bug: 505513391