### PR TITLE
cvd: prune old log files in user log directory

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
@@ -56,10 +56,26 @@ cf_cc_library(
     name = "log_files",
     srcs = ["log_files.cpp"],
     hdrs = ["log_files.h"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/commands/cvd/utils",
+        "//cuttlefish/result",
+        "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/strings",
+    ],
+)
+
+cf_cc_test(
+    name = "log_files_test",
+    srcs = ["log_files_test.cpp"],
+    clang_format_enabled = True,
+    deps = [
+        "//cuttlefish/common/libs/utils:files",
+        "//cuttlefish/host/commands/cvd/cli:log_files",
+        "//cuttlefish/host/commands/cvd/utils",
+        "//cuttlefish/result:result_matchers",
+        "@abseil-cpp//absl/cleanup",
     ],
 )
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/log_files.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/log_files.cpp
@@ -16,6 +16,7 @@
 
 #include "cuttlefish/host/commands/cvd/cli/log_files.h"
 
+#include <algorithm>
 #include <chrono>
 #include <iomanip>
 #include <iostream>
@@ -23,24 +24,32 @@
 #include <string>
 #include <vector>
 
-#include "absl/strings/str_cat.h"
+#include "absl/log/log.h"
+#include "absl/strings/match.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/commands/cvd/utils/common.h"
 
 namespace cuttlefish {
+namespace {
 
-std::optional<std::string> GetCvdLogFile() {
-  std::string log_dir = PerUserDir() + "/logs";
-  if (!EnsureDirectoryExists(log_dir, 0777).ok()) {
-    std::cerr << "Failed to create log directory: " << log_dir
-              << ". Logging to file disabled." << std::endl;
-    return std::nullopt;
-  }
+constexpr std::string_view kLogFilePrefix = "cvd_";
+constexpr std::string_view kLogFileSuffix = ".log";
 
-  std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
-  std::time_t now_time_t = std::chrono::system_clock::to_time_t(now);
-  std::chrono::milliseconds now_ms =
+bool IsNotLogFile(std::string_view name) {
+  const bool prefix_match = absl::StartsWith(name, kLogFilePrefix);
+  const bool suffix_match = absl::EndsWith(name, kLogFileSuffix);
+  return !(prefix_match && suffix_match);
+}
+
+}  // namespace
+
+std::string CvdUserLogDir() { return PerUserDir() + "/logs"; }
+
+std::string GetCvdLogFileName(const std::string& log_dir,
+                              const std::chrono::system_clock::time_point now) {
+  const std::time_t now_time_t = std::chrono::system_clock::to_time_t(now);
+  const std::chrono::milliseconds now_ms =
       std::chrono::duration_cast<std::chrono::milliseconds>(
           now.time_since_epoch()) %
       1000;
@@ -49,9 +58,32 @@ std::optional<std::string> GetCvdLogFile() {
   localtime_r(&now_time_t, &tm_now);
 
   std::stringstream ss;
-  ss << std::put_time(&tm_now, "%Y%m%d_%H%M%S") << "." << std::setfill('0')
-     << std::setw(3) << now_ms.count();
-  return absl::StrCat(log_dir, "/cvd_", ss.str(), ".log");
+  ss << log_dir << "/" << kLogFilePrefix
+     << std::put_time(&tm_now, "%Y%m%d_%H%M%S") << "." << std::setfill('0')
+     << std::setw(3) << now_ms.count() << kLogFileSuffix;
+  return ss.str();
+}
+
+Result<void> PruneLogsDirectory(const std::string& log_dir, size_t retain) {
+  if (!DirectoryExists(log_dir)) {
+    return {};
+  }
+  std::vector<std::string> log_files =
+      CF_EXPECTF(DirectoryContents(log_dir),
+                 "Failed to list log directory: '{}'", log_dir);
+  size_t non_log_files = std::erase_if(log_files, IsNotLogFile);
+  if (non_log_files > 0) {
+    VLOG(0) << non_log_files << " non-log files found.";
+  }
+
+  std::sort(log_files.begin(), log_files.end());
+
+  for (size_t i = 0; i + retain < log_files.size(); ++i) {
+    const std::string file_to_remove = log_dir + "/" + log_files[i];
+    CF_EXPECTF(RemoveFile(file_to_remove),
+               "Failed to remove old log file: '{}'", file_to_remove);
+  }
+  return {};
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/log_files.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/log_files.h
@@ -16,10 +16,17 @@
 
 #pragma once
 
-#include <optional>
+#include <chrono>
 #include <string>
 
+#include "cuttlefish/result/result.h"
+
 namespace cuttlefish {
+
+inline constexpr size_t kCvdRetainLogFilesNum = 30;
+
+/** A user-specific directory where log files from `cvd` are stored. */
+std::string CvdUserLogDir();
 
 /**
  * Returns the path to a new timestamped log file for the
@@ -27,6 +34,12 @@ namespace cuttlefish {
  * like cvd_YYYYMMDD_HHMMSS.ms.log. If the logs directory cannot be created, the
  * function returns std::nullopt.
  */
-std::optional<std::string> GetCvdLogFile();
+std::string GetCvdLogFileName(const std::string& log_dir = CvdUserLogDir(),
+                              std::chrono::system_clock::time_point now =
+                                  std::chrono::system_clock::now());
+
+/** Prunes the logs directory keeping only the most recent log files. */
+Result<void> PruneLogsDirectory(const std::string& log_dir = CvdUserLogDir(),
+                                size_t retain = kCvdRetainLogFilesNum);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/log_files_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/log_files_test.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/host/commands/cvd/cli/log_files.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+#include "absl/cleanup/cleanup.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/result/result_matchers.h"
+
+namespace cuttlefish {
+namespace {
+
+TEST(LogFilesTest, PruneLogsDirectory) {
+  const char* tmpdir = getenv("TEST_TMPDIR");
+  ASSERT_NE(tmpdir, nullptr);
+  std::string log_dir = std::string(tmpdir) + "/logs_XXXXXX";
+  ASSERT_NE(mkdtemp(log_dir.data()), nullptr);
+
+  absl::Cleanup cleanup = [log_dir]() {
+    (void)RecursivelyRemoveDirectory(log_dir);
+  };
+
+  // Create 35 log files
+  const std::chrono::system_clock::time_point base_time =
+      std::chrono::system_clock::now();
+  std::vector<std::string> expected_logs;
+  for (int i = 1; i <= 35; ++i) {
+    const std::chrono::system_clock::time_point fake_time =
+        base_time + std::chrono::seconds(i);
+    const std::string path = GetCvdLogFileName(log_dir, fake_time);
+    ASSERT_THAT(WriteNewFile(path, "content"), IsOk());
+    if (i >= 6) {
+      expected_logs.push_back(path.substr(log_dir.size() + 1));
+    }
+  }
+
+  // Also create one non-log file to ensure it's not pruned
+  const std::string non_log = log_dir + "/not_a_log.txt";
+  ASSERT_THAT(WriteNewFile(non_log, "content"), IsOk());
+
+  ASSERT_THAT(PruneLogsDirectory(log_dir, 30), IsOk());
+
+  Result<std::vector<std::string>> remaining = DirectoryContents(log_dir);
+  ASSERT_THAT(remaining, IsOk());
+
+  EXPECT_TRUE(FileExists(non_log));
+  std::erase(*remaining, "not_a_log.txt");
+
+  EXPECT_EQ(remaining->size(), 30);
+  // Verify the remaining ones are the newest (i from 6 to 35)
+  std::sort(remaining->begin(), remaining->end());
+  std::sort(expected_logs.begin(), expected_logs.end());
+  EXPECT_EQ(*remaining, expected_logs);
+}
+
+}  // namespace
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/main.cc
@@ -199,6 +199,23 @@ std::string ColoredUrl(const std::string& url) {
   return output;
 }
 
+void InitializeLogs(std::vector<std::string>& all_args) {
+  LogSeverity verbosity = CvdVerbosityOption(all_args);
+  MetadataLevel metadata_level =
+      isatty(0) ? MetadataLevel::ONLY_MESSAGE : MetadataLevel::FULL;
+
+  std::vector<std::string> log_files;
+  if (EnsureDirectoryExists(CvdUserLogDir(), 0777).ok()) {
+    log_files.push_back(GetCvdLogFileName(CvdUserLogDir()));
+  } else {
+    std::cerr << "File logging disabled, could not create " << CvdUserLogDir()
+              << std::endl;
+  }
+  LogToStderrAndFiles(log_files, "", metadata_level, verbosity);
+
+  (void)PruneLogsDirectory(CvdUserLogDir());
+}
+
 }  // namespace
 
 }  // namespace cuttlefish
@@ -206,22 +223,11 @@ std::string ColoredUrl(const std::string& url) {
 int main(int argc, char** argv) {
   srand(time(NULL));
 
-  cuttlefish::cvd_common::Args all_args = cuttlefish::ArgsToVec(argc, argv);
-  cuttlefish::LogSeverity verbosity =
-      cuttlefish::CvdVerbosityOption(all_args);
-  // set verbosity for this process
-  cuttlefish::MetadataLevel metadata_level =
-      isatty(0) ? cuttlefish::MetadataLevel::ONLY_MESSAGE
-                : cuttlefish::MetadataLevel::FULL;
+  std::vector<std::string> all_args = cuttlefish::ArgsToVec(argc, argv);
 
-  std::optional<std::string> log_file = cuttlefish::GetCvdLogFile();
-  std::vector<std::string> log_files;
-  if (log_file) {
-    log_files.push_back(*log_file);
-  }
-  cuttlefish::LogToStderrAndFiles(log_files, "", metadata_level, verbosity);
+  cuttlefish::InitializeLogs(all_args);
 
-  auto result = cuttlefish::CvdMain(std::move(all_args));
+  cuttlefish::Result<void> result = cuttlefish::CvdMain(std::move(all_args));
   if (result.ok()) {
     return 0;
   } else {


### PR DESCRIPTION
- Introduces PruneLogsDirectory to keep only the 30 most recent log files in PerUserDir() + "/logs".
- Refactors log initialization in main.cc to call this pruning function during startup.
- Refactors GetCvdLogFile into GetCvdLogFileName returning std::string.
- Adds a test for PruneLogsDirectory.

Assisted-by: Jetski <jetski@google.com>
Bug: b/507600500