### PR TITLE
Replace `cvd load` with `cvd create --config_file` in e2etests

### DIFF
--- a/e2etests/cvd/common/common.go
+++ b/e2etests/cvd/common/common.go
@@ -285,13 +285,13 @@ func (tc *TestContext) CVDPowerwash() error {
 	return nil
 }
 
-// Common parameters for `cvd load`.
+// Common parameters for `cvd create --config_file`.
 type LoadArgs struct {
 	LoadConfig string
 }
 
-// Performs `cvd load`.
-func (tc *TestContext) CVDLoad(load LoadArgs) error {
+// Performs `cvd create --config_file`.
+func (tc *TestContext) CVDCreateWithConfigFile(load LoadArgs) error {
 	configpath := path.Join(tc.tempdir, "cvd_load_config.json")
 
 	log.Printf("Writing config to %s", configpath)
@@ -302,21 +302,21 @@ func (tc *TestContext) CVDLoad(load LoadArgs) error {
 		return err
 	}
 
-	log.Printf("Creating instance(s) via `cvd load`...")
+	log.Printf("Creating instance(s) via `cvd create --config_file`...")
 	loadCmd := []string{
 		tc.TargetBin(),
-		"load",
-		configpath,
+		"create",
+		"--config_file=" + configpath,
 	}
 	credentialArg := os.Getenv("CREDENTIAL_SOURCE")
 	if credentialArg != "" {
 		loadCmd = append(loadCmd, fmt.Sprintf("--credential_source=%s", credentialArg))
 	}
 	if _, err := tc.RunCmd(loadCmd...); err != nil {
-		log.Printf("Failed to perform `cvd load`: %w", err)
+		log.Printf("Failed to perform `cvd create --config_file`: %w", err)
 		return err
 	}
-	log.Printf("Created instance(s) via `cvd load`!")
+	log.Printf("Created instance(s) via `cvd create --config_file`!")
 
 	tc.Cleanup(func() { tc.CVDStop() })
 	return nil

--- a/e2etests/cvd/cvd_load_tests/main_test.go
+++ b/e2etests/cvd/cvd_load_tests/main_test.go
@@ -142,7 +142,7 @@ func TestCvdLoad(t *testing.T) {
 			c.SetUp(t)
 			defer c.TearDown()
 
-			err := c.CVDLoad(e2etests.LoadArgs{
+			err := c.CVDCreateWithConfigFile(e2etests.LoadArgs{
 				LoadConfig: tc.loadconfig,
 			})
 			if err != nil {

--- a/e2etests/cvd/logs_tests/main_test.go
+++ b/e2etests/cvd/logs_tests/main_test.go
@@ -63,7 +63,7 @@ func TestPrintLogs(t *testing.T) {
 }
 `
 
-	if err := c.CVDLoad(e2etests.LoadArgs{LoadConfig: env_config}); err != nil {
+	if err := c.CVDCreateWithConfigFile(e2etests.LoadArgs{LoadConfig: env_config}); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
`cvd load` is deprecated

Bug: 512983143
Test: `bazel build //cvd/cvd_load_tests:cvd_load_tests`