### PR TITLE
Handle AMD GPU + KVM bug check

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
@@ -323,6 +323,27 @@ cf_cc_library(
 )
 
 cf_cc_library(
+    name = "semver",
+    srcs = ["semver.cpp"],
+    hdrs = ["semver.h"],
+    deps = [
+        "//cuttlefish/result",
+        "//cuttlefish/result:expect",
+        "@abseil-cpp//absl/strings",
+    ],
+)
+
+cf_cc_test(
+    name = "semver_test",
+    srcs = ["semver_test.cpp"],
+    deps = [
+        "//cuttlefish/common/libs/utils:semver",
+        "//cuttlefish/result:result_matchers",
+        "//cuttlefish/result:result_type",
+    ],
+)
+
+cf_cc_library(
     name = "shared_fd_flag",
     srcs = ["shared_fd_flag.cpp"],
     hdrs = ["shared_fd_flag.h"],

--- a/base/cvd/cuttlefish/common/libs/utils/semver.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/semver.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/common/libs/utils/semver.h"
+
+#include <regex>
+
+#include "absl/strings/numbers.h"
+
+namespace cuttlefish {
+
+Result<SemVer> ParseSemVer(std::string_view str) {
+  // From
+  // https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string:
+  std::regex semver_regex(
+      R"(^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$)");
+
+  std::string_view::const_iterator begin = str.begin();
+  std::string_view::const_iterator end = str.end();
+  std::match_results<std::string_view::const_iterator> matches;
+  CF_EXPECT(std::regex_match(begin, end, matches, semver_regex),
+            "Failed to parse semver from " << str);
+
+  CF_EXPECT_EQ(matches.size(), 6);
+
+  SemVer semver;
+  CF_EXPECT(absl::SimpleAtoi(matches[1].str(), &semver.major),
+            "Failed to parse int from " << matches[1]);
+  CF_EXPECT(absl::SimpleAtoi(matches[2].str(), &semver.minor),
+            "Failed to parse int from " << matches[2]);
+  CF_EXPECT(absl::SimpleAtoi(matches[3].str(), &semver.patch),
+            "Failed to parse int from " << matches[3]);
+  semver.prerelease = matches[4].str();
+  semver.build_metadata = matches[5].str();
+  return semver;
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/semver.h
+++ b/base/cvd/cuttlefish/common/libs/utils/semver.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <string_view>
+
+#include "cuttlefish/result/result.h"
+
+namespace cuttlefish {
+
+struct SemVer {
+  int major;
+  int minor;
+  int patch;
+  std::string prerelease;
+  std::string build_metadata;
+};
+
+Result<SemVer> ParseSemVer(std::string_view str);
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/semver_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/semver_test.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "cuttlefish/common/libs/utils/semver.h"
+
+namespace cuttlefish {
+
+TEST(SemVer, ParseBasic) {
+  auto result = ParseSemVer("1.2.3");
+  ASSERT_TRUE(result.ok()) << result.error().Trace();
+  EXPECT_EQ(result->major, 1);
+  EXPECT_EQ(result->minor, 2);
+  EXPECT_EQ(result->patch, 3);
+  EXPECT_EQ(result->prerelease, "");
+  EXPECT_EQ(result->build_metadata, "");
+}
+
+TEST(SemVer, ParseWithPrereleaseAndMetadata) {
+  auto result = ParseSemVer("1.2.3-alpha.1+build.123");
+  ASSERT_TRUE(result.ok()) << result.error().Trace();
+  EXPECT_EQ(result->major, 1);
+  EXPECT_EQ(result->minor, 2);
+  EXPECT_EQ(result->patch, 3);
+  EXPECT_EQ(result->prerelease, "alpha.1");
+  EXPECT_EQ(result->build_metadata, "build.123");
+}
+
+TEST(SemVer, ParseInvalid) {
+  auto result = ParseSemVer("asdfsf");
+  EXPECT_FALSE(result.ok());
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -424,6 +424,8 @@ cf_cc_library(
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:files",
+        "//cuttlefish/common/libs/utils:host_info",
+        "//cuttlefish/common/libs/utils:semver",
         "//cuttlefish/common/libs/utils:subprocess",
         "//cuttlefish/common/libs/utils:subprocess_managed_stdio",
         "//cuttlefish/host/commands/assemble_cvd:guest_config",

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/graphics_flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/graphics_flags.cc
@@ -30,6 +30,8 @@
 
 #include "cuttlefish/common/libs/utils/contains.h"
 #include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/common/libs/utils/host_info.h"
+#include "cuttlefish/common/libs/utils/semver.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"
 #include "cuttlefish/common/libs/utils/subprocess_managed_stdio.h"
 #include "cuttlefish/host/graphics_detector/graphics_detector.pb.h"
@@ -52,12 +54,30 @@ namespace {
 struct CommonState {
   const VmmMode vmm_mode;
   const GuestConfig& guest_config;
+  const HostInfo host_info;
   const gfxstream::proto::GraphicsAvailability& graphics_availability;
 };
 
 bool IsLikelySoftwareRenderer(const std::string& renderer) {
   const std::string lower_renderer = absl::AsciiStrToLower(renderer);
   return lower_renderer.find("llvmpipe") != std::string::npos;
+}
+
+bool IsAmdGpu(const gfxstream::proto::GraphicsAvailability& availability) {
+  return (availability.has_egl() &&
+          ((availability.egl().has_gles2_availability() &&
+            availability.egl().gles2_availability().has_vendor() &&
+            availability.egl().gles2_availability().vendor().find("AMD") !=
+                std::string::npos) ||
+           (availability.egl().has_gles3_availability() &&
+            availability.egl().gles3_availability().has_vendor() &&
+            availability.egl().gles3_availability().vendor().find("AMD") !=
+                std::string::npos))) ||
+         (availability.has_vulkan() &&
+          !availability.vulkan().physical_devices().empty() &&
+          availability.vulkan().physical_devices(0).has_name() &&
+          availability.vulkan().physical_devices(0).name().find("AMD") !=
+              std::string::npos);
 }
 
 using MeetsRequirementFunc = std::function<bool(const CommonState& common)>;
@@ -71,7 +91,10 @@ struct RequirementWithReason {
 const std::unordered_map<GpuMode, std::vector<RequirementWithReason>>&
 GetGpuModeRequirementsMap() {
   const RequirementWithReason kHostIsNonArm{
-      .func = [](const CommonState&) { return HostArch() != Arch::Arm64; },
+      .func =
+          [](const CommonState& common) {
+            return common.host_info.arch != Arch::Arm64;
+          },
       .success_explanation = "The host is not ARM64.",
       .failure_explanation =
           "The host is ARM64. Not enabling accelerated modes on ARM64 until "
@@ -172,6 +195,30 @@ GetGpuModeRequirementsMap() {
           "Consider enabling --gpu_mode=gfxstream_guest_angle_host_swiftshader "
           "for host software rendering which has a vetted software renderer.",
   };
+  const RequirementWithReason kHostVulkanMemoryCanBeMappedIntoKvm{
+      .func =
+          [](const CommonState& common) {
+            // Issue only reported on AMD so far.
+            if (!IsAmdGpu(common.graphics_availability)) {
+              return true;
+            }
+
+            auto semver_result = ParseSemVer(common.host_info.release);
+            if (!semver_result.ok()) {
+              return false;
+            }
+            SemVer semver = *semver_result;
+            return semver.major >= 6 && semver.minor >= 13;
+          },
+      .success_explanation =
+          "The host's KVM should be able to map GPU memory into the guest.",
+      .failure_explanation =
+          "The host's KVM is likely unable to map GPU memory into the guest's "
+          "address space (see "
+          "https://lore.kernel.org/all/"
+          "20241010182427.1434605-1-seanjc@google.com/). "
+          "Please ensure your host release is at least 6.13.",
+  };
   static const auto* kGpuModeRequirements =
       new std::unordered_map<GpuMode, std::vector<RequirementWithReason>>{
           {
@@ -202,6 +249,7 @@ GetGpuModeRequirementsMap() {
                   kHostIsNonArm,
                   kHostVulkanAvailable,
                   kHostVulkanIsNonSoftwareRenderer,
+                  kHostVulkanMemoryCanBeMappedIntoKvm,
                   kNotUsingHostQemu,
               },
           },
@@ -452,6 +500,7 @@ Result<GpuMode> SelectGpuMode(
   const CommonState common = {
       .vmm_mode = vmm,
       .guest_config = guest_config,
+      .host_info = GetHostInfo(),
       .graphics_availability = graphics_availability,
   };
   if (gpu_mode_arg != GpuMode::Auto) {
@@ -558,23 +607,6 @@ Result<GuestRendererPreload> SelectGuestRendererPreload(
 
 #endif
 
-bool IsAmdGpu(const gfxstream::proto::GraphicsAvailability& availability) {
-  return (availability.has_egl() &&
-          ((availability.egl().has_gles2_availability() &&
-            availability.egl().gles2_availability().has_vendor() &&
-            availability.egl().gles2_availability().vendor().find("AMD") !=
-                std::string::npos) ||
-           (availability.egl().has_gles3_availability() &&
-            availability.egl().gles3_availability().has_vendor() &&
-            availability.egl().gles3_availability().vendor().find("AMD") !=
-                std::string::npos))) ||
-         (availability.has_vulkan() &&
-          !availability.vulkan().physical_devices().empty() &&
-          availability.vulkan().physical_devices(0).has_name() &&
-          availability.vulkan().physical_devices(0).name().find("AMD") !=
-              std::string::npos);
-}
-
 const std::string kGfxstreamTransportAsg = "virtio-gpu-asg";
 const std::string kGfxstreamTransportPipe = "virtio-gpu-pipe";
 
@@ -630,17 +662,6 @@ Result<void> SetGfxstreamFlags(
   // which introduced a backward incompatible change (b/267483000).
   if (guest_config.android_version_number == "11.0.0") {
     gfxstream_transport = kGfxstreamTransportPipe;
-  }
-
-  if (IsAmdGpu(availability)) {
-    // KVM does not support mapping host graphics buffers into the guest because
-    // the AMD GPU driver uses TTM memory. More info in
-    // https://lore.kernel.org/all/20230911021637.1941096-1-stevensd@google.com
-    //
-    // TODO(b/254721007): replace with a kernel version check after KVM patches
-    // land.
-    CF_EXPECT(gpu_mode != GpuMode::GfxstreamGuestAngle,
-              "--gpu_mode=gfxstream_guest_angle is broken on AMD GPUs.");
   }
 
   std::unordered_map<std::string, bool> features;


### PR DESCRIPTION
... so that the `--gpu_mode=gfxstream_guest_angle` mode will not be the preferred candidate only to error out later.

Bug: b/254721007