### PR TITLE
Revert "Treat all monitored subprocesses as critical."

### DIFF
--- a/base/cvd/cuttlefish/host/libs/feature/command_source.h
+++ b/base/cvd/cuttlefish/host/libs/feature/command_source.h
@@ -30,7 +30,7 @@ struct MonitorCommand {
   Command command;
   bool is_critical;
 
-  MonitorCommand(Command command, bool is_critical = true)
+  MonitorCommand(Command command, bool is_critical = false)
       : command(std::move(command)), is_critical(is_critical) {}
 };
 


### PR DESCRIPTION
Reverts google/android-cuttlefish#2592