### PR TITLE
cvd: Introduce setup command and refactor host validation

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/users.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/users.cpp
@@ -114,9 +114,16 @@ Result<std::string> SystemWideUserHome() {
 }
 
 Result<std::string> CurrentUserName() {
-  char buf[LOGIN_NAME_MAX + 1];
-  CF_EXPECT(getlogin_r(buf, sizeof(buf)) == 0, strerror(errno));
-  return std::string(buf);
+  uid_t uid = getuid();
+  struct passwd pwd;
+  struct passwd* result;
+  long val = sysconf(_SC_GETPW_R_SIZE_MAX);
+  size_t bufsize = (val == -1) ? 16384 : val;
+  std::vector<char> buffer(bufsize);
+  int s = getpwuid_r(uid, &pwd, buffer.data(), buffer.size(), &result);
+  CF_EXPECT(s == 0, "getpwuid_r failed: " << strerror(s));
+  CF_EXPECT(result != nullptr, "User not found for uid " << uid);
+  return std::string(pwd.pw_name);
 }
 
 } // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/BUILD.bazel
@@ -21,8 +21,8 @@ cf_cc_library(
         "//cuttlefish/host/commands/cvd/instances:instance_manager",
         "//cuttlefish/host/commands/cvd/instances/lock",
         "//cuttlefish/host/commands/cvd/utils",
+        "//cuttlefish/host/libs/vm_manager",
         "//cuttlefish/result",
-        "//libbase",
     ],
 )
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
@@ -107,6 +107,7 @@ cf_cc_library(
         "//cuttlefish/host/commands/cvd/cli/commands:reset",
         "//cuttlefish/host/commands/cvd/cli/commands:restart",
         "//cuttlefish/host/commands/cvd/cli/commands:screen_recording",
+        "//cuttlefish/host/commands/cvd/cli/commands:setup",
         "//cuttlefish/host/commands/cvd/cli/commands:snapshot",
         "//cuttlefish/host/commands/cvd/cli/commands:start",
         "//cuttlefish/host/commands/cvd/cli/commands:status",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
@@ -510,3 +510,18 @@ cf_cc_library(
         "@jsoncpp",
     ],
 )
