### PR TITLE
Set up shared library targets.

### DIFF
--- a/base/cvd/BUILD.bazel
+++ b/base/cvd/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:cc_import.bzl", "cc_import")
-load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 
 package_group(
     name = "android_cuttlefish",
@@ -77,4 +77,47 @@ cc_import(
     name = "gfxstream_backend_import",
     shared_library = ":gfxstream_backend",
     visibility = ["//visibility:public"],
+)
+
+cc_shared_library(
+    name = "absl_shared",
+    exports_filter = [
+        "@abseil-cpp//:__subpackages__",
+    ],
+    shared_lib_name = "libcuttlefish_absl.so",
+    deps = [
+        "@abseil-cpp//absl/base",
+        "@abseil-cpp//absl/cleanup",
+        "@abseil-cpp//absl/container:flat_hash_map",
+        "@abseil-cpp//absl/container:flat_hash_set",
+        "@abseil-cpp//absl/debugging:stacktrace",
+        "@abseil-cpp//absl/debugging:symbolize",
+        "@abseil-cpp//absl/flags:flag",
+        "@abseil-cpp//absl/flags:parse",
+        "@abseil-cpp//absl/hash",
+        "@abseil-cpp//absl/log",
+        "@abseil-cpp//absl/log:check",
+        "@abseil-cpp//absl/log:globals",
+        "@abseil-cpp//absl/log:initialize",
+        "@abseil-cpp//absl/numeric:int128",
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/strings:cord",
+        "@abseil-cpp//absl/strings:internal",
+        "@abseil-cpp//absl/strings:str_format",
+        "@abseil-cpp//absl/synchronization",
+        "@abseil-cpp//absl/time",
+    ],
+)
+
+cc_shared_library(
+    name = "fmt_shared",
+    exports_filter = [
+        "@fmt//:__subpackages__",
+    ],
+    shared_lib_name = "libcuttlefish_fmt.so",
+    deps = [
+        "@fmt",
+    ],
 )

--- a/base/cvd/build_variables.bzl
+++ b/base/cvd/build_variables.bzl
@@ -6,4 +6,6 @@ COPTS = [
 ]
 
 LINKOPTS = [
+    "-Wl,-rpath,$ORIGIN/../lib64",
+    "-Wl,-rpath,$ORIGIN/../lib",
 ]

--- a/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("//cuttlefish/bazel:rules.bzl", "cf_cc_library", "cf_cc_test")
 
 package(
@@ -14,6 +15,24 @@ cf_cc_library(
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/result",
+    ],
+)
+
+cc_shared_library(
+    name = "fs_shared",
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
+    shared_lib_name = "libcuttlefish_fs.so",
+    user_link_flags = [
+        "-Wl,-rpath,$ORIGIN/",
+    ],
+    deps = [
+        ":fs",
+        "//cuttlefish/common/libs/utils:environment",
+        "//cuttlefish/posix:strerror",
     ],
 )
 

--- a/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("//cuttlefish/bazel:rules.bzl", "cf_cc_library", "cf_cc_test")
 
 package(
@@ -102,6 +103,22 @@ cf_cc_test(
     deps = [
         ":environment",
         "@abseil-cpp//absl/cleanup",
+    ],
+)
+
+cc_shared_library(
+    name = "files_shared",
+    dynamic_deps = ["//cuttlefish/common/libs/fs:fs_shared"],
+    shared_lib_name = "libcuttlefish_files.so",
+    user_link_flags = [
+        "-Wl,-rpath,$ORIGIN/",
+    ],
+    deps = [
+        ":files",
+        ":users",
+        "//cuttlefish/common/libs/utils:in_sandbox",
+        "//cuttlefish/posix:rename",
+        "//cuttlefish/posix:symlink",
     ],
 )
 

--- a/base/cvd/cuttlefish/package/BUILD.bazel
+++ b/base/cvd/cuttlefish/package/BUILD.bazel
@@ -132,6 +132,12 @@ package_files(
         "cuttlefish-common/usr/share/webrtc/assets/js/gamepad.js": "//cuttlefish/host/frontend/webrtc/html_client:js/gamepad.js",
         "cuttlefish-common/usr/share/webrtc/assets/js/rootcanal.js": "//cuttlefish/host/frontend/webrtc/html_client:js/rootcanal.js",
         "cuttlefish-common/usr/share/webrtc/assets/js/touch.js": "//cuttlefish/host/frontend/webrtc/html_client:js/touch.js",
+        "cuttlefish-common/lib64/libcuttlefish_result.so": "//cuttlefish/result:result_shared",
+        "cuttlefish-common/lib64/libcuttlefish_files.so": "//cuttlefish/common/libs/utils:files_shared",
+        "cuttlefish-common/lib64/libcuttlefish_fs.so": "//cuttlefish/common/libs/fs:fs_shared",
+        "cuttlefish-common/lib64/libcuttlefish_libbase.so": "//libbase:libbase_shared",
+        "cuttlefish-common/lib64/libcuttlefish_absl.so": "//:absl_shared",
+        "cuttlefish-common/lib64/libcuttlefish_fmt.so": "//:fmt_shared",
     },
     visibility = ["//:android_cuttlefish"],
 )

--- a/base/cvd/cuttlefish/result/BUILD.bazel
+++ b/base/cvd/cuttlefish/result/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("//cuttlefish/bazel:rules.bzl", "cf_cc_library", "cf_cc_test")
 
 package(
@@ -24,6 +25,22 @@ cf_cc_library(
         "//libbase",
         "@abseil-cpp//absl/log",
         "@fmt",
+    ],
+)
+
+cc_shared_library(
+    name = "result_shared",
+    dynamic_deps = [
+        "//libbase:libbase_shared",
+        "//:absl_shared",
+    ],
+    shared_lib_name = "libcuttlefish_result.so",
+    user_link_flags = [
+        "-Wl,-rpath,$ORIGIN/",
+    ],
+    deps = [
+        ":error_type",
+        ":result",
     ],
 )
 

--- a/base/cvd/libbase/BUILD.bazel
+++ b/base/cvd/libbase/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
-
+load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("//:build_variables.bzl", "COPTS")
 
 package(
@@ -24,6 +24,20 @@ cc_library(
     copts = ["-D_POSIX_C_SOURCE=200112"],
     features = ["-use_header_modules"],
     visibility = ["//visibility:private"],
+)
+
+cc_shared_library(
+    name = "libbase_shared",
+    dynamic_deps = [
+        "//:fmt_shared",
+    ],
+    shared_lib_name = "libcuttlefish_libbase.so",
+    user_link_flags = [
+        "-Wl,-rpath,$ORIGIN/",
+    ],
+    deps = [
+        ":libbase",
+    ],
 )
 
 cc_library(


### PR DESCRIPTION
Here we create Bazel cc_shared_library targets for the result, libbase, files, and fs libraries. These were determined to have the most usages across all targets.

Since these libraries have external dependencies, they must be resolved by dynamic linkage as well. This necessitates creating some targets to facilitate this. We put this at top level rather than creating new directory structure, since we might want to adjust how this looks.

We also do the needful to ensure these libraries are packaged. This will incur a slight bit of bloat, but we'll perform the migration soon enough that this should be temporary and possibly not even noticed.