### PR TITLE
Don't store references to cuttlefish::CuttlefishConfig::InstanceSpecific

### DIFF
--- a/base/cvd/cuttlefish/host/commands/run_cvd/boot_state_machine.cc
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/boot_state_machine.cc
@@ -640,7 +640,7 @@ class CvdBootStateMachine : public SetupFeature, public KernelLogPipeConsumer {
   AutoSetup<ProcessLeader>::Type& process_leader_;
   KernelLogPipeProvider& kernel_log_pipe_provider_;
   const vm_manager::VmManager& vm_manager_;
-  const CuttlefishConfig::InstanceSpecific& instance_;
+  const CuttlefishConfig::InstanceSpecific instance_;
 
   std::thread boot_event_handler_;
   std::thread restore_complete_handler_;

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/control_env_proxy_server.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/control_env_proxy_server.cpp
@@ -60,7 +60,7 @@ class ControlEnvProxyServer : public CommandSource {
   std::unordered_set<SetupFeature*> Dependencies() const override { return {}; }
   Result<void> ResultSetup() override { return {}; }
 
-  const CuttlefishConfig::InstanceSpecific& instance_;
+  const CuttlefishConfig::InstanceSpecific instance_;
   GrpcSocketCreator& grpc_socket_;
 };
 

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/cvdalloc.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/cvdalloc.h
@@ -50,7 +50,7 @@ class Cvdalloc : public vm_manager::VmmDependencyCommand {
   Result<void> IsUsable() const;
   StopperResult Stop();
 
-  const CuttlefishConfig::InstanceSpecific &instance_;
+  const CuttlefishConfig::InstanceSpecific instance_;
   SharedFD socket_, their_socket_;
   std::mutex availability_mutex_;
   CvdallocStatus status_;

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/grpc_socket_creator.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/grpc_socket_creator.h
@@ -30,7 +30,7 @@ class GrpcSocketCreator {
   std::string CreateGrpcSocket(const std::string& process_name);
 
  private:
-  const CuttlefishConfig::InstanceSpecific& instance_;
+  const CuttlefishConfig::InstanceSpecific instance_;
 };
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/kernel_log_monitor.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/kernel_log_monitor.cpp
@@ -111,7 +111,7 @@ class KernelLogMonitor : public CommandSource,
   }
 
   int number_of_event_pipes_ = 0;
-  const CuttlefishConfig::InstanceSpecific& instance_;
+  const CuttlefishConfig::InstanceSpecific instance_;
   SharedFD fifo_;
   std::vector<SharedFD> event_pipe_write_ends_;
   std::vector<SharedFD> event_pipe_read_ends_;

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/log_tee_creator.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/log_tee_creator.h
@@ -38,7 +38,7 @@ class LogTeeCreator {
                                Subprocess::StdIOChannel log_channel);
 
  private:
-  const CuttlefishConfig::InstanceSpecific& instance_;
+  const CuttlefishConfig::InstanceSpecific instance_;
 };
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/mcu.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/mcu.cpp
@@ -114,7 +114,7 @@ class Mcu : public vm_manager::VmmDependencyCommand {
   std::unordered_set<SetupFeature*> Dependencies() const override { return {}; }
 
   std::string mcu_dir_;
-  const CuttlefishConfig::InstanceSpecific& instance_;
+  const CuttlefishConfig::InstanceSpecific instance_;
   LogTeeCreator& log_tee_;
 };
 

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/netsim_server.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/netsim_server.cpp
@@ -215,7 +215,7 @@ class NetsimServer : public CommandSource {
  private:
   std::vector<Device> devices_;
   const CuttlefishConfig& config_;
-  const CuttlefishConfig::InstanceSpecific& instance_;
+  const CuttlefishConfig::InstanceSpecific instance_;
 };
 
 }  // namespace

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/open_wrt.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/open_wrt.cpp
@@ -187,7 +187,7 @@ class OpenWrt : public CommandSource {
 
   const CuttlefishConfig& config_;
   const CuttlefishConfig::EnvironmentSpecific& environment_;
-  const CuttlefishConfig::InstanceSpecific& instance_;
+  const CuttlefishConfig::InstanceSpecific instance_;
   LogTeeCreator& log_tee_;
   WmediumdServer& wmediumd_server_;
   Cvdalloc& cvdalloc_;

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/root_canal.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/root_canal.cpp
@@ -136,7 +136,7 @@ class RootCanal : public CommandSource {
   Result<void> ResultSetup() override { return {}; }
 
   const CuttlefishConfig& config_;
-  const CuttlefishConfig::InstanceSpecific& instance_;
+  const CuttlefishConfig::InstanceSpecific instance_;
   LogTeeCreator& log_tee_;
 };
 

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/streamer.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/streamer.cpp
@@ -191,7 +191,7 @@ class StreamerSockets : public virtual SetupFeature {
   }
 
   const CuttlefishConfig& config_;
-  const CuttlefishConfig::InstanceSpecific& instance_;
+  const CuttlefishConfig::InstanceSpecific instance_;
   InputConnectionsProvider& input_connections_provider_;
   SharedFD frames_server_;
   SharedFD audio_server_;
@@ -289,7 +289,7 @@ class WebRtcServer : public virtual CommandSource,
   }
 
   const CuttlefishConfig& config_;
