### PR TITLE
Create privileged executable for refreshing groups

### DIFF
--- a/base/cvd/cuttlefish/host/commands/refresh_groups/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/refresh_groups/BUILD.bazel
@@ -1,0 +1,10 @@
+load("//cuttlefish/bazel:rules.bzl", "cf_cc_binary")
+
+package(
+    default_visibility = ["//:android_cuttlefish"],
+)
+
+cf_cc_binary(
+    name = "cvd_refresh_groups",
+    srcs = ["cvd_refresh_groups.cc"],
+)

--- a/base/cvd/cuttlefish/host/commands/refresh_groups/cvd_refresh_groups.cc
+++ b/base/cvd/cuttlefish/host/commands/refresh_groups/cvd_refresh_groups.cc
@@ -1,0 +1,55 @@
+//
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <grp.h>
+#include <limits.h>
+#include <stdio.h>
+#include <unistd.h>
+
+/**
+ * Privileged executable that calls initgroups to refresh the secondary groups
+ * list. Comparable to `sg`, except that it doesn't update the primary group,
+ * and refreshes the entire list of secondary groups.
+ *
+ * Necessary because Debian 13's `sg` no longer updates the secondary groups
+ * list.
+ *
+ * - https://www.github.com/util-linux/util-linux/issues/4098
+ * - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1130245
+ *
+ * Sample invocation:
+ * ```
+ * cvd_refresh_groups /usr/bin/groups groups
+ * ```
+ */
+int main(int argc, char** argv) {
+  if (argc < 3) {
+    fprintf(stderr,
+            "Usage: cvd_refresh_groups <file> <argv[0]> [argv<N> ...]\n");
+    return 1;
+  }
+  char user[LOGIN_NAME_MAX];
+  if (getlogin_r(user, sizeof(user))) {
+    perror("getlogin_r failed");
+    return 1;
+  }
+  if (initgroups(user, getgid())) {
+    perror("initgroups failed");
+    return 1;
+  }
+  execv(argv[1], argv + 2);
+  perror("execvp failed");
+  return 1;
+}

--- a/base/cvd/cuttlefish/package/BUILD.bazel
+++ b/base/cvd/cuttlefish/package/BUILD.bazel
@@ -33,6 +33,7 @@ package_files(
         "cuttlefish-common/bin/cvd_internal_start": "//cuttlefish/host/commands/start:cvd_internal_start",
         "cuttlefish-common/bin/cvd_internal_status": "//cuttlefish/host/commands/status:cvd_internal_status",
         "cuttlefish-common/bin/cvd_internal_stop": "//cuttlefish/host/commands/stop:cvd_internal_stop",
+        "cuttlefish-common/bin/cvd_refresh_groups": "//cuttlefish/host/commands/refresh_groups:cvd_refresh_groups",
         "cuttlefish-common/bin/cvd_send_id_disclosure": "//cuttlefish/host/commands/cvd_send_id_disclosure",
         "cuttlefish-common/bin/cvd_send_sms": "//cuttlefish/host/commands/cvd_send_sms",
         "cuttlefish-common/bin/cvd_update_location": "//cuttlefish/host/commands/cvd_update_location",

--- a/base/debian/cuttlefish-base.postinst
+++ b/base/debian/cuttlefish-base.postinst
@@ -27,6 +27,8 @@ case "$1" in
 
     setcap cap_net_admin,cap_net_bind_service,cap_net_raw=+ep \
         /usr/lib/cuttlefish-common/bin/cvdalloc
+    setcap cap_setgid=+ep \
+        /usr/lib/cuttlefish-common/bin/cvd_refresh_groups
     ;;
 esac
 


### PR DESCRIPTION
`acloud` relies on [`sg`](https://man7.org/linux/man-pages/man1/sg.1.html) to [refresh group membership](https://cs.android.com/android/platform/superproject/+/android-latest-release:tools/acloud/internal/lib/utils.py;l=1322;drc=02cef780efe034b789d0e3708d4929d2f236327b) if the user has joined the `cvdnetwork` / `kvm` / `render` groups but has not yet restarted or re-logged in.

Debian 13 changed providers of `sg` / `newgrp` from `shadow` to `util-linux`. In the `util-linux` implementation, `sg` only updates the primary group but does not update secondary groups.

- https://www.github.com/util-linux/util-linux/issues/4098
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1130245

Since `sg` no longer works to refresh the apparent secondary group memberships, we'll need an alternative implementation.

Mechanism for raising privilege copied from https://www.github.com/google/android-cuttlefish/pull/1706

Sample invocation:
```
cvd_refresh_groups /usr/bin/groups groups
```

Bug: b/510899675