### PR TITLE
Refresh groups if necessary when running `cvd` commands

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
@@ -151,6 +151,7 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:subprocess",
+        "//cuttlefish/common/libs/utils:users",
         "//cuttlefish/host/commands/cvd/instances:config_path",
         "//cuttlefish/host/commands/cvd/utils",
         "//cuttlefish/host/libs/config:config_constants",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
@@ -25,14 +25,15 @@
 #include <utility>
 #include <vector>
 
-#include <android-base/file.h>
 #include "absl/strings/str_cat.h"
+#include "android-base/file.h"
 #include "fmt/format.h"
 #include "fmt/ranges.h"  // NOLINT(misc-include-cleaner): version difference
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/contains.h"
 #include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/common/libs/utils/users.h"
 #include "cuttlefish/host/commands/cvd/instances/config_path.h"
 #include "cuttlefish/host/commands/cvd/utils/common.h"
 #include "cuttlefish/host/libs/config/config_constants.h"
@@ -55,9 +56,21 @@ Result<void> CheckProcessExitedNormally(siginfo_t infop,
   }
 }
 
+static Command FixGroupsIfNecessary(const std::string& command_name,
+                                    const std::string& bin_path) {
+  if (InGroup("cvdnetwork") && InGroup("kvm")) {
+    return Command(command_name).SetExecutable(bin_path);
+  }
+  const std::string refresh_groups =
+      android::base::GetExecutableDirectory() + "/cvd_refresh_groups";
+  return Command("cvd_refresh_groups")
+      .SetExecutable(refresh_groups)
+      .AddParameter(bin_path)
+      .AddParameter(command_name);
+}
+
 Result<Command> ConstructCommand(const ConstructCommandParam& param) {
-  Command command(param.command_name);
-  command.SetExecutable(param.bin_path);
+  Command command = FixGroupsIfNecessary(param.command_name, param.bin_path);
   for (const std::string& arg : param.args) {
     command.AddParameter(arg);
   }

--- a/base/cvd/cuttlefish/host/commands/refresh_groups/cvd_refresh_groups.cc
+++ b/base/cvd/cuttlefish/host/commands/refresh_groups/cvd_refresh_groups.cc
@@ -14,8 +14,9 @@
 // limitations under the License.
 
 #include <grp.h>
-#include <limits.h>
+#include <pwd.h>
 #include <stdio.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 /**
@@ -40,12 +41,13 @@ int main(int argc, char** argv) {
             "Usage: cvd_refresh_groups <file> <argv[0]> [argv<N> ...]\n");
     return 1;
   }
-  char user[LOGIN_NAME_MAX];
-  if (getlogin_r(user, sizeof(user))) {
-    perror("getlogin_r failed");
+  uid_t uid = getuid();
+  struct passwd* pw = getpwuid(uid);
+  if (!pw) {
+    perror("getpwuid failed");
     return 1;
   }
-  if (initgroups(user, getgid())) {
+  if (initgroups(pw->pw_name, getgid())) {
     perror("initgroups failed");
     return 1;
   }


### PR DESCRIPTION
Check user groups in ConstructCommand and fallback to cvd_refresh_groups if necessary

`cvd_refresh_groups` is changed to use `getpwuid(getuid())` instead of `getlogin_r` to support the `sudo -u` flow used in the end-to-end tests.

Introduces a check in ConstructCommand to ensure the user is a member of cvdnetwork, kvm, and render groups. If not, it executes the command via cvd_refresh_groups.

Assisted-by: Jetski <jetski@google.com>
Bug: b/510930737