### PR TITLE
Add CvdMonitor command to monitor device logs.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
@@ -99,6 +99,7 @@ cf_cc_library(
         "//cuttlefish/host/commands/cvd/cli/commands:lint",
         "//cuttlefish/host/commands/cvd/cli/commands:login",
         "//cuttlefish/host/commands/cvd/cli/commands:logs",
+        "//cuttlefish/host/commands/cvd/cli/commands:monitor",
         "//cuttlefish/host/commands/cvd/cli/commands:power_btn",
         "//cuttlefish/host/commands/cvd/cli/commands:powerwash",
         "//cuttlefish/host/commands/cvd/cli/commands:remove",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//cuttlefish/bazel:rules.bzl", "cf_cc_library")
+load("//cuttlefish/bazel:rules.bzl", "cf_cc_library", "cf_cc_test")
 
 package(
     default_visibility = ["//:android_cuttlefish"],
@@ -469,5 +469,39 @@ cf_cc_library(
         "//cuttlefish/result",
         "//libbase",
         "@abseil-cpp//absl/log",
+    ],
+)
+
+cf_cc_library(
+    name = "monitor",
+    srcs = ["monitor.cpp"],
+    hdrs = ["monitor.h"],
+    deps = [
+        "//cuttlefish/common/libs/fs",
+        "//cuttlefish/common/libs/utils:flag_parser",
+        "//cuttlefish/host/commands/cvd/cli:command_request",
+        "//cuttlefish/host/commands/cvd/cli:types",
+        "//cuttlefish/host/commands/cvd/cli:utils",
+        "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
+        "//cuttlefish/host/commands/cvd/cli/selector",
+        "//cuttlefish/host/commands/cvd/instances",
+        "//cuttlefish/host/commands/cvd/instances:instance_manager",
+        "//cuttlefish/result",
+        "//libbase",
+        "@abseil-cpp//absl/log:check",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/strings:cord",
+        "@fmt",
+    ],
+)
+
+cf_cc_test(
+    name = "monitor_test",
+    srcs = ["monitor_test.cpp"],
+    deps = [
+        ":monitor",
+        "//cuttlefish/common/libs/fs",
+        "//cuttlefish/result:result_matchers",
+        "@abseil-cpp//absl/strings",
     ],
 )

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
@@ -225,6 +225,58 @@ cf_cc_library(
 )
 
 cf_cc_library(
+    name = "logs",
+    srcs = ["logs.cpp"],
+    hdrs = ["logs.h"],
+    deps = [
+        "//cuttlefish/common/libs/utils:files",
+        "//cuttlefish/common/libs/utils:flag_parser",
+        "//cuttlefish/host/commands/cvd/cli:command_request",
+        "//cuttlefish/host/commands/cvd/cli:types",
+        "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
+        "//cuttlefish/host/commands/cvd/cli/selector",
+        "//cuttlefish/host/commands/cvd/instances:instance_manager",
+        "//cuttlefish/result",
+        "//libbase",
+        "@abseil-cpp//absl/log",
+    ],
+)
+
+cf_cc_library(
+    name = "monitor",
+    srcs = ["monitor.cpp"],
+    hdrs = ["monitor.h"],
+    deps = [
+        "//cuttlefish/common/libs/fs",
+        "//cuttlefish/common/libs/utils:flag_parser",
+        "//cuttlefish/host/commands/cvd/cli:command_request",
+        "//cuttlefish/host/commands/cvd/cli:types",
+        "//cuttlefish/host/commands/cvd/cli:utils",
+        "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
+        "//cuttlefish/host/commands/cvd/cli/selector",
+        "//cuttlefish/host/commands/cvd/instances",
+        "//cuttlefish/host/commands/cvd/instances:instance_manager",
+        "//cuttlefish/result",
+        "//libbase",
+        "@abseil-cpp//absl/log:check",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/strings:cord",
+        "@fmt",
+    ],
+)
+
+cf_cc_test(
+    name = "monitor_test",
+    srcs = ["monitor_test.cpp"],
+    deps = [
+        ":monitor",
+        "//cuttlefish/common/libs/fs",
+        "//cuttlefish/result:result_matchers",
+        "@abseil-cpp//absl/strings",
+    ],
+)
+
+cf_cc_library(
     name = "power_btn",
     srcs = ["power_btn.cpp"],
     hdrs = ["power_btn.h"],
@@ -256,26 +308,6 @@ cf_cc_library(
         "//cuttlefish/result",
         "//libbase",
         "@fmt",
-    ],
-)
-
-cf_cc_library(
-    name = "screen_recording",
-    srcs = ["screen_recording.cpp"],
-    hdrs = ["screen_recording.h"],
-    deps = [
-        "//cuttlefish/common/libs/utils:flag_parser",
-        "//cuttlefish/host/commands/cvd/cli:command_request",
-        "//cuttlefish/host/commands/cvd/cli:types",
-        "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
-        "//cuttlefish/host/commands/cvd/cli/selector",
-        "//cuttlefish/host/commands/cvd/instances",
-        "//cuttlefish/host/commands/cvd/instances:instance_manager",
-        "//cuttlefish/result",
-        "//libbase",
-        "@abseil-cpp//absl/log",
-        "@fmt",
-        "@jsoncpp",
     ],
 )
 
@@ -330,6 +362,26 @@ cf_cc_library(
         "//cuttlefish/result",
         "//libbase",
         "@fmt",
+    ],
+)
+
+cf_cc_library(
+    name = "screen_recording",
+    srcs = ["screen_recording.cpp"],
+    hdrs = ["screen_recording.h"],
+    deps = [
+        "//cuttlefish/common/libs/utils:flag_parser",
+        "//cuttlefish/host/commands/cvd/cli:command_request",
+        "//cuttlefish/host/commands/cvd/cli:types",
+        "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
+        "//cuttlefish/host/commands/cvd/cli/selector",
+        "//cuttlefish/host/commands/cvd/instances",
+        "//cuttlefish/host/commands/cvd/instances:instance_manager",
+        "//cuttlefish/result",
+        "//libbase",
+        "@abseil-cpp//absl/log",
+        "@fmt",
+        "@jsoncpp",
     ],
 )
 
