### PR TITLE
Use fixed build_id for media_test.

### DIFF
--- a/e2etests/cvd/media_tests/main_test.go
+++ b/e2etests/cvd/media_tests/main_test.go
@@ -27,7 +27,7 @@ func TestEmulatedCameraV4l2Compliance(t *testing.T) {
 		target string
 	}{
 		{
-			branch: "git_main",
+			branch: "15346462", // TODO(b/510415749)
 			target: "aosp_cf_x86_64_only_phone-trunk_staging-userdebug",
 		},
 	}


### PR DESCRIPTION
Recent `git_main` pushes breaks the device launching with media devices. As there are no presumbit checks on the Android side when using virtio-media devices let's use a fixed build id that works with it for now to avoid this sort of breakeages in the future.

Bug: b/510416374