### PR TITLE
cvd: start and bugreport help works everywhere

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd.cc
@@ -615,17 +615,10 @@ Result<int> AssembleCvdMain(int argc, char** argv) {
   FetcherConfigs fetcher_configs =
       FetcherConfigs::ReadFromDirectories(system_image_dir.AsVector());
 
-  AndroidBuilds android_builds =
-      CF_EXPECT(FindAndroidBuilds(system_image_dir, fetcher_configs));
-
-  VLOG(0) << android_builds;
-
   InitramfsPathFlag initramfs_path =
       InitramfsPathFlag::FromGlobalGflags(fetcher_configs);
   KernelPathFlag kernel_path = KernelPathFlag::FromGlobalGflags(fetcher_configs);
 
-  BootImageFlag boot_image =
-      CF_EXPECT(BootImageFlag::FromGlobalGflags(android_builds));
   SuperImageFlag super_image =
       SuperImageFlag::FromGlobalGflags(system_image_dir);
 
@@ -652,6 +645,14 @@ Result<int> AssembleCvdMain(int argc, char** argv) {
     }
     return 1;  // For parity with gflags
   }
+
+  AndroidBuilds android_builds =
+      CF_EXPECT(FindAndroidBuilds(system_image_dir, fetcher_configs));
+
+  VLOG(0) << android_builds;
+
+  BootImageFlag boot_image =
+      CF_EXPECT(BootImageFlag::FromGlobalGflags(android_builds));
 
   CF_EXPECT(VerifyConditionsOnSnapshotRestore(FLAGS_snapshot_path),
             "The conditions for --snapshot_path=<dir> do not meet.");

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
@@ -153,6 +153,7 @@ cf_cc_library(
         "//cuttlefish/host/commands/cvd/utils",
         "//cuttlefish/host/libs/config:config_constants",
         "//cuttlefish/result",
+        "//libbase",
         "@abseil-cpp//absl/strings",
         "@fmt",
     ],

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/bugreport.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/bugreport.cpp
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 
 #include <functional>
+#include <iostream>
 #include <memory>
 #include <string>
 #include <utility>
