### PR TITLE
modem_simulator: move the time update when the modem is turned on

### DIFF
--- a/base/cvd/cuttlefish/host/commands/modem_simulator/modem_simulator.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/modem_simulator.cpp
@@ -121,10 +121,6 @@ void ModemSimulator::DispatchCommand(const Client& client,
 }
 
 void ModemSimulator::OnFirstClientConnected() {
-  if (misc_service_) {
-    misc_service_->TimeUpdate();
-  }
-
   if (network_service_) {
     network_service_->OnVoiceRegisterStateChanged();
     network_service_->OnDataRegisterStateChanged();

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/network_service.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/network_service.cpp
@@ -321,6 +321,7 @@ void NetworkService::HandleRadioPower(const Client& client, std::string& command
         auto sim_status = sim_service_->GetSimStatus();
         OnSimStatusChanged(sim_status);
       }
+      misc_service_->TimeUpdate();
       break;
     default:
       client.SendCommandResponse(kCmeErrorOperationNotSupported);


### PR DESCRIPTION
`OnFirstClientConnected` is called too early and
the time value is sitting (during booting) in
the buffer which makes that value obsolete.

Bug: 503430159
Change-Id: I41e6a45032babed16e24a138052a89b86171ef82