### PR TITLE
Do not show full group JSON to users by default at the end of `cvd create`

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -20,6 +20,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <algorithm>
 #include <cstdlib>
@@ -449,8 +450,10 @@ Result<void> CvdStartCommandHandler::Handle(const CommandRequest& request) {
   CF_EXPECT(instance_manager_.UpdateInstanceGroup(group));
   listener_handle.reset();
 
-  auto group_json = CF_EXPECT(group.FetchStatus());
-  std::cout << group_json.toStyledString();
+  if (!isatty(0)) {
+    auto group_json = CF_EXPECT(group.FetchStatus());
+    std::cout << group_json.toStyledString();
+  }
 
   return {};
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -391,7 +391,7 @@ Result<void> CvdStartCommandHandler::Handle(const CommandRequest& request) {
   CF_EXPECT(ConsumeDaemonModeFlag(subcmd_args));
   subcmd_args.push_back("--daemon=true");
 
-  auto group =
+  LocalInstanceGroup group =
       CF_EXPECT(selector::SelectGroup(instance_manager_, request),
                 "Failed to select group to start, did you mean 'cvd create'?");
 
@@ -450,7 +450,15 @@ Result<void> CvdStartCommandHandler::Handle(const CommandRequest& request) {
   CF_EXPECT(instance_manager_.UpdateInstanceGroup(group));
   listener_handle.reset();
 
-  if (!isatty(0)) {
+  // show user a more succinct output
+  if (isatty(0)) {
+    std::vector<std::string> instance_names;
+    for (const auto& instance : group.Instances()) {
+      instance_names.push_back(instance.name());
+    }
+    std::cout << fmt::format("group:{}|instance(s):{}\n", group.GroupName(),
+                             absl::StrJoin(instance_names, ","));
+  } else {
     auto group_json = CF_EXPECT(group.FetchStatus());
     std::cout << group_json.toStyledString();
   }


### PR DESCRIPTION
Show only the group and instance names instead, but leave the full JSON output for tools like the host orchestrator.

Bug: 511258310