### PR TITLE
Make -arch mandatory across all tools.

### DIFF
--- a/tools/baseimage/cmd/create_gce_fixed_kernel/main.go
+++ b/tools/baseimage/cmd/create_gce_fixed_kernel/main.go
@@ -62,6 +62,9 @@ func init() {
 func main() {
 	flag.Parse()
 
+	if arch.String() == "" {
+		log.Fatal("usage: `-arch` must not be empty")
+	}
 	if project == "" {
 		log.Fatal("usage: `-project` must not be empty")
 	}

--- a/tools/baseimage/cmd/gce_install_cuttlefish_container/main.go
+++ b/tools/baseimage/cmd/gce_install_cuttlefish_container/main.go
@@ -50,6 +50,9 @@ func main() {
 
 	flag.Parse()
 
+	if arch.String() == "" {
+		log.Fatal("usage: `-arch` must not be empty")
+	}
 	if project == "" {
 		log.Fatal("usage: `-project` must not be empty")
 	}

--- a/tools/baseimage/cmd/gce_install_cuttlefish_packages/main.go
+++ b/tools/baseimage/cmd/gce_install_cuttlefish_packages/main.go
@@ -72,6 +72,9 @@ func main() {
 
 	flag.Parse()
 
+	if arch.String() == "" {
+		log.Fatal("usage: `-arch` must not be empty")
+	}
 	if project == "" {
 		log.Fatal("usage: `-project` must not be empty")
 	}


### PR DESCRIPTION
In #2481 we made -arch mandatory in create_gce_base_image because cli.Arch unfortunately chooses a default. Enforce the mandatory usage of the -arch flag across the remaining tools to ameliorate the issue.

Bug: 505513391