### PR TITLE
Remove deleted target from substitution file

### DIFF
--- a/e2etests/debian_substitution_marker
+++ b/e2etests/debian_substitution_marker
@@ -6,11 +6,6 @@ symlinks {
 }
 
 symlinks {
-  target: "/usr/lib/cuttlefish-common/bin/allocd_client"
-  link_name: "bin/allocd_client"
-}
-
-symlinks {
   target: "/usr/lib/cuttlefish-common/bin/assemble_cvd"
   link_name: "bin/assemble_cvd"
 }


### PR DESCRIPTION
This triggers an error message.  Removed from the `cvd` package target in https://github.com/google/android-cuttlefish/pull/1982.

Bug: 507537392