### PR TITLE
Remove udev rules for /dev/vhost-vsock and /dev/vhost-net

### DIFF
--- a/base/debian/cuttlefish-base.udev
+++ b/base/debian/cuttlefish-base.udev
@@ -1,5 +1,2 @@
-ACTION=="add", KERNEL=="vhost-net", SUBSYSTEM=="misc", MODE="0660", GROUP="cvdnetwork"
-ACTION=="add", KERNEL=="vhost-vsock", SUBSYSTEM=="misc", MODE="0660", GROUP="cvdnetwork"
-
 ACTION=="add", SUBSYSTEM=="net", ENV{ID_NET_DRIVER}=="cdc_ncm", ENV{ID_VENDOR_ID}=="18d1", ENV{ID_MODEL_ID}=="4ef2", ENV{NM_UNMANAGED}="1", RUN+="/sbin/ip link set dev $env{ID_NET_NAME} master cvd-ebr up"
 ACTION=="add", SUBSYSTEM=="net", ENV{ID_NET_DRIVER}=="cdc_ncm", ENV{ID_VENDOR_ID}=="18d1", ENV{ID_MODEL_ID}=="4ef3", ENV{NM_UNMANAGED}="1", RUN+="/sbin/ip link set dev $env{ID_NET_NAME} master cvd-ebr up"


### PR DESCRIPTION
In [PR #10 (2019)](https://www.github.com/google/android-cuttlefish/pull/10) we added a udev rule to put `/dev/vhost-vsock` in the `cvdnetwork` group. IIRC before that the `/dev/vhost-vsock` device was owned by both the `root` user and `root` group. systemd's
[PR #18214](https://github.com/systemd/systemd/pull/18214) (2021) added the `/dev/vhost-vsock` and `/dev/vhost-net` devices to the `kvm` group so we can probably drop our own udev rules now as we already require users to be in the `kvm` group.

Issue brought up by @0405ysj in the team notes.

Bug: b/514792751