### PR TITLE
Use mirror.gcr.io rather than docker hub for pulling base image

### DIFF
--- a/container/image/Containerfile
+++ b/container/image/Containerfile
@@ -5,7 +5,7 @@
 ARG BUILD_OPTION=prod
 
 
-FROM debian:12 AS runner-base
+FROM mirror.gcr.io/library/debian:12 AS runner-base
 
 # Expose Operator Port (HTTP:1080, HTTPS:1443)
 EXPOSE 1080 1443

--- a/tools/buildutils/cw/Containerfile
+++ b/tools/buildutils/cw/Containerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-20250811 AS base
+FROM mirror.gcr.io/library/debian:bookworm-20250811 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/tools/testutils/cw/Containerfile
+++ b/tools/testutils/cw/Containerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-20250811 AS base
+FROM mirror.gcr.io/library/debian:bookworm-20250811 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV OVERRIDE_BAZEL_WRAPPER_DOWNLOAD_DIR=/tmp/cw_bazel


### PR DESCRIPTION
GitHub presubmit checks pull docker image to get debian base images for building debian packages or docker images. However, there was a [report](https://github.com/google/android-cuttlefish/actions/runs/26053502653/job/76608254031?pr=2563) that it failed to pull docker image because of the [rate limit of Docker Hub usage](https://docs.docker.com/docker-hub/usage/).

This PR aims for switching the source of image from Docker Hub into `mirror.gcr.io`, where doesn't limit the rate and more preferred source to download in Google I think.

Btw, GitHub presubmit check may need to have caches to download docker images. But, it's out of scope from this PR.

Context: b/514409720