### PR TITLE
Migrate to using shared libraries.

### DIFF
--- a/base/cvd/cuttlefish/common/frontend/socket_vsock_proxy/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/frontend/socket_vsock_proxy/BUILD.bazel
@@ -13,6 +13,11 @@ cf_cc_binary(
         "server.h",
         "socket_vsock_proxy.cpp",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:contains",

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -23,6 +23,13 @@ cf_cc_library(
 cf_cc_binary(
     name = "assemble_cvd",
     srcs = ["assemble_cvd.cc"],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/utils:files_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:contains",

--- a/base/cvd/cuttlefish/host/commands/casimir_control_server/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/casimir_control_server/BUILD.bazel
@@ -12,6 +12,12 @@ cf_cc_binary(
     srcs = [
         "main.cpp",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//:fmt_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         ":libcasimir",
         ":libcasimir_control_server",

--- a/base/cvd/cuttlefish/host/commands/console_forwarder/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/console_forwarder/BUILD.bazel
@@ -9,6 +9,11 @@ cf_cc_binary(
     srcs = [
         "main.cpp",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/host/commands/kernel_log_monitor:kernel_log_monitor_utils",

--- a/base/cvd/cuttlefish/host/commands/control_env_proxy_server/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/control_env_proxy_server/BUILD.bazel
@@ -33,6 +33,9 @@ cf_cc_binary(
     srcs = [
         "main.cpp",
     ],
+    dynamic_deps = [
+        "//cuttlefish/common/libs/utils:files_shared",
+    ],
     deps = [
         ":libcontrol_env_proxy_server",
         "//cuttlefish/common/libs/utils:files",

--- a/base/cvd/cuttlefish/host/commands/cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/BUILD.bazel
@@ -29,6 +29,12 @@ cf_cc_library(
 cf_cc_binary(
     name = "cvd",
     srcs = ["main.cc"],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/utils:files_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         ":libcvd",
         "//cuttlefish/common/libs/utils:environment",

--- a/base/cvd/cuttlefish/host/commands/cvd_env/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd_env/BUILD.bazel
@@ -9,6 +9,11 @@ cf_cc_binary(
     srcs = [
         "main.cc",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/utils:tee_logging",
         "//cuttlefish/host/libs/config:cuttlefish_config",

--- a/base/cvd/cuttlefish/host/commands/cvd_import_locations/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd_import_locations/BUILD.bazel
@@ -9,6 +9,11 @@ cf_cc_binary(
     srcs = [
         "main.cc",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:tee_logging",

--- a/base/cvd/cuttlefish/host/commands/cvd_send_id_disclosure/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd_send_id_disclosure/BUILD.bazel
@@ -9,6 +9,11 @@ cf_cc_binary(
     srcs = [
         "main.cc",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         ":libcvd_id_disclosure_builder",
         "//cuttlefish/common/libs/fs",

--- a/base/cvd/cuttlefish/host/commands/cvd_send_sms/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd_send_sms/BUILD.bazel
@@ -9,6 +9,11 @@ cf_cc_binary(
     srcs = [
         "main.cc",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         ":libcvd_send_sms",
         "//cuttlefish/common/libs/fs",

--- a/base/cvd/cuttlefish/host/commands/cvd_update_location/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd_update_location/BUILD.bazel
@@ -9,6 +9,10 @@ cf_cc_binary(
     srcs = [
         "main.cc",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/utils:tee_logging",
         "//cuttlefish/host/libs/config:cuttlefish_config",

--- a/base/cvd/cuttlefish/host/commands/cvd_update_security_algorithm/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd_update_security_algorithm/BUILD.bazel
@@ -9,6 +9,11 @@ cf_cc_binary(
     srcs = [
         "main.cc",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         ":libcvd_update_security_algorithm_builder",
         "//cuttlefish/common/libs/fs",

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/BUILD.bazel
@@ -48,6 +48,11 @@ cf_cc_binary(
     srcs = [
         "cvdalloc.cpp",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         ":interface",
         ":privilege",

--- a/base/cvd/cuttlefish/host/commands/defaults/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/defaults/BUILD.bazel
@@ -9,6 +9,11 @@ cf_cc_binary(
     srcs = [
         "defaults.cpp",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/key_equals_value",
         "//cuttlefish/host/libs/web/http_client:curl_http_client",

--- a/base/cvd/cuttlefish/host/commands/display/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/display/BUILD.bazel
@@ -9,6 +9,13 @@ cf_cc_binary(
     srcs = [
         "main.cpp",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/utils:files_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",

--- a/base/cvd/cuttlefish/host/commands/gnss_grpc_proxy/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/gnss_grpc_proxy/BUILD.bazel
@@ -12,6 +12,11 @@ cf_cc_binary(
     srcs = [
         "gnss_grpc_proxy.cpp",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         ":libcvd_gnss_grpc_proxy",
         "//cuttlefish/common/libs/fs",

--- a/base/cvd/cuttlefish/host/commands/health/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/health/BUILD.bazel
@@ -9,6 +9,10 @@ cf_cc_binary(
     srcs = [
         "health.cpp",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/utils:subprocess",
         "//cuttlefish/common/libs/utils:subprocess_managed_stdio",

--- a/base/cvd/cuttlefish/host/commands/host_bugreport/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/host_bugreport/BUILD.bazel
@@ -7,6 +7,13 @@ package(
 cf_cc_binary(
     name = "cvd_internal_host_bugreport",
     srcs = ["main.cc"],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/utils:files_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:environment",

--- a/base/cvd/cuttlefish/host/commands/kernel_log_monitor/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/kernel_log_monitor/BUILD.bazel
@@ -12,6 +12,11 @@ cf_cc_binary(
         "main.cc",
     ],
     clang_format_enabled = True,
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         ":kernel_log_monitor_utils",
         "//cuttlefish/common/libs/fs",

--- a/base/cvd/cuttlefish/host/commands/log_tee/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/log_tee/BUILD.bazel
@@ -9,6 +9,11 @@ cf_cc_binary(
     srcs = [
         "log_tee.cpp",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:tee_logging",

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/BUILD.bazel
@@ -9,6 +9,11 @@ cf_cc_binary(
     srcs = [
         "main.cpp",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/host/libs/config:config_instance_derived",

--- a/base/cvd/cuttlefish/host/commands/metrics/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/metrics/BUILD.bazel
@@ -51,6 +51,13 @@ cf_cc_binary(
         "host_receiver.h",
         "metrics.cc",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/utils:files_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",
@@ -129,6 +136,10 @@ cf_cc_binary(
     name = "metrics_transmitter",
     srcs = [
         "metrics_transmitter.cc",
+    ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/result:result_shared",
     ],
     deps = [
         "//cuttlefish/common/libs/utils:tee_logging",

--- a/base/cvd/cuttlefish/host/commands/metrics_launcher/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/metrics_launcher/BUILD.bazel
@@ -9,6 +9,11 @@ cf_cc_binary(
     srcs = [
         "metrics_launcher.cpp",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/utils:tee_logging",
         "//cuttlefish/host/libs/metrics",

--- a/base/cvd/cuttlefish/host/commands/mkenvimage_slim/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/mkenvimage_slim/BUILD.bazel
@@ -9,6 +9,11 @@ exports_files([".clang-tidy"])
 cf_cc_binary(
     name = "mkenvimage_slim",
     srcs = ["mkenvimage_slim.cc"],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/utils:tee_logging",
         "//cuttlefish/host/libs/config:mkenvimage_slim",

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/BUILD.bazel
@@ -162,6 +162,11 @@ cf_cc_binary(
     srcs = [
         "main.cpp",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:tee_logging",

--- a/base/cvd/cuttlefish/host/commands/openwrt_control_server/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/openwrt_control_server/BUILD.bazel
@@ -33,6 +33,13 @@ cf_cc_binary(
     srcs = [
         "main.cpp",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/utils:files_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         ":libopenwrt_control_server",
         "//cuttlefish/common/libs/utils:files",

--- a/base/cvd/cuttlefish/host/commands/powerbtn_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/powerbtn_cvd/BUILD.bazel
@@ -9,6 +9,11 @@ cf_cc_binary(
     srcs = [
         "powerbtn_cvd.cc",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:subprocess",

--- a/base/cvd/cuttlefish/host/commands/powerwash_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/powerwash_cvd/BUILD.bazel
@@ -9,6 +9,11 @@ cf_cc_binary(
     srcs = [
         "powerwash_cvd.cc",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:tee_logging",

--- a/base/cvd/cuttlefish/host/commands/process_restarter/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/process_restarter/BUILD.bazel
@@ -11,6 +11,11 @@ cf_cc_binary(
         "parser.cc",
         "parser.h",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:flag_parser",

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/BUILD.bazel
@@ -117,6 +117,9 @@ cf_cc_library(
 cf_cc_binary(
     name = "process_sandboxer",
     srcs = ["main.cpp"],
+    dynamic_deps = [
+        "//:absl_shared",
+    ],
     deps = [
         "//cuttlefish/host/commands/process_sandboxer:logs",
         "//cuttlefish/host/commands/process_sandboxer:pidfd",
@@ -181,6 +184,9 @@ cf_cc_library(
 cf_cc_binary(
     name = "sandboxer_proxy",
     srcs = ["sandboxer_proxy.cpp"],
+    dynamic_deps = [
+        "//:absl_shared",
+    ],
     deps = [
         "//cuttlefish/host/commands/process_sandboxer:proxy_common",
         "@abseil-cpp//absl/status",

--- a/base/cvd/cuttlefish/host/commands/record_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/record_cvd/BUILD.bazel
@@ -9,6 +9,11 @@ cf_cc_binary(
     srcs = [
         "record_cvd.cc",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/utils:tee_logging",
         "//cuttlefish/host/libs/config:cuttlefish_config",

--- a/base/cvd/cuttlefish/host/commands/restart_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/restart_cvd/BUILD.bazel
@@ -9,6 +9,11 @@ cf_cc_binary(
     srcs = [
         "restart_cvd.cc",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:tee_logging",

--- a/base/cvd/cuttlefish/host/commands/run_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/BUILD.bazel
@@ -53,6 +53,13 @@ cf_cc_library(
 cf_cc_binary(
     name = "run_cvd",
     srcs = ["main.cc"],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/utils:files_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:tee_logging",

--- a/base/cvd/cuttlefish/host/commands/screen_recording_server/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/screen_recording_server/BUILD.bazel
@@ -33,6 +33,11 @@ cf_cc_binary(
     srcs = [
         "main.cpp",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         ":libscreen_recording_server",
         "//cuttlefish/common/libs/fs",

--- a/base/cvd/cuttlefish/host/commands/secure_env/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/secure_env/BUILD.bazel
@@ -7,6 +7,11 @@ package(
 cf_cc_binary(
     name = "secure_env",
     srcs = ["secure_env_only_oemlock.cpp"],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         ":suspend_resume_handler",
         ":worker_thread_loop_body",

--- a/base/cvd/cuttlefish/host/commands/sensors_simulator/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/sensors_simulator/BUILD.bazel
@@ -45,6 +45,10 @@ cf_cc_binary(
     srcs = [
         "main.cpp",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         ":libsensors_hal_proxy",
         ":libsensors_simulator",

--- a/base/cvd/cuttlefish/host/commands/snapshot_util_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/snapshot_util_cvd/BUILD.bazel
@@ -13,6 +13,13 @@ cf_cc_binary(
         "snapshot_taker.cc",
         "snapshot_taker.h",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/utils:files_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:contains",

--- a/base/cvd/cuttlefish/host/commands/start/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/start/BUILD.bazel
@@ -17,6 +17,11 @@ cf_cc_binary(
         "validate_metrics_confirmation.cpp",
         "validate_metrics_confirmation.h",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//libbase:libbase_shared",
+    ],
     # `layering_check` conflicts with the combination of the clang prebuilt and
     # the cmake build rules used for @libxml2.
     features = ["-layering_check"],

--- a/base/cvd/cuttlefish/host/commands/status/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/status/BUILD.bazel
@@ -9,6 +9,12 @@ cf_cc_binary(
     srcs = [
         "main.cc",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",

--- a/base/cvd/cuttlefish/host/commands/stop/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/stop/BUILD.bazel
@@ -9,6 +9,13 @@ cf_cc_binary(
     srcs = [
         "main.cc",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/utils:files_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:environment",

--- a/base/cvd/cuttlefish/host/commands/tcp_connector/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/tcp_connector/BUILD.bazel
@@ -9,6 +9,11 @@ cf_cc_binary(
     srcs = [
         "main.cpp",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/host/libs/config:logging",

--- a/base/cvd/cuttlefish/host/commands/tombstone_receiver/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/tombstone_receiver/BUILD.bazel
@@ -9,6 +9,11 @@ cf_cc_binary(
     srcs = [
         "main.cpp",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:flag_parser",

--- a/base/cvd/cuttlefish/host/example_custom_actions/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/example_custom_actions/BUILD.bazel
@@ -15,6 +15,11 @@ cf_cc_binary(
     srcs = [
         "main.cpp",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/host/libs/config:cuttlefish_config",

--- a/base/cvd/cuttlefish/host/frontend/adb_connector/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/frontend/adb_connector/BUILD.bazel
@@ -11,6 +11,11 @@ cf_cc_binary(
         "adb_connection_maintainer.h",
         "main.cpp",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:environment",

--- a/base/cvd/cuttlefish/host/frontend/operator_proxy/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/frontend/operator_proxy/BUILD.bazel
@@ -7,6 +7,11 @@ package(
 cf_cc_binary(
     name = "operator_proxy",
     srcs = ["main.cpp"],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:socket2socket_proxy",

--- a/base/cvd/cuttlefish/host/frontend/webrtc/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/BUILD.bazel
@@ -314,6 +314,13 @@ cf_cc_binary(
     srcs = [
         "main.cpp",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+        "//cuttlefish/common/libs/fs:fs_shared",
+        "//cuttlefish/common/libs/utils:files_shared",
+        "//cuttlefish/result:result_shared",
+        "//libbase:libbase_shared",
+    ],
     deps = [
         ":libcuttlefish_webrtc_adb_handler",
         ":libcuttlefish_webrtc_audio_handler",

--- a/base/cvd/cuttlefish/host/graphics_detector/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/graphics_detector/BUILD.bazel
@@ -57,6 +57,9 @@ cf_cc_binary(
         "-DVULKAN_HPP_RAII_NO_EXCEPTIONS=1",
         "-Wno-module-import-in-extern-c",
     ],
+    dynamic_deps = [
+        "//:absl_shared",
+    ],
     deps = [
         ":graphics_detector_cc_proto",
         "//cuttlefish/host/graphics_detector/shaders:graphics_detector_shaders",

--- a/base/cvd/cuttlefish/result/BUILD.bazel
+++ b/base/cvd/cuttlefish/result/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("//cuttlefish/bazel:rules.bzl", "cf_cc_library", "cf_cc_test")
 
 package(
@@ -24,6 +25,23 @@ cf_cc_library(
         "//libbase",
         "@abseil-cpp//absl/log",
         "@fmt",
+    ],
+)
+
+cc_shared_library(
+    name = "result_shared",
+    dynamic_deps = [
+        "//libbase:libbase_shared",
+        "//:absl_shared",
+        "//:fmt_shared",
+    ],
+    shared_lib_name = "libcuttlefish_result.so",
+    user_link_flags = [
+        "-Wl,-rpath,$ORIGIN/",
+    ],
+    deps = [
+        ":error_type",
+        ":result",
     ],
 )
 


### PR DESCRIPTION
In #2573 we set up some new targets to build shared libraries. This commit migrates all binary targets with dependencies on //cuttlefish/result, //libbase, //cuttlefish/common/libs/fs:fs, and //cuttlefish/common/utils:files to use the shared library targets instead.

This results in the generated deb decreasing from 110M to 103M and the reported Installed-Size decreasing from 450179K to 414364K, a reduction of 35M. Actual on-disk build size has reduced from 2.4G to 2.2G. More aggressive reductions could likely be achieved by migrating other common libraries to shared libraries.

While we are here: we also ensure //cuttlefish/result has a dependency on fmt, to ensure that inline usages (like in casimir_control_server) correctly depend on fmt.