### PR TITLE
Enforce `clang-format` on Cuttlefish code

### DIFF
--- a/base/cvd/.clang-format
+++ b/base/cvd/.clang-format
@@ -1,0 +1,1 @@
+../../.clang-format

--- a/base/cvd/BUILD.bazel
+++ b/base/cvd/BUILD.bazel
@@ -12,7 +12,10 @@ package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
-exports_files([".clang-tidy"])
+exports_files([
+    ".clang-format",
+    ".clang-tidy",
+])
 
 genrule(
     name = "build_compilation_mode_txt",

--- a/base/cvd/MODULE.bazel
+++ b/base/cvd/MODULE.bazel
@@ -7,7 +7,7 @@
 
 bazel_dep(name = "abseil-cpp", version = "20260107.0")
 bazel_dep(name = "aspect_bazel_lib", version = "2.19.3")
-bazel_dep(name = "aspect_rules_lint", version = "1.4.4", dev_dependency = True)
+bazel_dep(name = "aspect_rules_lint", version = "2.5.2", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.8.2", dev_dependency = True)
 bazel_dep(name = "boringssl", version = "0.20241024.0")
 bazel_dep(name = "brotli")

--- a/base/cvd/cuttlefish/bazel/rules.bzl
+++ b/base/cvd/cuttlefish/bazel/rules.bzl
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@aspect_rules_lint//format:defs.bzl", "format_test")
+load("@cc_compatibility_proxy//:proxy.bzl", "cc_binary", "cc_library", "cc_test")
 load("//:build_variables.bzl", BUILD_VAR_COPTS = "COPTS")
 load("//tools/lint:linters.bzl", "clang_tidy_test")
-load("@cc_compatibility_proxy//:proxy.bzl", "cc_binary", "cc_library", "cc_test")
 
 visibility(["//..."])
 
 COPTS = BUILD_VAR_COPTS
 
-def _cf_cc_binary_implementation(name, clang_tidy_enabled, copts, **kwargs):
+def _cf_cc_binary_implementation(name, clang_format_enabled, clang_tidy_enabled, copts, **kwargs):
     if not clang_tidy_enabled and not kwargs["deprecation"]:
         kwargs["deprecation"] = "Not covered by clang-tidy"
     cc_binary(
@@ -28,6 +29,14 @@ def _cf_cc_binary_implementation(name, clang_tidy_enabled, copts, **kwargs):
         copts = (copts or []) + COPTS,
         **kwargs,
     )
+    if clang_format_enabled:
+        format_test(
+            name = name + "_format_test",
+            cc = "//tools/format:clang_format",
+            disable_git_attribute_checks = True,
+            srcs = (kwargs.get("srcs") or []) + (kwargs.get("hdrs") or []),
+            visibility = ["//visibility:private"],
+        )
     if clang_tidy_enabled:
         clang_tidy_test(
             name = name + "_clang_tidy",
@@ -39,13 +48,14 @@ def _cf_cc_binary_implementation(name, clang_tidy_enabled, copts, **kwargs):
 cf_cc_binary = macro(
     inherit_attrs = cc_binary,
     attrs = {
+        "clang_format_enabled": attr.bool(configurable = False, default = False, doc = "Decide if a corresponding format_test target is generated"),
         "clang_tidy_enabled": attr.bool(configurable = False, default = True, doc = "Decide if a corresponding clang_tidy_test target is generated"),
         "copts": attr.string_list(configurable = False, default = []),
     },
     implementation = _cf_cc_binary_implementation,
 )
 
-def _cf_cc_library_implementation(name, clang_tidy_enabled, copts, **kwargs):
+def _cf_cc_library_implementation(name, clang_format_enabled, clang_tidy_enabled, copts, **kwargs):
     if not clang_tidy_enabled and not kwargs["deprecation"]:
         kwargs["deprecation"] = "Not covered by clang-tidy"
     cc_library(
@@ -53,6 +63,14 @@ def _cf_cc_library_implementation(name, clang_tidy_enabled, copts, **kwargs):
         copts = (copts or []) + COPTS,
         **kwargs,
     )
+    if clang_format_enabled:
+        format_test(
+            name = name + "_format_test",
+            cc = "//tools/format:clang_format",
+            disable_git_attribute_checks = True,
+            srcs = (kwargs.get("srcs") or []) + (kwargs.get("hdrs") or []),
+            visibility = ["//visibility:private"],
+        )
     if clang_tidy_enabled:
         clang_tidy_test(
             name = name + "_clang_tidy",
@@ -64,13 +82,14 @@ def _cf_cc_library_implementation(name, clang_tidy_enabled, copts, **kwargs):
 cf_cc_library = macro(
     inherit_attrs = cc_library,
     attrs = {
+        "clang_format_enabled": attr.bool(configurable = False, default = False, doc = "Decide if a corresponding format_test target is generated"),
         "clang_tidy_enabled": attr.bool(configurable = False, default = True, doc = "Decide if a corresponding clang_tidy_test target is generated"),
         "copts": attr.string_list(configurable = False, default = []),
     },
     implementation = _cf_cc_library_implementation,
 )
 
-def _cf_cc_test_implementation(name, clang_tidy_enabled, copts, deps, **kwargs):
+def _cf_cc_test_implementation(name, clang_format_enabled, clang_tidy_enabled, copts, deps, **kwargs):
     if not clang_tidy_enabled and not kwargs["deprecation"]:
         kwargs["deprecation"] = "Not covered by clang-tidy"
     cc_test(
@@ -82,6 +101,14 @@ def _cf_cc_test_implementation(name, clang_tidy_enabled, copts, deps, **kwargs):
         ],
         **kwargs,
     )
+    if clang_format_enabled:
+        format_test(
+            name = name + "_format_test",
+            cc = "//tools/format:clang_format",
+            disable_git_attribute_checks = True,
+            srcs = (kwargs.get("srcs") or []) + (kwargs.get("hdrs") or []),
+            visibility = ["//visibility:private"],
+        )
     if clang_tidy_enabled:
         clang_tidy_test(
             name = name + "_clang_tidy",
@@ -93,6 +120,7 @@ def _cf_cc_test_implementation(name, clang_tidy_enabled, copts, deps, **kwargs):
 cf_cc_test = macro(
     inherit_attrs = cc_test,
     attrs = {
+        "clang_format_enabled": attr.bool(configurable = False, default = False, doc = "Decide if a corresponding format_test target is generated"),
         "clang_tidy_enabled": attr.bool(configurable = False, default = True, doc = "Decide if a corresponding clang_tidy_test target is generated"),
         "copts": attr.string_list(configurable = False, default = []),
         "deps": attr.label_list(configurable = False),

--- a/base/cvd/cuttlefish/host/commands/kernel_log_monitor/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/kernel_log_monitor/BUILD.bazel
@@ -1,5 +1,4 @@
 load("//cuttlefish/bazel:rules.bzl", "cf_cc_binary", "cf_cc_library")
-load("@aspect_rules_lint//format:defs.bzl", "format_test")
 
 package(
     default_visibility = ["//:android_cuttlefish"],
@@ -12,6 +11,7 @@ cf_cc_binary(
     srcs = [
         "main.cc",
     ],
+    clang_format_enabled = True,
     deps = [
         ":kernel_log_monitor_utils",
         "//cuttlefish/common/libs/fs",
@@ -29,13 +29,6 @@ cf_cc_binary(
     ],
 )
 
-format_test(
-    name = "kernel_log_monitor_format_test",
-    cc = "//tools/format:clang_format",
-    disable_git_attribute_checks = True,
-    srcs = ["main.cc"],
-)
-
 cf_cc_library(
     name = "kernel_log_monitor_utils",
     srcs = [
@@ -46,6 +39,7 @@ cf_cc_library(
         "kernel_log_server.h",
         "utils.h",
     ],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:json",

--- a/base/cvd/cuttlefish/host/commands/kernel_log_monitor/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/kernel_log_monitor/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//cuttlefish/bazel:rules.bzl", "cf_cc_binary", "cf_cc_library")
+load("@aspect_rules_lint//format:defs.bzl", "format_test")
 
 package(
     default_visibility = ["//:android_cuttlefish"],
@@ -26,6 +27,13 @@ cf_cc_binary(
         "@gflags",
         "@jsoncpp",
     ],
+)
+
+format_test(
+    name = "kernel_log_monitor_format_test",
+    cc = "//tools/format:clang_format",
+    disable_git_attribute_checks = True,
+    srcs = ["main.cc"],
 )
 
 cf_cc_library(

--- a/base/cvd/cuttlefish/host/commands/kernel_log_monitor/kernel_log_server.cc
+++ b/base/cvd/cuttlefish/host/commands/kernel_log_monitor/kernel_log_server.cc
@@ -25,14 +25,14 @@
 #include <utility>
 #include <vector>
 
+#include "absl/log/log.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/str_split.h"
-#include "absl/log/log.h"
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/fs/shared_select.h"
-#include "cuttlefish/host/libs/config/cuttlefish_config.h"
 #include "cuttlefish/host/libs/config/config_constants.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
 
 namespace cuttlefish::monitor {
 namespace {
@@ -87,8 +87,8 @@ void ProcessSubscriptions(Json::Value message,
     if (action == SubscriptionAction::ContinueSubscription) {
       ++idx;
     } else {
-      // Cancel the subscription by swapping it with the last active subscription
-      // and decreasing the active subscription count
+      // Cancel the subscription by swapping it with the last active
+      // subscription and decreasing the active subscription count
       --active_subscription_count;
       std::swap((*subscribers)[idx], (*subscribers)[active_subscription_count]);
     }
@@ -135,7 +135,7 @@ bool KernelLogServer::HandleIncomingMessage() {
   }
 
   // Detect VIRTUAL_DEVICE_BOOT_*
-  for (ssize_t i=0; i<ret; i++) {
+  for (ssize_t i = 0; i < ret; i++) {
     if ('\n' == buf[i]) {
       for (auto& [match, prefix] : kInformationalPatterns) {
         auto pos = line_.find(match);

--- a/base/cvd/cuttlefish/host/commands/kernel_log_monitor/kernel_log_server.h
+++ b/base/cvd/cuttlefish/host/commands/kernel_log_monitor/kernel_log_server.h
@@ -21,7 +21,7 @@
 #include <string>
 #include <vector>
 
-#include <json/json.h>
+#include "json/json.h"
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/fs/shared_select.h"

--- a/base/cvd/cuttlefish/host/commands/kernel_log_monitor/main.cc
+++ b/base/cvd/cuttlefish/host/commands/kernel_log_monitor/main.cc
@@ -23,11 +23,11 @@
 #include <string>
 #include <vector>
 
-#include "absl/strings/str_split.h"
-#include <gflags/gflags.h>
-#include <json/value.h>
 #include "absl/log/check.h"
 #include "absl/log/log.h"
+#include "absl/strings/str_split.h"
+#include "gflags/gflags.h"
+#include "json/value.h"
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/fs/shared_select.h"
@@ -42,9 +42,10 @@ DEFINE_int32(log_pipe_fd, -1,
              "A file descriptor representing a (UNIX) socket from which to "
              "read the logs. If -1 is given the socket is created according to "
              "the instance configuration");
-DEFINE_string(subscriber_fds, "",
-             "A comma separated list of file descriptors (most likely pipes) to"
-             " send kernel log events to.");
+DEFINE_string(
+    subscriber_fds, "",
+    "A comma separated list of file descriptors (most likely pipes) to"
+    " send kernel log events to.");
 
 namespace cuttlefish::monitor {
 namespace {
@@ -52,7 +53,7 @@ namespace {
 std::vector<SharedFD> SubscribersFromCmdline() {
   // Validate the parameter
   std::string fd_list = FLAGS_subscriber_fds;
-  for (auto c: fd_list) {
+  for (auto c : fd_list) {
     if (c != ',' && (c < '0' || c > '9')) {
       LOG(ERROR) << "Invalid file descriptor list: " << fd_list;
       std::exit(1);
@@ -61,7 +62,7 @@ std::vector<SharedFD> SubscribersFromCmdline() {
 
   std::vector<std::string> fds = absl::StrSplit(FLAGS_subscriber_fds, ',');
   std::vector<SharedFD> shared_fds;
-  for (auto& fd_str: fds) {
+  for (auto& fd_str : fds) {
     auto fd = std::stoi(fd_str);
     auto shared_fd = SharedFD::Dup(fd);
     close(fd);
@@ -84,8 +85,7 @@ int KernelLogMonitorMain(int argc, char** argv) {
   auto subscriber_fds = SubscribersFromCmdline();
 
   // Disable default handling of SIGPIPE
-  struct sigaction new_action {
-  }, old_action{};
+  struct sigaction new_action{}, old_action{};
   new_action.sa_handler = SIG_IGN;
   sigaction(SIGPIPE, &new_action, &old_action);
 
@@ -105,7 +105,7 @@ int KernelLogMonitorMain(int argc, char** argv) {
 
   KernelLogServer klog{pipe, instance.PerInstanceLogPath(kLogNameKernel)};
 
-  for (auto subscriber_fd: subscriber_fds) {
+  for (auto subscriber_fd : subscriber_fds) {
     if (subscriber_fd->IsOpen()) {
       klog.SubscribeToEvents([subscriber_fd](Json::Value message) {
         if (!WriteEvent(subscriber_fd, message)) {

--- a/base/cvd/cuttlefish/host/commands/kernel_log_monitor/utils.cc
+++ b/base/cvd/cuttlefish/host/commands/kernel_log_monitor/utils.cc
@@ -22,9 +22,9 @@
 #include <optional>
 #include <string>
 
-#include <json/value.h>
-#include <json/writer.h>
 #include "absl/log/log.h"
+#include "json/value.h"
+#include "json/writer.h"
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"

--- a/base/cvd/cuttlefish/host/commands/kernel_log_monitor/utils.h
+++ b/base/cvd/cuttlefish/host/commands/kernel_log_monitor/utils.h
@@ -15,8 +15,9 @@
  */
 #pragma once
 
-#include <json/json.h>
 #include <optional>
+
+#include "json/json.h"
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/host/commands/kernel_log_monitor/kernel_log_server.h"

--- a/base/cvd/tools/format/BUILD.bazel
+++ b/base/cvd/tools/format/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+
+package(
+    default_visibility = ["//:android_cuttlefish"],
+)
+
+native_binary(
+    name = "clang_format",
+    src = "@llvm_toolchain//:clang-format",
+    out = "clang_format",
+    data = ["//:.clang-format"],
+)

--- a/base/cvd/tools/lint/linters.bzl
+++ b/base/cvd/tools/lint/linters.bzl
@@ -4,6 +4,7 @@ load("@aspect_rules_lint//lint:lint_test.bzl", "lint_test")
 clang_tidy = lint_clang_tidy_aspect(
     binary = "@@//tools/lint:clang_tidy",
     configs = ["@@//:clang_tidy_config"],
+    rule_kinds = ["cc_binary", "cc_library", "cc_test"],
 )
 
 clang_tidy_test = lint_test(aspect = clang_tidy)


### PR DESCRIPTION
With AI generating code in the repository, it helps to enforce that the AI generated code is formatted following project guidelines.

Assisted-by: Jetski <jetski@google.com>
Bug: b/512215781