### PR TITLE
cvd: Cleanup unused CommandSequenceExecutor code

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/command_sequence.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/command_sequence.cpp
@@ -15,11 +15,11 @@
 
 #include "cuttlefish/host/commands/cvd/cli/command_sequence.h"
 
+#include <iostream>
 #include <memory>
 #include <ostream>
 #include <sstream>
 #include <string>
-#include <unordered_set>
 #include <vector>
 
 #include "absl/strings/str_replace.h"
@@ -80,27 +80,13 @@ CommandSequenceExecutor::CommandSequenceExecutor(
     const std::vector<std::unique_ptr<CvdCommandHandler>>& server_handlers)
     : server_handlers_(server_handlers) {}
 
-Result<void> CommandSequenceExecutor::ExecuteOne(const CommandRequest& request,
-                                                 std::ostream& report) {
-  report << FormattedCommand(request);
+Result<void> CommandSequenceExecutor::ExecuteOne(
+    const CommandRequest& request) {
+  std::cerr << FormattedCommand(request);
 
   auto handler = CF_EXPECT(RequestHandler(request, server_handlers_));
-  handler_stack_.push_back(handler);
   CF_EXPECT(handler->Handle(request));
-  handler_stack_.pop_back();
   return {};
-}
-
-std::vector<std::string> CommandSequenceExecutor::CmdList() const {
-  std::unordered_set<std::string> subcmds;
-  for (const auto& handler : server_handlers_) {
-    auto&& cmds_list = handler->CmdList();
-    for (const auto& cmd : cmds_list) {
-      subcmds.insert(cmd);
-    }
-  }
-  // duplication removed
-  return std::vector<std::string>{subcmds.begin(), subcmds.end()};
 }
 
 Result<CvdCommandHandler*> CommandSequenceExecutor::GetHandler(

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/command_sequence.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/command_sequence.h
@@ -30,13 +30,11 @@ class CommandSequenceExecutor {
   CommandSequenceExecutor(
       const std::vector<std::unique_ptr<CvdCommandHandler>>& server_handlers);
 
-  Result<void> ExecuteOne(const CommandRequest&, std::ostream& report);
+  Result<void> ExecuteOne(const CommandRequest&);
 
-  std::vector<std::string> CmdList() const;
   Result<CvdCommandHandler*> GetHandler(const CommandRequest& request);
 
  private:
   const std::vector<std::unique_ptr<CvdCommandHandler>>& server_handlers_;
-  std::vector<CvdCommandHandler*> handler_stack_;
 };
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
@@ -304,7 +304,7 @@ Result<void> CvdCreateCommandHandler::Handle(const CommandRequest& request) {
   if (!flags.config_file.empty()) {
     auto subrequest =
         CF_EXPECT(CreateLoadCommand(request, subcmd_args, flags.config_file));
-    CF_EXPECT(command_executor_.ExecuteOne(subrequest, std::cerr));
+    CF_EXPECT(command_executor_.ExecuteOne(subrequest));
     return {};
   }
 
@@ -329,7 +329,7 @@ Result<void> CvdCreateCommandHandler::Handle(const CommandRequest& request) {
 
   if (flags.start) {
     auto start_cmd = CF_EXPECT(CreateStartCommand(group, subcmd_args, envs));
-    CF_EXPECT(command_executor_.ExecuteOne(start_cmd, std::cerr));
+    CF_EXPECT(command_executor_.ExecuteOne(start_cmd));
 
     if (CF_EXPECT(IsDefaultGroup(request))) {
       // For backward compatibility, we add extra symlink in system wide home

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.cpp
@@ -167,7 +167,7 @@ class LoadConfigsCommand : public CvdCommandHandler {
 
     if (!cvd_flags.fetch_cvd_flags.empty()) {
       auto fetch_cmd = CF_EXPECT(BuildFetchCmd(request, cvd_flags));
-      auto fetch_res = executor_.ExecuteOne(fetch_cmd, std::cerr);
+      auto fetch_res = executor_.ExecuteOne(fetch_cmd);
       if (!fetch_res.ok()) {
         group.SetAllStates(cvd::INSTANCE_STATE_PREPARE_FAILED);
         // TODO: b/471069557 - diagnose unused
@@ -183,7 +183,7 @@ class LoadConfigsCommand : public CvdCommandHandler {
     CF_EXPECT(instance_manager_.UpdateInstanceGroup(group));
 
     auto start_cmd = CF_EXPECT(BuildStartCommand(request, cvd_flags, group));
-    CF_EXPECT(executor_.ExecuteOne(start_cmd, std::cerr));
+    CF_EXPECT(executor_.ExecuteOne(start_cmd));
     return {};
   }
 


### PR DESCRIPTION
Remove unused methods, variables, and simplify function signatures:
- Remove unused CmdList() from CommandSequenceExecutor.
- Remove unused handler_stack_ from CommandSequenceExecutor.
- Remove unused std::ostream report parameter from ExecuteOne, logging to std::cerr directly.

Assisted-by: Jetski