### PR TITLE
Update frontend build to go 1.25

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: Install go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.23.1'
+        go-version: '1.25.9'
     - name: Install buildozer
       run: go install github.com/bazelbuild/buildtools/buildozer@latest
     - name: Validate formatting

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,3 +1,4 @@
 /src/host_orchestrator/host_orchestrator
 /src/cvdserver_bootstrapper/cvdserver_bootstrapper
 /src/operator/operator
+go.work.sum

--- a/frontend/MODULE.bazel
+++ b/frontend/MODULE.bazel
@@ -3,6 +3,9 @@ module(name = "com_github_google_android_cuttlefish_frontend")
 bazel_dep(name = "rules_go", version = "0.60.0")
 bazel_dep(name = "gazelle", version = "0.50.0")
 
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.25.7")
+
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_work = "//:go.work")
 # Note: The following com_github_google_android_cuttlefish_frontend_src_* repos

--- a/frontend/MODULE.bazel
+++ b/frontend/MODULE.bazel
@@ -8,6 +8,7 @@ go_sdk.download(version = "1.25.7")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_work = "//:go.work")
+
 # Note: The following com_github_google_android_cuttlefish_frontend_src_* repos
 # are listed here because Gazelle's go_deps extension reports them as direct
 # dependencies based on go.mod files. However, they are NOT pulled from external
