### PR TITLE
Expose operator into another port of the host to avoid port collision

### DIFF
--- a/container/src/podcvd/internal/const.go
+++ b/container/src/podcvd/internal/const.go
@@ -17,8 +17,9 @@ package internal
 var imageName = "us-docker.pkg.dev/android-cuttlefish-artifacts/cuttlefish-orchestration/cuttlefish-orchestration:nightly"
 
 const (
-	portOperatorHttps = 1443
-	ifName            = "podcvd"
+	portOperatorHttps       = 1443
+	portOperatorHttpsOnHost = 11443
+	ifName                  = "podcvd"
 )
 
 const (

--- a/container/src/podcvd/internal/host.go
+++ b/container/src/podcvd/internal/host.go
@@ -328,7 +328,9 @@ func createAndStartContainer(ccm libcfcontainer.CuttlefishContainerManager, comm
 			return "", err
 		}
 		containerHostCfg.PortBindings = nat.PortMap{}
-		appendPortBindingRange(containerHostCfg.PortBindings, ip, "tcp", portOperatorHttps, portOperatorHttps)
+		containerHostCfg.PortBindings[nat.Port(fmt.Sprintf("%d/tcp", portOperatorHttps))] = []nat.PortBinding{
+			{HostIP: ip, HostPort: fmt.Sprintf("%d", portOperatorHttpsOnHost)},
+		}
 		appendPortBindingRange(containerHostCfg.PortBindings, ip, "tcp", 6520, 6529)
 		appendPortBindingRange(containerHostCfg.PortBindings, ip, "tcp", 15550, 15599)
 		appendPortBindingRange(containerHostCfg.PortBindings, ip, "udp", 15550, 15599)
@@ -371,7 +373,7 @@ func ensureOperatorHealthy(ip string) error {
 	var lastErr error
 	for i := 1; i <= retryCount; i++ {
 		time.Sleep(retryInterval)
-		resp, err := client.Get(fmt.Sprintf("https://%s:%d/devices", ip, portOperatorHttps))
+		resp, err := client.Get(fmt.Sprintf("https://%s:%d/devices", ip, portOperatorHttpsOnHost))
 		if err != nil {
 			lastErr = fmt.Errorf("failed to check health of operator: %w", err)
 			continue


### PR DESCRIPTION
`podcvd` tries to bind `1443` port of specified IP address via pasta setup, but it fails to bind when operator installed via `cuttlefish-user` obtains same port. This change is for using another port rather than `1443`, when exposing operator running in containers.

Context: b/509403701