### PR TITLE
Treat all monitored subprocesses as critical.

### DIFF
--- a/base/cvd/cuttlefish/host/libs/feature/command_source.h
+++ b/base/cvd/cuttlefish/host/libs/feature/command_source.h
@@ -30,7 +30,7 @@ struct MonitorCommand {
   Command command;
   bool is_critical;
 
-  MonitorCommand(Command command, bool is_critical = false)
+  MonitorCommand(Command command, bool is_critical = true)
       : command(std::move(command)), is_critical(is_critical) {}
 };
 


### PR DESCRIPTION
If we default monitored subprocesses to being noncritical, then when we do encounter a problem with a critical subprocess that isn't labeled as such, cvd will appear to hang/take forever. Therefore, it is better to assume all subprocesses as critical and be explicit about which ones aren't.

Even if we later introduce timeouts to ensure creations never hang forever, it is better that we be proactive and just abend.

Bug: 508320217