@@ -24,7 +25,6 @@ use_repo(
     "com_github_google_uuid",
     "com_github_gorilla_mux",
     "com_github_gorilla_websocket",
-    "com_github_hashicorp_go_multierror",
     "com_github_pion_logging",
     "com_github_pion_webrtc_v3",
     "org_golang_google_grpc",

--- a/frontend/go.work
+++ b/frontend/go.work
@@ -1,4 +1,4 @@
-go 1.18
+go 1.25
 
 use (
 	./src/host_orchestrator

--- a/frontend/src/host_orchestrator/go.mod
+++ b/frontend/src/host_orchestrator/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.0
-	github.com/hashicorp/go-multierror v1.1.1
 )
 
 require (

--- a/frontend/src/host_orchestrator/go.mod
+++ b/frontend/src/host_orchestrator/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/android-cuttlefish/frontend/src/host_orchestrator
 
-go 1.17
+go 1.25
 
 require (
 	github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20240822182916-7bea0dafdbde

--- a/frontend/src/host_orchestrator/orchestrator/createcvdaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/createcvdaction.go
@@ -16,7 +16,6 @@ package orchestrator
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -145,7 +144,7 @@ const ErrMsgLaunchCVDFailed = "failed to launch cvd"
 
 func (a *CreateCVDAction) launchFromAndroidCI(
 	buildSource *apiv1.AndroidCIBuildSource, instancesCount uint32, op apiv1.Operation) (*cvd.Group, error) {
-	targetDir, err := ioutil.TempDir(a.paths.InstancesDir, "ins*")
+	targetDir, err := os.MkdirTemp(a.paths.InstancesDir, "ins*")
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +213,7 @@ func validateRequest(r *apiv1.CreateCVDRequest) error {
 
 // See https://pkg.go.dev/io/ioutil@go1.13.15#TempFile
 func createTempFile(pattern string, data string, mode os.FileMode) (*os.File, error) {
-	file, err := ioutil.TempFile("", pattern)
+	file, err := os.CreateTemp("", pattern)
 	if err != nil {
 		return nil, err
 	}

--- a/frontend/src/host_orchestrator/orchestrator/displayscreenshotaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/displayscreenshotaction.go
@@ -16,7 +16,6 @@ package orchestrator
 
 import (
 	"encoding/base64"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -64,7 +63,7 @@ func (a *DisplayScreenshotAction) Run() (apiv1.Operation, error) {
 }
 
 func (a *DisplayScreenshotAction) createScreenshot(op apiv1.Operation) (*apiv1.DisplayScreenshotResponse, error) {
-	tempdir, err := ioutil.TempDir("", "screenshot")
+	tempdir, err := os.MkdirTemp("", "screenshot")
 	if err != nil {
 		return nil, operator.NewInternalError("failed to create temp directory", err)
 	}
@@ -77,7 +76,7 @@ func (a *DisplayScreenshotAction) createScreenshot(op apiv1.Operation) (*apiv1.D
 		return nil, operator.NewInternalError("cvd display screenshot failed", err)
 	}
 
-	screenshotBytes, err := ioutil.ReadFile(screenshotPath)
+	screenshotBytes, err := os.ReadFile(screenshotPath)
 	if err != nil {
 		return nil, operator.NewInternalError("failed to read screenshot file", err)
 	}

--- a/frontend/src/host_orchestrator/orchestrator/fetchartifactsaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/fetchartifactsaction.go
@@ -17,7 +17,6 @@ package orchestrator
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -76,7 +75,7 @@ func (a *FetchArtifactsAction) startDownload(op apiv1.Operation) OperationResult
 			Error: operator.NewInternalError("error cloning request", err),
 		}
 	}
-	dir, err := ioutil.TempDir(a.paths.InstancesDir, "ins*")
+	dir, err := os.MkdirTemp(a.paths.InstancesDir, "ins*")
 	if err != nil {
 		return OperationResult{Error: operator.NewInternalError("error creating tmp dir", err)}
 	}

--- a/frontend/src/host_orchestrator/orchestrator/imagedirectories.go
+++ b/frontend/src/host_orchestrator/orchestrator/imagedirectories.go
@@ -16,7 +16,6 @@ package orchestrator
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -69,7 +68,7 @@ func (m *ImageDirectoriesManagerImpl) ListImageDirectories() ([]string, error) {
 	} else if !exists {
 		return imageDirs, nil
 	}
-	entries, err := ioutil.ReadDir(m.RootDir)
+	entries, err := os.ReadDir(m.RootDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read directory: %w", err)
 	}
@@ -94,7 +93,7 @@ func (m *ImageDirectoriesManagerImpl) UpdateImageDirectory(imageDirName, dir str
 	} else if !exists {
 		return operator.NewNotFoundError(fmt.Sprintf("image directory(dir:%q) not found", imageDirName), nil)
 	}
-	entries, err := ioutil.ReadDir(dir)
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return fmt.Errorf("failed to read directory: %w", err)
 	}

--- a/frontend/src/host_orchestrator/orchestrator/imagedirectories_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/imagedirectories_test.go
@@ -15,7 +15,6 @@
 package orchestrator
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -86,14 +85,14 @@ func TestUpdateImageDirectorySucceeds(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer f.Close()
-	if err := ioutil.WriteFile(src, []byte("hello_world"), 0600); err != nil {
+	if err := os.WriteFile(src, []byte("hello_world"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
 	if err := idm.UpdateImageDirectory(imageDir, srcDir); err != nil {
 		t.Fatal(err)
 	}
-	if output, err := ioutil.ReadFile(filepath.Join(rootDir, imageDir, "foo.txt")); err != nil {
+	if output, err := os.ReadFile(filepath.Join(rootDir, imageDir, "foo.txt")); err != nil {
 		t.Fatal(err)
 	} else if diff := cmp.Diff("hello_world", string(output)); diff != "" {
 		t.Errorf("response mismatch (-want +got):\n%s", diff)
@@ -117,20 +116,20 @@ func TestUpdateImageDirectorySucceedsWithModification(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer f.Close()
-	if err := ioutil.WriteFile(src, []byte("hello_world"), 0600); err != nil {
+	if err := os.WriteFile(src, []byte("hello_world"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	if err := idm.UpdateImageDirectory(imageDir, srcDir); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(src, []byte("hello_world_again"), 0600); err != nil {
+	if err := os.WriteFile(src, []byte("hello_world_again"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
 	if err := idm.UpdateImageDirectory(imageDir, srcDir); err != nil {
 		t.Fatal(err)
 	}
-	if output, err := ioutil.ReadFile(filepath.Join(rootDir, imageDir, "foo.txt")); err != nil {
+	if output, err := os.ReadFile(filepath.Join(rootDir, imageDir, "foo.txt")); err != nil {
 		t.Fatal(err)
 	} else if diff := cmp.Diff("hello_world_again", string(output)); diff != "" {
 		t.Errorf("response mismatch (-want +got):\n%s", diff)
@@ -182,7 +181,7 @@ func TestDeleteImageDirectorySucceeds(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer f.Close()
-	if err := ioutil.WriteFile(src, []byte("hello_world"), 0600); err != nil {
+	if err := os.WriteFile(src, []byte("hello_world"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	if err := idm.UpdateImageDirectory(imageDir, srcDir); err != nil {

--- a/frontend/src/host_orchestrator/orchestrator/testing/testing.go
+++ b/frontend/src/host_orchestrator/orchestrator/testing/testing.go
@@ -1,7 +1,6 @@
 package testing
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -13,7 +12,7 @@ import (
 // Similar to https://pkg.go.dev/testing#T.TempDir without the cleanup part. testing#T.TempDir cannot be used
 // as it was introduced in go 1.15.
 func TempDir(t *testing.T) string {
-	name, err := ioutil.TempDir("", "cuttlefishTestDir")
+	name, err := os.MkdirTemp("", "cuttlefishTestDir")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/frontend/src/host_orchestrator/orchestrator/userartifacts.go
+++ b/frontend/src/host_orchestrator/orchestrator/userartifacts.go
@@ -21,7 +21,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -156,7 +155,7 @@ func (m *UserArtifactsManagerImpl) ExtractArtifact(checksum string) error {
 	if err != nil {
 		return err
 	}
-	workDir, err := ioutil.TempDir(m.WorkDir, "")
+	workDir, err := os.MkdirTemp(m.WorkDir, "")
 	if err != nil {
 		return err
 	}
@@ -288,7 +287,7 @@ func (m *UserArtifactsManagerImpl) getFilePath(checksum string) (string, error) 
 	} else if !exists {
 		return "", operator.NewNotFoundError(fmt.Sprintf("user artifact(checksum:%q) not found", checksum), nil)
 	}
-	if entries, err := ioutil.ReadDir(dir); err != nil {
+	if entries, err := os.ReadDir(dir); err != nil {
 		return "", fmt.Errorf("failed to read directory where user artifact located: %w", err)
 	} else if len(entries) != 1 || entries[0].IsDir() {
 		return "", fmt.Errorf("directory where user artifact located should contain a single file only")

--- a/frontend/src/host_orchestrator/orchestrator/userartifacts_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/userartifacts_test.go
@@ -21,7 +21,6 @@ import (
 	"compress/gzip"
 	"crypto/sha256"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -59,7 +58,7 @@ func TestUpdateArtifactWithSingleChunkSucceeds(t *testing.T) {
 	if err := uam.UpdateArtifact(checksum, chunk); err != nil {
 		t.Fatal(err)
 	}
-	b, err := ioutil.ReadFile(filepath.Join(rootDir, checksum, testFileName))
+	b, err := os.ReadFile(filepath.Join(rootDir, checksum, testFileName))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,7 +157,7 @@ func TestUpdateArtifactWithMultipleSerialChunkSucceeds(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	b, err := ioutil.ReadFile(filepath.Join(rootDir, checksum, testFileName))
+	b, err := os.ReadFile(filepath.Join(rootDir, checksum, testFileName))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,7 +188,7 @@ func TestUpdateArtifactWithMultipleParallelChunkSucceeds(t *testing.T) {
 		}(chunk)
 	}
 	wg.Wait()
-	b, err := ioutil.ReadFile(filepath.Join(rootDir, checksum, testFileName))
+	b, err := os.ReadFile(filepath.Join(rootDir, checksum, testFileName))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,7 +256,7 @@ func TestExtractArtifactSucceedsWithZipFormat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	data, err := ioutil.ReadFile(zipFile)
+	data, err := os.ReadFile(zipFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -303,7 +302,7 @@ func TestExtractArtifactSucceedsWithTarGzFormat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	data, err := ioutil.ReadFile(tarFile)
+	data, err := os.ReadFile(tarFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -368,7 +367,7 @@ func TestExtractArtifactAfterArtifactIsFullyExtractedFails(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	data, err := ioutil.ReadFile(archive)
+	data, err := os.ReadFile(archive)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -594,7 +593,7 @@ func getContents(dir string) (map[string]string, error) {
 		}
 		if relPath, err := filepath.Rel(dir, path); err != nil {
 			return err
-		} else if content, err := ioutil.ReadFile(path); err != nil {
+		} else if content, err := os.ReadFile(path); err != nil {
 			return err
 		} else {
 			contents[relPath] = string(content)
@@ -608,7 +607,7 @@ func getContents(dir string) (map[string]string, error) {
 }
 
 func createZip(dir string, contents map[string]string) (string, error) {
-	zipFile, err := ioutil.TempFile(dir, "*.zip")
+	zipFile, err := os.CreateTemp(dir, "*.zip")
 	if err != nil {
 		return "", err
 	}
@@ -651,7 +650,7 @@ func getSubdirs(path string) []string {
 }
 
 func createTarGz(dir string, contents map[string]string) (string, error) {
-	tarFile, err := ioutil.TempFile(dir, "*.tar.gz")
+	tarFile, err := os.CreateTemp(dir, "*.tar.gz")
 	if err != nil {
 		return "", err
 	}

--- a/frontend/src/libhoclient/go.mod
+++ b/frontend/src/libhoclient/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/android-cuttlefish/frontend/src/libhoclient
 
-go 1.18
+go 1.25
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/frontend/src/liboperator/go.mod
+++ b/frontend/src/liboperator/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/android-cuttlefish/frontend/src/liboperator
 
-go 1.17
+go 1.25
 
 require (
 	github.com/gorilla/mux v1.8.0

--- a/frontend/src/liboperator/operator/operator.go
+++ b/frontend/src/liboperator/operator/operator.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -414,7 +413,7 @@ func grpcCallUnaryMethod(w http.ResponseWriter, r *http.Request, pool *DevicePoo
 	}
 	defer conn.Close()
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/frontend/src/operator/go.mod
+++ b/frontend/src/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/android-cuttlefish/frontend/src/operator
 
-go 1.17
+go 1.25
 
 replace github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-unpublished => ../liboperator
 


### PR DESCRIPTION
This is a prerequisite for using the go-sdk mcp library: https://github.com/modelcontextprotocol/go-sdk/blob/f5f2015413f17f578fbacc839d2c05d0fdb3f1cc/go.mod#L3

Assisted-by: Antigravity:Gemini Next
Bug: b/508728217