### PR TITLE
Load modules in postinst.

### DIFF
--- a/base/debian/cuttlefish-base.postinst
+++ b/base/debian/cuttlefish-base.postinst
@@ -25,6 +25,16 @@ case "$1" in
         addgroup --system kvm
     fi
 
+    if [ -f /etc/modules-load.d/cuttlefish-common.conf ]; then
+        while read -r module || [ -n "$module" ]; do
+            case "$module" in
+                [\#]*) continue ;;
+                "") continue ;;
+            esac
+            modprobe "$module" || true
+        done < /etc/modules-load.d/cuttlefish-common.conf
+    fi
+
     setcap cap_net_admin,cap_net_bind_service,cap_net_raw=+ep \
         /usr/lib/cuttlefish-common/bin/cvdalloc
     ;;


### PR DESCRIPTION
This alleviates the need to reboot after installation. We should also improve the module presence checks, but we'll tackle that separately.

Bug: 507983767