### PR TITLE
Name the disk when attaching it.

### DIFF
--- a/tools/baseimage/pkg/gce/gce.go
+++ b/tools/baseimage/pkg/gce/gce.go
@@ -83,7 +83,8 @@ func (h *GceHelper) DeleteDisk(name string) error {
 
 func (h *GceHelper) AttachDisk(ins, disk string) error {
 	attachedDisk := &compute.AttachedDisk{
-		Source: fmt.Sprintf("projects/%s/zones/%s/disks/%s", h.Project, h.Zone, disk),
+		Source:     fmt.Sprintf("projects/%s/zones/%s/disks/%s", h.Project, h.Zone, disk),
+		DeviceName: disk,
 	}
 	op, err := h.Service.Instances.AttachDisk(h.Project, h.Zone, ins, attachedDisk).Do()
 	if err != nil {


### PR DESCRIPTION
We attempt to detach the disk later in the process by disk name. If we do not explicitly name the disk at attach time by setting DeviceName like this, GCE picks the name (see verbiage in https://docs.cloud.google.com/compute/docs/reference/rest/v1/instances#AttachedDisk:~:text=for%20regional%20disk.-,disks%5B%5D.deviceName,-string). This causes an error to be reported at detach time. This is not fatal, because the image is still created by this time, but it can still mislead and confuse.

Bug: 505513391