### PR TITLE
Fix 1 ClangTidyReadability finding: redundant get() call on smart pointer.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/stop/main.cc
+++ b/base/cvd/cuttlefish/host/commands/stop/main.cc
@@ -58,7 +58,7 @@ std::set<std::string> FallbackDirs() {
   paths.insert(parent_path + "/cuttlefish_assembly");
 
   std::unique_ptr<DIR, int(*)(DIR*)> dir(opendir(parent_path.c_str()), closedir);
-  if (!dir.get()) {
+  if (!dir) {
     return paths;
   }
 


### PR DESCRIPTION
Applies cl/911758454

Assisted-by: Jetski