+
+cf_cc_library(
+    name = "setup",
+    srcs = ["setup.cc"],
+    hdrs = ["setup.h"],
+    deps = [
+        "//cuttlefish/common/libs/utils:subprocess",
+        "//cuttlefish/host/commands/cvd/cli:command_request",
+        "//cuttlefish/host/commands/cvd/cli:types",
+        "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
+        "//cuttlefish/host/libs/vm_manager",
+        "//cuttlefish/result",
+        "@abseil-cpp//absl/strings",
+    ],
+)

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/command_handler.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/command_handler.h
@@ -34,6 +34,7 @@ class CvdCommandHandler {
   // used for command help text
   virtual std::string SummaryHelp() const = 0;
   virtual bool RequiresDeviceExists() const;
+  virtual bool RequiresHostConfiguration() const { return true; }
   virtual Result<std::string> DetailedHelp(const CommandRequest&) const = 0;
 };
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/help.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/help.cpp
@@ -93,7 +93,7 @@ class CvdHelpHandler : public CvdCommandHandler {
 
   std::string SummaryHelp() const override { return kSummaryHelpText; }
 
-
+  bool RequiresHostConfiguration() const override { return false; }
 
   Result<std::string> DetailedHelp(const CommandRequest& request) const override {
     return kDetailedHelpText;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/setup.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/setup.cc
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/host/commands/cvd/cli/commands/setup.h"
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "absl/strings/str_join.h"
+
+#include "cuttlefish/common/libs/utils/subprocess.h"
+#include "cuttlefish/host/commands/cvd/cli/command_request.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
+#include "cuttlefish/host/commands/cvd/cli/types.h"
+#include "cuttlefish/host/libs/vm_manager/host_configuration.h"
+#include "cuttlefish/result/result.h"
+
+namespace cuttlefish {
+namespace {
+
+constexpr char kSummaryHelpText[] = "Configure the host for Cuttlefish";
+
+constexpr char kDetailedHelpText[] =
+    R"(cvd setup - configure host for cuttlefish
+
+Checks host configuration (kernel version, group memberships) and automatically applies fixes (e.g., adding user to kvm and cvdnetwork groups). Some fixes may require sudo permissions.
+
+Usage:
+  cvd setup
+)";
+
+using vm_manager::HostConfigurationAction;
+using vm_manager::ValidateHostConfiguration;
+
+class CvdSetupHandler : public CvdCommandHandler {
+ public:
+  CvdSetupHandler() = default;
+
+  Result<void> Handle(const CommandRequest& request) override {
+    std::vector<HostConfigurationAction> actions =
+        CF_EXPECT(ValidateHostConfiguration());
+    if (actions.empty()) {
+      std::cout << "Host configuration is already valid. No setup required."
+                << std::endl;
+      return {};
+    }
+
+    std::cout << "Applying host configuration fixes..." << std::endl;
+    for (const HostConfigurationAction& action : actions) {
+      if (!action.description.empty()) {
+        std::cout << "Purpose: " << action.description << std::endl;
+      }
+      if (action.command.empty()) {
+        std::cout
+            << "Manual intervention required (no automated command available)."
+            << std::endl;
+        continue;
+      }
+
+      std::cout << "Running: " << absl::StrJoin(action.command, " ")
+                << std::endl;
+      const int status = Execute(action.command);
+      CF_EXPECTF(status == 0, "Failed to execute command: `{}`, exit code: {}",
+                 absl::StrJoin(action.command, " "), status);
+    }
+
+    std::cout << "Setup completed successfully." << std::endl;
+    return {};
+  }
+
+  cvd_common::Args CmdList() const override { return {"setup"}; }
+
+  std::string SummaryHelp() const override { return kSummaryHelpText; }
+
+  bool RequiresDeviceExists() const override { return false; }
+
+  bool RequiresHostConfiguration() const override { return false; }
+
+  Result<std::string> DetailedHelp(const CommandRequest&) const override {
+    return kDetailedHelpText;
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<CvdCommandHandler> NewCvdSetupHandler() {
+  return std::unique_ptr<CvdCommandHandler>(new CvdSetupHandler());
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/setup.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/setup.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
+
+namespace cuttlefish {
+
+std::unique_ptr<CvdCommandHandler> NewCvdSetupHandler();
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/request_context.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/request_context.cpp
@@ -45,6 +45,7 @@
 #include "cuttlefish/host/commands/cvd/cli/commands/reset.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/restart.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/screen_recording.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/setup.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/snapshot.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/start.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/status.h"
@@ -114,6 +115,7 @@ RequestContext::RequestContext(InstanceManager& instance_manager,
       NewScreenRecordingCommandHandler(instance_manager));
   request_handlers_.emplace_back(
       NewCvdSnapshotCommandHandler(instance_manager));
+  request_handlers_.emplace_back(NewCvdSetupHandler());
   request_handlers_.emplace_back(NewCvdStartCommandHandler(instance_manager));
   request_handlers_.emplace_back(NewCvdStatusCommandHandler(instance_manager));
   request_handlers_.emplace_back(NewCvdVersionHandler());

--- a/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
@@ -21,14 +21,13 @@
 #include <unordered_map>
 #include <vector>
 
-#include <android-base/file.h>
-
 #include "cuttlefish/common/libs/utils/flag_parser.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
 #include "cuttlefish/host/commands/cvd/cli/frontline_parser.h"
 #include "cuttlefish/host/commands/cvd/cli/request_context.h"
 #include "cuttlefish/host/commands/cvd/instances/instance_manager.h"
 #include "cuttlefish/host/commands/cvd/instances/lock/instance_lock.h"
+#include "cuttlefish/host/libs/vm_manager/host_configuration.h"
 #include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
@@ -37,6 +36,13 @@ Cvd::Cvd(InstanceManager& instance_manager,
          InstanceLockFileManager& lock_file_manager)
     : instance_manager_(instance_manager),
       lock_file_manager_(lock_file_manager) {}
+
+static Result<void> EnforceHostConfigured() {
+  std::vector<vm_manager::HostConfigurationAction> actions =
+      CF_EXPECT(vm_manager::ValidateHostConfiguration());
+  CF_EXPECT(actions.empty(), "Run `cvd setup` to configure the host.");
+  return {};
+}
 
 Result<void> Cvd::HandleCommand(
     const std::vector<std::string>& cvd_process_args,
@@ -50,12 +56,19 @@ Result<void> Cvd::HandleCommand(
                     .Build());
 
   RequestContext context(instance_manager_, lock_file_manager_);
-  auto handler = CF_EXPECT(context.Handler(request));
+  CvdCommandHandler* handler = CF_EXPECT(context.Handler(request));
+
   if (CF_EXPECT(HasHelpFlag(request.SubcommandArguments()))) {
     std::cout << CF_EXPECT(handler->DetailedHelp(request)) << std::endl;
-  } else {
-    CF_EXPECT(handler->Handle(request));
+    return {};
   }
+
+  if (handler->RequiresHostConfiguration()) {
+    CF_EXPECT(EnforceHostConfigured());
+  }
+
+  CF_EXPECT(handler->Handle(request));
+
   return {};
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/main.cc
@@ -41,7 +41,6 @@
 #include "cuttlefish/host/commands/cvd/cvd.h"
 #include "cuttlefish/host/commands/cvd/utils/common.h"
 #include "cuttlefish/host/commands/cvd/version/version.h"
-#include "cuttlefish/host/libs/vm_manager/host_configuration.h"
 #include "cuttlefish/posix/strerror.h"
 // TODO(315772518) Re-enable once metrics send is reenabled
 // #include "cuttlefish/host/commands/cvd/metrics/cvd_metrics_api.h"
@@ -200,22 +199,6 @@ std::string ColoredUrl(const std::string& url) {
   return output;
 }
 
-bool ValidateHostConfiguration() {
-  // Validate the host before attempting to access directories.
-  std::vector<std::string> config_commands;
-  bool valid = vm_manager::ValidateHostConfiguration(&config_commands);
-  if (!valid) {
-    std::cerr << "Validation of host configuration failed." << std::endl;
-    std::cerr << "Execute the following commands:" << std::endl;
-    for (const auto& cmd : config_commands) {
-      std::cerr << "    " << cmd << std::endl;
-    }
-    std::cerr << "You may need to logout for the changes to take effect"
-              << std::endl;
-  }
-  return valid;
-}
-
 }  // namespace
 
 }  // namespace cuttlefish
@@ -238,9 +221,6 @@ int main(int argc, char** argv) {
   }
   cuttlefish::LogToStderrAndFiles(log_files, "", metadata_level, verbosity);
 
-  if (!cuttlefish::ValidateHostConfiguration()) {
-    return -1;
-  }
   auto result = cuttlefish::CvdMain(std::move(all_args));
   if (result.ok()) {
     return 0;

--- a/base/cvd/cuttlefish/host/commands/run_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/BUILD.bazel
@@ -173,5 +173,7 @@ cf_cc_library(
         "//cuttlefish/result",
         "//libbase",
         "@abseil-cpp//absl/log",
+        "@abseil-cpp//absl/strings",
+        "@fmt",
     ],
 )

--- a/base/cvd/cuttlefish/host/commands/run_cvd/validate.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/validate.cpp
@@ -18,12 +18,17 @@
 
 #include <errno.h>
 #include <sys/utsname.h>
+#include <string>
+#include <vector>
 
 #include "absl/log/log.h"
+#include "absl/strings/str_join.h"
+#include "fmt/ranges.h"
 
 #include "allocd/alloc_utils.h"
 #include "cuttlefish/common/libs/utils/in_sandbox.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/vm_manager/host_configuration.h"
 #include "cuttlefish/posix/strerror.h"
 #include "cuttlefish/result/result.h"
 
@@ -59,15 +64,24 @@ Result<void> ValidateTapDevices(
 }
 
 Result<void> ValidateHostConfiguration() {
-#ifdef __ANDROID__
-  std::vector<std::string> config_commands;
-  CF_EXPECTF(vm_manager::ValidateHostConfiguration(&config_commands),
-             "Validation of user configuration failed.\n"
-             "Execute the following to correctly configure: \n[{}]\n",
-             "You may need to logout for the changes to take effect.\n",
-             fmt::join(config_commands, "\n"));
-#endif
-  return {};
+  std::vector<vm_manager::HostConfigurationAction> actions =
+      CF_EXPECT(vm_manager::ValidateHostConfiguration());
+  if (actions.empty()) {
+    return {};
+  }
+  std::vector<std::string> error_msgs;
+  for (const vm_manager::HostConfigurationAction& action : actions) {
+    if (!action.description.empty()) {
+      error_msgs.push_back("# " + action.description);
+    }
+    if (!action.command.empty()) {
+      error_msgs.push_back(absl::StrJoin(action.command, " "));
+    }
+  }
+  return CF_ERRF(
+      "Validation of user configuration failed.\n"
+      "Execute the following to correctly configure: \n[{}]\n",
+      fmt::join(error_msgs, "\n"));
 }
 
 Result<void> ValidateHostKernel() {

--- a/base/cvd/cuttlefish/host/libs/vm_manager/host_configuration.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/host_configuration.cpp
@@ -16,12 +16,12 @@
 
 #include "cuttlefish/host/libs/vm_manager/host_configuration.h"
 
+#include <sys/utsname.h>
+
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <sys/utsname.h>
-#include "absl/log/log.h"
 
 #include "cuttlefish/common/libs/utils/container.h"
 #include "cuttlefish/common/libs/utils/users.h"
@@ -30,20 +30,27 @@ namespace cuttlefish {
 namespace vm_manager {
 namespace {
 
-__attribute__((unused)) bool UserInGroup(
-    const std::string& group, std::vector<std::string>* config_commands) {
-  if (!InGroup(group)) {
-    LOG(ERROR) << "User must be a member of " << group;
-    config_commands->push_back("# Add your user to the " + group + " group:");
-    config_commands->push_back("sudo usermod -aG " + group + " $USER");
-    return false;
+template <typename T>
+void PushOptional(std::vector<T>& vec, std::optional<T> opt) {
+  if (opt) {
+    vec.push_back(std::move(*opt));
   }
-  return true;
 }
 
-constexpr std::pair<int,int> invalid_linux_version = std::pair<int,int>();
+Result<std::optional<HostConfigurationAction>> PutUserInGroup(
+    const std::string& group) {
+  if (InGroup(group)) {
+    return std::nullopt;
+  }
+  std::string username =
+      CF_EXPECT(CurrentUserName(), "Failed to get current username");
+  return HostConfigurationAction{
+      .command = {"sudo", "usermod", "-aG", group, username},
+      .description = "Add your user to the " + group + " group",
+  };
+}
 
-__attribute__((unused)) std::pair<int, int> GetLinuxVersion() {
+Result<std::pair<int, int>> GetLinuxVersion() {
   struct utsname info;
   if (!uname(&info)) {
     char* digit = strtok(info.release, "+.-");
@@ -54,38 +61,30 @@ __attribute__((unused)) std::pair<int, int> GetLinuxVersion() {
       return std::pair<int,int>{major, minor};
     }
   }
-  LOG(ERROR) << "Failed to detect Linux kernel version";
-  return invalid_linux_version;
+  return CF_ERR("Failed to detect Linux kernel version");
 }
 
-__attribute__((unused)) bool LinuxVersionAtLeast(
-    std::vector<std::string>* config_commands,
+Result<std::optional<HostConfigurationAction>> EnforceLinuxVersionAtLeast(
     const std::pair<int, int>& version, int major, int minor) {
   if (version.first > major ||
       (version.first == major && version.second >= minor)) {
-    return true;
+    return std::nullopt;
   }
 
-  LOG(ERROR) << "Kernel version must be >=" << major << "." << minor
-             << ", have " << version.first << "." << version.second;
-  config_commands->push_back("# Please upgrade your kernel to >=" +
-                             std::to_string(major) + "." +
-                             std::to_string(minor));
-  return false;
+  return HostConfigurationAction{
+      .command = {},
+      .description = "Please upgrade your kernel to >= " +
+                     std::to_string(major) + "." + std::to_string(minor),
+  };
 }
 
 } // namespace
 
-bool ValidateHostConfiguration(std::vector<std::string>* config_commands) {
-#ifdef __APPLE__
-  (void)config_commands;
-  return true;
-#else
+Result<std::vector<HostConfigurationAction>> ValidateHostConfiguration() {
+  std::vector<HostConfigurationAction> actions;
+#ifndef __APPLE__
   // if we can't detect the kernel version, just fail
-  auto version = GetLinuxVersion();
-  if (version == invalid_linux_version) {
-    return false;
-  }
+  std::pair<int, int> version = CF_EXPECT(GetLinuxVersion());
 
   // Checking host configuration via GID or group name on rootless container
   // instance is hard as user namespace is separated from the host.
@@ -93,28 +92,28 @@ bool ValidateHostConfiguration(std::vector<std::string>* config_commands) {
     // TODO(seungjaeyoo): Validate access on actual resources like devices
     // rather than group name, which is applicable for all host environments
     // including container.
-    return LinuxVersionAtLeast(config_commands, version, 4, 8);
+    PushOptional(actions, CF_EXPECT(EnforceLinuxVersionAtLeast(version, 4, 8)));
+    return actions;
   }
 
   // the check for cvdnetwork needs to happen even if the user is not in kvm, so
   // we can't just say UserInGroup("kvm") && UserInGroup("cvdnetwork")
-  auto in_cvdnetwork = UserInGroup("cvdnetwork", config_commands);
+  PushOptional(actions, CF_EXPECT(PutUserInGroup("cvdnetwork")));
 
   // if we're in the virtaccess group this is likely to be a CrOS environment.
-  auto is_cros = InGroup("virtaccess");
+  bool is_cros = InGroup("virtaccess");
   if (is_cros) {
     // relax the minimum kernel requirement slightly, as chromeos-4.4 has the
     // needed backports to enable vhost_vsock
-    auto linux_ver_4_4 = LinuxVersionAtLeast(config_commands, version, 4, 4);
-    return in_cvdnetwork && linux_ver_4_4;
+    PushOptional(actions, CF_EXPECT(EnforceLinuxVersionAtLeast(version, 4, 4)));
   } else {
     // this is regular Linux, so use the Debian group name and be more
     // conservative with the kernel version check.
-    auto in_kvm = UserInGroup("kvm", config_commands);
-    auto linux_ver_4_8 = LinuxVersionAtLeast(config_commands, version, 4, 8);
-    return in_cvdnetwork && in_kvm && linux_ver_4_8;
+    PushOptional(actions, CF_EXPECT(PutUserInGroup("kvm")));
+    PushOptional(actions, CF_EXPECT(EnforceLinuxVersionAtLeast(version, 4, 8)));
   }
 #endif
+  return actions;
 }
 
 } // namespace vm_manager

--- a/base/cvd/cuttlefish/host/libs/vm_manager/host_configuration.h
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/host_configuration.h
@@ -18,10 +18,24 @@
 #include <string>
 #include <vector>
 
+#include "cuttlefish/result/result.h"
+
 namespace cuttlefish {
 namespace vm_manager {
 
-bool ValidateHostConfiguration(std::vector<std::string>* config_commands);
+// Represents an action required to configure the host for Cuttlefish.
+struct HostConfigurationAction {
+  // The command to execute to automatically apply the fix, expressed a list of
+  // strings that can be given to execvp.
+  //
+  // If empty, manual intervention is required.
+  std::vector<std::string> command;
+  // A human-readable description of the purpose of this action or the issue it
+  // fixes.
+  std::string description;
+};
+
+Result<std::vector<HostConfigurationAction>> ValidateHostConfiguration();
 
 } // namespace vm_manager
 } // namespace cuttlefish


### PR DESCRIPTION
- Add a new `cvd setup` command to automatically apply host configuration fixes.
- Refactor `ValidateHostConfiguration` to return a list of structured `HostConfigurationAction`s instead of raw command strings, allowing better programmatic handling.
- Update `run_cvd` validation to use the new structured validation API.

Assisted-by: Jetski <jetski@google.com>
Bug: b/512582358