@@ -451,57 +503,5 @@ cf_cc_library(
         "//cuttlefish/result",
         "@fmt",
         "@jsoncpp",
-    ],
-)
-
-cf_cc_library(
-    name = "logs",
-    srcs = ["logs.cpp"],
-    hdrs = ["logs.h"],
-    deps = [
-        "//cuttlefish/common/libs/utils:files",
-        "//cuttlefish/common/libs/utils:flag_parser",
-        "//cuttlefish/host/commands/cvd/cli:command_request",
-        "//cuttlefish/host/commands/cvd/cli:types",
-        "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
-        "//cuttlefish/host/commands/cvd/cli/selector",
-        "//cuttlefish/host/commands/cvd/instances:instance_manager",
-        "//cuttlefish/result",
-        "//libbase",
-        "@abseil-cpp//absl/log",
-    ],
-)
-
-cf_cc_library(
-    name = "monitor",
-    srcs = ["monitor.cpp"],
-    hdrs = ["monitor.h"],
-    deps = [
-        "//cuttlefish/common/libs/fs",
-        "//cuttlefish/common/libs/utils:flag_parser",
-        "//cuttlefish/host/commands/cvd/cli:command_request",
-        "//cuttlefish/host/commands/cvd/cli:types",
-        "//cuttlefish/host/commands/cvd/cli:utils",
-        "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
-        "//cuttlefish/host/commands/cvd/cli/selector",
-        "//cuttlefish/host/commands/cvd/instances",
-        "//cuttlefish/host/commands/cvd/instances:instance_manager",
-        "//cuttlefish/result",
-        "//libbase",
-        "@abseil-cpp//absl/log:check",
-        "@abseil-cpp//absl/strings",
-        "@abseil-cpp//absl/strings:cord",
-        "@fmt",
-    ],
-)
-
-cf_cc_test(
-    name = "monitor_test",
-    srcs = ["monitor_test.cpp"],
-    deps = [
-        ":monitor",
-        "//cuttlefish/common/libs/fs",
-        "//cuttlefish/result:result_matchers",
-        "@abseil-cpp//absl/strings",
     ],
 )

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor.cpp
@@ -1,0 +1,255 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor.h"
+
+#include <fcntl.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "absl/log/check.h"
+#include "absl/strings/cord.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_replace.h"
+#include "absl/strings/str_split.h"
+
+#include "cuttlefish/common/libs/fs/shared_buf.h"
+#include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/host/commands/cvd/cli/command_request.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
+#include "cuttlefish/host/commands/cvd/cli/selector/selector.h"
+#include "cuttlefish/host/commands/cvd/cli/types.h"
+#include "cuttlefish/host/commands/cvd/cli/utils.h"
+#include "cuttlefish/host/commands/cvd/instances/instance_manager.h"
+#include "cuttlefish/result/result.h"
+
+namespace cuttlefish {
+
+namespace {
+
+Result<std::vector<std::string>> GetLastNLines(SharedFD fd, size_t n) {
+  off_t file_size = fd->LSeek(0, SEEK_END);
+  CF_EXPECT(file_size != -1, "Failed to seek to end of file");
+
+  absl::Cord accumulated_data;
+  off_t offset = file_size;
+  size_t newline_count = 0;
+
+  while (offset > 0 && newline_count < n + 1) {
+    static constexpr off_t kChunkSize = 4096;
+    size_t to_read = std::min(kChunkSize, offset);
+    offset -= to_read;
+    fd->LSeek(offset, SEEK_SET);
+
+    std::string chunk(to_read, '\0');
+    ssize_t bytes_read = ReadExact(fd, &chunk);
+    CF_EXPECTF(bytes_read == static_cast<ssize_t>(to_read), "Read failed: '{}'",
+               fd->StrError());
+
+    newline_count += std::count(chunk.begin(), chunk.end(), '\n');
+    accumulated_data.Prepend(std::move(chunk));
+  }
+
+  std::vector<std::string> all_lines =
+      absl::StrSplit(std::string(accumulated_data), '\n');
+
+  // Handle trailing newline
+  if (!all_lines.empty() && all_lines.back().empty()) {
+    all_lines.pop_back();
+  }
+
+  size_t start_idx = all_lines.size() > n ? all_lines.size() - n : 0;
+  all_lines.erase(all_lines.begin(), all_lines.begin() + start_idx);
+
+  return all_lines;
+}
+
+}  // namespace
+
+LogMonitorDisplay::LogMonitorDisplay(size_t width)
+    : width_(width), total_lines_drawn_(0) {}
+
+void LogMonitorDisplay::DrawFile(SharedFD fd, const std::string& title) {
+  std::vector<std::string> lines;
+  if (fd->IsOpen()) {
+    Result<std::vector<std::string>> lines_result = GetLastNLines(fd, 10);
+    if (lines_result.ok()) {
+      lines = *lines_result;
+    } else {
+      lines.push_back(absl::StrCat("Failed to read ", title, ":"));
+      std::string error_str =
+          lines_result.error().FormatForEnv(/*color=*/false);
+      for (const auto& el : absl::StrSplit(error_str, '\n')) {
+        if (!el.empty()) {
+          lines.push_back(std::string(el));
+        }
+      }
+    }
+  } else {
+    lines.push_back(absl::StrCat("Failed to read ", title, ": File not open"));
+    lines.push_back(absl::StrCat("Error: ", fd->StrError()));
+  }
+
+  while (lines.size() < 10) {
+    lines.push_back("");
+  }
+
+  DrawBorderedText(lines, title);
+}
+
+std::string LogMonitorDisplay::Finalize() {
+  CHECK_GE(width_, 2);
+  ss_ << "+" << std::string(width_ - 2, '-') << "+\n";
+  total_lines_drawn_++;
+  return ss_.str();
+}
+
+int LogMonitorDisplay::TotalLinesDrawn() const { return total_lines_drawn_; }
+
+void LogMonitorDisplay::DrawBorderedText(const std::vector<std::string>& lines,
+                                         const std::string& title) {
+  std::string top_border = absl::StrCat("+--", title, " ");
+  CHECK_GE(width_, 2);
+  top_border.resize(width_ - 1, '-');
+  ss_ << top_border << "+\n";
+
+  for (std::string line : lines) {
+    absl::StrReplaceAll({{"\t", "    "}, {"\r", ""}, {"\n", ""}}, &line);
+
+    line.resize(width_ - 2, ' ');
+    ss_ << "|" << line << "|\n";
+  }
+  total_lines_drawn_ += 1 + lines.size();
+}
+
+namespace {
+
+constexpr char kSummaryHelpText[] =
+    "Monitor device logs (launcher, kernel, and logcat) in real-time.";
+constexpr char kDetailedHelpText[] =
+    R"(monitor: Monitors a particular device by displaying the last 10 lines of its logs.
+It requires an interactive terminal and will continuously update the display every 50ms.
+
+It displays:
+- launcher.log
+- kernel.log
+- logcat
+
+Usage:
+  cvd [selector options] monitor
+)";
+
+constexpr char kMonitorCmd[] = "monitor";
+
+void ClearLastNLines(int n) {
+  if (n > 0) {
+    // Move cursor up N lines and clear to end of screen
+    std::cout << "\033[" << n << "A\033[J" << std::flush;
+  }
+}
+
+class CvdMonitorCommandHandler : public CvdCommandHandler {
+ public:
+  CvdMonitorCommandHandler(InstanceManager& instance_manager)
+      : instance_manager_{instance_manager} {}
+
+  Result<void> Handle(const CommandRequest& request) override {
+    CF_EXPECT(CanHandle(request));
+
+    CF_EXPECT(isatty(0),
+              "The monitor command requires an interactive terminal.");
+
+    auto [instance, unused] =
+        CF_EXPECT(selector::SelectInstance(instance_manager_, request),
+                  "Unable to select an instance");
+
+    std::string kernel_log = instance.instance_dir() + "/logs/kernel.log";
+    std::string launcher_log = instance.instance_dir() + "/logs/launcher.log";
+    std::string logcat = instance.instance_dir() + "/logs/logcat";
+
+    SharedFD kernel_fd;
+    SharedFD launcher_fd;
+    SharedFD logcat_fd;
+
+    while (true) {
+      if (!kernel_fd->IsOpen()) {
+        kernel_fd = SharedFD::Open(kernel_log, O_RDONLY);
+      }
+      if (!launcher_fd->IsOpen()) {
+        launcher_fd = SharedFD::Open(launcher_log, O_RDONLY);
+      }
+      if (!logcat_fd->IsOpen()) {
+        logcat_fd = SharedFD::Open(logcat, O_RDONLY);
+      }
+
+      Result<TerminalSize> term_size_result = GetTerminalSize();
+      int width = 79;  // Default fallback width (80 - 1)
+      if (term_size_result.ok()) {
+        width = term_size_result->columns - 1;
+      }
+      LogMonitorDisplay display(width);
+
+      display.DrawFile(launcher_fd, "launcher.log");
+      display.DrawFile(kernel_fd, "kernel.log");
+      display.DrawFile(logcat_fd, "logcat");
+
+      std::cout << display.Finalize() << std::flush;
+
+      // Wait a bit before clearing and redrawing
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      ClearLastNLines(display.TotalLinesDrawn());
+    }
+
+    return {};
+  }
+
+  cvd_common::Args CmdList() const override { return {kMonitorCmd}; }
+
+  Result<std::string> SummaryHelp() const override { return kSummaryHelpText; }
+
+  bool RequiresDeviceExists() const override { return true; }
+
+  Result<std::string> DetailedHelp(
+      const CommandRequest& request) const override {
+    return kDetailedHelpText;
+  }
+
+ private:
+  InstanceManager& instance_manager_;
+};
+
+}  // namespace
+
+std::unique_ptr<CvdCommandHandler> NewCvdMonitorCommandHandler(
+    InstanceManager& instance_manager) {
+  return std::unique_ptr<CvdCommandHandler>(
+      new CvdMonitorCommandHandler(instance_manager));
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
+#include "cuttlefish/host/commands/cvd/instances/instance_manager.h"
+
+namespace cuttlefish {
+
+class LogMonitorDisplay {
+ public:
+  LogMonitorDisplay(size_t width);
+
+  void DrawFile(SharedFD fd, const std::string& title);
+
+  std::string Finalize();
+
+  int TotalLinesDrawn() const;
+
+ private:
+  void DrawBorderedText(const std::vector<std::string>& lines,
+                        const std::string& title);
+
+  size_t width_;
+  std::stringstream ss_;
+  int total_lines_drawn_;
+};
+
+std::unique_ptr<CvdCommandHandler> NewCvdMonitorCommandHandler(
+    InstanceManager& instance_manager);
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor_test.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor.h"
+
+#include <cstddef>
+#include <string>
+
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "gtest/gtest.h"
+
+#include "cuttlefish/common/libs/fs/shared_fd.h"
+
+namespace cuttlefish {
+
+TEST(LogMonitorDisplayTest, DrawFileValid) {
+  SharedFD fd =
+      SharedFD::MemfdCreateWithData("test_log", "line1\nline2\nline3\n");
+  ASSERT_TRUE(fd->IsOpen());
+
+  LogMonitorDisplay display(40);
+  display.DrawFile(fd, "test.log");
+
+  std::string output = display.Finalize();
+  EXPECT_TRUE(absl::StrContains(output, "+--test.log "));
+  EXPECT_TRUE(
+      absl::StrContains(output, "|line1                                 |"));
+  EXPECT_TRUE(
+      absl::StrContains(output, "|line2                                 |"));
+  EXPECT_TRUE(
+      absl::StrContains(output, "|line3                                 |"));
+  EXPECT_TRUE(
+      absl::StrContains(output, "+--------------------------------------+"));
+}
+
+TEST(LogMonitorDisplayTest, DrawFileInvalid) {
+  SharedFD fd;  // Invalid FD
+
+  LogMonitorDisplay display(40);
+  display.DrawFile(fd, "test.log");
+
+  std::string output = display.Finalize();
+  EXPECT_TRUE(absl::StrContains(output, "+--test.log "));
+  EXPECT_TRUE(
+      absl::StrContains(output, "|Failed to read test.log: File not open|"));
+  EXPECT_TRUE(
+      absl::StrContains(output, "+--------------------------------------+"));
+}
+
+TEST(LogMonitorDisplayTest, TotalLinesDrawn) {
+  SharedFD fd = SharedFD::MemfdCreateWithData("test_log", "line1\n");
+  LogMonitorDisplay display(40);
+
+  EXPECT_EQ(display.TotalLinesDrawn(), 0);
+
+  display.DrawFile(fd, "test.log");
+  EXPECT_EQ(display.TotalLinesDrawn(),
+            11);  // 10 lines of content + 1 top border
+
+  display.Finalize();
+  EXPECT_EQ(display.TotalLinesDrawn(), 12);  // +1 bottom border
+}
+
+TEST(LogMonitorDisplayTest, DrawFileLastNLinesOrder) {
+  std::string data;
+  for (int i = 1; i <= 12; ++i) {
+    data += absl::StrCat("line", i, "\n");
+  }
+  SharedFD fd = SharedFD::MemfdCreateWithData("test_log", data);
+  ASSERT_TRUE(fd->IsOpen());
+
+  LogMonitorDisplay display(40);
+  display.DrawFile(fd, "test.log");
+
+  std::string output = display.Finalize();
+
+  // Should contain line3 to line12
+  for (int i = 3; i <= 12; ++i) {
+    EXPECT_TRUE(absl::StrContains(output, absl::StrCat("|line", i)));
+  }
+  // Should NOT contain line1 or line2
+  EXPECT_FALSE(absl::StrContains(output, "|line1 "));
+  EXPECT_FALSE(absl::StrContains(output, "|line2 "));
+
+  // Check order
+  size_t last_pos = 0;
+  for (int i = 3; i <= 12; ++i) {
+    size_t pos = output.find(absl::StrCat("|line", i));
+    ASSERT_NE(pos, std::string::npos);
+    EXPECT_GT(pos, last_pos);
+    last_pos = pos;
+  }
+}
+
+TEST(LogMonitorDisplayTest, DrawFileLinesAcrossChunks) {
+  std::string data;
+  for (int i = 1; i <= 10; ++i) {
+    std::string line = absl::StrCat("Line ", i, ": ");
+    int fill_len = 500 - line.length() - 1;
+    line += std::string(fill_len, 'A' + i);
+    line += "\n";
+    data += line;
+  }
+  ASSERT_EQ(data.size(), 5000);
+
+  SharedFD fd = SharedFD::MemfdCreateWithData("test_log", data);
+  ASSERT_TRUE(fd->IsOpen());
+
+  LogMonitorDisplay display(80);
+  display.DrawFile(fd, "test.log");
+
+  std::string output = display.Finalize();
+
+  // Verify all lines are present
+  for (int i = 1; i <= 10; ++i) {
+    EXPECT_TRUE(absl::StrContains(output, absl::StrCat("Line ", i, ": ")));
+  }
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/request_context.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/request_context.cpp
@@ -39,6 +39,7 @@
 #include "cuttlefish/host/commands/cvd/cli/commands/login.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/logs.h"
 
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/power_btn.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/powerwash.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/remove.h"
@@ -101,6 +102,7 @@ RequestContext::RequestContext(InstanceManager& instance_manager,
       NewCvdDevicePowerBtnCommandHandler(instance_manager));
   request_handlers_.emplace_back(
       NewCvdDevicePowerwashCommandHandler(instance_manager));
+  request_handlers_.emplace_back(NewCvdMonitorCommandHandler(instance_manager));
   request_handlers_.emplace_back(
       NewCvdDeviceRestartCommandHandler(instance_manager));
   request_handlers_.emplace_back(NewRemoveCvdCommandHandler(instance_manager));

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
@@ -16,6 +16,8 @@
 
 #include "cuttlefish/host/commands/cvd/cli/utils.h"
 
+#include <sys/ioctl.h>
+#include <unistd.h>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -169,6 +171,13 @@ std::string NoGroupMessage(const CommandRequest& request) {
                      fmt::join(request.SubcommandArguments(), " "),
                      colors.Reset(), colors.BoldRed(), "no device",
                      colors.Reset());
+}
+
+Result<TerminalSize> GetTerminalSize() {
+  struct winsize w;
+  CF_EXPECT(ioctl(STDOUT_FILENO, TIOCGWINSZ, &w) != -1,
+            "Failed to get terminal size: " << strerror(errno));
+  return TerminalSize{.rows = w.ws_row, .columns = w.ws_col};
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.h
@@ -64,6 +64,12 @@ Result<Command> ConstructCvdGenericNonHelpCommand(
 // The function does not verify that.
 std::string NoGroupMessage(const CommandRequest& request);
 
+struct TerminalSize {
+  int rows;
+  int columns;
+};
+Result<TerminalSize> GetTerminalSize();
+
 class TerminalColors {
  public:
   TerminalColors(bool is_tty): is_tty_(is_tty){}


### PR DESCRIPTION
This command repeatedly clears and prints the last 10 lines of launcher.log, kernel.log, and logcat in a bordered ASCII box. It includes unit tests for the display logic.

The second commit alphabetizes build targets.

See the attached bug for an example video.

Assisted-by: Jetski
Bug: b/510094996