### PR TITLE
Support different emulated camera types for splane and mplane

### DIFF
--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/vhost_user_media_devices.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/vhost_user_media_devices.cpp
@@ -40,8 +40,8 @@ namespace {
 
 using Subprocess::StdIOChannel::kStdErr;
 
-Command NewCommand(const std::string& socket_path) {
-  Command cmd(VhostUserMediaEmulatedCameraSPlaneBinary());
+Command NewCommand(const std::string& binary_path, const std::string& socket_path) {
+  Command cmd(binary_path);
   cmd.AddParameter("--socket-path=", socket_path);
   cmd.AddParameter("--verbosity=", "debug");
   cmd.RedirectStdIO(Subprocess::StdIOChannel::kStdOut,
@@ -57,7 +57,18 @@ class VhostUserMediaDevices : public CommandSource {
   Result<std::vector<MonitorCommand>> Commands() override {
     std::vector<MonitorCommand> commands;
     for (int index = 0; index < instance_.media_configs().size(); index++) {
-      Command cmd = NewCommand(instance_.media_socket_path(index));
+      auto config = instance_.media_configs()[index];
+      std::string binary_path;
+      if (config.type == CuttlefishConfig::MediaType::kV4l2EmulatedCameraMPlane) {
+        binary_path = VhostUserMediaEmulatedCameraMPlaneBinary();
+      } else if (config.type == CuttlefishConfig::MediaType::kV4l2EmulatedCameraSPlane) {
+        binary_path = VhostUserMediaEmulatedCameraSPlaneBinary();
+      } else if (config.type == CuttlefishConfig::MediaType::kV4l2Proxy) {
+        continue;
+      } else {
+        CF_EXPECT(false, "unknown media type");
+      }
+      Command cmd = NewCommand(binary_path, instance_.media_socket_path(index));
       Command cmd_log_tee = CF_EXPECT(
           log_tee_.CreateLogTee(cmd, "vhu_media_simple_device", kStdErr), "Failed to create log tee command for media device");
       commands.emplace_back(std::move(cmd));

--- a/base/cvd/cuttlefish/host/commands/vhost_user_media/emulated_camera_mplane/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_media/emulated_camera_mplane/BUILD.bazel
@@ -3,8 +3,16 @@ load("@vhost_user_media_workspace_crates//:defs.bzl", "crate_deps")
 
 package(default_visibility = ["//:android_cuttlefish"])
 
-rust_binary(
+alias(
     name = "emulated_camera_mplane",
+    actual = select({
+        "@platforms//cpu:x86_64": ":emulated_camera_mplane_binary",
+        "//conditions:default": ":unsupported_binary",
+    }),
+)
+
+rust_binary(
+    name = "emulated_camera_mplane_binary",
     srcs = [
         "src/device.rs",
         "src/main.rs",
@@ -23,4 +31,15 @@ rust_binary(
     ]) + [
         "//cuttlefish/host/commands/vhost_user_media/vhu_media",
     ],
+)
+
+genrule(
+    name = "unsupported_binary",
+    outs = ["unsupported.sh"],
+    cmd = """cat << 'EOF' > $@
+#!/bin/bash
+echo "platform unsupported" >&2
+exit 1
+EOF""",
+    executable = True,
 )

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
@@ -115,7 +115,8 @@ class CuttlefishConfig {
 
   enum class MediaType {
     kUnknown = 0,
-    kV4l2EmulatedCamera,
+    kV4l2EmulatedCameraSPlane,
+    kV4l2EmulatedCameraMPlane,
     kV4l2Proxy,
   };
 

--- a/base/cvd/cuttlefish/host/libs/config/known_paths.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/known_paths.cpp
@@ -225,5 +225,9 @@ std::string VhostUserMediaEmulatedCameraSPlaneBinary() {
   return HostBinaryPath("vhu_media_emulated_camera_splane");
 }
 
+std::string VhostUserMediaEmulatedCameraMPlaneBinary() {
+  return HostBinaryPath("vhu_media_emulated_camera_mplane");
+}
+
 }  // namespace cuttlefish
 

--- a/base/cvd/cuttlefish/host/libs/config/known_paths.h
+++ b/base/cvd/cuttlefish/host/libs/config/known_paths.h
@@ -70,6 +70,7 @@ std::string VhalProxyServerBinary();
 std::string VhalProxyServerConfig();
 std::string VhostUserInputBinary();
 std::string VhostUserMediaEmulatedCameraSPlaneBinary();
+std::string VhostUserMediaEmulatedCameraMPlaneBinary();
 std::string WebRtcBinary();
 std::string WebRtcSigServerBinary();
 std::string WebRtcSigServerProxyBinary();

--- a/base/cvd/cuttlefish/host/libs/config/media.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/media.cpp
@@ -29,7 +29,8 @@
 
 namespace cuttlefish {
 
-static constexpr char kMediaTypeV4l2EmulatedCamera[] = "v4l2_emulated_camera";
+static constexpr char kMediaTypeV4l2EmulatedCameraSPlane[] = "v4l2_emulated_camera_splane";
+static constexpr char kMediaTypeV4l2EmulatedCameraMPlane[] = "v4l2_emulated_camera_mplane";
 static constexpr char kMediaTypeV4l2Proxy[] = "v4l2_proxy";
 
 Result<std::optional<CuttlefishConfig::MediaConfig>> ParseMediaConfig(
@@ -50,8 +51,10 @@ Result<std::optional<CuttlefishConfig::MediaConfig>> ParseMediaConfig(
   auto type_it = props.find("type");
   CF_EXPECT(type_it != props.end(), "Missing media type");
   CuttlefishConfig::MediaType type { CuttlefishConfig::MediaType::kUnknown };
-  if (type_it->second == kMediaTypeV4l2EmulatedCamera) {
-    type = CuttlefishConfig::MediaType::kV4l2EmulatedCamera;
+  if (type_it->second == kMediaTypeV4l2EmulatedCameraSPlane) {
+    type = CuttlefishConfig::MediaType::kV4l2EmulatedCameraSPlane;
+  } else if (type_it->second == kMediaTypeV4l2EmulatedCameraMPlane) {
+    type = CuttlefishConfig::MediaType::kV4l2EmulatedCameraMPlane;
   } else if (type_it->second == kMediaTypeV4l2Proxy) {
     type = CuttlefishConfig::MediaType::kV4l2Proxy;
   } else {

--- a/base/cvd/cuttlefish/host/libs/config/media.h
+++ b/base/cvd/cuttlefish/host/libs/config/media.h
@@ -26,11 +26,12 @@ constexpr const char kMediaFlag[] = "media";
 constexpr const char kMediaHelp[] =
     "Comma separated key=value pairs of media device properties. Supported "
     "properties:\n"
-    " 'type': optional, defaults to 'v4l2_emulated_camera', supported values:\n"
-    "    'v4l2_emulated_camera': emulated media capture device\n"
+    " 'type': optional, defaults to 'v4l2_emulated_camera_splane', supported values:\n"
+    "    'v4l2_emulated_camera_splane': emulated media capture device (single-plane)\n"
+    "    'v4l2_emulated_camera_mplane': emulated media capture device (multi-plane)\n"
     "    'v4l2_proxy': proxy a host V4L2 device into the guest\n "
     "Example usage:\n"
-    "  --media=type=v4l2_emulated_camera\n";
+    "  --media=type=v4l2_emulated_camera_splane\n";
 
 Result<std::optional<CuttlefishConfig::MediaConfig>> ParseMediaConfig(
     const std::string& flag);

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
@@ -931,7 +931,8 @@ Result<std::vector<MonitorCommand>> CrosvmManager::StartCommands(
 
   for (int index = 0; index < instance.media_configs().size(); index++) {
     auto config = instance.media_configs()[index];
-    if (config.type == CuttlefishConfig::MediaType::kV4l2EmulatedCamera) {
+    if (config.type == CuttlefishConfig::MediaType::kV4l2EmulatedCameraSPlane ||
+        config.type == CuttlefishConfig::MediaType::kV4l2EmulatedCameraMPlane) {
       crosvm_cmd.Cmd().AddParameter("--vhost-user=type=media,socket=", instance.media_socket_path(index));
     } else if (config.type == CuttlefishConfig::MediaType::kV4l2Proxy) {
       crosvm_cmd.Cmd().AddParameter("--v4l2-proxy=", "/dev/video0");

--- a/base/cvd/cuttlefish/package/BUILD.bazel
+++ b/base/cvd/cuttlefish/package/BUILD.bazel
@@ -99,6 +99,7 @@ package_files(
         "cuttlefish-common/bin/tombstone_receiver": "//cuttlefish/host/commands/tombstone_receiver",
         "cuttlefish-common/bin/unpack_bootimg.py": "@mkbootimg//:unpack_bootimg.py",
         "cuttlefish-common/bin/vhu_media_emulated_camera_splane": "//cuttlefish/host/commands/vhost_user_media/emulated_camera_splane",
+        "cuttlefish-common/bin/vhu_media_emulated_camera_mplane": "//cuttlefish/host/commands/vhost_user_media/emulated_camera_mplane",
         "cuttlefish-common/bin/vk_lavapipe_icd.json": "//cuttlefish/host/graphics/vulkan:vk_lavapipe_icd",
         "cuttlefish-common/bin/vk_swiftshader_icd.json": "//cuttlefish/host/graphics/vulkan:vk_swiftshader_icd",
         "cuttlefish-common/bin/webRTC": "//cuttlefish/host/frontend/webrtc:webRTC",

--- a/e2etests/cvd/media_tests/main_test.go
+++ b/e2etests/cvd/media_tests/main_test.go
@@ -44,7 +44,7 @@ func TestEmulatedCameraV4l2Compliance(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := c.CVDCreate(e2etests.CreateArgs{Args: []string{"--media=type=v4l2_emulated_camera"}}); err != nil {
+			if err := c.CVDCreate(e2etests.CreateArgs{Args: []string{"--media=type=v4l2_emulated_camera_splane"}}); err != nil {
 				t.Fatal(err)
 			}
 


### PR DESCRIPTION
Bug: 474406105
Test:
```
bazel run //cuttlefish/package:cvd -- create --media="type=v4l2_emulated_camera_mplane"
```

Then verify the device cap:
```
adb shell v4l2-ctl -d1 --info
```