### PR TITLE
Disable cvdalloc if iptables cannot be resolved.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
@@ -115,6 +115,7 @@ cf_cc_library(
     srcs = ["cvdalloc.cpp"],
     hdrs = ["cvdalloc.h"],
     deps = [
+        "//allocd:alloc_utils",
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:subprocess",
         "//cuttlefish/host/commands/cvdalloc:privilege",

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/cvdalloc.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/cvdalloc.cpp
@@ -31,6 +31,7 @@
 #include <fruit/fruit_forward_decls.h>
 #include "absl/log/log.h"
 
+#include "allocd/alloc_utils.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"
 #include "cuttlefish/host/commands/cvdalloc/privilege.h"
 #include "cuttlefish/host/commands/cvdalloc/sem.h"
@@ -70,7 +71,14 @@ Result<std::vector<MonitorCommand>> Cvdalloc::Commands() {
 }
 
 std::string Cvdalloc::Name() const { return "Cvdalloc"; }
-bool Cvdalloc::Enabled() const { return instance_.use_cvdalloc(); }
+
+bool Cvdalloc::Enabled() const {
+  if (!IsUsable().ok()) {
+    return false;
+  }
+  return instance_.use_cvdalloc();
+}
+
 std::unordered_set<SetupFeature *> Cvdalloc::Dependencies() const { return {}; }
 
 Result<void> Cvdalloc::WaitForAvailability() {
@@ -103,6 +111,11 @@ Result<void> Cvdalloc::BinaryIsValid(std::string_view path) {
   CF_EXPECT(r == 0, "Could not stat the cvdalloc binary at "
                         << path << ": " << StrError(errno));
   CF_EXPECT(ValidateCvdallocBinary(path));
+  return {};
+}
+
+Result<void> Cvdalloc::IsUsable() const {
+  CF_EXPECT(IptablesPath());
   return {};
 }
 

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/cvdalloc.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/cvdalloc.h
@@ -47,6 +47,7 @@ class Cvdalloc : public vm_manager::VmmDependencyCommand {
  private:
   Result<void> ResultSetup() override;
   Result<void> BinaryIsValid(std::string_view path);
+  Result<void> IsUsable() const;
   StopperResult Stop();
 
   const CuttlefishConfig::InstanceSpecific &instance_;


### PR DESCRIPTION
If for whatever reason we cannot resolve the iptables binary from PATH, fall back to non-cvdalloc behavior. This will give a better chance of the instance actually starting up properly, considering that we currently both have statically allocated tap resources being created by cuttlefish-host-resources. This won't be as elegant in a future where we remove the static resource allocation, but we'll cross that bridge when we get to it.