### PR TITLE
cvd: Better help for load and start subcommands

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/flag_parser.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/flag_parser.cpp
@@ -425,10 +425,10 @@ std::ostream& operator<<(std::ostream& out, const Flag& flag) {
   }
   out << "\n";
   if (flag.help_) {
-    out << "  " << *flag.help_ << "\n";
+    out <<  *flag.help_ << "\n";
   }
   if (flag.getter_) {
-    out << "  Current value: \"" << (*flag.getter_)() << "\"\n";
+    out << "Current value: \"" << (*flag.getter_)() << "\"\n";
   }
   return out;
 }

--- a/base/cvd/cuttlefish/common/libs/utils/flag_parser.h
+++ b/base/cvd/cuttlefish/common/libs/utils/flag_parser.h
@@ -95,6 +95,7 @@ class Flag {
   Flag AddValidator(std::function<Result<void>()>) &&;
 
   const std::string& Name() const { return name_; }
+  bool operator<(const Flag& other) const { return Name() < other.Name(); }
 
   /* Examines a list of arguments, removing any matches from the list and
    * invoking the `Setter` for every match. Returns `false` if the callback ever

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
@@ -41,6 +41,18 @@ cf_cc_test(
 )
 
 cf_cc_library(
+    name = "help_format",
+    srcs = ["help_format.cpp"],
+    hdrs = ["help_format.h"],
+    deps = [
+        "//cuttlefish/common/libs/utils:flag_parser",
+        "@abseil-cpp//absl/log",
+        "@abseil-cpp//absl/log:check",
+        "@abseil-cpp//absl/strings",
+    ],
+)
+
+cf_cc_library(
     name = "interruptible_terminal",
     srcs = ["interruptible_terminal.cpp"],
     hdrs = ["interruptible_terminal.h"],

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
@@ -116,6 +116,7 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:subprocess",
         "//cuttlefish/common/libs/utils:users",
         "//cuttlefish/host/commands/cvd/cli:command_request",
+        "//cuttlefish/host/commands/cvd/cli:help_format",
         "//cuttlefish/host/commands/cvd/cli:types",
         "//cuttlefish/host/commands/cvd/cli/commands:bugreport",
         "//cuttlefish/host/commands/cvd/cli/commands:cache",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
@@ -82,13 +82,12 @@ cf_cc_library(
     srcs = ["command_handler.cpp"],
     hdrs = ["command_handler.h"],
     deps = [
-        "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:flag_parser",
         "//cuttlefish/host/commands/cvd/cli:command_request",
+        "//cuttlefish/host/commands/cvd/cli:help_format",
         "//cuttlefish/host/commands/cvd/cli:types",
         "//cuttlefish/host/commands/cvd/cli/selector:selector_common_parser",
         "//cuttlefish/result",
-        "@abseil-cpp//absl/strings",
     ],
 )
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
@@ -198,7 +198,7 @@ cf_cc_library(
     srcs = ["lint.cpp"],
     hdrs = ["lint.h"],
     deps = [
-        "//cuttlefish/common/libs/utils:files",
+        "//cuttlefish/common/libs/utils:flag_parser",
         "//cuttlefish/host/commands/cvd/cli:command_request",
         "//cuttlefish/host/commands/cvd/cli:types",
         "//cuttlefish/host/commands/cvd/cli/commands:command_handler",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
@@ -427,6 +427,7 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:subprocess_managed_stdio",
         "//cuttlefish/common/libs/utils:users",
         "//cuttlefish/host/commands/cvd/cli:command_request",
+        "//cuttlefish/host/commands/cvd/cli:help_format",
         "//cuttlefish/host/commands/cvd/cli:types",
         "//cuttlefish/host/commands/cvd/cli:utils",
         "//cuttlefish/host/commands/cvd/cli/commands:command_handler",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
@@ -83,9 +83,12 @@ cf_cc_library(
     hdrs = ["command_handler.h"],
     deps = [
         "//cuttlefish/common/libs/utils:contains",
+        "//cuttlefish/common/libs/utils:flag_parser",
         "//cuttlefish/host/commands/cvd/cli:command_request",
         "//cuttlefish/host/commands/cvd/cli:types",
+        "//cuttlefish/host/commands/cvd/cli/selector:selector_common_parser",
         "//cuttlefish/result",
+        "@abseil-cpp//absl/strings",
     ],
 )
 
@@ -430,7 +433,6 @@ cf_cc_library(
         "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
         "//cuttlefish/host/commands/cvd/cli/commands:host_tool_target",
         "//cuttlefish/host/commands/cvd/cli/selector",
-        "//cuttlefish/host/commands/cvd/cli/selector:selector_common_parser",
         "//cuttlefish/host/commands/cvd/fetch:substitute",
         "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/commands/cvd/instances:cvd_persistent_data",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/command_handler.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/command_handler.cpp
@@ -16,8 +16,127 @@
 
 #include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 
+#include <stddef.h>
+
+#include <algorithm>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "absl/strings/str_join.h"
+#include "absl/strings/str_split.h"
+
+#include "cuttlefish/common/libs/utils/flag_parser.h"
+#include "cuttlefish/host/commands/cvd/cli/command_request.h"
+#include "cuttlefish/host/commands/cvd/cli/selector/selector_common_parser.h"
+#include "cuttlefish/host/commands/cvd/cli/types.h"
+#include "cuttlefish/result/result.h"
+
 namespace cuttlefish {
+namespace {
+
+constexpr size_t kMaxLineLength = 80;
+
+std::vector<std::string> WrapAroundLine(
+    std::string_view str, size_t max_line_length = kMaxLineLength) {
+  std::vector<std::string> ret;
+  std::vector<std::string_view> words = absl::StrSplit(str, ' ');
+  size_t total_word_sizes = 0;
+  std::vector<std::string_view> line;
+  for (std::string_view word : words) {
+    // line.size() accounts for the spaces added when joining the words.
+    if (total_word_sizes + word.size() + line.size() >= max_line_length) {
+      // If the line is empty at this point it means the current word is too
+      // long, it will be added to the line anyways and printed on its own in
+      // the next iteration.
+      if (!line.empty()) {
+        ret.push_back(absl::StrJoin(line, " "));
+      }
+      total_word_sizes = 0;
+      line.clear();
+    }
+    total_word_sizes += word.size();
+    line.push_back(word);
+  }
+  if (!line.empty()) {
+    // Print the last line
+    ret.push_back(absl::StrJoin(line, " "));
+  }
+  return ret;
+}
+
+}  // namespace
 
 bool CvdCommandHandler::RequiresDeviceExists() const { return false; }
+
+std::vector<std::string> CvdCommandHandler::Description() const { return {}; }
+
+Result<std::vector<Flag>> CvdCommandHandler::Flags(const CommandRequest&) {
+  return {};
+}
+
+Result<std::string> CvdCommandHandler::DetailedHelp(
+    const CommandRequest& request) {
+  std::stringstream ss;
+  std::vector<std::string> cmd_list = CmdList();
+  CF_EXPECT(!cmd_list.empty(), "Command aliases list is empty");
+
+  ss << "cvd " << cmd_list[0] << " - " << SummaryHelp() << "\n";
+  ss << "\n";
+  for (const std::string& paragraph : Description()) {
+    for (std::string_view line : WrapAroundLine(paragraph)) {
+      ss << line << "\n";
+    }
+    // Empty line after paragraphs
+    ss << "\n";
+  }
+
+  std::vector<Flag> flags = CF_EXPECT(Flags(request));
+  // Consume flags to ensure "current value" is accurate
+  cvd_common::Args args = request.SubcommandArguments();
+
+  CF_EXPECT(ConsumeFlags(flags, args));
+  selector::SelectorOptions selector_options = request.Selectors();
+  if (RequiresDeviceExists()) {
+    // Add the common selector flags if the command supports them. This doesn't
+    // need to hapen before consuming as the selector flags were consumed
+    // already. Using the selectors from the request ensures the flags's
+    // "current value" is correct.
+    std::vector<Flag> selector_flags =
+        selector::BuildCommonSelectorFlags(selector_options);
+    flags.insert(flags.end(), selector_flags.begin(), selector_flags.end());
+  }
+
+  // Make sure the flags are in alphabetical order
+  std::sort(flags.begin(), flags.end());
+
+  for (const Flag& flag : flags) {
+    std::stringstream ss2;
+    ss2 << flag;
+    std::string flag_help = ss2.str();
+    std::vector<std::string_view> flag_help_lines =
+        absl::StrSplit(flag_help, '\n');
+    bool first_line = true;
+    for (std::string_view& line : flag_help_lines) {
+      if (line.empty()) {
+        continue;
+      }
+      if (first_line) {
+        // The first line contains the --flag=value examples, don't indent or
+        // wrap those.
+        ss << line << "\n";
+        first_line = false;
+      } else {
+        for (std::string_view l : WrapAroundLine(line, kMaxLineLength - 4)) {
+          ss << "    " << l << "\n";
+        }
+      }
+    }
+    ss << "\n";
+  }
+
+  return ss.str();
+}
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/command_handler.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/command_handler.cpp
@@ -21,52 +21,16 @@
 #include <algorithm>
 #include <sstream>
 #include <string>
-#include <string_view>
 #include <vector>
-
-#include "absl/strings/str_join.h"
-#include "absl/strings/str_split.h"
 
 #include "cuttlefish/common/libs/utils/flag_parser.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
+#include "cuttlefish/host/commands/cvd/cli/help_format.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector_common_parser.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
-namespace {
-
-constexpr size_t kMaxLineLength = 80;
-
-std::vector<std::string> WrapAroundLine(
-    std::string_view str, size_t max_line_length = kMaxLineLength) {
-  std::vector<std::string> ret;
-  std::vector<std::string_view> words = absl::StrSplit(str, ' ');
-  size_t total_word_sizes = 0;
-  std::vector<std::string_view> line;
-  for (std::string_view word : words) {
-    // line.size() accounts for the spaces added when joining the words.
-    if (total_word_sizes + word.size() + line.size() >= max_line_length) {
-      // If the line is empty at this point it means the current word is too
-      // long, it will be added to the line anyways and printed on its own in
-      // the next iteration.
-      if (!line.empty()) {
-        ret.push_back(absl::StrJoin(line, " "));
-      }
-      total_word_sizes = 0;
-      line.clear();
-    }
-    total_word_sizes += word.size();
-    line.push_back(word);
-  }
-  if (!line.empty()) {
-    // Print the last line
-    ret.push_back(absl::StrJoin(line, " "));
-  }
-  return ret;
-}
-
-}  // namespace
 
 bool CvdCommandHandler::RequiresDeviceExists() const { return false; }
 
@@ -84,19 +48,13 @@ Result<std::string> CvdCommandHandler::DetailedHelp(
 
   ss << "cvd " << cmd_list[0] << " - " << SummaryHelp() << "\n";
   ss << "\n";
-  for (const std::string& paragraph : Description()) {
-    for (std::string_view line : WrapAroundLine(paragraph)) {
-      ss << line << "\n";
-    }
-    // Empty line after paragraphs
-    ss << "\n";
-  }
+  ss << FormatHelpText(Description());
 
   std::vector<Flag> flags = CF_EXPECT(Flags(request));
   // Consume flags to ensure "current value" is accurate
   cvd_common::Args args = request.SubcommandArguments();
-
   CF_EXPECT(ConsumeFlags(flags, args));
+
   selector::SelectorOptions selector_options = request.Selectors();
   if (RequiresDeviceExists()) {
     // Add the common selector flags if the command supports them. This doesn't
@@ -111,30 +69,7 @@ Result<std::string> CvdCommandHandler::DetailedHelp(
   // Make sure the flags are in alphabetical order
   std::sort(flags.begin(), flags.end());
 
-  for (const Flag& flag : flags) {
-    std::stringstream ss2;
-    ss2 << flag;
-    std::string flag_help = ss2.str();
-    std::vector<std::string_view> flag_help_lines =
-        absl::StrSplit(flag_help, '\n');
-    bool first_line = true;
-    for (std::string_view& line : flag_help_lines) {
-      if (line.empty()) {
-        continue;
-      }
-      if (first_line) {
-        // The first line contains the --flag=value examples, don't indent or
-        // wrap those.
-        ss << line << "\n";
-        first_line = false;
-      } else {
-        for (std::string_view l : WrapAroundLine(line, kMaxLineLength - 4)) {
-          ss << "    " << l << "\n";
-        }
-      }
-    }
-    ss << "\n";
-  }
+  ss << FormatFlagsHelp(flags);
 
   return ss.str();
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/command_handler.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/command_handler.cpp
@@ -34,7 +34,7 @@ namespace cuttlefish {
 
 bool CvdCommandHandler::RequiresDeviceExists() const { return false; }
 
-std::vector<std::string> CvdCommandHandler::Description() const { return {}; }
+std::vector<HelpParagraph> CvdCommandHandler::Description() const { return {}; }
 
 Result<std::vector<Flag>> CvdCommandHandler::Flags(const CommandRequest&) {
   return {};

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/command_handler.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/command_handler.h
@@ -20,6 +20,7 @@
 
 #include "cuttlefish/common/libs/utils/flag_parser.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
+#include "cuttlefish/host/commands/cvd/cli/help_format.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/result/result.h"
 
@@ -36,12 +37,7 @@ class CvdCommandHandler {
   virtual std::string SummaryHelp() const = 0;
   virtual bool RequiresDeviceExists() const;
   virtual Result<std::string> DetailedHelp(const CommandRequest&);
-  // Each string returned by Description() is treated as a paragraph. The
-  // default implementation of DetailedHelp will visually separate each
-  // paragraph. That implementation will also split each paragraph in lines not
-  // longer than 80 characters, so implementations of Description() don't need
-  // to (and probably shouldn't) use line breaks for formatting.
-  virtual std::vector<std::string> Description() const;
+  virtual std::vector<HelpParagraph> Description() const;
   virtual Result<std::vector<Flag>> Flags(const CommandRequest&);
 
   virtual bool RequiresHostConfiguration() const { return true; }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/command_handler.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/command_handler.h
@@ -18,6 +18,7 @@
 
 #include <string>
 
+#include "cuttlefish/common/libs/utils/flag_parser.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/result/result.h"
@@ -34,8 +35,16 @@ class CvdCommandHandler {
   // used for command help text
   virtual std::string SummaryHelp() const = 0;
   virtual bool RequiresDeviceExists() const;
+  virtual Result<std::string> DetailedHelp(const CommandRequest&);
+  // Each string returned by Description() is treated as a paragraph. The
+  // default implementation of DetailedHelp will visually separate each
+  // paragraph. That implementation will also split each paragraph in lines not
+  // longer than 80 characters, so implementations of Description() don't need
+  // to (and probably shouldn't) use line breaks for formatting.
+  virtual std::vector<std::string> Description() const;
+  virtual Result<std::vector<Flag>> Flags(const CommandRequest&);
+
   virtual bool RequiresHostConfiguration() const { return true; }
-  virtual Result<std::string> DetailedHelp(const CommandRequest&) = 0;
 };
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/lint.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/lint.cpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <vector>
 
-#include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/common/libs/utils/flag_parser.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.h"
@@ -47,8 +47,7 @@ Usage: cvd lint /path/to/input.json
 
 Result<void> LintCommandHandler::Handle(const CommandRequest& request) {
   std::vector<std::string> args = request.SubcommandArguments();
-  auto working_directory = CurrentDirectory();
-  const auto config_path = CF_EXPECT(ValidateConfig(args, working_directory));
+  const auto config_path = CF_EXPECT(ValidateConfig(args));
 
   std::cout << "Lint of flags and config \"" << config_path << "\" succeeded\n";
 
@@ -65,10 +64,17 @@ Result<std::string> LintCommandHandler::DetailedHelp(
 }
 
 Result<std::string> LintCommandHandler::ValidateConfig(
-    std::vector<std::string>& args, const std::string& working_directory) {
-  const LoadFlags flags = CF_EXPECT(GetFlags(args, working_directory));
-  CF_EXPECT(GetEnvironmentSpecification(flags));
-  return flags.config_path;
+    std::vector<std::string>& args) {
+  LoadFlags load_flags;
+  std::vector<Flag> flags = BuildCvdLoadFlags(load_flags);
+  CF_EXPECT(ConsumeFlags(flags, args));
+  CF_EXPECT(
+      !args.empty(),
+      "No arguments provided to cvd command, please provide path to json file");
+  std::string& config_path = args.front();
+  CF_EXPECT(ValidateCvdLoadFlags(load_flags));
+  CF_EXPECT(GetEnvironmentSpecification(config_path, load_flags.overrides));
+  return config_path;
 }
 
 std::unique_ptr<CvdCommandHandler> NewLintCommand() {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/lint.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/lint.cpp
@@ -72,7 +72,6 @@ Result<std::string> LintCommandHandler::ValidateConfig(
       !args.empty(),
       "No arguments provided to cvd command, please provide path to json file");
   std::string& config_path = args.front();
-  CF_EXPECT(ValidateCvdLoadFlags(load_flags));
   CF_EXPECT(GetEnvironmentSpecification(config_path, load_flags.overrides));
   return config_path;
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/lint.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/lint.h
@@ -34,8 +34,7 @@ class LintCommandHandler : public CvdCommandHandler {
   Result<std::string> DetailedHelp(const CommandRequest& request) override;
 
  private:
-  Result<std::string> ValidateConfig(std::vector<std::string>& args,
-                                     const std::string& working_directory);
+  Result<std::string> ValidateConfig(std::vector<std::string>& args);
 };
 
 std::unique_ptr<CvdCommandHandler> NewLintCommand();

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.cpp
@@ -27,10 +27,12 @@
 #include "absl/log/log.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/common/libs/utils/flag_parser.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/fetch.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/start.h"
+#include "cuttlefish/host/commands/cvd/cli/help_format.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/load_config.pb.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector_common_parser.h"
@@ -52,26 +54,8 @@ namespace {
 constexpr char kLoadSubCmd[] = "load";
 
 constexpr char kSummaryHelpText[] =
-    R"(Loads the given JSON configuration file and launches devices based on the options provided)";
+    "Creates and starts an instance group from a JSON configuration file";
 
-constexpr char kDetailedHelpText[] = R"(
-Warning: This command is deprecated, use cvd create --config_file instead.
-
-Usage:
-cvd load <config_filepath> [--override=<key>:<value>]
-
-Reads the fields in the JSON configuration file and translates them to corresponding start command and flags.
-
-Optionally fetches remote artifacts prior to launching the cuttlefish environment.
-
-The --override flag can be used to give new values for properties in the config file without needing to edit the file directly.  Convenient for one-off invocations.
-)";
-
-Result<LoadFlags> GetLoadFlags(const CommandRequest& request) {
-  std::vector<std::string> args = request.SubcommandArguments();
-  auto working_directory = CurrentDirectory();
-  return CF_EXPECT(GetFlags(args, working_directory));
-}
 
 Result<CommandRequest> BuildFetchCmd(const CommandRequest& request,
                                      const CvdFlags& cvd_flags) {
@@ -133,9 +117,17 @@ LoadConfigsCommand::LoadConfigsCommand(InstanceManager& instance_manager)
     : instance_manager_(instance_manager) {}
 
 Result<void> LoadConfigsCommand::Handle(const CommandRequest& request) {
-  LoadFlags load_flags = CF_EXPECT(GetLoadFlags(request));
+  std::vector<std::string> args = request.SubcommandArguments();
+  std::vector<Flag> flags = CF_EXPECT(Flags(request));
+  CF_EXPECT(ConsumeFlags(flags, args));
+  CF_EXPECT(
+      !args.empty(),
+      "No arguments provided to cvd command, please provide path to json file");
+  std::string& config_path = args.front();
+  CF_EXPECT(ValidateCvdLoadFlags(flags_));
+
   EnvironmentSpecification env_spec =
-      CF_EXPECT(GetEnvironmentSpecification(load_flags));
+      CF_EXPECT(GetEnvironmentSpecification(config_path, flags_.overrides));
 
   std::mutex group_creation_mtx;
   // Have to use the group name because LocalInstanceGroup can't be default
@@ -181,7 +173,7 @@ Result<void> LoadConfigsCommand::Handle(const CommandRequest& request) {
   group_creation_mtx.lock();
   // Don't use CF_EXPECT here or the mutex will be left locked.
   auto group_res =
-      CreateGroup(instance_manager_, load_flags.base_dir, env_spec);
+      CreateGroup(instance_manager_, flags_.base_dir, env_spec);
   if (group_res.ok()) {
     // Have to initialize the group_name variable before releasing the mutex.
     group_name = (*group_res).GroupName();
@@ -250,9 +242,71 @@ cvd_common::Args LoadConfigsCommand::CmdList() const { return {kLoadSubCmd}; }
 
 std::string LoadConfigsCommand::SummaryHelp() const { return kSummaryHelpText; }
 
-Result<std::string> LoadConfigsCommand::DetailedHelp(
+std::vector<std::string> LoadConfigsCommand::Description() const {
+  return {
+      "This command is an alias of `cvd create --config_file=<config_filepath> "
+      "[--override=<key>:<value>]...`, provided for convenience and backwards "
+      "compatibility.",
+
+      "Usage:",
+
+      "    cvd load <config_filepath> [--override=<key>:<value>]",
+
+      "Creates and starts a new instance group from a specification file. An "
+      "example specification file looks like:",
+
+      MarkAsRawText(R"(  {
+    "instances": [
+      {
+        "name": "ins-1",
+        "disk": {
+          "default_build": "@ab/aosp-android-latest-release/aosp_cf_x86_64_only_phone-userdebug"
+        },
+        "vm": {
+          "cpus": 8,
+          "memory_mb": 2048
+        }
+      },
+      {
+        "name": "ins-2",
+        "disk": {
+          "default_build": "/path/to/android/build"
+        }
+      }
+    ]
+  })"),
+
+      "A complete reference of the specification file format can be found in "
+      "https://github.com/google/android-cuttlefish/blob/main/base/cvd/"
+      "cuttlefish/host/commands/cvd/cli/parser/load_config.proto.",
+
+      "While most config file properties are self explanatory, the build "
+      "properties (default_build, kernel.build, bootloader.build, etc) require "
+      "more explanation. These properties support two types of values:",
+
+      MarkAsRawText(
+          R"( - "@ab/<branch_or_build_id>[/<target>[{<filepath>}]]"
+ - "<absolute_path>")"),
+
+      "If the build value starts with \"@ab\", cvd will fetch the specified "
+      "Android build target from the Android build servers. By default it will "
+      "download the cuttlefish host package archive or the images zip as "
+      "needed, but for more advanced use cases the file to download from the "
+      "server can be specified with the <filepath> optional parameter in curly "
+      "braces. For more information on build fetching and caching operations "
+      "refer to `cvd help fetch`.",
+
+      "Alternatively, the build value may point to an absolute path (starts "
+      "with '/') in the filesystem where the Android source code has been "
+      "checked out and a Cuttlefish target has been built. This is "
+      "particularly useful for rapid iteration during development in "
+      "combination with incremental builds and the `cvd stop` and `cvd start` "
+      "subcommands."};
+}
+
+Result<std::vector<Flag>> LoadConfigsCommand::Flags(
     const CommandRequest& request) {
-  return kDetailedHelpText;
+  return BuildCvdLoadFlags(flags_);
 }
 
 std::unique_ptr<CvdCommandHandler> NewLoadConfigsCommand(

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.cpp
@@ -241,20 +241,23 @@ cvd_common::Args LoadConfigsCommand::CmdList() const { return {kLoadSubCmd}; }
 
 std::string LoadConfigsCommand::SummaryHelp() const { return kSummaryHelpText; }
 
-std::vector<std::string> LoadConfigsCommand::Description() const {
-  return {
+std::vector<HelpParagraph> LoadConfigsCommand::Description() const {
+  std::vector<HelpParagraph> description;
+  description.emplace_back(
       "This command is an alias of `cvd create --config_file=<config_filepath> "
       "[--override=<key>:<value>]...`, provided for convenience and backwards "
-      "compatibility.",
+      "compatibility.");
 
-      "Usage:",
+  description.emplace_back("Usage:");
 
-      "    cvd load <config_filepath> [--override=<key>:<value>]",
+  description.emplace_back(
+      "    cvd load <config_filepath> [--override=<key>:<value>]");
 
+  description.emplace_back(
       "Creates and starts a new instance group from a specification file. An "
-      "example specification file looks like:",
+      "example specification file looks like:");
 
-      MarkAsRawText(R"(  {
+  description.emplace_back(HelpParagraph::Raw(R"(  {
     "instances": [
       {
         "name": "ins-1",
@@ -273,34 +276,39 @@ std::vector<std::string> LoadConfigsCommand::Description() const {
         }
       }
     ]
-  })"),
+  })"));
 
+  description.emplace_back(
       "A complete reference of the specification file format can be found in "
       "https://github.com/google/android-cuttlefish/blob/main/base/cvd/"
-      "cuttlefish/host/commands/cvd/cli/parser/load_config.proto.",
+      "cuttlefish/host/commands/cvd/cli/parser/load_config.proto.");
 
+  description.emplace_back(
       "While most config file properties are self explanatory, the build "
       "properties (default_build, kernel.build, bootloader.build, etc) require "
-      "more explanation. These properties support two types of values:",
+      "more explanation. These properties support two types of values:");
 
-      MarkAsRawText(
-          R"( - "@ab/<branch_or_build_id>[/<target>[{<filepath>}]]"
- - "<absolute_path>")"),
+  description.emplace_back(HelpParagraph::Raw(
+      R"( - "@ab/<branch_or_build_id>[/<target>[{<filepath>}]]"
+ - "<absolute_path>")"));
 
+  description.emplace_back(
       "If the build value starts with \"@ab\", cvd will fetch the specified "
       "Android build target from the Android build servers. By default it will "
       "download the cuttlefish host package archive or the images zip as "
       "needed, but for more advanced use cases the file to download from the "
       "server can be specified with the <filepath> optional parameter in curly "
       "braces. For more information on build fetching and caching operations "
-      "refer to `cvd help fetch`.",
+      "refer to `cvd help fetch`.");
 
+  description.emplace_back(
       "Alternatively, the build value may point to an absolute path (starts "
       "with '/') in the filesystem where the Android source code has been "
       "checked out and a Cuttlefish target has been built. This is "
       "particularly useful for rapid iteration during development in "
       "combination with incremental builds and the `cvd stop` and `cvd start` "
-      "subcommands."};
+      "subcommands.");
+  return description;
 }
 
 Result<std::vector<Flag>> LoadConfigsCommand::Flags(

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.cpp
@@ -124,7 +124,6 @@ Result<void> LoadConfigsCommand::Handle(const CommandRequest& request) {
       !args.empty(),
       "No arguments provided to cvd command, please provide path to json file");
   std::string& config_path = args.front();
-  CF_EXPECT(ValidateCvdLoadFlags(flags_));
 
   EnvironmentSpecification env_spec =
       CF_EXPECT(GetEnvironmentSpecification(config_path, flags_.overrides));

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.h
@@ -35,13 +35,15 @@ class LoadConfigsCommand : public CvdCommandHandler {
   Result<void> Handle(const CommandRequest& request) override;
   cvd_common::Args CmdList() const override;
   std::string SummaryHelp() const override;
-  Result<std::string> DetailedHelp(const CommandRequest& request) override;
+  std::vector<std::string> Description() const override;
+  Result<std::vector<Flag>> Flags(const CommandRequest&) override;
 
  private:
   Result<void> LoadGroup(const CommandRequest& request,
                          LocalInstanceGroup& group, CvdFlags cvd_flags);
 
   InstanceManager& instance_manager_;
+  LoadFlags flags_;
 };
 
 /*

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.h
@@ -20,6 +20,7 @@
 
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
+#include "cuttlefish/host/commands/cvd/cli/help_format.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.h"
 #include "cuttlefish/host/commands/cvd/instances/instance_manager.h"
 #include "cuttlefish/host/commands/cvd/instances/local_instance_group.h"
@@ -35,7 +36,7 @@ class LoadConfigsCommand : public CvdCommandHandler {
   Result<void> Handle(const CommandRequest& request) override;
   cvd_common::Args CmdList() const override;
   std::string SummaryHelp() const override;
-  std::vector<std::string> Description() const override;
+  std::vector<HelpParagraph> Description() const override;
   Result<std::vector<Flag>> Flags(const CommandRequest&) override;
 
  private:

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -30,7 +30,6 @@
 #include <memory>
 #include <optional>
 #include <set>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -53,7 +52,6 @@
 #include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/host_tool_target.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector.h"
-#include "cuttlefish/host/commands/cvd/cli/selector/selector_common_parser.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/host/commands/cvd/cli/utils.h"
 #include "cuttlefish/host/commands/cvd/fetch/substitute.h"
@@ -74,18 +72,6 @@
 
 namespace cuttlefish {
 namespace {
-
-constexpr char kCommandDescription[] =
-    R"(The `cvd start` command applies to the instance group, not specific instances
-because Cuttlefish instances in the same group must all be started (and stopped)
-in unisom. The group to be started is chosen using the standar selector flags.
-
-Flags that modify individual instances accept a comma separated list of values.
-If the number of values in one of these flags is less than the number of
-instances, then the last instances in the group will default to the first value
-in the list (as a result a single value provided applies to all instances). The
-empty string is interpreted as a valid value, to force a particular instance to
-use its intended default value the special value "unset" must be given.)";
 
 std::optional<std::string> GetConfigPath(cvd_common::Args& args) {
   size_t initial_size = args.size();
@@ -521,34 +507,32 @@ Result<void> CvdStartCommandHandler::LaunchDeviceInterruptible(
   return {};
 }
 
-Result<std::string> CvdStartCommandHandler::DetailedHelp(
+std::vector<std::string> CvdStartCommandHandler::Description() const {
+  return {
+      "The `cvd start` command applies to the instance group, not specific "
+      "instances because Cuttlefish instances in the same group must all be "
+      "started (and stopped) in unisom. The group to be started is chosen "
+      "using the standard selector flags.",
+      "Flags that modify individual instances accept a comma separated list of "
+      "values. If the number of values in one of these flags is less than the "
+      "number of instances, then the last instances in the group will default "
+      "to the first value in the list (as a result a single value provided "
+      "applies to all instances). The empty string is interpreted as a valid "
+      "value, to force a particular instance to use its intended default value "
+      "the special value \"unset\" must be given."};
+}
+
+Result<std::vector<Flag>> CvdStartCommandHandler::Flags(
     const CommandRequest& request) {
-  cvd_common::Args args = request.SubcommandArguments();
   std::vector<Flag> own_flags = BuildOwnFlags();
-  CF_EXPECT(ConsumeFlags(own_flags, args));
 
   std::vector<Flag> internal_flags = CF_EXPECT(GetCvdInternalStartFlags(
       request.SubcommandArguments(), cvd_common::Envs()));
 
-  selector::SelectorOptions selector_options = request.Selectors();
-  std::vector<Flag> selector_flags =
-      selector::BuildCommonSelectorFlags(selector_options);
-
-  std::vector<Flag> flags = std::move(selector_flags);
-  flags.insert(flags.end(), own_flags.begin(), own_flags.end());
+  std::vector<Flag> flags = std::move(own_flags);
   flags.insert(flags.end(), internal_flags.begin(), internal_flags.end());
 
-  // Make sure the flags are in alphabetical order
-  std::sort(flags.begin(), flags.end(),
-            [](auto f1, auto f2) { return f1.Name() < f2.Name(); });
-
-  std::stringstream ss;
-  ss << SummaryHelp() << "\n\n";
-  ss << kCommandDescription << "\n\n";
-  for (const Flag& flag : flags) {
-    ss << flag << std::endl;
-  }
-  return ss.str();
+  return flags;
 }
 
 std::vector<Flag> CvdStartCommandHandler::BuildOwnFlags() {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -51,6 +51,7 @@
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/host_tool_target.h"
+#include "cuttlefish/host/commands/cvd/cli/help_format.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/host/commands/cvd/cli/utils.h"
@@ -507,19 +508,22 @@ Result<void> CvdStartCommandHandler::LaunchDeviceInterruptible(
   return {};
 }
 
-std::vector<std::string> CvdStartCommandHandler::Description() const {
-  return {
+std::vector<HelpParagraph> CvdStartCommandHandler::Description() const {
+  std::vector<HelpParagraph> description;
+  description.emplace_back(
       "The `cvd start` command applies to the instance group, not specific "
       "instances because Cuttlefish instances in the same group must all be "
       "started (and stopped) in unisom. The group to be started is chosen "
-      "using the standard selector flags.",
+      "using the standard selector flags.");
+  description.emplace_back(
       "Flags that modify individual instances accept a comma separated list of "
       "values. If the number of values in one of these flags is less than the "
       "number of instances, then the last instances in the group will default "
       "to the first value in the list (as a result a single value provided "
       "applies to all instances). The empty string is interpreted as a valid "
       "value, to force a particular instance to use its intended default value "
-      "the special value \"unset\" must be given."};
+      "the special value \"unset\" must be given.");
+  return description;
 }
 
 Result<std::vector<Flag>> CvdStartCommandHandler::Flags(

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.h
@@ -37,9 +37,10 @@ class CvdStartCommandHandler : public CvdCommandHandler {
   std::string SummaryHelp() const override {
     return "Start all Cuttlefish Instances in a group";
   }
+  std::vector<std::string> Description() const override;
+  Result<std::vector<Flag>> Flags(const CommandRequest&) override;
 
   bool RequiresDeviceExists() const override { return true; }
-  Result<std::string> DetailedHelp(const CommandRequest& request) override;
 
  private:
   Result<void> LaunchDevice(Command command, LocalInstanceGroup& group,

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.h
@@ -37,7 +37,7 @@ class CvdStartCommandHandler : public CvdCommandHandler {
   std::string SummaryHelp() const override {
     return "Start all Cuttlefish Instances in a group";
   }
-  std::vector<std::string> Description() const override;
+  std::vector<HelpParagraph> Description() const override;
   Result<std::vector<Flag>> Flags(const CommandRequest&) override;
 
   bool RequiresDeviceExists() const override { return true; }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/help_format.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/help_format.cpp
@@ -29,8 +29,13 @@
 namespace cuttlefish {
 namespace {
 
+constexpr char kRawTextMark[] = "_RAW_TEXT:";
+
 std::vector<std::string> WrapAroundLine(std::string_view str,
                                         size_t max_line_length) {
+  if (absl::ConsumePrefix(&str, kRawTextMark)) {
+    return {std::string(str)};
+  }
   std::vector<std::string> ret;
   size_t total_word_sizes = 0;
   std::vector<std::string_view> line;
@@ -98,6 +103,10 @@ std::string FormatFlagsHelp(const std::vector<Flag>& flags,
     ss << "\n";
   }
   return ss.str();
+}
+
+std::string MarkAsRawText(std::string_view str) {
+  return absl::StrCat(kRawTextMark, str);
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/help_format.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/help_format.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/host/commands/cvd/cli/help_format.h"
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "absl/log/check.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/str_split.h"
+
+#include "cuttlefish/common/libs/utils/flag_parser.h"
+
+namespace cuttlefish {
+namespace {
+
+std::vector<std::string> WrapAroundLine(std::string_view str,
+                                        size_t max_line_length) {
+  std::vector<std::string> ret;
+  size_t total_word_sizes = 0;
+  std::vector<std::string_view> line;
+  for (std::string_view word : absl::StrSplit(str, absl::ByAnyChar(" \t\r\n"))) {
+    // line.size() accounts for the spaces added when joining the words.
+    if (total_word_sizes + word.size() + line.size() >= max_line_length) {
+      // If the line is empty at this point it means the current word is too
+      // long, it will be added to the line anyways and printed on its own in
+      // the next iteration.
+      if (!line.empty()) {
+        ret.push_back(absl::StrJoin(line, " "));
+      }
+      total_word_sizes = 0;
+      line.clear();
+    }
+    total_word_sizes += word.size();
+    line.push_back(word);
+  }
+  if (!line.empty()) {
+    // Print the last line
+    ret.push_back(absl::StrJoin(line, " "));
+  }
+  return ret;
+}
+
+std::vector<std::string> GetFlagHelpMessage(const Flag& flag) {
+  std::stringstream ss;
+  ss << flag;
+  std::vector<std::string> flag_help_lines =
+      absl::StrSplit(ss.str(), '\n', absl::SkipWhitespace());
+  return flag_help_lines;
+}
+
+}  // namespace
+
+std::string FormatHelpText(const std::vector<std::string>& text,
+                           size_t max_line_width) {
+  std::stringstream ss;
+  for (const std::string& paragraph : text) {
+    for (std::string_view line : WrapAroundLine(paragraph, max_line_width)) {
+      ss << line << "\n";
+    }
+    // Empty line after paragraphs
+    ss << "\n";
+  }
+  return ss.str();
+}
+
+std::string FormatFlagsHelp(const std::vector<Flag>& flags,
+                            size_t max_line_width) {
+  std::stringstream ss;
+  for (const Flag& flag : flags) {
+    std::vector<std::string> help_lines = GetFlagHelpMessage(flag);
+    CHECK(!help_lines.empty())
+        << "Flag produced empty help message: " << flag.Name();
+    // The first line contains the --flag=value examples, don't indent or wrap
+    // those.
+    ss << help_lines.front() << "\n";
+    for (size_t i = 1; i < help_lines.size(); ++i) {
+      for (std::string_view l :
+           WrapAroundLine(help_lines[i], max_line_width - 4)) {
+        ss << "    " << l << "\n";
+      }
+    }
+    ss << "\n";
+  }
+  return ss.str();
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/help_format.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/help_format.cpp
@@ -29,13 +29,8 @@
 namespace cuttlefish {
 namespace {
 
-constexpr char kRawTextMark[] = "_RAW_TEXT:";
-
 std::vector<std::string> WrapAroundLine(std::string_view str,
                                         size_t max_line_length) {
-  if (absl::ConsumePrefix(&str, kRawTextMark)) {
-    return {std::string(str)};
-  }
   std::vector<std::string> ret;
   size_t total_word_sizes = 0;
   std::vector<std::string_view> line;
@@ -71,15 +66,30 @@ std::vector<std::string> GetFlagHelpMessage(const Flag& flag) {
 
 }  // namespace
 
-std::string FormatHelpText(const std::vector<std::string>& text,
+HelpParagraph HelpParagraph::Raw(std::string text) {
+  return HelpParagraph(std::move(text), Style::Raw);
+}
+
+HelpParagraph::HelpParagraph(std::string text)
+    : text_(std::move(text)), style_(Style::Wrapped) {}
+HelpParagraph::HelpParagraph(std::string text, Style style)
+    : text_(std::move(text)), style_(style) {}
+
+std::string HelpParagraph::Formatted(size_t max_line_width) const {
+  switch(style_) {
+    case Style::Wrapped:
+      return absl::StrJoin(WrapAroundLine(text_, max_line_width), "\n");
+    case Style::Raw:
+      return text_;
+  }
+}
+
+std::string FormatHelpText(const std::vector<HelpParagraph>& text,
                            size_t max_line_width) {
   std::stringstream ss;
-  for (const std::string& paragraph : text) {
-    for (std::string_view line : WrapAroundLine(paragraph, max_line_width)) {
-      ss << line << "\n";
-    }
+  for (const HelpParagraph& paragraph : text) {
     // Empty line after paragraphs
-    ss << "\n";
+    ss << paragraph.Formatted(max_line_width) << "\n\n";
   }
   return ss.str();
 }
@@ -91,22 +101,15 @@ std::string FormatFlagsHelp(const std::vector<Flag>& flags,
     std::vector<std::string> help_lines = GetFlagHelpMessage(flag);
     CHECK(!help_lines.empty())
         << "Flag produced empty help message: " << flag.Name();
-    // The first line contains the --flag=value examples, don't indent or wrap
-    // those.
-    ss << help_lines.front() << "\n";
-    for (size_t i = 1; i < help_lines.size(); ++i) {
-      for (std::string_view l :
-           WrapAroundLine(help_lines[i], max_line_width - 4)) {
-        ss << "    " << l << "\n";
+    for (std::string_view line : help_lines) {
+      for (std::string_view wrapped_line :
+           WrapAroundLine(line, max_line_width - 4)) {
+        ss << "    " << wrapped_line << "\n";
       }
     }
     ss << "\n";
   }
   return ss.str();
-}
-
-std::string MarkAsRawText(std::string_view str) {
-  return absl::StrCat(kRawTextMark, str);
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/help_format.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/help_format.h
@@ -19,6 +19,7 @@
 #include <stddef.h>
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "cuttlefish/common/libs/utils/flag_parser.h"
@@ -40,5 +41,8 @@ std::string FormatHelpText(const std::vector<std::string>& text,
 // except when necessary to avoid splitting a word.
 std::string FormatFlagsHelp(const std::vector<Flag>& flags,
                             size_t max_line_width = kDefaultMaxLineWidth);
+
+// Marks a string as raw text so that FormatHelpText doesn't modify it.
+std::string MarkAsRawText(std::string_view str);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/help_format.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/help_format.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stddef.h>
+
+#include <string>
+#include <vector>
+
+#include "cuttlefish/common/libs/utils/flag_parser.h"
+
+namespace cuttlefish {
+
+constexpr size_t kDefaultMaxLineWidth = 80;
+
+// Formats text (typically a command description) to be displayed in the
+// terminal. Each string in the input is considered to be a different paragraph
+// and should not contain line changes. Each paragraph will be broken into lines
+// of at most max_line_width columns without splitting individual words. An
+// empty line will be added after each paragraph.
+std::string FormatHelpText(const std::vector<std::string>& text,
+                           size_t max_line_width = kDefaultMaxLineWidth);
+
+// Formats the help messages of a list of flags to be displayed in the terminal.
+// The return string will contain lines of at most max_line_width characters
+// except when necessary to avoid splitting a word.
+std::string FormatFlagsHelp(const std::vector<Flag>& flags,
+                            size_t max_line_width = kDefaultMaxLineWidth);
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/help_format.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/help_format.h
@@ -19,7 +19,6 @@
 #include <stddef.h>
 
 #include <string>
-#include <string_view>
 #include <vector>
 
 #include "cuttlefish/common/libs/utils/flag_parser.h"
@@ -28,12 +27,32 @@ namespace cuttlefish {
 
 constexpr size_t kDefaultMaxLineWidth = 80;
 
+class HelpParagraph {
+ public:
+  static HelpParagraph Raw(std::string text);
+
+  explicit HelpParagraph(std::string);
+
+  std::string Formatted(size_t max_line_width) const;
+
+ private:
+  enum class Style {
+    Wrapped,
+    Raw,
+  };
+
+  HelpParagraph(std::string, Style style);
+
+  std::string text_;
+  Style style_;
+};
+
 // Formats text (typically a command description) to be displayed in the
 // terminal. Each string in the input is considered to be a different paragraph
 // and should not contain line changes. Each paragraph will be broken into lines
 // of at most max_line_width columns without splitting individual words. An
 // empty line will be added after each paragraph.
-std::string FormatHelpText(const std::vector<std::string>& text,
+std::string FormatHelpText(const std::vector<HelpParagraph>& text,
                            size_t max_line_width = kDefaultMaxLineWidth);
 
 // Formats the help messages of a list of flags to be displayed in the terminal.
@@ -41,8 +60,4 @@ std::string FormatHelpText(const std::vector<std::string>& text,
 // except when necessary to avoid splitting a word.
 std::string FormatFlagsHelp(const std::vector<Flag>& flags,
                             size_t max_line_width = kDefaultMaxLineWidth);
-
-// Marks a string as raw text so that FormatHelpText doesn't modify it.
-std::string MarkAsRawText(std::string_view str);
-
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/BUILD.bazel
@@ -92,6 +92,7 @@ cf_cc_test(
         "//cuttlefish/common/libs/utils:flag_parser",
         "//cuttlefish/host/commands/cvd/cli/parser:load_configs_parser",
         "//cuttlefish/host/commands/cvd/cli/parser:test_common",
+        "//cuttlefish/result:result_matchers",
         "//libbase",
     ],
 )

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/BUILD.bazel
@@ -89,6 +89,8 @@ cf_cc_test(
     name = "flags_parser_test",
     srcs = ["flags_parser_test.cc"],
     deps = [
+        "//cuttlefish/common/libs/utils:flag_parser",
+        "//cuttlefish/host/commands/cvd/cli/parser:load_configs_parser",
         "//cuttlefish/host/commands/cvd/cli/parser:test_common",
         "//libbase",
     ],

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/flags_parser_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/flags_parser_test.cc
@@ -14,11 +14,15 @@
  * limitations under the License.
  */
 
+#include <algorithm>
+#include <sstream>
 #include <string>
 
 #include <android-base/file.h>
 #include <gtest/gtest.h>
 
+#include "cuttlefish/common/libs/utils/flag_parser.h"
+#include "cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/test_common.h"
 
 namespace cuttlefish {
@@ -168,6 +172,118 @@ TEST(BootFlagsParserTest, ParseNetSimFlagEnabled) {
       << "netsim_bt flag is missing or wrongly formatted";
   EXPECT_TRUE(FindConfig(*serialized_data, R"(--netsim_uwb=true)"))
       << "netsim_uwb flag is missing or wrongly formatted";
+}
+
+TEST(CvdLoadFlagsTest, CredentialSourceGetterSetter) {
+  LoadFlags load_flags;
+
+  // Test Setter
+  {
+    auto flags = BuildCvdLoadFlags(load_flags);
+    std::vector<std::string> args = {"--credential_source=first_val"};
+    auto result = ConsumeFlags(flags, args);
+    ASSERT_TRUE(result.ok()) << result.error().Trace();
+
+    ASSERT_EQ(load_flags.overrides.size(), 1);
+    EXPECT_EQ(load_flags.overrides[0].config_path, "fetch.credential_source");
+    EXPECT_EQ(load_flags.overrides[0].new_value, "first_val");
+  }
+
+  // Test Getter (should return "first_val" now)
+  {
+    auto flags = BuildCvdLoadFlags(load_flags);
+    auto flag_it = std::find_if(flags.begin(), flags.end(), [](const Flag& f) {
+      return f.Name() == "credential_source";
+    });
+    ASSERT_NE(flag_it, flags.end());
+
+    std::stringstream ss;
+    ss << *flag_it;
+    EXPECT_NE(ss.str().find("Current value: \"first_val\""), std::string::npos)
+        << "Help text was: " << ss.str();
+  }
+
+  // Test Setter again (should append and override)
+  {
+    auto flags = BuildCvdLoadFlags(load_flags);
+    std::vector<std::string> args = {"--credential_source=second_val"};
+    auto result = ConsumeFlags(flags, args);
+    ASSERT_TRUE(result.ok()) << result.error().Trace();
+
+    ASSERT_EQ(load_flags.overrides.size(), 2);
+    EXPECT_EQ(load_flags.overrides[1].config_path, "fetch.credential_source");
+    EXPECT_EQ(load_flags.overrides[1].new_value, "second_val");
+  }
+
+  // Test Getter again (should return "second_val" because it searches from the end)
+  {
+    auto flags = BuildCvdLoadFlags(load_flags);
+    auto flag_it = std::find_if(flags.begin(), flags.end(), [](const Flag& f) {
+      return f.Name() == "credential_source";
+    });
+    ASSERT_NE(flag_it, flags.end());
+
+    std::stringstream ss;
+    ss << *flag_it;
+    EXPECT_NE(ss.str().find("Current value: \"second_val\""), std::string::npos)
+        << "Help text was: " << ss.str();
+  }
+}
+
+TEST(CvdLoadFlagsTest, ProjectIDGetterSetter) {
+  LoadFlags load_flags;
+
+  // Test Setter
+  {
+    auto flags = BuildCvdLoadFlags(load_flags);
+    std::vector<std::string> args = {"--project_id=first_project"};
+    auto result = ConsumeFlags(flags, args);
+    ASSERT_TRUE(result.ok()) << result.error().Trace();
+
+    ASSERT_EQ(load_flags.overrides.size(), 1);
+    EXPECT_EQ(load_flags.overrides[0].config_path, "fetch.project_id");
+    EXPECT_EQ(load_flags.overrides[0].new_value, "first_project");
+  }
+
+  // Test Getter
+  {
+    auto flags = BuildCvdLoadFlags(load_flags);
+    auto flag_it = std::find_if(flags.begin(), flags.end(), [](const Flag& f) {
+      return f.Name() == "project_id";
+    });
+    ASSERT_NE(flag_it, flags.end());
+
+    std::stringstream ss;
+    ss << *flag_it;
+    EXPECT_NE(ss.str().find("Current value: \"first_project\""), std::string::npos)
+        << "Help text was: " << ss.str();
+  }
+
+  // Test Setter again
+  {
+    auto flags = BuildCvdLoadFlags(load_flags);
+    std::vector<std::string> args = {"--project_id=second_project"};
+    auto result = ConsumeFlags(flags, args);
+    ASSERT_TRUE(result.ok()) << result.error().Trace();
+
+    ASSERT_EQ(load_flags.overrides.size(), 2);
+    EXPECT_EQ(load_flags.overrides[1].config_path, "fetch.project_id");
+    EXPECT_EQ(load_flags.overrides[1].new_value, "second_project");
+  }
+
+  // Test Getter again
+  {
+    auto flags = BuildCvdLoadFlags(load_flags);
+    auto flag_it = std::find_if(flags.begin(), flags.end(), [](const Flag& f) {
+      return f.Name() == "project_id";
+    });
+    ASSERT_NE(flag_it, flags.end());
+
+    std::stringstream ss;
+    ss << *flag_it;
+    EXPECT_NE(ss.str().find("Current value: \"second_project\""), std::string::npos)
+        << "Help text was: " << ss.str();
+  }
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/flags_parser_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/flags_parser_test.cc
@@ -24,6 +24,7 @@
 #include "cuttlefish/common/libs/utils/flag_parser.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/test_common.h"
+#include "cuttlefish/result/result_matchers.h"
 
 namespace cuttlefish {
 
@@ -174,116 +175,131 @@ TEST(BootFlagsParserTest, ParseNetSimFlagEnabled) {
       << "netsim_uwb flag is missing or wrongly formatted";
 }
 
-TEST(CvdLoadFlagsTest, CredentialSourceGetterSetter) {
+TEST(CvdLoadFlagsTest, CredentialSourceSetter) {
   LoadFlags load_flags;
 
-  // Test Setter
-  {
-    auto flags = BuildCvdLoadFlags(load_flags);
-    std::vector<std::string> args = {"--credential_source=first_val"};
-    auto result = ConsumeFlags(flags, args);
-    ASSERT_TRUE(result.ok()) << result.error().Trace();
+  auto flags = BuildCvdLoadFlags(load_flags);
+  std::vector<std::string> args = {"--credential_source=foo"};
+  auto result = ConsumeFlags(flags, args);
+  ASSERT_TRUE(result.ok()) << result.error().Trace();
 
-    ASSERT_EQ(load_flags.overrides.size(), 1);
-    EXPECT_EQ(load_flags.overrides[0].config_path, "fetch.credential_source");
-    EXPECT_EQ(load_flags.overrides[0].new_value, "first_val");
-  }
-
-  // Test Getter (should return "first_val" now)
-  {
-    auto flags = BuildCvdLoadFlags(load_flags);
-    auto flag_it = std::find_if(flags.begin(), flags.end(), [](const Flag& f) {
-      return f.Name() == "credential_source";
-    });
-    ASSERT_NE(flag_it, flags.end());
-
-    std::stringstream ss;
-    ss << *flag_it;
-    EXPECT_NE(ss.str().find("Current value: \"first_val\""), std::string::npos)
-        << "Help text was: " << ss.str();
-  }
-
-  // Test Setter again (should append and override)
-  {
-    auto flags = BuildCvdLoadFlags(load_flags);
-    std::vector<std::string> args = {"--credential_source=second_val"};
-    auto result = ConsumeFlags(flags, args);
-    ASSERT_TRUE(result.ok()) << result.error().Trace();
-
-    ASSERT_EQ(load_flags.overrides.size(), 2);
-    EXPECT_EQ(load_flags.overrides[1].config_path, "fetch.credential_source");
-    EXPECT_EQ(load_flags.overrides[1].new_value, "second_val");
-  }
-
-  // Test Getter again (should return "second_val" because it searches from the end)
-  {
-    auto flags = BuildCvdLoadFlags(load_flags);
-    auto flag_it = std::find_if(flags.begin(), flags.end(), [](const Flag& f) {
-      return f.Name() == "credential_source";
-    });
-    ASSERT_NE(flag_it, flags.end());
-
-    std::stringstream ss;
-    ss << *flag_it;
-    EXPECT_NE(ss.str().find("Current value: \"second_val\""), std::string::npos)
-        << "Help text was: " << ss.str();
-  }
+  ASSERT_EQ(load_flags.overrides.size(), 1);
+  EXPECT_EQ(load_flags.overrides.count("fetch.credential_source"), 1);
+  EXPECT_EQ(load_flags.overrides["fetch.credential_source"], "foo");
 }
 
-TEST(CvdLoadFlagsTest, ProjectIDGetterSetter) {
+TEST(CvdLoadFlagsTest, CredentialSourceGetter) {
+  LoadFlags load_flags;
+  load_flags.overrides["fetch.credential_source"] = "bar";
+
+  auto flags = BuildCvdLoadFlags(load_flags);
+  auto flag_it = std::find_if(flags.begin(), flags.end(), [](const Flag& f) {
+    return f.Name() == "credential_source";
+  });
+  ASSERT_NE(flag_it, flags.end());
+
+  std::stringstream ss;
+  ss << *flag_it;
+  EXPECT_NE(ss.str().find("Current value: \"bar\""), std::string::npos)
+      << "Help text was: " << ss.str();
+}
+
+TEST(CvdLoadFlagsTest, CredentialSourceDuplicated) {
   LoadFlags load_flags;
 
-  // Test Setter
-  {
-    auto flags = BuildCvdLoadFlags(load_flags);
-    std::vector<std::string> args = {"--project_id=first_project"};
-    auto result = ConsumeFlags(flags, args);
-    ASSERT_TRUE(result.ok()) << result.error().Trace();
+  auto flags = BuildCvdLoadFlags(load_flags);
+  std::vector<std::string> args = {"--credential_source=first_val",
+                                   "--credential_source=second_val"};
+  auto result = ConsumeFlags(flags, args);
+  EXPECT_THAT(result, IsError());
+}
 
-    ASSERT_EQ(load_flags.overrides.size(), 1);
-    EXPECT_EQ(load_flags.overrides[0].config_path, "fetch.project_id");
-    EXPECT_EQ(load_flags.overrides[0].new_value, "first_project");
-  }
+TEST(CvdLoadFlagsTest, ProjectIDSetter) {
+  LoadFlags load_flags;
 
-  // Test Getter
-  {
-    auto flags = BuildCvdLoadFlags(load_flags);
-    auto flag_it = std::find_if(flags.begin(), flags.end(), [](const Flag& f) {
-      return f.Name() == "project_id";
-    });
-    ASSERT_NE(flag_it, flags.end());
+  auto flags = BuildCvdLoadFlags(load_flags);
+  std::vector<std::string> args = {"--project_id=foo"};
+  auto result = ConsumeFlags(flags, args);
+  ASSERT_TRUE(result.ok()) << result.error().Trace();
 
-    std::stringstream ss;
-    ss << *flag_it;
-    EXPECT_NE(ss.str().find("Current value: \"first_project\""), std::string::npos)
-        << "Help text was: " << ss.str();
-  }
+  ASSERT_EQ(load_flags.overrides.size(), 1);
+  EXPECT_EQ(load_flags.overrides.count("fetch.project_id"), 1);
+  EXPECT_EQ(load_flags.overrides["fetch.project_id"], "foo");
+}
 
-  // Test Setter again
-  {
-    auto flags = BuildCvdLoadFlags(load_flags);
-    std::vector<std::string> args = {"--project_id=second_project"};
-    auto result = ConsumeFlags(flags, args);
-    ASSERT_TRUE(result.ok()) << result.error().Trace();
+TEST(CvdLoadFlagsTest, ProjectIDGetter) {
+  LoadFlags load_flags;
+  load_flags.overrides["fetch.project_id"] = "bar";
 
-    ASSERT_EQ(load_flags.overrides.size(), 2);
-    EXPECT_EQ(load_flags.overrides[1].config_path, "fetch.project_id");
-    EXPECT_EQ(load_flags.overrides[1].new_value, "second_project");
-  }
+  auto flags = BuildCvdLoadFlags(load_flags);
+  auto flag_it = std::find_if(flags.begin(), flags.end(), [](const Flag& f) {
+    return f.Name() == "project_id";
+  });
+  ASSERT_NE(flag_it, flags.end());
 
-  // Test Getter again
-  {
-    auto flags = BuildCvdLoadFlags(load_flags);
-    auto flag_it = std::find_if(flags.begin(), flags.end(), [](const Flag& f) {
-      return f.Name() == "project_id";
-    });
-    ASSERT_NE(flag_it, flags.end());
+  std::stringstream ss;
+  ss << *flag_it;
+  EXPECT_NE(ss.str().find("Current value: \"bar\""),
+            std::string::npos)
+      << "Help text was: " << ss.str();
+}
 
-    std::stringstream ss;
-    ss << *flag_it;
-    EXPECT_NE(ss.str().find("Current value: \"second_project\""), std::string::npos)
-        << "Help text was: " << ss.str();
-  }
+TEST(CvdLoadFlagsTest, ProjectIDDuplicated) {
+  LoadFlags load_flags;
+
+  auto flags = BuildCvdLoadFlags(load_flags);
+  std::vector<std::string> args = {"--project_id=first_project",
+                                   "--project_id=second_project"};
+  auto result = ConsumeFlags(flags, args);
+  EXPECT_FALSE(result.ok()) << "Expected duplicate flag to fail";
+}
+
+TEST(CvdLoadFlagsTest, CredentialSourceConflictWithOverride) {
+  LoadFlags load_flags;
+  auto flags = BuildCvdLoadFlags(load_flags);
+  std::vector<std::string> args = {
+      "--override=fetch.credential_source:override_val",
+      "--credential_source=flag_val"};
+  auto result = ConsumeFlags(flags, args);
+  EXPECT_FALSE(result.ok()) << "Expected override followed by flag to fail";
+}
+
+TEST(CvdLoadFlagsTest, OverrideConflictWithCredentialSource) {
+  LoadFlags load_flags;
+  auto flags = BuildCvdLoadFlags(load_flags);
+  std::vector<std::string> args = {
+      "--credential_source=flag_val",
+      "--override=fetch.credential_source:override_val"};
+  auto result = ConsumeFlags(flags, args);
+  EXPECT_FALSE(result.ok()) << "Expected flag followed by override to fail";
+}
+
+TEST(CvdLoadFlagsTest, ProjectIDConflictWithOverride) {
+  LoadFlags load_flags;
+  auto flags = BuildCvdLoadFlags(load_flags);
+  std::vector<std::string> args = {
+      "--override=fetch.project_id:override_project",
+      "--project_id=flag_project"};
+  auto result = ConsumeFlags(flags, args);
+  EXPECT_FALSE(result.ok()) << "Expected override followed by flag to fail";
+}
+
+TEST(CvdLoadFlagsTest, OverrideConflictWithProjectID) {
+  LoadFlags load_flags;
+  auto flags = BuildCvdLoadFlags(load_flags);
+  std::vector<std::string> args = {
+      "--project_id=flag_project",
+      "--override=fetch.project_id:override_project"};
+  auto result = ConsumeFlags(flags, args);
+  EXPECT_FALSE(result.ok()) << "Expected flag followed by override to fail";
+}
+
+TEST(CvdLoadFlagsTest, DuplicateOverridesFail) {
+  LoadFlags load_flags;
+  auto flags = BuildCvdLoadFlags(load_flags);
+  std::vector<std::string> args = {"--override=fetch.credential_source:val1", "--override=fetch.credential_source:val2"};
+  auto result = ConsumeFlags(flags, args);
+  EXPECT_FALSE(result.ok()) << "Expected duplicate overrides to fail";
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.cpp
@@ -246,13 +246,44 @@ EnvironmentSpecification FillEmptyInstanceNames(
 std::vector<Flag> BuildCvdLoadFlags(LoadFlags& load_flags) {
   std::vector<Flag> flags;
   flags.emplace_back(
-      GflagsCompatFlag("credential_source", load_flags.credential_source)
+      GflagsCompatFlag("credential_source")
           .Help("Source of credentials to access the Android Build Server API. "
                 "Can be left empty in most cases, see the help for `login` and "
-                "`fetch` for details."));
-  flags.emplace_back(GflagsCompatFlag("project_id", load_flags.project_id)
-                         .Help("Google Cloud Project ID for Android Build "
-                               "Server API access and quotas."));
+                "`fetch` for details.")
+          .Setter([&load_flags](const FlagMatch& match) -> Result<void> {
+            load_flags.overrides.push_back(
+                Override{.config_path = std::string(kCredentialSourceOverride),
+                         .new_value = match.value});
+            return {};
+          })
+          .Getter([&load_flags]() -> std::string {
+            for (auto it = load_flags.overrides.rbegin();
+                 it != load_flags.overrides.rend(); ++it) {
+              if (it->config_path == kCredentialSourceOverride) {
+                return it->new_value;
+              }
+            }
+            return "";
+          }));
+  flags.emplace_back(
+      GflagsCompatFlag("project_id")
+          .Help("Google Cloud Project ID for Android Build "
+                "Server API access and quotas.")
+          .Setter([&load_flags](const FlagMatch& match) -> Result<void> {
+            load_flags.overrides.push_back(
+                Override{.config_path = std::string(kProjectIDOverride),
+                         .new_value = match.value});
+            return {};
+          })
+          .Getter([&load_flags]() -> std::string {
+            for (auto it = load_flags.overrides.rbegin();
+                 it != load_flags.overrides.rend(); ++it) {
+              if (it->config_path == kProjectIDOverride) {
+                return it->new_value;
+              }
+            }
+            return "";
+          }));
   flags.emplace_back(
       GflagsCompatFlag("base_directory", load_flags.base_dir)
           .Help(fmt::format(
@@ -336,32 +367,6 @@ std::ostream& operator<<(std::ostream& out, const Override& override) {
   fmt::print(out, "(config_path=\"{}\", new_value=\"{}\")",
              override.config_path, override.new_value);
   return out;
-}
-
-Result<void> ValidateCvdLoadFlags(LoadFlags& load_flags) {
-  auto working_directory = CurrentDirectory();
-
-  if (!load_flags.credential_source.empty()) {
-    for (const auto& flag : load_flags.overrides) {
-      CF_EXPECT(!absl::StartsWith(flag.config_path, kCredentialSourceOverride),
-                "Specifying both --override=fetch.credential_source and the "
-                "--credential_source flag is not allowed.");
-    }
-    load_flags.overrides.emplace_back(
-        Override{.config_path = std::string(kCredentialSourceOverride),
-                 .new_value = load_flags.credential_source});
-  }
-  if (!load_flags.project_id.empty()) {
-    for (const auto& flag : load_flags.overrides) {
-      CF_EXPECT(!absl::StartsWith(flag.config_path, kProjectIDOverride),
-                "Specifying both --override=fetch.project_id and the "
-                "--project_id flag is not allowed.");
-    }
-    load_flags.overrides.emplace_back(
-        Override{.config_path = std::string(kProjectIDOverride),
-                 .new_value = load_flags.project_id});
-  }
-  return {};
 }
 
 Result<EnvironmentSpecification> GetEnvironmentSpecification(

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.cpp
@@ -71,35 +71,39 @@ bool IsLocalBuild(std::string path) {
 }
 
 Flag GflagsCompatFlagOverride(const std::string& name,
-                              std::vector<Override>& values) {
+                              std::map<std::string, std::string>& overrides) {
   return GflagsCompatFlag(name)
-      .Getter([&values]() {
-        return absl::StrJoin(values, ",", absl::StreamFormatter());
+      .Getter([&overrides]() {
+        std::vector<std::string> formatted;
+        for (const auto& [k, v] : overrides) {
+          formatted.push_back(fmt::format("({}=\"{}\")", k, v));
+        }
+        return absl::StrJoin(formatted, ",");
       })
-      .Setter([&values](const FlagMatch& match) -> Result<void> {
+      .Setter([&overrides](const FlagMatch& match) -> Result<void> {
         size_t separator_index = match.value.find(kOverrideSeparator);
         CF_EXPECTF(separator_index != std::string::npos,
                    "Unable to find separator \"{}\" in input \"{}\"",
                    kOverrideSeparator, match.value);
-        auto result =
-            Override{.config_path = match.value.substr(0, separator_index),
-                     .new_value = match.value.substr(separator_index + 1)};
-        CF_EXPECTF(!result.config_path.empty(),
+        auto property_path = match.value.substr(0, separator_index);
+        auto new_value = match.value.substr(separator_index + 1);
+        CF_EXPECTF(overrides.count(property_path) == 0,
+                   "Property \"{}\" is already overridden", property_path);
+        CF_EXPECTF(!property_path.empty(),
                    "Config path before the separator \"{}\" cannot be empty in "
                    "input \"{}\"",
                    kOverrideSeparator, match.value);
-        CF_EXPECTF(!result.new_value.empty(),
+        CF_EXPECTF(!new_value.empty(),
                    "New value after the separator \"{}\" cannot be empty in "
                    "input \"{}\"",
                    kOverrideSeparator, match.value);
-        CF_EXPECTF(result.config_path.front() != '.' &&
-                       result.config_path.back() != '.',
+        CF_EXPECTF(property_path.front() != '.' && property_path.back() != '.',
                    "Config path \"{}\" must not start or end with dot",
-                   result.config_path);
-        CF_EXPECTF(result.config_path.find("..") == std::string::npos,
+                   property_path);
+        CF_EXPECTF(property_path.find("..") == std::string::npos,
                    "Config path \"{}\" cannot contain two consecutive dots",
-                   result.config_path);
-        values.emplace_back(result);
+                   property_path);
+        overrides[property_path] = new_value;
         return {};
       });
 }
@@ -204,14 +208,11 @@ std::optional<std::string> GetSystemHostPath(
 
 Result<Json::Value> GetOverriddenConfig(
     const std::string& config_path,
-    const std::vector<Override>& override_flags) {
+    const std::map<std::string, std::string>& override_flags) {
   Json::Value result = CF_EXPECT(ParseJsonFile(config_path));
 
-  if (!override_flags.empty()) {
-    for (const auto& flag : override_flags) {
-      MergeTwoJsonObjs(result,
-                       OverrideToJson(flag.config_path, flag.new_value));
-    }
+  for (const auto& [key, val] : override_flags) {
+    MergeTwoJsonObjs(result, OverrideToJson(key, val));
   }
 
   return result;
@@ -246,22 +247,32 @@ EnvironmentSpecification FillEmptyInstanceNames(
 std::vector<Flag> BuildCvdLoadFlags(LoadFlags& load_flags) {
   std::vector<Flag> flags;
   flags.emplace_back(
+      GflagsCompatFlagOverride("override", load_flags.overrides)
+          .Help(
+              "Override or add new properties to the group specification. This "
+              "flag may appear multiple times to affect different properties. "
+              "The format is `--override=<path.to.property>:<value>`. "
+              "For example: `--override=instance.0.vm.cpus=16`."));
+  flags.emplace_back(
       GflagsCompatFlag("credential_source")
           .Help("Source of credentials to access the Android Build Server API. "
                 "Can be left empty in most cases, see the help for `login` and "
                 "`fetch` for details.")
           .Setter([&load_flags](const FlagMatch& match) -> Result<void> {
-            load_flags.overrides.push_back(
-                Override{.config_path = std::string(kCredentialSourceOverride),
-                         .new_value = match.value});
+            CF_EXPECTF(load_flags.overrides.count(
+                           std::string(kCredentialSourceOverride)) == 0,
+                       "Specifying both --override={} and the "
+                       "--credential_source flag is not allowed.",
+                       kCredentialSourceOverride);
+            load_flags.overrides[std::string(kCredentialSourceOverride)] =
+                match.value;
             return {};
           })
           .Getter([&load_flags]() -> std::string {
-            for (auto it = load_flags.overrides.rbegin();
-                 it != load_flags.overrides.rend(); ++it) {
-              if (it->config_path == kCredentialSourceOverride) {
-                return it->new_value;
-              }
+            auto it = load_flags.overrides.find(
+                std::string(kCredentialSourceOverride));
+            if (it != load_flags.overrides.end()) {
+              return it->second;
             }
             return "";
           }));
@@ -270,17 +281,19 @@ std::vector<Flag> BuildCvdLoadFlags(LoadFlags& load_flags) {
           .Help("Google Cloud Project ID for Android Build "
                 "Server API access and quotas.")
           .Setter([&load_flags](const FlagMatch& match) -> Result<void> {
-            load_flags.overrides.push_back(
-                Override{.config_path = std::string(kProjectIDOverride),
-                         .new_value = match.value});
+            CF_EXPECTF(load_flags.overrides.count(
+                           std::string(kProjectIDOverride)) == 0,
+                       "Specifying both --override={} and the --project_id "
+                       "flag is not allowed.",
+                       kProjectIDOverride);
+            load_flags.overrides[std::string(kProjectIDOverride)] = match.value;
             return {};
           })
           .Getter([&load_flags]() -> std::string {
-            for (auto it = load_flags.overrides.rbegin();
-                 it != load_flags.overrides.rend(); ++it) {
-              if (it->config_path == kProjectIDOverride) {
-                return it->new_value;
-              }
+            auto it =
+                load_flags.overrides.find(std::string(kProjectIDOverride));
+            if (it != load_flags.overrides.end()) {
+              return it->second;
             }
             return "";
           }));
@@ -290,13 +303,6 @@ std::vector<Flag> BuildCvdLoadFlags(LoadFlags& load_flags) {
               "Parent directory for artifacts and runtime files. When not "
               "provided a new directory under {}/{} will be created.",
               CvdDir(), getuid())));
-  flags.emplace_back(
-      GflagsCompatFlagOverride("override", load_flags.overrides)
-          .Help(
-              "Override or add new properties to the group specification. This "
-              "flag may appear multiple times to affect different properties. "
-              "The format is `--override=<path.to.property>:<value>`. "
-              "Forexample: `--override=instance.0.vm.cpus=16`."));
   return flags;
 }
 
@@ -363,14 +369,11 @@ Result<CvdFlags> ParseCvdConfigs(const EnvironmentSpecification& env_spec,
   return flags;
 }
 
-std::ostream& operator<<(std::ostream& out, const Override& override) {
-  fmt::print(out, "(config_path=\"{}\", new_value=\"{}\")",
-             override.config_path, override.new_value);
-  return out;
-}
+
 
 Result<EnvironmentSpecification> GetEnvironmentSpecification(
-    const std::string& config_path, const std::vector<Override>& overrides) {
+    const std::string& config_path,
+    const std::map<std::string, std::string>& overrides) {
   Json::Value json_configs =
       CF_EXPECT(GetOverriddenConfig(config_path, overrides));
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.cpp
@@ -23,8 +23,8 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdio>
+#include <functional>
 #include <optional>
-#include <ostream>
 #include <set>
 #include <sstream>
 #include <stack>
@@ -70,8 +70,9 @@ bool IsLocalBuild(std::string path) {
   return absl::StartsWith(path, "/");
 }
 
-Flag GflagsCompatFlagOverride(const std::string& name,
-                              std::map<std::string, std::string>& overrides) {
+Flag GflagsCompatFlagOverride(
+    const std::string& name,
+    std::map<std::string, std::string, std::less<void>>& overrides) {
   return GflagsCompatFlag(name)
       .Getter([&overrides]() {
         std::vector<std::string> formatted;
@@ -208,7 +209,7 @@ std::optional<std::string> GetSystemHostPath(
 
 Result<Json::Value> GetOverriddenConfig(
     const std::string& config_path,
-    const std::map<std::string, std::string>& override_flags) {
+    const std::map<std::string, std::string, std::less<void>>& override_flags) {
   Json::Value result = CF_EXPECT(ParseJsonFile(config_path));
 
   for (const auto& [key, val] : override_flags) {
@@ -259,18 +260,17 @@ std::vector<Flag> BuildCvdLoadFlags(LoadFlags& load_flags) {
                 "Can be left empty in most cases, see the help for `login` and "
                 "`fetch` for details.")
           .Setter([&load_flags](const FlagMatch& match) -> Result<void> {
-            CF_EXPECTF(load_flags.overrides.count(
-                           std::string(kCredentialSourceOverride)) == 0,
-                       "Specifying both --override={} and the "
-                       "--credential_source flag is not allowed.",
-                       kCredentialSourceOverride);
-            load_flags.overrides[std::string(kCredentialSourceOverride)] =
-                match.value;
+            CF_EXPECTF(
+                load_flags.overrides.count(kCredentialSourceOverride) == 0,
+                "Specifying both --override={} and the "
+                "--credential_source flag is not allowed.",
+                kCredentialSourceOverride);
+            load_flags.overrides.emplace(kCredentialSourceOverride,
+                                         match.value);
             return {};
           })
           .Getter([&load_flags]() -> std::string {
-            auto it = load_flags.overrides.find(
-                std::string(kCredentialSourceOverride));
+            auto it = load_flags.overrides.find(kCredentialSourceOverride);
             if (it != load_flags.overrides.end()) {
               return it->second;
             }
@@ -281,17 +281,16 @@ std::vector<Flag> BuildCvdLoadFlags(LoadFlags& load_flags) {
           .Help("Google Cloud Project ID for Android Build "
                 "Server API access and quotas.")
           .Setter([&load_flags](const FlagMatch& match) -> Result<void> {
-            CF_EXPECTF(load_flags.overrides.count(
-                           std::string(kProjectIDOverride)) == 0,
+            CF_EXPECTF(load_flags.overrides.count(kProjectIDOverride) == 0,
                        "Specifying both --override={} and the --project_id "
                        "flag is not allowed.",
                        kProjectIDOverride);
-            load_flags.overrides[std::string(kProjectIDOverride)] = match.value;
+            load_flags.overrides.emplace(kProjectIDOverride, match.value);
             return {};
           })
           .Getter([&load_flags]() -> std::string {
             auto it =
-                load_flags.overrides.find(std::string(kProjectIDOverride));
+                load_flags.overrides.find(kProjectIDOverride);
             if (it != load_flags.overrides.end()) {
               return it->second;
             }
@@ -369,11 +368,9 @@ Result<CvdFlags> ParseCvdConfigs(const EnvironmentSpecification& env_spec,
   return flags;
 }
 
-
-
 Result<EnvironmentSpecification> GetEnvironmentSpecification(
     const std::string& config_path,
-    const std::map<std::string, std::string>& overrides) {
+    const std::map<std::string, std::string, std::less<void>>& overrides) {
   Json::Value json_configs =
       CF_EXPECT(GetOverriddenConfig(config_path, overrides));
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.cpp
@@ -172,29 +172,6 @@ Json::Value OverrideToJson(const std::string& key,
   return leaf;
 }
 
-std::vector<Flag> GetFlagsVector(LoadFlags& load_flags) {
-  std::vector<Flag> flags;
-  flags.emplace_back(
-      GflagsCompatFlag("credential_source", load_flags.credential_source));
-  flags.emplace_back(GflagsCompatFlag("project_id", load_flags.project_id));
-  flags.emplace_back(
-      GflagsCompatFlag("base_directory", load_flags.base_dir)
-          .Help(
-              "Parent directory for artifacts and runtime files. Defaults to " +
-              CvdDir() + "<uid>/<timestamp>."));
-  flags.emplace_back(GflagsCompatFlagOverride("override", load_flags.overrides)
-                         .Help("Use --override=<config_identifier>:<new_value> "
-                               "to override config values"));
-  return flags;
-}
-
-void MakeAbsolute(std::string& path, const std::string& working_dir) {
-  if (!path.empty() && path[0] == '/') {
-    return;
-  }
-  path.insert(0, working_dir + "/");
-}
-
 Result<Json::Value> ParseJsonFile(const std::string& file_path) {
   CF_EXPECTF(FileExists(file_path),
              "Provided file \"{}\" to cvd command does not exist", file_path);
@@ -266,6 +243,32 @@ EnvironmentSpecification FillEmptyInstanceNames(
 
 }  // namespace
 
+std::vector<Flag> BuildCvdLoadFlags(LoadFlags& load_flags) {
+  std::vector<Flag> flags;
+  flags.emplace_back(
+      GflagsCompatFlag("credential_source", load_flags.credential_source)
+          .Help("Source of credentials to access the Android Build Server API. "
+                "Can be left empty in most cases, see the help for `login` and "
+                "`fetch` for details."));
+  flags.emplace_back(GflagsCompatFlag("project_id", load_flags.project_id)
+                         .Help("Google Cloud Project ID for Android Build "
+                               "Server API access and quotas."));
+  flags.emplace_back(
+      GflagsCompatFlag("base_directory", load_flags.base_dir)
+          .Help(fmt::format(
+              "Parent directory for artifacts and runtime files. When not "
+              "provided a new directory under {}/{} will be created.",
+              CvdDir(), getuid())));
+  flags.emplace_back(
+      GflagsCompatFlagOverride("override", load_flags.overrides)
+          .Help(
+              "Override or add new properties to the group specification. This "
+              "flag may appear multiple times to affect different properties. "
+              "The format is `--override=<path.to.property>:<value>`. "
+              "Forexample: `--override=instance.0.vm.cpus=16`."));
+  return flags;
+}
+
 Result<InstanceManager::GroupDirectories> GetGroupCreationDirectories(
     const std::string& parent_directory,
     const EnvironmentSpecification& env_spec) {
@@ -335,26 +338,12 @@ std::ostream& operator<<(std::ostream& out, const Override& override) {
   return out;
 }
 
-Result<LoadFlags> GetFlags(std::vector<std::string>& args,
-                           const std::string& working_directory) {
-  LoadFlags load_flags;
-  auto flags = GetFlagsVector(load_flags);
-  CF_EXPECT(ConsumeFlags(flags, args));
-  CF_EXPECT(
-      !args.empty(),
-      "No arguments provided to cvd command, please provide path to json file");
-
-  if (!load_flags.base_dir.empty()) {
-    MakeAbsolute(load_flags.base_dir, working_directory);
-  }
-
-  load_flags.config_path = args.front();
-  MakeAbsolute(load_flags.config_path, working_directory);
+Result<void> ValidateCvdLoadFlags(LoadFlags& load_flags) {
+  auto working_directory = CurrentDirectory();
 
   if (!load_flags.credential_source.empty()) {
     for (const auto& flag : load_flags.overrides) {
-      CF_EXPECT(!absl::StartsWith(flag.config_path,
-                                           kCredentialSourceOverride),
+      CF_EXPECT(!absl::StartsWith(flag.config_path, kCredentialSourceOverride),
                 "Specifying both --override=fetch.credential_source and the "
                 "--credential_source flag is not allowed.");
     }
@@ -364,22 +353,21 @@ Result<LoadFlags> GetFlags(std::vector<std::string>& args,
   }
   if (!load_flags.project_id.empty()) {
     for (const auto& flag : load_flags.overrides) {
-      CF_EXPECT(
-          !absl::StartsWith(flag.config_path, kProjectIDOverride),
-          "Specifying both --override=fetch.project_id and the "
-          "--project_id flag is not allowed.");
+      CF_EXPECT(!absl::StartsWith(flag.config_path, kProjectIDOverride),
+                "Specifying both --override=fetch.project_id and the "
+                "--project_id flag is not allowed.");
     }
     load_flags.overrides.emplace_back(
         Override{.config_path = std::string(kProjectIDOverride),
                  .new_value = load_flags.project_id});
   }
-  return load_flags;
+  return {};
 }
 
 Result<EnvironmentSpecification> GetEnvironmentSpecification(
-    const LoadFlags& flags) {
+    const std::string& config_path, const std::vector<Override>& overrides) {
   Json::Value json_configs =
-      CF_EXPECT(GetOverriddenConfig(flags.config_path, flags.overrides));
+      CF_EXPECT(GetOverriddenConfig(config_path, overrides));
 
   EnvironmentSpecification env_spec =
       CF_EXPECT(ValidateCfConfigs(json_configs));

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.h
@@ -44,17 +44,17 @@ std::ostream& operator<<(std::ostream& out, const Override& override);
 
 struct LoadFlags {
   std::vector<Override> overrides;
-  std::string config_path;
   std::string credential_source;
   std::string project_id;
   std::string base_dir;
 };
 
-Result<LoadFlags> GetFlags(std::vector<std::string>& args,
-                           const std::string& working_directory);
+std::vector<Flag> BuildCvdLoadFlags(LoadFlags& load_flags);
+
+Result<void> ValidateCvdLoadFlags(LoadFlags& load_flags);
 
 Result<cvd::config::EnvironmentSpecification> GetEnvironmentSpecification(
-    const LoadFlags& flags);
+    const std::string& config_path, const std::vector<Override>& overrides);
 
 Result<InstanceManager::GroupDirectories> GetGroupCreationDirectories(
     const std::string& parent_directory,

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <ostream>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -35,22 +35,16 @@ struct CvdFlags {
   std::string target_directory;
 };
 
-struct Override {
-  std::string config_path;
-  std::string new_value;
-};
-
-std::ostream& operator<<(std::ostream& out, const Override& override);
-
 struct LoadFlags {
-  std::vector<Override> overrides;
+  std::map<std::string, std::string> overrides;
   std::string base_dir;
 };
 
 std::vector<Flag> BuildCvdLoadFlags(LoadFlags& load_flags);
 
 Result<cvd::config::EnvironmentSpecification> GetEnvironmentSpecification(
-    const std::string& config_path, const std::vector<Override>& overrides);
+    const std::string& config_path,
+    const std::map<std::string, std::string>& overrides);
 
 Result<InstanceManager::GroupDirectories> GetGroupCreationDirectories(
     const std::string& parent_directory,

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.h
@@ -44,14 +44,10 @@ std::ostream& operator<<(std::ostream& out, const Override& override);
 
 struct LoadFlags {
   std::vector<Override> overrides;
-  std::string credential_source;
-  std::string project_id;
   std::string base_dir;
 };
 
 std::vector<Flag> BuildCvdLoadFlags(LoadFlags& load_flags);
-
-Result<void> ValidateCvdLoadFlags(LoadFlags& load_flags);
 
 Result<cvd::config::EnvironmentSpecification> GetEnvironmentSpecification(
     const std::string& config_path, const std::vector<Override>& overrides);

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <functional>
 #include <map>
 #include <string>
 #include <vector>
@@ -36,7 +37,7 @@ struct CvdFlags {
 };
 
 struct LoadFlags {
-  std::map<std::string, std::string> overrides;
+  std::map<std::string, std::string, std::less<void>> overrides;
   std::string base_dir;
 };
 
@@ -44,7 +45,7 @@ std::vector<Flag> BuildCvdLoadFlags(LoadFlags& load_flags);
 
 Result<cvd::config::EnvironmentSpecification> GetEnvironmentSpecification(
     const std::string& config_path,
-    const std::map<std::string, std::string>& overrides);
+    const std::map<std::string, std::string, std::less<void>>& overrides);
 
 Result<InstanceManager::GroupDirectories> GetGroupCreationDirectories(
     const std::string& parent_directory,


### PR DESCRIPTION
Added a default implementation of DetailedHelp that prints in the same format for all commands (unless they override it, which most still do):
```
cvd `CmdList()[0]` - `SummaryHelp()`

`Description()`

`Flags()`
```
Both `load` and `start` make use of that default implementation.

Added more information and missing flags to both command's help output.

Some QoL improvements to the load command.