### PR TITLE
run_cvd: Improve tap device validation error messages

### DIFF
--- a/base/cvd/allocd/BUILD.bazel
+++ b/base/cvd/allocd/BUILD.bazel
@@ -38,6 +38,7 @@ cc_library(
     }) + [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",
+        "//cuttlefish/common/libs/utils:network",
         "//cuttlefish/common/libs/utils:subprocess",
         "//cuttlefish/host/commands/cvd/utils:common",
         "//cuttlefish/host/libs/config:logging",

--- a/base/cvd/allocd/alloc_utils.cpp
+++ b/base/cvd/allocd/alloc_utils.cpp
@@ -28,6 +28,7 @@
 #include "absl/strings/str_format.h"
 
 #include "allocd/alloc_driver.h"
+#include "cuttlefish/common/libs/utils/network.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/commands/cvd/utils/common.h"
@@ -158,6 +159,11 @@ bool CreateTap(std::string_view name) {
 
 #ifdef __linux__
 Result<void> ValidateTapInterfaceIsUsable(const std::string& interface_name) {
+  CF_EXPECT(NetworkInterfaceExists(interface_name),
+             "Tap interface does not exist. Ensure "
+             "\"cuttlefish-host-resources.service\" is running (start with "
+             "\"sudo systemctl start cuttlefish-host-resources.service\").");
+
   constexpr auto kTunTapDev = "/dev/net/tun";
 
   auto tap_fd = SharedFD::Open(kTunTapDev, O_RDWR | O_NONBLOCK);
@@ -170,8 +176,8 @@ Result<void> ValidateTapInterfaceIsUsable(const std::string& interface_name) {
   strncpy(ifr.ifr_name, interface_name.c_str(), IFNAMSIZ);
 
   int err = tap_fd->Ioctl(TUNSETIFF, &ifr);
-  CF_EXPECTF(err == 0, "Unable to connect to {} tap interface: {}",
-             interface_name, tap_fd->StrError());
+  CF_EXPECTF(err == 0, "Unable to connect to tap interface: {}",
+             tap_fd->StrError());
 
   return {};
 }

--- a/base/cvd/cuttlefish/host/commands/run_cvd/validate.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/validate.cpp
@@ -41,12 +41,11 @@ static Result<void> TestTapDevices(
     return {};
   }
   auto wifi = instance.wifi_tap_name();
-  CF_EXPECTF(ValidateTapInterfaceIsUsable(wifi), "Device \"{}\" in use", wifi);
+  CF_EXPECTF(ValidateTapInterfaceIsUsable(wifi), "Failed to validate tap interface: {}", wifi);
   auto mobile = instance.mobile_tap_name();
-  CF_EXPECTF(ValidateTapInterfaceIsUsable(mobile), "Device \"{}\" in use",
-             mobile);
+  CF_EXPECTF(ValidateTapInterfaceIsUsable(mobile), "Failed to validate tap interface: {}", mobile);
   auto eth = instance.ethernet_tap_name();
-  CF_EXPECTF(ValidateTapInterfaceIsUsable(eth), "Device \"{}\" in use", eth);
+  CF_EXPECTF(ValidateTapInterfaceIsUsable(eth), "Failed to validate tap interface: {}", eth);
 #else
   (void)instance;
 #endif
@@ -56,9 +55,7 @@ static Result<void> TestTapDevices(
 Result<void> ValidateTapDevices(
     const CuttlefishConfig::InstanceSpecific& instance) {
   CF_EXPECT(TestTapDevices(instance),
-            "There appears to be another cuttlefish device"
-            " already running, using the requested host "
-            "resources. Try `cvd reset` or `pkill run_cvd` "
+            "Failed to validate tap devices. Try `cvd reset` or `pkill run_cvd` "
             "and `pkill crosvm`");
   return {};
 }


### PR DESCRIPTION
Refactor ValidateTapInterfaceUnused to check if the interface exists first, avoiding misleading "Operation not permitted" errors when the device simply does not exist.

Update ValidateTapDevices to remove the assumption that another device is running, while keeping the actionable suggestions (cvd reset, pkill).

Also remove redundant "Device in use" messages in TestTapDevices to keep logs terse.

Bug: 512536991
Test: Built it with a intentionally incorrect interface name, ensured
      output stated interface did not exist instead of a misleading error