### PR TITLE
Map old commands at cvd into actively supported command in podcvd

### DIFF
--- a/container/src/podcvd/internal/parser.go
+++ b/container/src/podcvd/internal/parser.go
@@ -41,13 +41,17 @@ func ParseCvdArgs(allArgs []string) *CvdArgs {
 	fs.BoolVar(&commonArgs.Help, "help", false, "Print help message")
 	fs.StringVar(&commonArgs.Verbosity, "verbosity", "", "Verbosity level of the command")
 	fs.Parse(allArgs)
+	subcommandArgs := fs.Args()
+	if len(subcommandArgs) > 0 {
+		subcommandArgs[0] = mapSubcommand(subcommandArgs[0])
+	}
 	return &CvdArgs{
 		CommonArgs: &commonArgs,
 		// Golang's standard library 'flag' stops parsing just before the first
 		// non-flag argument. As the command 'cvd' expects only selector and driver
 		// options before the subcommand argument, 'subcommandArgs' should be empty
 		// or starting with subcommand name.
-		SubCommandArgs: fs.Args(),
+		SubCommandArgs: subcommandArgs,
 		flagSet:        fs,
 	}
 }
@@ -105,4 +109,20 @@ func (a *CvdArgs) GetStringFlagValueOnSubCommandArgs(flagName string) string {
 		}
 	}
 	return ""
+}
+
+func mapSubcommand(subcmd string) string {
+	aliases := map[string]string{
+		"fetch_cvd":          "fetch",
+		"host_bugreport":     "bugreport",
+		"cvd_host_bugreport": "bugreport",
+		"stop_cvd":           "stop",
+		"rm":                 "remove",
+		"launch_cvd":         "start",
+		"cvd_status":         "status",
+	}
+	if mapped, exists := aliases[subcmd]; exists {
+		return mapped
+	}
+	return subcmd
 }

--- a/container/src/podcvd/internal/util.go
+++ b/container/src/podcvd/internal/util.go
@@ -103,4 +103,3 @@ func readUserCidrFromConfig(username string) (string, error) {
 	}
 	return "", fmt.Errorf("user %q not found in /etc/podcvd.users", username)
 }
-


### PR DESCRIPTION
`podcvd help` just does execute `cvd help` from the container and print the output. There are some explanation around missing subcommands, however some aren't mapped properly. This may not be necessary as those seem to be deprecated, however add subcommand mapping logic in the beginning of `podcvd` when parsing the command to reduce differences between help message and actual behavior.

Context: b/491256959