### PR TITLE
Create library for declaring log names.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -71,6 +71,7 @@ cf_cc_binary(
         "//cuttlefish/host/libs/config/defaults",
         "//cuttlefish/host/libs/config/fastboot",
         "//cuttlefish/host/libs/feature:inject",
+        "//cuttlefish/host/libs/log_names",
         "//cuttlefish/posix:symlink",
         "//cuttlefish/pretty:vector",
         "//libbase",

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd.cc
@@ -110,7 +110,7 @@ Result<void> CreateLegacySymlinks(
                              "launcher.log",
                              "logcat",
                              "metrics.log",
-                             "modem_simulator.log",
+                             kLogNameModemSimulator,
                              "crosvm_openwrt.log",
                              "crosvm_openwrt_boot.log"};
   for (const auto& log_file : log_files) {
@@ -245,7 +245,7 @@ Result<std::set<std::string>> PreservingOnResume(
     preserving.insert(kLogNameKernel);
     preserving.insert("launcher.log");
     preserving.insert("logcat");
-    preserving.insert("modem_simulator.log");
+    preserving.insert(kLogNameModemSimulator);
     preserving.insert("crosvm_openwrt.log");
     preserving.insert("crosvm_openwrt_boot.log");
     preserving.insert("metrics.log");

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd.cc
@@ -68,6 +68,7 @@
 #include "cuttlefish/host/libs/config/fastboot/fastboot.h"
 #include "cuttlefish/host/libs/config/fetcher_configs.h"
 #include "cuttlefish/host/libs/config/log_string_to_dir.h"
+#include "cuttlefish/host/libs/log_names/log_names.h"
 #include "cuttlefish/host/libs/feature/inject.h"
 #include "cuttlefish/posix/symlink.h"
 #include "cuttlefish/pretty/vector.h"
@@ -105,7 +106,7 @@ Result<void> SaveConfig(const CuttlefishConfig& tmp_config_obj) {
 Result<void> CreateLegacySymlinks(
     const CuttlefishConfig::InstanceSpecific& instance,
     const CuttlefishConfig::EnvironmentSpecific& environment) {
-  std::string log_files[] = {"kernel.log",
+  std::string log_files[] = {kLogNameKernel,
                              "launcher.log",
                              "logcat",
                              "metrics.log",
@@ -241,7 +242,7 @@ Result<std::set<std::string>> PreservingOnResume(
   preserving.insert("oemlock_insecure");
   // Preserve logs if restoring from a snapshot.
   if (!snapshot_path.empty()) {
-    preserving.insert("kernel.log");
+    preserving.insert(kLogNameKernel);
     preserving.insert("launcher.log");
     preserving.insert("logcat");
     preserving.insert("modem_simulator.log");

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
@@ -258,6 +258,7 @@ cf_cc_library(
         "//cuttlefish/host/commands/cvd/cli/selector",
         "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/commands/cvd/instances:instance_manager",
+        "//cuttlefish/host/libs/log_names",
         "//cuttlefish/result",
         "//libbase",
         "@abseil-cpp//absl/log:check",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor.cpp
@@ -48,6 +48,7 @@
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/host/commands/cvd/cli/utils.h"
 #include "cuttlefish/host/commands/cvd/instances/instance_manager.h"
+#include "cuttlefish/host/libs/log_names/log_names.h"
 #include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
@@ -193,7 +194,8 @@ class CvdMonitorCommandHandler : public CvdCommandHandler {
         CF_EXPECT(selector::SelectInstance(instance_manager_, request),
                   "Unable to select an instance");
 
-    std::string kernel_log = instance.instance_dir() + "/logs/kernel.log";
+    std::string kernel_log =
+        absl::StrCat(instance.instance_dir(), "/logs/", kLogNameKernel);
     std::string launcher_log = instance.instance_dir() + "/logs/launcher.log";
     std::string logcat = instance.instance_dir() + "/logs/logcat";
 
@@ -220,7 +222,7 @@ class CvdMonitorCommandHandler : public CvdCommandHandler {
       LogMonitorDisplay display(width);
 
       display.DrawFile(launcher_fd, "launcher.log");
-      display.DrawFile(kernel_fd, "kernel.log");
+      display.DrawFile(kernel_fd, kLogNameKernel);
       display.DrawFile(logcat_fd, "logcat");
 
       std::cout << display.Finalize() << std::flush;

--- a/base/cvd/cuttlefish/host/commands/host_bugreport/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/host_bugreport/BUILD.bazel
@@ -14,6 +14,7 @@ cf_cc_binary(
         "//cuttlefish/common/libs/utils:subprocess",
         "//cuttlefish/common/libs/utils:tee_logging",
         "//cuttlefish/host/libs/config:cuttlefish_config",
+        "//cuttlefish/host/libs/log_names",
         "//cuttlefish/host/libs/zip:zip_file",
         "//cuttlefish/posix:strerror",
         "//cuttlefish/result",

--- a/base/cvd/cuttlefish/host/commands/host_bugreport/main.cc
+++ b/base/cvd/cuttlefish/host/commands/host_bugreport/main.cc
@@ -30,6 +30,7 @@
 #include "cuttlefish/common/libs/utils/subprocess.h"
 #include "cuttlefish/common/libs/utils/tee_logging.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/log_names/log_names.h"
 #include "cuttlefish/host/libs/zip/zip_file.h"
 #include "cuttlefish/posix/strerror.h"
 #include "cuttlefish/result/result.h"
@@ -147,7 +148,7 @@ void TakeHostBugreport(const CuttlefishConfig* config, WritableZip& archive) {
                    << result.error().FormatForEnv(/* color = */ false);
       }
     } else {
-      save("kernel.log");
+      save(kLogNameKernel);
       save("launcher.log");
       save("logcat");
       save("metrics.log");

--- a/base/cvd/cuttlefish/host/commands/kernel_log_monitor/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/kernel_log_monitor/BUILD.bazel
@@ -17,6 +17,7 @@ cf_cc_binary(
         "//cuttlefish/host/libs/config:config_instance_derived",
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:logging",
+        "//cuttlefish/host/libs/log_names",
         "//cuttlefish/result",
         "//libbase",
         "@abseil-cpp//absl/log",

--- a/base/cvd/cuttlefish/host/commands/kernel_log_monitor/main.cc
+++ b/base/cvd/cuttlefish/host/commands/kernel_log_monitor/main.cc
@@ -36,6 +36,7 @@
 #include "cuttlefish/host/libs/config/config_instance_derived.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 #include "cuttlefish/host/libs/config/logging.h"
+#include "cuttlefish/host/libs/log_names/log_names.h"
 
 DEFINE_int32(log_pipe_fd, -1,
              "A file descriptor representing a (UNIX) socket from which to "
@@ -102,7 +103,7 @@ int KernelLogMonitorMain(int argc, char** argv) {
     return 2;
   }
 
-  KernelLogServer klog{pipe, instance.PerInstanceLogPath("kernel.log")};
+  KernelLogServer klog{pipe, instance.PerInstanceLogPath(kLogNameKernel)};
 
   for (auto subscriber_fd: subscriber_fds) {
     if (subscriber_fd->IsOpen()) {

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/BUILD.bazel
@@ -167,6 +167,7 @@ cf_cc_binary(
         "//cuttlefish/common/libs/utils:tee_logging",
         "//cuttlefish/host/commands/modem_simulator:modem_simulator_class",
         "//cuttlefish/host/libs/config:cuttlefish_config",
+        "//cuttlefish/host/libs/log_names",
         "//libbase",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/log:check",

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/main.cpp
@@ -28,6 +28,7 @@
 #include "cuttlefish/common/libs/utils/tee_logging.h"
 #include "cuttlefish/host/commands/modem_simulator/modem_simulator.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/log_names/log_names.h"
 
 // we can start multiple modems simultaneously; each modem
 // will listen to one server fd for incoming sms/phone call
@@ -67,7 +68,7 @@ int ModemSimulatorMain(int argc, char** argv) {
   auto config = CuttlefishConfig::Get();
   auto instance = config->ForDefaultInstance();
 
-  auto modem_log_path = instance.PerInstanceLogPath("modem_simulator.log");
+  auto modem_log_path = instance.PerInstanceLogPath(kLogNameModemSimulator);
 
   {
     auto log_path = instance.launcher_log_path();

--- a/base/cvd/cuttlefish/host/libs/log_names/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/log_names/BUILD.bazel
@@ -1,0 +1,12 @@
+load("//cuttlefish/bazel:rules.bzl", "cf_cc_library")
+
+package(
+    default_visibility = ["//:android_cuttlefish"],
+)
+
+cf_cc_library(
+    name = "log_names",
+    hdrs = [
+        "log_names.h",
+    ],
+)

--- a/base/cvd/cuttlefish/host/libs/log_names/log_names.h
+++ b/base/cvd/cuttlefish/host/libs/log_names/log_names.h
@@ -19,5 +19,6 @@ namespace cuttlefish {
 
 // Per instance log names.
 inline constexpr char kLogNameKernel[] = "kernel.log";
+inline constexpr char kLogNameModemSimulator[] = "modem_simulator.log";
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/log_names/log_names.h
+++ b/base/cvd/cuttlefish/host/libs/log_names/log_names.h
@@ -1,0 +1,23 @@
+//
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace cuttlefish {
+
+// Per instance log names.
+inline constexpr char kLogNameKernel[] = "kernel.log";
+
+}  // namespace cuttlefish


### PR DESCRIPTION
Declared log names in a single place rather than being spread in the codebase.

Starting with kernel.log

Bug: b/511186368