### PR TITLE
Prompt users on instance operations

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/BUILD.bazel
@@ -70,7 +70,6 @@ cf_cc_library(
         "//cuttlefish/host/commands/cvd/cli:utils",
         "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/commands/cvd/instances:instance_manager",
-        "//cuttlefish/host/libs/config:config_constants",
         "//cuttlefish/result",
         "//libbase",
         "@abseil-cpp//absl/strings",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
@@ -29,7 +29,6 @@
 #include "cuttlefish/host/commands/cvd/cli/interruptible_terminal.h"
 #include "cuttlefish/host/commands/cvd/cli/utils.h"
 #include "cuttlefish/host/commands/cvd/instances/local_instance_group.h"
-#include "cuttlefish/host/libs/config/config_constants.h"
 
 namespace cuttlefish {
 namespace selector {
@@ -46,7 +45,7 @@ Result<LocalInstanceGroup> GetDefaultGroup(
 }
 
 Result<InstanceDatabase::Filter> BuildFilterFromSelectors(
-    const SelectorOptions& selectors, const cvd_common::Envs& env) {
+    const SelectorOptions& selectors) {
   InstanceDatabase::Filter filter;
   filter.group_name = selectors.group_name;
   if (selectors.instance_names) {
@@ -55,12 +54,6 @@ Result<InstanceDatabase::Filter> BuildFilterFromSelectors(
     for (const auto& per_instance_name : per_instance_names) {
       filter.instance_names.insert(per_instance_name);
     }
-  }
-  auto it = env.find(kCuttlefishInstanceEnvVarName);
-  if (it != env.end()) {
-    unsigned id;
-    std::string cuttlefish_instance = it->second;
-    CF_EXPECT(absl::SimpleAtoi(cuttlefish_instance, &id));
   }
 
   return filter;
@@ -88,7 +81,7 @@ std::string SelectionMenu(const std::vector<LocalInstanceGroup>& groups) {
 
 Result<LocalInstanceGroup> PromptUserForGroup(
     const InstanceManager& instance_manager, const CommandRequest& request,
-    const cvd_common::Envs& envs, InstanceDatabase::Filter filter) {
+    InstanceDatabase::Filter filter) {
   // show the menu and let the user choose
   std::vector<LocalInstanceGroup> groups =
       CF_EXPECT(instance_manager.FindGroups({}));
@@ -156,10 +149,9 @@ Result<LocalInstanceGroup> SelectGroup(const InstanceManager& instance_manager,
                                        const CommandRequest& request) {
   const bool has_groups = CF_EXPECT(instance_manager.HasInstanceGroups());
   CF_EXPECT(std::move(has_groups), "No instance groups available");
-  const cvd_common::Envs& env = request.Env();
   const SelectorOptions& selector_options = request.Selectors();
   InstanceDatabase::Filter filter =
-      CF_EXPECT(BuildFilterFromSelectors(selector_options, request.Env()));
+      CF_EXPECT(BuildFilterFromSelectors(selector_options));
   Result<LocalInstanceGroup> group_selection_result =
       FindGroupOrDefault(filter, instance_manager);
   if (group_selection_result.ok()) {
@@ -169,13 +161,13 @@ Result<LocalInstanceGroup> SelectGroup(const InstanceManager& instance_manager,
             "Multiple groups found. Narrow the selection with selector "
             "arguments or run in an interactive terminal.");
   return CF_EXPECT(
-      PromptUserForGroup(instance_manager, request, env, std::move(filter)));
+      PromptUserForGroup(instance_manager, request, std::move(filter)));
 }
 
 Result<std::pair<LocalInstance, LocalInstanceGroup>> SelectInstance(
     const InstanceManager& instance_manager, const CommandRequest& request) {
   InstanceDatabase::Filter filter =
-      CF_EXPECT(BuildFilterFromSelectors(request.Selectors(), request.Env()));
+      CF_EXPECT(BuildFilterFromSelectors(request.Selectors()));
 
   return filter.Empty()
              ? CF_EXPECT(FindDefaultInstance(instance_manager))

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
@@ -34,16 +34,6 @@ namespace cuttlefish {
 namespace selector {
 namespace {
 
-Result<LocalInstanceGroup> GetDefaultGroup(
-    const InstanceManager& instance_manager) {
-  const std::vector<LocalInstanceGroup> all_groups =
-      CF_EXPECT(instance_manager.FindGroups({}));
-  CF_EXPECTF(all_groups.size() == 1,
-             "There are {} instance groups, unable to pick one",
-             all_groups.size());
-  return all_groups.front();
-}
-
 Result<InstanceDatabase::Filter> BuildFilterFromSelectors(
     const SelectorOptions& selectors) {
   InstanceDatabase::Filter filter;
@@ -122,13 +112,10 @@ Result<LocalInstanceGroup> PromptUserForGroup(
   }
 }
 
-Result<std::pair<LocalInstance, LocalInstanceGroup>> FindDefaultInstance(
-    const InstanceManager& instance_manager) {
-  const LocalInstanceGroup group = CF_EXPECT(GetDefaultGroup(instance_manager));
-  const std::vector<LocalInstance> instances = group.Instances();
-  CF_EXPECT_EQ(instances.size(), 1u,
-               "Default instance is the single instance in the default group.");
-  return std::make_pair(instances.front(), group);
+Result<std::pair<LocalInstance, LocalInstanceGroup>> PromptUserForInstance(
+    const InstanceManager& instance_manager, const CommandRequest& request,
+    InstanceDatabase::Filter filter) {
+  return CF_ERR("TODO(chadreynolds): implement in follow-up commit");
 }
 
 }  // namespace
@@ -152,12 +139,21 @@ Result<LocalInstanceGroup> SelectGroup(const InstanceManager& instance_manager,
 
 Result<std::pair<LocalInstance, LocalInstanceGroup>> SelectInstance(
     const InstanceManager& instance_manager, const CommandRequest& request) {
-  InstanceDatabase::Filter filter =
+  const InstanceDatabase::Filter filter =
       CF_EXPECT(BuildFilterFromSelectors(request.Selectors()));
-
-  return filter.Empty()
-             ? CF_EXPECT(FindDefaultInstance(instance_manager))
-             : CF_EXPECT(instance_manager.FindInstanceWithGroup(filter));
+  std::vector<std::pair<LocalInstanceGroup, std::vector<LocalInstance>>>
+      found_instances = CF_EXPECT(instance_manager.FindInstances(filter));
+  CF_EXPECT(!found_instances.empty(), "No instances available");
+  if (found_instances.size() == 1 &&
+      found_instances.front().second.size() == 1) {
+    auto [group, instances] = found_instances.front();
+    return std::make_pair(instances.front(), group);
+  }
+  CF_EXPECT(isatty(0),
+            "Multiple instances found.  Narrow the selection with selector "
+            "arguments or run in an interactive terminal");
+  return CF_EXPECT(
+      PromptUserForInstance(instance_manager, request, std::move(filter)));
 }
 
 }  // namespace selector

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
@@ -77,10 +77,9 @@ std::string SelectionMenu(const std::vector<LocalInstanceGroup>& groups) {
   for (const auto& group : groups) {
     fmt::print(ss, "  [{}] : {} (created: {})\n", group_idx, group.GroupName(),
                Format(group.StartTime()));
-    char instance_idx = 'a';
     for (const auto& instance : group.Instances()) {
-      fmt::print(ss, "    <{}> {}-{} (id : {})\n", instance_idx++,
-                 group.GroupName(), instance.Name(), instance.Id());
+      fmt::print(ss, "    {}-{} (id : {})\n", group.GroupName(),
+                 instance.Name(), instance.Id());
     }
     group_idx++;
   }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
@@ -122,18 +122,6 @@ Result<LocalInstanceGroup> PromptUserForGroup(
   }
 }
 
-Result<LocalInstanceGroup> FindGroupOrDefault(
-    const InstanceDatabase::Filter& filter,
-    const InstanceManager& instance_manager) {
-  if (filter.Empty()) {
-    return CF_EXPECT(GetDefaultGroup(instance_manager));
-  }
-  std::vector<LocalInstanceGroup> groups =
-      CF_EXPECT(instance_manager.FindGroups(filter));
-  CF_EXPECT_EQ(groups.size(), 1u, "groups.size() = " << groups.size());
-  return groups.front();
-}
-
 Result<std::pair<LocalInstance, LocalInstanceGroup>> FindDefaultInstance(
     const InstanceManager& instance_manager) {
   const LocalInstanceGroup group = CF_EXPECT(GetDefaultGroup(instance_manager));
@@ -147,15 +135,13 @@ Result<std::pair<LocalInstance, LocalInstanceGroup>> FindDefaultInstance(
 
 Result<LocalInstanceGroup> SelectGroup(const InstanceManager& instance_manager,
                                        const CommandRequest& request) {
-  const bool has_groups = CF_EXPECT(instance_manager.HasInstanceGroups());
-  CF_EXPECT(std::move(has_groups), "No instance groups available");
-  const SelectorOptions& selector_options = request.Selectors();
-  InstanceDatabase::Filter filter =
-      CF_EXPECT(BuildFilterFromSelectors(selector_options));
-  Result<LocalInstanceGroup> group_selection_result =
-      FindGroupOrDefault(filter, instance_manager);
-  if (group_selection_result.ok()) {
-    return CF_EXPECT(std::move(group_selection_result));
+  const InstanceDatabase::Filter filter =
+      CF_EXPECT(BuildFilterFromSelectors(request.Selectors()));
+  std::vector<LocalInstanceGroup> groups =
+      CF_EXPECT(instance_manager.FindGroups(filter));
+  CF_EXPECT(!groups.empty(), "No instance groups available");
+  if (groups.size() == 1) {
+    return groups.front();
   }
   CF_EXPECT(isatty(0),
             "Multiple groups found. Narrow the selection with selector "

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
@@ -18,6 +18,7 @@
 
 #include <iostream>
 #include <memory>
+#include <ostream>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -34,6 +35,11 @@ namespace cuttlefish {
 namespace selector {
 namespace {
 
+enum class DisplayBehavior {
+  LabelGroup,
+  LabelInstance,
+};
+
 Result<InstanceDatabase::Filter> BuildFilterFromSelectors(
     const SelectorOptions& selectors) {
   InstanceDatabase::Filter filter;
@@ -49,67 +55,75 @@ Result<InstanceDatabase::Filter> BuildFilterFromSelectors(
   return filter;
 }
 
-std::string SelectionMenu(const std::vector<LocalInstanceGroup>& groups) {
-  // Multiple instance groups found, please choose one:
-  //   [i] : group_name (created: TIME)
-  //      <a> instance0.device_name() (id: instance_id)
-  //      <b> instance1.device_name() (id: instance_id)
-  std::stringstream ss;
-  ss << "Multiple instance groups found, please choose one:" << std::endl;
-  int group_idx = 0;
-  for (const auto& group : groups) {
-    fmt::print(ss, "  [{}] : {} (created: {})\n", group_idx, group.GroupName(),
-               Format(group.StartTime()));
-    for (const auto& instance : group.Instances()) {
-      fmt::print(ss, "    {}-{} (id : {})\n", group.GroupName(),
-                 instance.Name(), instance.Id());
+std::string GroupDisplay(const std::vector<LocalInstanceGroup>& groups,
+                         const DisplayBehavior behavior) {
+  std::stringstream result;
+  int group_index = 0;
+  for (const LocalInstanceGroup& group : groups) {
+    if (behavior == DisplayBehavior::LabelGroup) {
+      fmt::print(result, "[{}] - ", group_index);
     }
-    group_idx++;
+    fmt::print(result, "{} (created: {})\n", group.GroupName(),
+               Format(group.StartTime()));
+
+    int instance_index = 0;
+    for (const LocalInstance& instance : group.Instances()) {
+      result << "\t";
+      if (behavior == DisplayBehavior::LabelInstance) {
+        fmt::print(result, "[{}] - ", instance_index);
+      }
+      fmt::print(result, "{}-{} (id : {})\n", group.GroupName(),
+                 instance.Name(), instance.Id());
+
+      instance_index++;
+    }
+
+    group_index++;
   }
-  return ss.str();
+  return result.str();
+}
+
+Result<int> PromptForSelection(const int max_selection) {
+  std::unique_ptr<InterruptibleTerminal> terminal =
+      std::make_unique<InterruptibleTerminal>();
+
+  TerminalColors colors(isatty(2));
+
+  int selection = -1;
+  while (selection < 0 || selection > max_selection) {
+    fmt::print(std::cout, "\nSelect {}[0,{}]{}: ", colors.Cyan(), max_selection,
+               colors.Reset());
+    std::cout << std::flush;
+    std::string input_line = CF_EXPECT(terminal->ReadLine());
+    if (!absl::SimpleAtoi(input_line, &selection)) {
+      selection = -1;
+      fmt::print(std::cerr, "Selection \"{}{}{}\" is not a valid.\n",
+                 colors.BoldRed(), input_line, colors.Reset());
+      continue;
+    }
+    if (selection > max_selection) {
+      fmt::print(std::cerr,
+                 "Selection \"{}{}{}\" is beyond the allowed range.\n",
+                 colors.BoldRed(), selection, colors.Reset());
+      continue;
+    }
+  }
+  return selection;
 }
 
 Result<LocalInstanceGroup> PromptUserForGroup(
     const InstanceManager& instance_manager, const CommandRequest& request,
     InstanceDatabase::Filter filter) {
-  // show the menu and let the user choose
-  std::vector<LocalInstanceGroup> groups =
+  const std::vector<LocalInstanceGroup> groups =
       CF_EXPECT(instance_manager.FindGroups({}));
-  std::string menu = SelectionMenu(groups);
+  std::cout << GroupDisplay(groups, DisplayBehavior::LabelGroup);
 
-  std::cout << menu << "\n";
-  std::unique_ptr<InterruptibleTerminal> terminal_ =
-      std::make_unique<InterruptibleTerminal>();
+  const int selection = CF_EXPECT(PromptForSelection(groups.size() - 1));
+  auto group_filter = InstanceDatabase::Filter{
+      .group_name = groups[selection].GroupName(),
+  };
 
-  TerminalColors colors(isatty(2));
-  while (true) {
-    std::string input_line = CF_EXPECT(terminal_->ReadLine());
-    int selection = -1;
-    std::string chosen_group_name;
-    if (absl::SimpleAtoi(input_line, &selection)) {
-      const int n_groups = groups.size();
-      if (n_groups <= selection || selection < 0) {
-        fmt::print(std::cerr,
-                   "\n  Selection {}{}{} is beyond the range {}[0, {}]{}\n\n",
-                   colors.BoldRed(), selection, colors.Reset(), colors.Cyan(),
-                   n_groups - 1, colors.Reset());
-        continue;
-      }
-      chosen_group_name = groups[selection].GroupName();
-    } else {
-      chosen_group_name = std::string(absl::StripAsciiWhitespace(input_line));
-    }
-
-    filter.group_name = chosen_group_name;
-    Result<LocalInstanceGroup> instance_group_result =
-        instance_manager.FindGroup(filter);
-    if (instance_group_result.ok()) {
-      return instance_group_result;
-    }
-    fmt::print(std::cerr,
-               "\n  Failed to find a group whose name is {}\"{}\"{}\n\n",
-               colors.BoldRed(), chosen_group_name, colors.Reset());
-  }
+  return CF_EXPECT(instance_manager.FindGroup(group_filter));
 }
 
 Result<std::pair<LocalInstance, LocalInstanceGroup>> PromptUserForInstance(

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
@@ -129,7 +129,24 @@ Result<LocalInstanceGroup> PromptUserForGroup(
 Result<std::pair<LocalInstance, LocalInstanceGroup>> PromptUserForInstance(
     const InstanceManager& instance_manager, const CommandRequest& request,
     InstanceDatabase::Filter filter) {
-  return CF_ERR("TODO(chadreynolds): implement in follow-up commit");
+  const LocalInstanceGroup group =
+      CF_EXPECT(PromptUserForGroup(instance_manager, request, filter));
+  const std::vector<LocalInstance>& instances = group.Instances();
+  if (instances.size() == 1) {
+    fmt::print(std::cout,
+               "Single instance in group {}, defaulting to that choice.\n",
+               group.GroupName());
+    return std::pair(instances.front(), group);
+  }
+
+  std::cout << GroupDisplay({group}, DisplayBehavior::LabelInstance);
+
+  const int selection = CF_EXPECT(PromptForSelection(instances.size() - 1));
+  auto instance_filter = InstanceDatabase::Filter{
+      .group_name = group.GroupName(),
+      .instance_names = {instances[selection].Name()},
+  };
+  return CF_EXPECT(instance_manager.FindInstanceWithGroup(instance_filter));
 }
 
 }  // namespace

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
@@ -27,8 +27,10 @@
 #include "absl/strings/ascii.h"
 #include "absl/strings/numbers.h"
 
+#include "cuttlefish/host/commands/cvd/cli/command_request.h"
 #include "cuttlefish/host/commands/cvd/cli/interruptible_terminal.h"
 #include "cuttlefish/host/commands/cvd/cli/utils.h"
+#include "cuttlefish/host/commands/cvd/instances/local_instance.h"
 #include "cuttlefish/host/commands/cvd/instances/local_instance_group.h"
 
 namespace cuttlefish {
@@ -51,7 +53,6 @@ Result<InstanceDatabase::Filter> BuildFilterFromSelectors(
       filter.instance_names.insert(per_instance_name);
     }
   }
-
   return filter;
 }
 
@@ -112,8 +113,7 @@ Result<int> PromptForSelection(const int max_selection) {
 }
 
 Result<LocalInstanceGroup> PromptUserForGroup(
-    const InstanceManager& instance_manager, const CommandRequest& request,
-    InstanceDatabase::Filter filter) {
+    const InstanceManager& instance_manager) {
   const std::vector<LocalInstanceGroup> groups =
       CF_EXPECT(instance_manager.FindGroups({}));
   std::cout << GroupDisplay(groups, DisplayBehavior::LabelGroup);
@@ -127,10 +127,9 @@ Result<LocalInstanceGroup> PromptUserForGroup(
 }
 
 Result<std::pair<LocalInstance, LocalInstanceGroup>> PromptUserForInstance(
-    const InstanceManager& instance_manager, const CommandRequest& request,
-    InstanceDatabase::Filter filter) {
+    const InstanceManager& instance_manager) {
   const LocalInstanceGroup group =
-      CF_EXPECT(PromptUserForGroup(instance_manager, request, filter));
+      CF_EXPECT(PromptUserForGroup(instance_manager));
   const std::vector<LocalInstance>& instances = group.Instances();
   if (instances.size() == 1) {
     fmt::print(std::cout,
@@ -161,11 +160,10 @@ Result<LocalInstanceGroup> SelectGroup(const InstanceManager& instance_manager,
   if (groups.size() == 1) {
     return groups.front();
   }
-  CF_EXPECT(isatty(0),
-            "Multiple groups found. Narrow the selection with selector "
-            "arguments or run in an interactive terminal.");
-  return CF_EXPECT(
-      PromptUserForGroup(instance_manager, request, std::move(filter)));
+  CF_EXPECT(
+      isatty(0),
+      "Multiple groups found. Narrow the selection with selector arguments.");
+  return CF_EXPECT(PromptUserForGroup(instance_manager));
 }
 
 Result<std::pair<LocalInstance, LocalInstanceGroup>> SelectInstance(
@@ -182,9 +180,8 @@ Result<std::pair<LocalInstance, LocalInstanceGroup>> SelectInstance(
   }
   CF_EXPECT(isatty(0),
             "Multiple instances found.  Narrow the selection with selector "
-            "arguments or run in an interactive terminal");
-  return CF_EXPECT(
-      PromptUserForInstance(instance_manager, request, std::move(filter)));
+            "arguments.");
+  return CF_EXPECT(PromptUserForInstance(instance_manager));
 }
 
 }  // namespace selector

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_database.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_database.cpp
@@ -254,6 +254,37 @@ InstanceDatabase::FindInstanceWithGroup(const Filter& filter) const {
       });
 }
 
+Result<std::vector<std::pair<LocalInstanceGroup, std::vector<LocalInstance>>>>
+InstanceDatabase::FindInstances(const Filter& filter) const {
+  return viewer_.WithSharedLock<
+      std::vector<std::pair<LocalInstanceGroup, std::vector<LocalInstance>>>>(
+      [&filter](const auto& data)
+          -> Result<std::vector<
+              std::pair<LocalInstanceGroup, std::vector<LocalInstance>>>> {
+        std::vector<std::pair<LocalInstanceGroup, std::vector<LocalInstance>>>
+            result;
+        for (const auto& group : data.instance_groups()) {
+          if (!GroupMatches(group, filter)) {
+            continue;
+          }
+          LocalInstanceGroup local_group =
+              CF_EXPECT(LocalInstanceGroup::Create(group));
+          std::vector<LocalInstance> instance_results;
+          for (int i = 0; i < group.instances_size(); ++i) {
+            const auto& instance = group.instances(i);
+            if (!InstanceMatches(instance, filter)) {
+              continue;
+            }
+            instance_results.push_back(local_group.Instances()[i]);
+          }
+          if (!instance_results.empty()) {
+            result.push_back(std::make_pair(local_group, instance_results));
+          }
+        }
+        return result;
+      });
+}
+
 Result<std::vector<LocalInstanceGroup>> InstanceDatabase::InstanceGroups()
     const {
   return viewer_.WithSharedLock<std::vector<LocalInstanceGroup>>(

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_database.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_database.h
@@ -80,6 +80,8 @@ class InstanceDatabase {
   }
   Result<std::pair<LocalInstance, LocalInstanceGroup>> FindInstanceWithGroup(
       const Filter& filter) const;
+  Result<std::vector<std::pair<LocalInstanceGroup, std::vector<LocalInstance>>>>
+  FindInstances(const Filter& filter) const;
 
  private:
   template <typename T>

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_manager.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_manager.cpp
@@ -105,6 +105,11 @@ InstanceManager::FindInstanceWithGroup(
   return CF_EXPECT(instance_db_.FindInstanceWithGroup(filter));
 }
 
+Result<std::vector<std::pair<LocalInstanceGroup, std::vector<LocalInstance>>>>
+InstanceManager::FindInstances(const InstanceDatabase::Filter& filter) const {
+  return CF_EXPECT(instance_db_.FindInstances(filter));
+}
+
 Result<bool> InstanceManager::HasInstanceGroups() const {
   return !CF_EXPECT(instance_db_.IsEmpty());
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_manager.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_manager.h
@@ -77,6 +77,8 @@ class InstanceManager {
 
   Result<std::pair<LocalInstance, LocalInstanceGroup>> FindInstanceWithGroup(
       const InstanceDatabase::Filter& filter) const;
+  Result<std::vector<std::pair<LocalInstanceGroup, std::vector<LocalInstance>>>>
+  FindInstances(const InstanceDatabase::Filter& filter) const;
 
   // Stops the device by asking it over the control socket. If launcher_timeout
   // has a value, it will wait for at most that time before returning an error.


### PR DESCRIPTION
When an instance-focused operation (eg `logs`) is not given selectors or enough selectors, then have `cvd` prompt the user to select an instance rather than failing.  This matches what we do for group-focused operations (`remove`).

Bug: 511316553