### PR TITLE
Add linkopts to build_variables.bzl.

### DIFF
--- a/base/cvd/build_variables.bzl
+++ b/base/cvd/build_variables.bzl
@@ -4,3 +4,6 @@ COPTS = [
     "-ftrivial-auto-var-init=zero",
     "-DNODISCARD_EXPECTED",
 ]
+
+LINKOPTS = [
+]

--- a/base/cvd/cuttlefish/bazel/rules.bzl
+++ b/base/cvd/cuttlefish/bazel/rules.bzl
@@ -14,19 +14,21 @@
 
 load("@aspect_rules_lint//format:defs.bzl", "format_test")
 load("@cc_compatibility_proxy//:proxy.bzl", "cc_binary", "cc_library", "cc_test")
-load("//:build_variables.bzl", BUILD_VAR_COPTS = "COPTS")
+load("//:build_variables.bzl", BUILD_VAR_COPTS = "COPTS", BUILD_VAR_LINKOPTS = "LINKOPTS")
 load("//tools/lint:linters.bzl", "clang_tidy_test")
 
 visibility(["//..."])
 
 COPTS = BUILD_VAR_COPTS
+LINKOPTS = BUILD_VAR_LINKOPTS
 
-def _cf_cc_binary_implementation(name, clang_format_enabled, clang_tidy_enabled, copts, **kwargs):
+def _cf_cc_binary_implementation(name, clang_format_enabled, clang_tidy_enabled, copts, linkopts, **kwargs):
     if not clang_tidy_enabled and not kwargs["deprecation"]:
         kwargs["deprecation"] = "Not covered by clang-tidy"
     cc_binary(
         name = name,
         copts = (copts or []) + COPTS,
+        linkopts = (linkopts or []) + LINKOPTS,
         **kwargs,
     )
     if clang_format_enabled:
@@ -51,6 +53,7 @@ cf_cc_binary = macro(
         "clang_format_enabled": attr.bool(configurable = False, default = False, doc = "Decide if a corresponding format_test target is generated"),
         "clang_tidy_enabled": attr.bool(configurable = False, default = True, doc = "Decide if a corresponding clang_tidy_test target is generated"),
         "copts": attr.string_list(configurable = False, default = []),
+        "linkopts": attr.string_list(configurable = False, default = []),
     },
     implementation = _cf_cc_binary_implementation,
 )


### PR DESCRIPTION
We may want to use shared/dynamic libraries shortly in order to deal with shared code being duplicated by being statically linked to multiple binaries. This changelist doesn't deal with that business yet, but it prepares the way by adding some infrastructure to the cf_cc_binary rule.

Namely, that infrastructure allows setting default linkopts in the build_variables.bzl like copts does. We need to do this because Bazel's rpath settings will not be correct when we take binaries built in the Bazel workspace and pull them into the Debian packaging. We will eventually just add $ORIGIN/../lib to the rpath to solve that problem.

This may still result in binaries with odd Bazel-generated rpaths, which might be a bit messy, but there might also be ways to clean that up in the future.