### PR TITLE
Fix launch with kernel repacking

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_image_utils.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_image_utils.cc
@@ -174,16 +174,12 @@ Result<void> UnpackRamdisk(const std::string& original_ramdisk_path,
   CF_EXPECT(EnsureDirectoryExists(ramdisk_stage_dir));
 
   SharedFD input = SharedFD::Open(original_ramdisk_path + kCpioExt, O_RDONLY);
-  int cpio_status;
-  do {
-    LOG(ERROR) << "Running";
-    cpio_status = Command(CpioBinary())
-                      .AddParameter("-idu")
-                      .SetWorkingDirectory(ramdisk_stage_dir)
-                      .RedirectStdIO(Subprocess::StdIOChannel::kStdIn, input)
-                      .Start()
-                      .Wait();
-  } while (cpio_status == 0);
+  Command(CpioBinary())
+      .AddParameter("-idu")
+      .SetWorkingDirectory(ramdisk_stage_dir)
+      .RedirectStdIO(Subprocess::StdIOChannel::kStdIn, input)
+      .Start()
+      .Wait();
   return {};
 }
 

--- a/base/cvd/cuttlefish/package/BUILD.bazel
+++ b/base/cvd/cuttlefish/package/BUILD.bazel
@@ -24,7 +24,7 @@ package_files(
         "cuttlefish-common/bin/cf_vhost_user_input": "//cuttlefish/host/commands/vhost_user_input:cf_vhost_user_input",
         "cuttlefish-common/bin/console_forwarder": "//cuttlefish/host/commands/console_forwarder",
         "cuttlefish-common/bin/control_env_proxy_server": "//cuttlefish/host/commands/control_env_proxy_server",
-        # "cuttlefish-common/bin/cpio": "@libarchive//cpio:cpio", # TODO(b/510369069)
+        "cuttlefish-common/bin/cpio": "@libarchive//cpio:cpio",
         "cuttlefish-common/bin/cuttlefish_example_action_server": "//cuttlefish/host/example_custom_actions:cuttlefish_example_action_server",
         "cuttlefish-common/bin/cvd_import_locations": "//cuttlefish/host/commands/cvd_import_locations",
         "cuttlefish-common/bin/cvd_internal_display": "//cuttlefish/host/commands/display:cvd_internal_display",


### PR DESCRIPTION
At some point assemble_cvd expected `cpio` to return non-zero values on success, which is no longer true. Newer versions of cpio return 0 on success. Ignoring the return value of cpio seems to work, the kernel is replaced successfully.

Tested with:
```
bazel-bin/cuttlefish/package/cuttlefish-common/bin/cvd fetch --default_build=git_main/aosp_cf_x86_64_only_phone-trunk_staging-userdebug --target_directory=$HOME/dl_kernel --kernel_build=aosp_kernel-common-android-mainline/kernel_virt_x86_64
bazel-bin/cuttlefish/package/cuttlefish-common/bin/cvd create --host_path=$HOME/dl_kernel --product_path=$HOME/dl_kernel
```

Bug: b/427835411
Bug: b/510369069