### PR TITLE
Add build opt to enable all host substitutions by default

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/BUILD.bazel
@@ -1,8 +1,21 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("//:build_variables.bzl", "COPTS")
 load("//cuttlefish/bazel:rules.bzl", "cf_cc_binary", "cf_cc_library")
 
 package(
     default_visibility = ["//:android_cuttlefish"],
+)
+
+bool_flag(
+    name = "all_host_substitutions",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "all_host_substitutions_enabled",
+    flag_values = {
+        ":all_host_substitutions": "true",
+    },
 )
 
 cf_cc_library(

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
@@ -357,6 +357,12 @@ cf_cc_library(
     name = "start",
     srcs = ["start.cpp"],
     hdrs = ["start.h"],
+    local_defines = select({
+        "//cuttlefish/host/commands/cvd:all_host_substitutions_enabled": [
+            "CUTTLEFISH_ENABLE_ALL_HOST_SUBSTITUTIONS_BY_DEFAULT",
+        ],
+        "//conditions:default": [],
+    }),
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:files",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -458,6 +458,9 @@ Result<void> CvdStartCommandHandler::Handle(const CommandRequest& request) {
   const auto bin = CF_EXPECT(FindStartBin(group.HostArtifactsPath()));
 
   std::vector<std::string> host_substitutions;
+#if defined(CUTTLEFISH_ENABLE_ALL_HOST_SUBSTITUTIONS_BY_DEFAULT)
+  host_substitutions.push_back("all");
+#endif
   Flag host_substitutions_flag =
       GflagsCompatFlag("host_substitutions", host_substitutions);
 

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/BUILD.bazel
@@ -218,6 +218,12 @@ cf_cc_library(
     name = "fetch_cvd_parser",
     srcs = ["fetch_cvd_parser.cc"],
     hdrs = ["fetch_cvd_parser.h"],
+    local_defines = select({
+        "//cuttlefish/host/commands/cvd:all_host_substitutions_enabled": [
+            "CUTTLEFISH_ENABLE_ALL_HOST_SUBSTITUTIONS_BY_DEFAULT",
+        ],
+        "//conditions:default": [],
+    }),
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:flag_parser",

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd_parser.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd_parser.cc
@@ -84,6 +84,10 @@ std::vector<Flag> GetFlagsVector(FetchFlags& fetch_flags,
 
 Result<FetchFlags> FetchFlags::Parse(std::vector<std::string>& args) {
   FetchFlags fetch_flags;
+#if defined(CUTTLEFISH_ENABLE_ALL_HOST_SUBSTITUTIONS_BY_DEFAULT)
+  fetch_flags.host_substitutions.push_back("all");
+#endif
+
   std::string directory;
   std::vector<Flag> flags = GetFlagsVector(fetch_flags, directory);
   CF_EXPECT(ConsumeFlags(flags, args), "Could not process command line flags.");


### PR DESCRIPTION
Bug: b/507966746
Test:
  Add an extra LOG() statement to assemble_cvd.

  ```
  bazel run //cuttlefish/package:cvd \
  -- create
  ```
  and confirm it does not show the log.

  ```
  bazel run //cuttlefish/package:cvd \
  --//cuttlefish/host/commands/cvd:all_host_substitutions=true \
  -- create
  ```
  and confirm it does show the log.