@@ -168,10 +169,13 @@ Result<std::string> CvdBugreportCommandHandler::DetailedHelp(
   Command command = CF_EXPECT(ConstructSiblingHelpCommand(
       kHostBugreportBin, request.Env(), request.SubcommandArguments()));
   std::string stdout;
-  int res = RunWithManagedStdio(std::move(command), nullptr, &stdout, nullptr);
+  std::string stderr;
+  int res = RunWithManagedStdio(std::move(command), nullptr, &stdout, &stderr);
   // gflags returns exit code 1 when --help is given
-  CF_EXPECTF(res == 0 || res == 1,
-             "Failed to execute bugreport binary, exit code: {}", res);
+  if (res != 0 && res != 1) {
+    std::cerr << stderr;
+    return CF_ERRF("Failed to execute bugreport binary, exit code: {}", res);
+  }
   return stdout;
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/bugreport.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/bugreport.cpp
@@ -165,10 +165,8 @@ bool CvdBugreportCommandHandler::RequiresDeviceExists() const { return true; }
 
 Result<std::string> CvdBugreportCommandHandler::DetailedHelp(
     const CommandRequest& request) const {
-  std::string android_host_out = CF_EXPECT(AndroidHostPath(request.Env()));
-  Command command = CF_EXPECT(
-      ConstructCvdHelpCommand(kHostBugreportBin, request.Env(),
-                              request.SubcommandArguments(), request));
+  Command command = CF_EXPECT(ConstructSiblingHelpCommand(
+      kHostBugreportBin, request.Env(), request.SubcommandArguments()));
   std::string stdout;
   int res = RunWithManagedStdio(std::move(command), nullptr, &stdout, nullptr);
   // gflags returns exit code 1 when --help is given

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -41,7 +41,6 @@
 #include "absl/log/log.h"
 #include "absl/strings/match.h"
 
-#include "cuttlefish/common/libs/utils/contains.h"
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/flag_parser.h"
 #include "cuttlefish/common/libs/utils/json.h"
@@ -536,22 +535,9 @@ Result<std::string> CvdStartCommandHandler::DetailedHelp(
       selector::SelectGroup(instance_manager_, request);
   if (group_res.ok()) {
     envs["HOME"] = group_res.value().HomeDir();
-  } else if (Contains(envs, "HOME")) {
-    if (envs["HOME"].empty()) {
-      envs.erase("HOME");
-    } else {
-      envs["HOME"] = AbsolutePath(envs.at("HOME"));
-    }
   }
-  auto android_host_out =
-      CF_EXPECT(AndroidHostPath(envs),
-                "\nTry running this command from the same directory as the "
-                "downloaded or fetched host tools.");
-  const auto bin = CF_EXPECT(FindStartBin(android_host_out));
-
-  Command command = CF_EXPECT(ConstructCvdHelpCommand(
-      bin, envs, request.SubcommandArguments(), request));
-  LOG(INFO) << "help command: " << command;
+  Command command = CF_EXPECT(ConstructSiblingHelpCommand(
+      "cvd_internal_start", envs, request.SubcommandArguments()));
   std::string stdout;
   int res = RunWithManagedStdio(std::move(command), nullptr, &stdout, nullptr);
   // gflags returns exit code 1 when --help is given

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -539,10 +539,13 @@ Result<std::string> CvdStartCommandHandler::DetailedHelp(
   Command command = CF_EXPECT(ConstructSiblingHelpCommand(
       "cvd_internal_start", envs, request.SubcommandArguments()));
   std::string stdout;
-  int res = RunWithManagedStdio(std::move(command), nullptr, &stdout, nullptr);
+  std::string stderr;
+  int res = RunWithManagedStdio(std::move(command), nullptr, &stdout, &stderr);
   // gflags returns exit code 1 when --help is given
-  CF_EXPECTF(res == 0 || res == 1,
-             "Failed to execute start binary, exit code: {}", res);
+  if (res != 0 && res != 1) {
+    std::cerr << stderr;
+    return CF_ERRF("Failed to execute start binary, exit code: {}", res);
+  }
   return stdout;
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
@@ -41,7 +41,7 @@
 namespace cuttlefish {
 
 Result<void> CheckProcessExitedNormally(siginfo_t infop,
-                                        const int expected_exit_code) {
+                                        int expected_exit_code) {
   if (infop.si_code == CLD_EXITED && infop.si_status == expected_exit_code) {
     return {};
   }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
@@ -25,6 +25,7 @@
 #include <utility>
 #include <vector>
 
+#include <android-base/file.h>
 #include "absl/strings/str_cat.h"
 #include "fmt/format.h"
 #include "fmt/ranges.h"  // NOLINT(misc-include-cleaner): version difference
@@ -105,6 +106,34 @@ Result<Command> ConstructCvdHelpCommand(
   };
   Command help_command = CF_EXPECT(ConstructCommand(construct_cmd_param));
   return help_command;
+}
+
+Result<Command> ConstructSiblingHelpCommand(
+    const std::string& bin_name,
+    const cvd_common::Envs& env,
+    const cvd_common::Args& subcmd_args) {
+  std::string exec_dir = android::base::GetExecutableDirectory();
+
+  std::string bin_path = exec_dir + "/" + bin_name;
+  CF_EXPECTF(FileExists(bin_path),
+             "Could not find {} in executable directory '{}'", bin_name,
+             exec_dir);
+
+  Command command(bin_name);
+  command.SetExecutable(bin_path);
+  for (const auto& [var, value]: env) {
+    if (var == kAndroidHostOut || var == kAndroidSoongHostOut) {
+      // These variables will cause cvd_internal_start to find the wrong
+      // assemble_cvd binary. $HOME could cause the same problem, but we need
+      // that one to find the correct image paths.
+      continue;
+    }
+    command.AddEnvironmentVariable(var, value);
+  }
+  for (const std::string& arg: subcmd_args) {
+    command.AddParameter(arg);
+  }
+  return command;
 }
 
 Result<Command> ConstructCvdGenericNonHelpCommand(

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
@@ -48,6 +48,11 @@ Result<Command> ConstructCvdHelpCommand(const std::string& bin_file,
                                         const cvd_common::Args& _args,
                                         const CommandRequest& request);
 
+Result<Command> ConstructSiblingHelpCommand(
+    const std::string& bin_name,
+    const cvd_common::Envs& env,
+    const cvd_common::Args& subcmd_args);
+
 // Constructs a command for cvd non-start-op
 struct ConstructNonHelpForm {
   std::string bin_file;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
@@ -30,7 +30,7 @@
 namespace cuttlefish {
 
 Result<void> CheckProcessExitedNormally(siginfo_t infop,
-                                        const int expected_exit_code = 0);
+                                        int expected_exit_code = 0);
 
 struct ConstructCommandParam {
   const std::string& bin_path;

--- a/base/cvd/cuttlefish/host/libs/config/config_flag.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/config_flag.cpp
@@ -87,7 +87,11 @@ class ConfigReader : public FlagFeature {
   std::unordered_set<FlagFeature*> Dependencies() const override { return {}; }
   Result<void> Process(std::vector<std::string>&) override {
     auto config_path = DefaultHostArtifactsPath("etc/cvd_config");
-    auto dir_contents = CF_EXPECT(DirectoryContents(config_path));
+    if (!DirectoryExists(config_path)) {
+      return {};
+    }
+    std::vector<std::string> dir_contents =
+        CF_EXPECT(DirectoryContents(config_path));
     for (const std::string& file : dir_contents) {
       std::string_view local_file(file);
       if (absl::ConsumePrefix(&local_file, "cvd_config_") &&
@@ -144,8 +148,14 @@ class ConfigFlagImpl : public ConfigFlag {
     LOG(INFO) << "Launching CVD using --config='"
               << VectorizedFlagValue(configs_) << "'.";
     for (size_t i = 0; i < configs_.size(); ++i) {
-      Json::Value config_values =
-          CF_EXPECT(config_reader_.ReadConfig(configs_[i]));
+      Result<Json::Value> config_values_res =
+          config_reader_.ReadConfig(configs_[i]);
+      if (!config_values_res.ok()) {
+        LOG(WARNING) << "Config '" << configs_[i]
+                     << "' not found: " << config_values_res.error();
+        continue;
+      }
+      Json::Value config_values = CF_EXPECT(std::move(config_values_res));
       for (const std::string& flag : config_values.getMemberNames()) {
         std::string value;
         if (flag == "custom_actions") {


### PR DESCRIPTION
Both commands rely on `cvd_internal_start` and `cvd_internal_host_bugreport` for their help output. Those executables are searched for in `$ANDROID_HOST_OUT/bin`, `$HOME/bin` and `./bin`, which means the command's help only works after building cuttlefish from source or downloading an android build from the server.

This PR makes cvd use the internal binaries it uses for executable substitution, which are located in the same directory where cvd is.

Bug: b/510047667