### PR TITLE
Rename the V2 metrics log

### DIFF
--- a/base/cvd/cuttlefish/host/libs/metrics/metrics_orchestration.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/metrics_orchestration.cc
@@ -43,7 +43,7 @@ namespace {
 
 using logs::proto::wireless::android::cuttlefish::CuttlefishLogEvent;
 
-constexpr char kMetricsLogName[] = "metrics.log";
+constexpr char kMetricsLogName[] = "metrics_v2.log";
 
 std::chrono::milliseconds GetEpochTime() {
   auto now = std::chrono::system_clock::now().time_since_epoch();


### PR DESCRIPTION
To avoid confusion for users with the V1 metrics log.  Particularly in `cvd logs` output.

The `e2etests/cvd` logic that gathers the V2 metrics log pulls in the whole `metrics` directory, so no updates are needed there.

Bug: 511264010