### PR TITLE
Single privacy notice

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -432,11 +432,6 @@ Result<void> CvdStartCommandHandler::LaunchDevice(
 
   CF_EXPECT(subprocess_waiter_.Setup(launch_command));
 
-  LOG(INFO)
-      << "By using this Android Virtual Device, you agree to Google Terms of "
-         "Service (https://policies.google.com/terms). The Google Privacy "
-         "Policy (https://policies.google.com/privacy) describes how Google "
-         "handles information generated as you use Google services.";
   GatherVmStartMetrics(group);
 
   // NOLINTNEXTLINE(misc-include-cleaner)

--- a/base/cvd/cuttlefish/host/commands/start/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/start/BUILD.bazel
@@ -35,6 +35,7 @@ cf_cc_binary(
         "//cuttlefish/host/libs/config:host_tools_version",
         "//cuttlefish/host/libs/config:instance_nums",
         "//cuttlefish/host/libs/log_names",
+        "//cuttlefish/host/libs/metrics:notification",
         "//cuttlefish/host/libs/vm_manager",
         "//libbase",
         "@abseil-cpp//absl/base:no_destructor",

--- a/base/cvd/cuttlefish/host/commands/start/validate_metrics_confirmation.cpp
+++ b/base/cvd/cuttlefish/host/commands/start/validate_metrics_confirmation.cpp
@@ -17,12 +17,26 @@
 
 #include <iostream>
 #include <string>
+#include <string_view>
 
 #include <android-base/macros.h>
 
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 namespace cuttlefish {
+namespace {
+
+constexpr std::string_view kFirstAnswerPrompt =
+    "Automatically send diagnostic information to Google from this Android "
+    "Virtual Device.";
+constexpr std::string_view kResponsePrompt = " (Y/n)?:";
+constexpr std::string_view kMustAnswerPrompt =
+    "Must accept/reject anonymous usage statistics reporting.";
+constexpr std::string_view kAdjustmentNotice =
+    "You can adjust the permission for sending diagnostic information to "
+    "Google by running \"--report_anonymous_usage_stats=n\"\n";
+
+}  // namespace
 
 std::string ValidateMetricsConfirmation(std::string use_metrics) {
   if (use_metrics.empty()) {
@@ -41,26 +55,23 @@ std::string ValidateMetricsConfirmation(std::string use_metrics) {
   char ch = !use_metrics.empty() ? tolower(use_metrics.at(0)) : -1;
   if (ch != 'n') {
     if (use_metrics.empty()) {
-      std::cout << "\nAutomatically send diagnostic information to Google from "
-                   "this Android Virtual "
-                   "Device. You can adjust this permission by running \"--report_anonymous_usage_stats=n\". (Y/n)?:";
-    } else {
-      std::cout << "You can adjust the permission for sending diagnostic "
-                   "information to Google by running \"--report_anonymous_usage_stats=n\"\n";
+      std::cout << kFirstAnswerPrompt << kResponsePrompt;
     }
   }
-  for (;;) {
+  std::string result;
+  while (result.empty()) {
     switch (ch) {
       case 0:
       case '\r':
       case '\n':
       case 'y':
-        return "y";
+        result = "y";
+        break;
       case 'n':
-        return "n";
+        result = "n";
+        break;
       default:
-        std::cout << "Must accept/reject anonymous usage statistics reporting "
-                     "(Y/n): ";
+        std::cout << kMustAnswerPrompt << kResponsePrompt;
         FALLTHROUGH_INTENDED;
       case -1:
         std::cin.get(ch);
@@ -72,7 +83,8 @@ std::string ValidateMetricsConfirmation(std::string use_metrics) {
         ch = tolower(ch);
     }
   }
-  return "";
+  std::cout << kAdjustmentNotice;
+  return result;
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/start/validate_metrics_confirmation.cpp
+++ b/base/cvd/cuttlefish/host/commands/start/validate_metrics_confirmation.cpp
@@ -22,19 +22,16 @@
 #include <android-base/macros.h>
 
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/metrics/notification.h"
 
 namespace cuttlefish {
 namespace {
 
 constexpr std::string_view kFirstAnswerPrompt =
     "Automatically send diagnostic information to Google from this Android "
-    "Virtual Device.";
-constexpr std::string_view kResponsePrompt = " (Y/n)?:";
+    "Virtual Device. (Y/n)?:";
 constexpr std::string_view kMustAnswerPrompt =
-    "Must accept/reject anonymous usage statistics reporting.";
-constexpr std::string_view kAdjustmentNotice =
-    "You can adjust the permission for sending diagnostic information to "
-    "Google by running \"--report_anonymous_usage_stats=n\"\n";
+    "Must accept/reject anonymous usage statistics reporting. ";
 
 }  // namespace
 
@@ -55,7 +52,7 @@ std::string ValidateMetricsConfirmation(std::string use_metrics) {
   char ch = !use_metrics.empty() ? tolower(use_metrics.at(0)) : -1;
   if (ch != 'n') {
     if (use_metrics.empty()) {
-      std::cout << kFirstAnswerPrompt << kResponsePrompt;
+      std::cout << kFirstAnswerPrompt;
     }
   }
   std::string result;
@@ -71,7 +68,7 @@ std::string ValidateMetricsConfirmation(std::string use_metrics) {
         result = "n";
         break;
       default:
-        std::cout << kMustAnswerPrompt << kResponsePrompt;
+        std::cout << kMustAnswerPrompt << kFirstAnswerPrompt;
         FALLTHROUGH_INTENDED;
       case -1:
         std::cin.get(ch);
@@ -83,7 +80,7 @@ std::string ValidateMetricsConfirmation(std::string use_metrics) {
         ch = tolower(ch);
     }
   }
-  std::cout << kAdjustmentNotice;
+  DisplayAdjustmentNoticeOnce();
   return result;
 }
 

--- a/base/cvd/cuttlefish/host/libs/config/config_flag.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/config_flag.cpp
@@ -145,8 +145,8 @@ class ConfigFlagImpl : public ConfigFlag {
       }
     }
     std::map<std::string, std::vector<std::string>> flags;
-    LOG(INFO) << "Launching CVD using --config='"
-              << VectorizedFlagValue(configs_) << "'.";
+    VLOG(0) << "Launching CVD using --config='" << VectorizedFlagValue(configs_)
+            << "'";
     for (size_t i = 0; i < configs_.size(); ++i) {
       Result<Json::Value> config_values_res =
           config_reader_.ReadConfig(configs_[i]);

--- a/base/cvd/cuttlefish/host/libs/metrics/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/metrics/BUILD.bazel
@@ -344,6 +344,7 @@ cf_cc_library(
         "//cuttlefish/host/libs/metrics:enabled",
         "//cuttlefish/result",
         "@abseil-cpp//absl/log",
+        "@abseil-cpp//absl/strings",
         "@fmt",
     ],
 )

--- a/base/cvd/cuttlefish/host/libs/metrics/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/metrics/BUILD.bazel
@@ -17,10 +17,10 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:tee_logging",
         "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/libs/metrics:device_event_type",
-        "//cuttlefish/host/libs/metrics:enabled",
         "//cuttlefish/host/libs/metrics:guest_metrics",
         "//cuttlefish/host/libs/metrics:metrics_conversion",
         "//cuttlefish/host/libs/metrics:metrics_orchestration",
+        "//cuttlefish/host/libs/metrics:notification",
         "//cuttlefish/host/libs/metrics:parsed_flags",
         "//cuttlefish/result",
         "@abseil-cpp//absl/log",
@@ -81,9 +81,9 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:tee_logging",
         "//cuttlefish/host/commands/cvd/fetch:fetch_cvd",
         "//cuttlefish/host/commands/cvd/fetch:fetch_cvd_parser",
-        "//cuttlefish/host/libs/metrics:enabled",
         "//cuttlefish/host/libs/metrics:metrics_conversion",
         "//cuttlefish/host/libs/metrics:metrics_orchestration",
+        "//cuttlefish/host/libs/metrics:notification",
         "//cuttlefish/result",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/strings",
@@ -327,6 +327,19 @@ cf_cc_library(
         "//external_proto:cf_log_cc_proto",
         "@fmt",
         "@protobuf",
+    ],
+)
+
+cf_cc_library(
+    name = "notification",
+    srcs = [
+        "notification.cc",
+    ],
+    hdrs = [
+        "notification.h",
+    ],
+    deps = [
+        "//cuttlefish/host/libs/metrics:enabled",
     ],
 )
 

--- a/base/cvd/cuttlefish/host/libs/metrics/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/metrics/BUILD.bazel
@@ -339,7 +339,12 @@ cf_cc_library(
         "notification.h",
     ],
     deps = [
+        "//cuttlefish/common/libs/utils:files",
+        "//cuttlefish/host/libs/directories",
         "//cuttlefish/host/libs/metrics:enabled",
+        "//cuttlefish/result",
+        "@abseil-cpp//absl/log",
+        "@fmt",
     ],
 )
 

--- a/base/cvd/cuttlefish/host/libs/metrics/device_metrics_orchestration.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/device_metrics_orchestration.cc
@@ -29,10 +29,10 @@
 #include "cuttlefish/host/commands/cvd/instances/local_instance.h"
 #include "cuttlefish/host/commands/cvd/instances/local_instance_group.h"
 #include "cuttlefish/host/libs/metrics/device_event_type.h"
-#include "cuttlefish/host/libs/metrics/enabled.h"
 #include "cuttlefish/host/libs/metrics/guest_metrics.h"
 #include "cuttlefish/host/libs/metrics/metrics_conversion.h"
 #include "cuttlefish/host/libs/metrics/metrics_orchestration.h"
+#include "cuttlefish/host/libs/metrics/notification.h"
 #include "cuttlefish/host/libs/metrics/parsed_flags.h"
 #include "cuttlefish/result/result.h"
 
@@ -117,6 +117,7 @@ Result<void> RunMetrics(const DeviceMetricsInput& metrics_input) {
 }  // namespace
 
 void GatherVmInstantiationMetrics(const LocalInstanceGroup& instance_group) {
+  DisplayPrivacyNotice();
   Result<DeviceMetricsInput> metrics_input_result = GetDeviceMetricsInput(
       instance_group, DeviceEventType::DeviceInstantiation);
   if (!metrics_input_result.ok()) {
@@ -130,9 +131,6 @@ void GatherVmInstantiationMetrics(const LocalInstanceGroup& instance_group) {
     VLOG(0) << fmt::format("Failed to initialize metrics.  Error: {}",
                            metrics_setup_result.error());
     return;
-  }
-  if (AreMetricsEnabled()) {
-    LOG(INFO) << kMetricsEnabledNotice;
   }
   Result<void> run_metrics_result = RunMetrics(*metrics_input_result);
   if (!run_metrics_result.ok()) {

--- a/base/cvd/cuttlefish/host/libs/metrics/fetch_metrics_orchestration.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/fetch_metrics_orchestration.cc
@@ -29,9 +29,9 @@
 #include "cuttlefish/common/libs/utils/tee_logging.h"
 #include "cuttlefish/host/commands/cvd/fetch/fetch_cvd.h"
 #include "cuttlefish/host/commands/cvd/fetch/fetch_cvd_parser.h"
-#include "cuttlefish/host/libs/metrics/enabled.h"
 #include "cuttlefish/host/libs/metrics/metrics_conversion.h"
 #include "cuttlefish/host/libs/metrics/metrics_orchestration.h"
+#include "cuttlefish/host/libs/metrics/notification.h"
 #include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
@@ -80,6 +80,7 @@ Result<void> RunMetrics(
 }  // namespace
 
 void GatherFetchStartMetrics(const FetchFlags& fetch_flags) {
+  DisplayPrivacyNotice();
   const MetricsInput metrics_input =
       GetFetchMetricsInput(fetch_flags.target_directory);
   Result<void> metrics_setup_result =
@@ -90,9 +91,6 @@ void GatherFetchStartMetrics(const FetchFlags& fetch_flags) {
     return;
   }
 
-  if (AreMetricsEnabled()) {
-    LOG(INFO) << kMetricsEnabledNotice;
-  }
   Result<void> run_metrics_result = RunMetrics(metrics_input, fetch_flags);
   if (!run_metrics_result.ok()) {
     VLOG(0) << fmt::format(

--- a/base/cvd/cuttlefish/host/libs/metrics/metrics_orchestration.h
+++ b/base/cvd/cuttlefish/host/libs/metrics/metrics_orchestration.h
@@ -25,11 +25,6 @@
 
 namespace cuttlefish {
 
-inline constexpr std::string_view kMetricsEnabledNotice =
-    "This will automatically send diagnostic information to "
-    "Google, such as crash reports and usage data from the host "
-    "machine managing the Android Virtual Device.";
-
 struct MetricsInput {
   std::string metrics_directory;
 };

--- a/base/cvd/cuttlefish/host/libs/metrics/notification.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/notification.cc
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/host/libs/metrics/notification.h"
+
+#include <iostream>
+#include <string_view>
+
+#include "cuttlefish/host/libs/metrics/enabled.h"
+
+namespace cuttlefish {
+namespace {
+
+constexpr std::string_view kTermsAndPrivacyNotice =
+    "By using this Android Virtual Device, you agree to Google Terms of "
+    "Service (https://policies.google.com/terms). The Google Privacy Policy "
+    "(https://policies.google.com/privacy) describes how Google handles "
+    "information generated as you use Google services.";
+
+constexpr std::string_view kMetricsEnabledNotice =
+    "This will automatically send diagnostic information to Google, such as "
+    "crash reports and usage data from the host machine managing the Android "
+    "Virtual Device.";
+
+}  // namespace
+
+void DisplayPrivacyNotice() {
+  std::cout << kTermsAndPrivacyNotice << std::endl;
+  if (AreMetricsEnabled()) {
+    std::cout << kMetricsEnabledNotice << std::endl;
+  }
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/metrics/notification.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/notification.cc
@@ -22,6 +22,7 @@
 #include <string_view>
 
 #include "absl/log/log.h"
+#include "absl/strings/str_cat.h"
 #include "fmt/format.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
@@ -33,6 +34,7 @@ namespace cuttlefish {
 namespace {
 
 constexpr std::string_view kNoticeFilename = "PRIVACY_NOTICE.txt";
+constexpr std::string_view kAdjustmentFilename = "ADJUST_PERMISSIONS.txt";
 
 constexpr std::string_view kTermsAndPrivacyNotice =
     "By using this Android Virtual Device, you agree to Google Terms of "
@@ -45,12 +47,25 @@ constexpr std::string_view kMetricsEnabledNotice =
     "crash reports and usage data from the host machine managing the Android "
     "Virtual Device.";
 
+constexpr std::string_view kAdjustmentNotice =
+    "You can adjust the permission for sending diagnostic information to "
+    "Google by running \"--report_anonymous_usage_stats=n\"";
+
 Result<std::string> GetNoticeFilepath() {
   return fmt::format("{}/{}", CF_EXPECT(CvdDataHome()), kNoticeFilename);
 }
 
+Result<std::string> GetAdjustmentFilepath() {
+  return fmt::format("{}/{}", CF_EXPECT(CvdDataHome()), kAdjustmentFilename);
+}
+
 Result<void> WriteNoticeFile(const std::string& contents) {
   CF_EXPECT(WriteCvdDataFile(kNoticeFilename, contents));
+  return {};
+}
+
+Result<void> WriteAdjustmentFile(const std::string& contents) {
+  CF_EXPECT(WriteCvdDataFile(kAdjustmentFilename, contents));
   return {};
 }
 
@@ -79,6 +94,24 @@ void DisplayPrivacyNotice() {
   Result<void> write_result = WriteNoticeFile(notice_message);
   if (!write_result.ok()) {
     VLOG(0) << "Failed writing notice file: " << write_result.error();
+  }
+}
+
+void DisplayAdjustmentNoticeOnce() {
+  Result<std::string> filepath_result = GetAdjustmentFilepath();
+  if (!filepath_result.ok()) {
+    VLOG(0) << "Failed generating adjustment filepath: "
+            << filepath_result.error();
+  } else if (FileExists(*filepath_result)) {
+    return;
+  }
+
+  std::cout << kAdjustmentNotice << "\n";
+
+  Result<void> write_result =
+      WriteAdjustmentFile(absl::StrCat(kAdjustmentNotice, "\n"));
+  if (!write_result.ok()) {
+    VLOG(0) << "Failed writing adjustment file: " << write_result.error();
   }
 }
 

--- a/base/cvd/cuttlefish/host/libs/metrics/notification.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/notification.cc
@@ -17,12 +17,22 @@
 #include "cuttlefish/host/libs/metrics/notification.h"
 
 #include <iostream>
+#include <sstream>
+#include <string>
 #include <string_view>
 
+#include "absl/log/log.h"
+#include "fmt/format.h"
+
+#include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/host/libs/directories/xdg.h"
 #include "cuttlefish/host/libs/metrics/enabled.h"
+#include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
 namespace {
+
+constexpr std::string_view kNoticeFilename = "PRIVACY_NOTICE.txt";
 
 constexpr std::string_view kTermsAndPrivacyNotice =
     "By using this Android Virtual Device, you agree to Google Terms of "
@@ -35,12 +45,40 @@ constexpr std::string_view kMetricsEnabledNotice =
     "crash reports and usage data from the host machine managing the Android "
     "Virtual Device.";
 
+Result<std::string> GetNoticeFilepath() {
+  return fmt::format("{}/{}", CF_EXPECT(CvdDataHome()), kNoticeFilename);
+}
+
+Result<void> WriteNoticeFile(const std::string& contents) {
+  CF_EXPECT(WriteCvdDataFile(kNoticeFilename, contents));
+  return {};
+}
+
+std::string GetNoticeMessage() {
+  std::stringstream result;
+  result << kTermsAndPrivacyNotice << std::endl;
+  if (AreMetricsEnabled()) {
+    result << kMetricsEnabledNotice << std::endl;
+  }
+  return result.str();
+}
+
 }  // namespace
 
 void DisplayPrivacyNotice() {
-  std::cout << kTermsAndPrivacyNotice << std::endl;
-  if (AreMetricsEnabled()) {
-    std::cout << kMetricsEnabledNotice << std::endl;
+  Result<std::string> filepath_result = GetNoticeFilepath();
+  if (!filepath_result.ok()) {
+    VLOG(0) << "Failed generating notice filepath: " << filepath_result.error();
+  } else if (FileExists(*filepath_result)) {
+    return;
+  }
+
+  const std::string notice_message = GetNoticeMessage();
+  std::cerr << notice_message;
+
+  Result<void> write_result = WriteNoticeFile(notice_message);
+  if (!write_result.ok()) {
+    VLOG(0) << "Failed writing notice file: " << write_result.error();
   }
 }
 

--- a/base/cvd/cuttlefish/host/libs/metrics/notification.h
+++ b/base/cvd/cuttlefish/host/libs/metrics/notification.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string_view>
+
+namespace cuttlefish {
+
+void DisplayPrivacyNotice();
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/metrics/notification.h
+++ b/base/cvd/cuttlefish/host/libs/metrics/notification.h
@@ -22,4 +22,6 @@ namespace cuttlefish {
 
 void DisplayPrivacyNotice();
 
+void DisplayAdjustmentNoticeOnce();
+
 }  // namespace cuttlefish


### PR DESCRIPTION
Trimming the `cvd create` output down further.

Bug: 511260927
