### PR TITLE
feat: support dynamic bind mounting in podcvd

### DIFF
--- a/container/src/podcvd/internal/host.go
+++ b/container/src/podcvd/internal/host.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"log"
 	"math/rand"
 	"net"
 	"net/http"
@@ -37,11 +38,11 @@ import (
 	"github.com/docker/go-connections/nat"
 )
 
-func CreateCuttlefishHost(ccm libcfcontainer.CuttlefishContainerManager, commonArgs *CvdCommonArgs) error {
+func CreateCuttlefishHost(ccm libcfcontainer.CuttlefishContainerManager, cvdArgs *CvdArgs) error {
 	if err := pullContainerImage(ccm); err != nil {
 		return err
 	}
-	ip, err := createAndStartContainer(ccm, commonArgs)
+	ip, err := createAndStartContainer(ccm, cvdArgs)
 	if err != nil {
 		return err
 	}
@@ -245,7 +246,8 @@ func findAvailableGroupName(groupNameIpAddrMap map[string]string) string {
 	return fmt.Sprintf("%s%d", prefix, maxNum+1)
 }
 
-func createAndStartContainer(ccm libcfcontainer.CuttlefishContainerManager, commonArgs *CvdCommonArgs) (string, error) {
+func createAndStartContainer(ccm libcfcontainer.CuttlefishContainerManager, cvdArgs *CvdArgs) (string, error) {
+	commonArgs := cvdArgs.CommonArgs
 	attemptID := uuid.New().String()
 	containerCfg := &container.Config{
 		Env: []string{
@@ -304,6 +306,75 @@ func createAndStartContainer(ccm libcfcontainer.CuttlefishContainerManager, comm
 			PidsLimit: &pidsLimit,
 		},
 	}
+	// A set to prevent duplicate mounts
+	parseBind := func(bind string) (string, string) {
+		parts := strings.SplitN(bind, ":", 3)
+		if len(parts) < 2 {
+			return "", ""
+		}
+		return parts[0], parts[1]
+	}
+
+	bindSet := make(map[string]bool)
+	for _, bind := range containerHostCfg.Binds {
+		// Existing bind format is "hostPath:containerPath:options"
+		host, container := parseBind(bind)
+		if host != "" {
+			bindSet[host+":"+container] = true
+		} else {
+			log.Printf("warning: ignoring malformed bind: %q\n", bind)
+		}
+	}
+
+	for _, arg := range cvdArgs.SubCommandArgs {
+		path := arg
+		if strings.Contains(arg, "=") {
+			path = strings.SplitN(arg, "=", 2)[1]
+		}
+		
+		// 1. Filter out empty strings which would incorrectly mount the CWD
+		if strings.TrimSpace(path) == "" {
+			continue
+		}
+
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			continue
+		}
+		if _, err := os.Stat(absPath); err != nil {
+			continue
+		}
+		// Prevent mounting critical system directories
+		if strings.HasPrefix(absPath, "/dev/") || strings.HasPrefix(absPath, "/sys/") || strings.HasPrefix(absPath, "/proc/") {
+			continue
+		}
+
+		pathsToMount := []string{absPath}
+		
+		// 2. Resolve symlinks and track the target file to ensure it's accessible inside
+		if realPath, err := filepath.EvalSymlinks(absPath); err == nil && realPath != absPath {
+			pathsToMount = append(pathsToMount, realPath)
+		}
+
+		// 3. Add to mount configuration while preventing duplicates
+		for _, p := range pathsToMount {
+			key := fmt.Sprintf("%s:%s", p, p)
+			if !bindSet[key] {
+				pInfo, err := os.Stat(p)
+				if err != nil {
+					log.Printf("warning: failed to stat path %q to mount: %v\n", p, err)
+					continue
+				}
+				opt := "ro"
+				if pInfo.IsDir() {
+					opt = "O"
+				}
+				containerHostCfg.Binds = append(containerHostCfg.Binds, fmt.Sprintf("%s:%s:%s", p, p, opt))
+				bindSet[key] = true
+			}
+		}
+	}
+
 	var lastErr error
 	for retryCount := 0; retryCount < 10; retryCount++ {
 		groupNameIpAddrMap, err := Ipv4AddressesByGroupNames(ccm, true)

--- a/container/src/podcvd/internal/main.go
+++ b/container/src/podcvd/internal/main.go
@@ -106,7 +106,7 @@ func handleSubcommandsForSingleInstanceGroup(ccm libcfcontainer.CuttlefishContai
 	subcommand := cvdArgs.SubCommandArgs[0]
 	switch subcommand {
 	case "create":
-		if err := CreateCuttlefishHost(ccm, cvdArgs.CommonArgs); err != nil {
+		if err := CreateCuttlefishHost(ccm, cvdArgs); err != nil {
 			return err
 		}
 	default:


### PR DESCRIPTION
- Add heuristic parsing for dynamic host path resolution in cvd arguments.
- Handle edge-cases including symlinks and empty paths.
- Resolve duplicate mount bugs by tracking bind mapping with a composite "hostPath:containerPath" key.
- Optimize mount options by using Overlay (:O) for directories to allow Cuttlefish boot writes, and Read-Only (:ro) for files to bypass kernel/crun file overlay limits.
- Enhance parsing robustness to prevent panics on malformed bind strings and log unexpected path stat errors.