### PR TITLE
Don't ask to choose groups on `cvd help start`

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -526,14 +526,8 @@ Result<std::string> CvdStartCommandHandler::DetailedHelp(
   std::vector<Flag> own_flags = BuildOwnFlags();
   CF_EXPECT(ConsumeFlags(own_flags, args));
 
-  cvd_common::Envs envs = request.Env();
-  Result<LocalInstanceGroup> group_res =
-      selector::SelectGroup(instance_manager_, request);
-  if (group_res.ok()) {
-    envs["HOME"] = group_res.value().HomeDir();
-  }
-  std::vector<Flag> internal_flags =
-      CF_EXPECT(GetCvdInternalStartFlags(request.SubcommandArguments(), envs));
+  std::vector<Flag> internal_flags = CF_EXPECT(GetCvdInternalStartFlags(
+      request.SubcommandArguments(), request.Env()));
 
   std::vector<Flag> flags = std::move(own_flags);
   flags.insert(flags.end(), internal_flags.begin(), internal_flags.end());

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -527,7 +527,7 @@ Result<std::string> CvdStartCommandHandler::DetailedHelp(
   CF_EXPECT(ConsumeFlags(own_flags, args));
 
   std::vector<Flag> internal_flags = CF_EXPECT(GetCvdInternalStartFlags(
-      request.SubcommandArguments(), request.Env()));
+      request.SubcommandArguments(), cvd_common::Envs()));
 
   std::vector<Flag> flags = std::move(own_flags);
   flags.insert(flags.end(), internal_flags.begin(), internal_flags.end());


### PR DESCRIPTION
Don't attempt to select a group for `cvd help start` to avoid showing a prompt to the user and run `cvd_internal_start --help` with an empty environment.

The help output most likely to be accurate is the one produced by the binaries in /usr/lib/cuttlefish-common/bin because of host binaries substitution. Running cvd_internal_start without environment variables defined ensures those binaries are executed even when in an Android source tree.

Bug: b/515822938