### PR TITLE
Declare contents: read on the seven workflows without an explicit scope

### DIFF
--- a/.github/workflows/cloud-init-image-for-cuttlefish.yaml
+++ b/.github/workflows/cloud-init-image-for-cuttlefish.yaml
@@ -8,6 +8,9 @@ on:
     branchs:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   build-cidata-iso-job:
     runs-on: ubuntu-22.04

--- a/.github/workflows/gigabyte-ampere-cuttlefish-installer.yaml
+++ b/.github/workflows/gigabyte-ampere-cuttlefish-installer.yaml
@@ -9,6 +9,9 @@ on:
     branchs:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   check-install-gigabyte-package-deb-job:
     runs-on: ubuntu-22.04-arm

--- a/.github/workflows/postsubmit.yaml
+++ b/.github/workflows/postsubmit.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   update-cache-and-deploy:
     if: github.repository_owner == 'google'

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -13,6 +13,9 @@ concurrency:
   # previous runs are cancelled when a new run is started
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   buildozer:
     runs-on: ubuntu-22.04

--- a/.github/workflows/scheduled-cache-update.yaml
+++ b/.github/workflows/scheduled-cache-update.yaml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 */12 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   update-cache:
     if: github.repository_owner == 'google'

--- a/.github/workflows/stable-channel.yaml
+++ b/.github/workflows/stable-channel.yaml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     if: github.repository_owner == 'google'

--- a/.github/workflows/unstable-channel.yaml
+++ b/.github/workflows/unstable-channel.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - 'version-[0-9]+.[0-9]+-dev'
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     if: github.repository_owner == 'google'


### PR DESCRIPTION
Seven workflows in `.github/workflows/` currently leave `GITHUB_TOKEN` scope implicit:

- **Pure CI**: `cloud-init-image-for-cuttlefish`, `gigabyte-ampere-cuttlefish-installer`, `presubmit` — all check out the repo and run build/test/lint inside debian containers or Ubuntu runners. No writes.
- **Deploy / cache callers**: `postsubmit`, `scheduled-cache-update`, `stable-channel`, `unstable-channel` — each delegates to `update-cache-and-deployment.yaml` with secrets. The reusable uses `google-github-actions/auth@v3` to authenticate to GCP via the `ARTIFACT_REGISTRY_UPLOADER` JSON-creds secret (not OIDC), so it doesn`t need `id-token: write`. `contents: read` covers the checkout in the reusable and stays consistent with what `update-cache-and-deployment.yaml` actually needs.

YAML validates locally.