### PR TITLE
Tidy up cURL error messages in metrics cases

### DIFF
--- a/base/cvd/.clang-tidy
+++ b/base/cvd/.clang-tidy
@@ -2,6 +2,7 @@
 # `parse_headers` bazel feature.
 
 Checks: &checks >-
+  bugprone-argument-comment,
   clang-analyzer-*,
   clang-diagnostic-*,
   -clang-diagnostic-pragma-once-outside-header,

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/login.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/login.cpp
@@ -76,7 +76,8 @@ class CvdLoginCommand : public CvdCommandHandler {
     }
 
     CurlGlobalInit init;
-    std::unique_ptr<HttpClient> http_client = CurlHttpClient(true);
+    std::unique_ptr<HttpClient> http_client =
+        CurlHttpClient(/*use_logging_debug_function=*/true);
     CF_EXPECT(http_client.get(), "Failed to create a http client");
 
     if (!oauth2_request.is_ssh) {

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/downloaders.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/downloaders.cc
@@ -62,8 +62,7 @@ Result<Downloaders> Downloaders::Create(const BuildApiFlags& flags,
                                         const std::string& cache_base_path) {
   std::unique_ptr<Downloaders::Impl> impl(new Downloaders::Impl());
 
-  const bool use_logging_debug_function = true;
-  impl->curl_ = CurlHttpClient(use_logging_debug_function);
+  impl->curl_ = CurlHttpClient(/*use_logging_debug_function=*/true);
   impl->retrying_http_client_ = RetryingServerErrorHttpClient(
       *impl->curl_, 10, std::chrono::milliseconds(5000));
 

--- a/base/cvd/cuttlefish/host/commands/metrics/metrics_transmission.cc
+++ b/base/cvd/cuttlefish/host/commands/metrics/metrics_transmission.cc
@@ -57,9 +57,8 @@ Result<void> TransmitMetricsEvent(
     const wireless_android_play_playlog::LogRequest& log_request,
     ClearcutEnvironment environment) {
   CurlGlobalInit curl_global_init;
-  const bool use_logging_debug_function = true;
   std::unique_ptr<HttpClient> http_client =
-      CurlHttpClient(use_logging_debug_function);
+      CurlHttpClient(/*use_logging_debug_function=*/true);
   CF_EXPECT(http_client.get() != nullptr,
             "Unable to create cURL client for metrics transmission");
   CF_EXPECT(

--- a/base/cvd/cuttlefish/host/libs/metrics/gce_environment.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/gce_environment.cc
@@ -86,7 +86,9 @@ Result<std::string> GetZoneValue(std::string_view response_string) {
 
 Result<std::optional<GceEnvironment>> DetectGceEnvironment() {
   CurlGlobalInit curl_init;
-  std::unique_ptr<HttpClient> http_client = CurlHttpClient();
+  const bool use_logging_debug_function = true;
+  std::unique_ptr<HttpClient> http_client =
+      CurlHttpClient(use_logging_debug_function);
   if (!CF_EXPECT(IsGceEnvironment(*http_client))) {
     return std::nullopt;
   }

--- a/base/cvd/cuttlefish/host/libs/metrics/gce_environment.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/gce_environment.cc
@@ -86,9 +86,8 @@ Result<std::string> GetZoneValue(std::string_view response_string) {
 
 Result<std::optional<GceEnvironment>> DetectGceEnvironment() {
   CurlGlobalInit curl_init;
-  const bool use_logging_debug_function = true;
   std::unique_ptr<HttpClient> http_client =
-      CurlHttpClient(use_logging_debug_function);
+      CurlHttpClient(/*use_logging_debug_function=*/true);
   if (!CF_EXPECT(IsGceEnvironment(*http_client))) {
     return std::nullopt;
   }


### PR DESCRIPTION
During the GCE environment detection logic, the HTTP request to make the detection would print out error lines if GCE was not detected.  This update makes all of the cURL outputs go into the logs, instead.

It makes the V2 `metrics/metrics.log` a bit noisier, but that is better than cluttering up the command-line output with the messages.

Bug: 508689956