-  const CuttlefishConfig::InstanceSpecific& instance_;
+  const CuttlefishConfig::InstanceSpecific instance_;
   StreamerSockets& sockets_;
   KernelLogPipeProvider& log_pipe_provider_;
   const CustomActionConfigProvider& custom_action_config_;

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/ti50_emulator.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/ti50_emulator.cpp
@@ -202,7 +202,7 @@ class Ti50Emulator : public vm_manager::VmmDependencyCommand {
     return CF_ERR("Failed to initialize Ti50 emulator");
   }
 
-  const CuttlefishConfig::InstanceSpecific& instance_;
+  const CuttlefishConfig::InstanceSpecific instance_;
   LogTeeCreator& log_tee_;
 
   std::unique_ptr<ProxyServer> socket_proxy_;

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/vhost_device_vsock.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/vhost_device_vsock.cpp
@@ -64,7 +64,7 @@ class VhostDeviceVsock : public vm_manager::VmmDependencyCommand {
   Result<void> ResultSetup() override { return {}; }
 
   LogTeeCreator& log_tee_;
-  const CuttlefishConfig::InstanceSpecific& instance_;
+  const CuttlefishConfig::InstanceSpecific instance_;
   const CuttlefishConfig& cfconfig_;
 };
 

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/vhost_input_devices.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/vhost_input_devices.cpp
@@ -314,7 +314,7 @@ class VhostInputDevices : public CommandSource,
     return {};
   }
 
-  const CuttlefishConfig::InstanceSpecific& instance_;
+  const CuttlefishConfig::InstanceSpecific instance_;
   LogTeeCreator& log_tee_;
   DeviceSockets rotary_sockets_;
   DeviceSockets mouse_sockets_;

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/vhost_user_media_devices.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/vhost_user_media_devices.cpp
@@ -72,7 +72,7 @@ class VhostUserMediaDevices : public CommandSource {
   std::unordered_set<SetupFeature*> Dependencies() const override { return {}; }
   Result<void> ResultSetup() override { return {}; }
 
-  const CuttlefishConfig::InstanceSpecific& instance_;
+  const CuttlefishConfig::InstanceSpecific instance_;
   LogTeeCreator& log_tee_;
 };
 

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/wmediumd_server.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/wmediumd_server.cpp
@@ -69,7 +69,7 @@ class ValidateWmediumdService : public SetupFeature {
  private:
   const CuttlefishConfig& config_;
   const CuttlefishConfig::EnvironmentSpecific& environment_;
-  const CuttlefishConfig::InstanceSpecific& instance_;
+  const CuttlefishConfig::InstanceSpecific instance_;
 };
 
 }  // namespace

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/wmediumd_server.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/wmediumd_server.h
@@ -51,7 +51,7 @@ class WmediumdServer : public vm_manager::VmmDependencyCommand {
   Result<void> ResultSetup() override;
 
   const CuttlefishConfig::EnvironmentSpecific& environment_;
-  const CuttlefishConfig::InstanceSpecific& instance_;
+  const CuttlefishConfig::InstanceSpecific instance_;
   LogTeeCreator& log_tee_;
   GrpcSocketCreator& grpc_socket_;
   std::string config_path_;

--- a/base/cvd/cuttlefish/host/commands/run_cvd/server_loop_impl.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/server_loop_impl.h
@@ -99,7 +99,7 @@ class ServerLoopImpl : public ServerLoop,
   Result<void> TakeCrosvmGuestSnapshot(const Json::Value&);
 
   const CuttlefishConfig& config_;
-  const CuttlefishConfig::InstanceSpecific& instance_;
+  const CuttlefishConfig::InstanceSpecific instance_;
 
   /*
    * This is needed to get the run_cvd side socket pair connected to

--- a/base/cvd/cuttlefish/host/libs/config/adb/launch.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/adb/launch.cpp
@@ -75,7 +75,7 @@ class AdbHelper {
   }
 
  private:
-  const CuttlefishConfig::InstanceSpecific& instance_;
+  const CuttlefishConfig::InstanceSpecific instance_;
   const AdbConfig& config_;
 };
 
@@ -217,7 +217,7 @@ class SocketVsockProxy : public CommandSource, public KernelLogPipeConsumer {
 
   const AdbHelper& helper_;
   const CuttlefishConfig& cuttlefish_config_;
-  const CuttlefishConfig::InstanceSpecific& instance_;
+  const CuttlefishConfig::InstanceSpecific instance_;
   KernelLogPipeProvider& log_pipe_provider_;
   SharedFD kernel_log_pipe_;
 };

--- a/base/cvd/cuttlefish/host/libs/config/fastboot/launch.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/fastboot/launch.cpp
@@ -85,7 +85,7 @@ class FastbootProxy : public CommandSource, public KernelLogPipeConsumer {
     return {};
   }
 
-  const CuttlefishConfig::InstanceSpecific& instance_;
+  const CuttlefishConfig::InstanceSpecific instance_;
   const FastbootConfig& fastboot_config_;
   KernelLogPipeProvider& log_pipe_provider_;
   SharedFD kernel_log_pipe_;


### PR DESCRIPTION
The instance specific class only holds a pointer to the global config object and its own name, so they are very cheap to copy.

This objects are usually created by calling
`cuttlefish::CuttlefishConfig::Instances` which creates ephemeral instances of `InstanceSpecific`.

Most cases addressed by this PR are "safe" because the `InstanceSpecific` object being referenced is created in run_cvd's main loop which doesn't return and therefore the objects never go out of scope. Other cases were addressed by
https://github.com/google/android-cuttlefish/pull/2541.

Bug: b/511301172