### PR TITLE
Fix two memory issues detected by asan

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/flag_parser.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/flag_parser.cpp
@@ -677,7 +677,7 @@ Flag GflagsCompatFlag(const std::string& name, std::vector<bool>& value,
                       const bool default_value) {
   return GflagsCompatFlag(name)
       .Getter([&value]() { return fmt::format("{}", fmt::join(value, ",")); })
-      .Setter([&name, &value,
+      .Setter([name, &value,
                default_value](const FlagMatch& match) -> Result<void> {
         if (match.value.empty()) {
           value.clear();

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/kernel_ramdisk_repacker.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/kernel_ramdisk_repacker.cpp
@@ -102,14 +102,14 @@ InstanceBootImage::InstanceBootImage(
     const CuttlefishConfig::InstanceSpecific& instance,
     const BootImageFlag& boot_image_flag)
     : config_(&config),
-      instance_(&instance),
+      instance_(instance),
       boot_image_flag_(&boot_image_flag) {
   // Repacking a boot.img doesn't work with Gem5 because the user must always
   // specify a vmlinux instead of an arm64 Image, and that file can be too
   // large to be repacked. Skip repack of boot.img on Gem5, as we need to be
   // able to extract the ramdisk.img in a later stage and so this step must
   // not fail (..and the repacked kernel wouldn't be used anyway).
-  if (instance_->kernel_path().empty() || VmManagerIsGem5(*config_)) {
+  if (instance_.kernel_path().empty() || VmManagerIsGem5(*config_)) {
     path_ = boot_image_flag.ForIndex(instance.index());
   }
 }
@@ -122,13 +122,13 @@ Result<std::string> InstanceBootImage::Generate() {
   }
 
   std::string previous_boot_image =
-      boot_image_flag_->ForIndex(instance_->index());
+      boot_image_flag_->ForIndex(instance_.index());
   CF_EXPECTF(FileHasContent(previous_boot_image), "File not found: {}",
              previous_boot_image);
 
-  std::string new_path = instance_->PerInstancePath("boot_repacked.img");
+  std::string new_path = instance_.PerInstancePath("boot_repacked.img");
   CF_EXPECT(
-      RepackBootImage(instance_->kernel_path(), previous_boot_image, new_path),
+      RepackBootImage(instance_.kernel_path(), previous_boot_image, new_path),
       "Failed to regenerate the boot image with the new kernel");
   path_ = new_path;
 

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/kernel_ramdisk_repacker.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/kernel_ramdisk_repacker.h
@@ -38,7 +38,7 @@ class InstanceBootImage : public ImageFile {
 
  private:
   const CuttlefishConfig* config_;
-  const CuttlefishConfig::InstanceSpecific* instance_;
+  const CuttlefishConfig::InstanceSpecific instance_;
   const BootImageFlag* boot_image_flag_;
   std::optional<std::string> path_;
 };


### PR DESCRIPTION
`name` and `instance_` both refer to objects that go out of scope.

Bug: b/511301172