### PR TITLE
Statically allocate the iptables path.

### DIFF
--- a/base/cvd/allocd/BUILD.bazel
+++ b/base/cvd/allocd/BUILD.bazel
@@ -42,6 +42,7 @@ cc_library(
         "//cuttlefish/host/commands/cvd/utils:common",
         "//cuttlefish/host/libs/config:logging",
         "//cuttlefish/result",
+        "@abseil-cpp//absl/base:no_destructor",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/strings:str_format",

--- a/base/cvd/allocd/alloc_utils.cpp
+++ b/base/cvd/allocd/alloc_utils.cpp
@@ -22,6 +22,7 @@
 #include <string_view>
 #include <sstream>
 
+#include "absl/base/no_destructor.h"
 #include "absl/log/log.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
@@ -37,6 +38,20 @@
 #endif
 
 #include <net/if.h>
+
+namespace {
+
+cuttlefish::Result<std::string> SearchForIptables() {
+  cuttlefish::Result<std::string> p =
+      cuttlefish::Search(cuttlefish::Path(), "iptables");
+  if (p.ok()) {
+    return p;
+  }
+
+  return cuttlefish::Search({"/usr/sbin", "/sbin"}, "iptables");
+}
+
+}  // namespace
 
 namespace cuttlefish {
 
@@ -337,17 +352,11 @@ bool DestroyEthernetBridgeIface(std::string_view name,
 }
 
 Result<std::string> IptablesPath() {
-  Result<std::string> path = Search(Path(), "iptables");
-  if (path.ok()) {
-    return *path;
-  }
+  static const absl::NoDestructor<std::string> iptables_path(
+     SearchForIptables().value_or(""));
 
-  path = Search({"/usr/sbin", "/sbin"}, "iptables");
-  if (path.ok()) {
-    return *path;
-  }
-
-  return CF_ERR("iptables not found in PATH or standard system locations");
+  CF_EXPECT(!iptables_path->empty(), "could not find iptables");
+  return *iptables_path;
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
@@ -115,6 +115,7 @@ cf_cc_library(
     deps = [
         ":environment",
         "//cuttlefish/common/libs/fs",
+        "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:in_sandbox",
         "//cuttlefish/common/libs/utils:users",
         "//cuttlefish/posix:rename",

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
@@ -115,6 +115,7 @@ cf_cc_library(
     srcs = ["cvdalloc.cpp"],
     hdrs = ["cvdalloc.h"],
     deps = [
+        "//allocd:alloc_utils",
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:subprocess",
         "//cuttlefish/host/commands/cvdalloc:privilege",


### PR DESCRIPTION
We resolve the path to iptables each time we call in to IptablesPath; we can make this slightly more efficient if we statically allocate the backing storage for the path string.