### PR TITLE
cvd: Begin simplifying creation analyzer

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
@@ -59,7 +59,6 @@ namespace cuttlefish {
 namespace {
 
 using selector::AnalyzeCreation;
-using selector::CreationAnalyzerParam;
 using selector::GroupCreationInfo;
 
 constexpr char kSummaryHelpText[] =

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/BUILD.bazel
@@ -44,7 +44,6 @@ cf_cc_library(
     deps = [
         ":selector_common_parser",
         "//cuttlefish/host/commands/cvd/cli:types",
-        "//cuttlefish/host/libs/config:config_constants",
         "//libbase",
         "@abseil-cpp//absl/strings",
         "@googletest//:gtest",
@@ -116,10 +115,8 @@ cf_cc_library(
     srcs = ["start_selector_parser.cpp"],
     hdrs = ["start_selector_parser.h"],
     deps = [
-        "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/host/commands/cvd/cli:types",
         "//cuttlefish/host/commands/cvd/cli/selector:selector_option_parser_utils",
-        "//cuttlefish/host/libs/config:config_constants",
         "//cuttlefish/host/libs/config:instance_nums",
         "//cuttlefish/result",
         "//libbase",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/BUILD.bazel
@@ -117,7 +117,6 @@ cf_cc_library(
     hdrs = ["start_selector_parser.h"],
     deps = [
         "//cuttlefish/common/libs/utils:contains",
-        "//cuttlefish/common/libs/utils:users",
         "//cuttlefish/host/commands/cvd/cli:types",
         "//cuttlefish/host/commands/cvd/cli/selector:selector_common_parser",
         "//cuttlefish/host/commands/cvd/cli/selector:selector_option_parser_utils",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/BUILD.bazel
@@ -118,7 +118,6 @@ cf_cc_library(
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/host/commands/cvd/cli:types",
-        "//cuttlefish/host/commands/cvd/cli/selector:selector_common_parser",
         "//cuttlefish/host/commands/cvd/cli/selector:selector_option_parser_utils",
         "//cuttlefish/host/libs/config:config_constants",
         "//cuttlefish/host/libs/config:instance_nums",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/creation_analyzer.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/creation_analyzer.cpp
@@ -45,7 +45,8 @@ class CreationAnalyzer {
 
  private:
   CreationAnalyzer(const CreationAnalyzerParam& param,
-                   StartSelectorParser&& selector_options_parser);
+                   StartSelectorParser&& selector_options_parser,
+                   SelectorOptions selector_options);
 
   Result<std::vector<InstanceParams>> AnalyzeInstances();
 
@@ -65,21 +66,25 @@ class CreationAnalyzer {
 
   // internal, temporary
   StartSelectorParser selector_options_parser_;
+  SelectorOptions selector_options_;
 };
 
 Result<CreationAnalyzer> CreationAnalyzer::Create(
     const CreationAnalyzerParam& param) {
   auto selector_options_parser =
       CF_EXPECT(StartSelectorParser::ConductSelectFlagsParser(
-          param.selectors, param.cmd_args, param.envs));
-  return CreationAnalyzer(param, std::move(selector_options_parser));
+          param.selectors.instance_names, param.cmd_args, param.envs));
+  return CreationAnalyzer(param, std::move(selector_options_parser),
+                          param.selectors);
 }
 
 CreationAnalyzer::CreationAnalyzer(
     const CreationAnalyzerParam& param,
-    StartSelectorParser&& selector_options_parser)
+    StartSelectorParser&& selector_options_parser,
+    SelectorOptions selector_options)
     : envs_(param.envs),
-      selector_options_parser_{std::move(selector_options_parser)} {}
+      selector_options_parser_{std::move(selector_options_parser)},
+      selector_options_(selector_options) {}
 
 Result<std::vector<InstanceParams>> CreationAnalyzer::AnalyzeInstances() {
   // As this test was done earlier, this line must not fail
@@ -91,7 +96,7 @@ Result<std::vector<InstanceParams>> CreationAnalyzer::AnalyzeInstances() {
   }
 
   std::optional<std::vector<std::string>> instance_names_opt =
-      selector_options_parser_.PerInstanceNames();
+      selector_options_.instance_names;
   if (instance_names_opt) {
     CF_EXPECT_EQ(instance_names_opt.value().size(), n_instances,
                  "Number of instance names provided doesn't match number of "
@@ -107,7 +112,7 @@ Result<std::vector<InstanceParams>> CreationAnalyzer::AnalyzeInstances() {
 Result<GroupCreationInfo> CreationAnalyzer::ExtractGroupInfo() {
   InstanceGroupParams group_params;
   group_params.instances = CF_EXPECT(AnalyzeInstances());
-  group_params.group_name = selector_options_parser_.GroupName().value_or("");
+  group_params.group_name = selector_options_.group_name.value_or("");
   InstanceManager::GroupDirectories group_directories{
       .home = CF_EXPECT(AnalyzeHome()),
       .host_artifacts_path = CF_EXPECT(AndroidHostPath(envs_)),

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/parser_ids_helper.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/parser_ids_helper.cpp
@@ -20,16 +20,10 @@
 
 #include "absl/strings/str_split.h"
 
-#include "cuttlefish/host/libs/config/config_constants.h"
-
 namespace cuttlefish {
 namespace selector {
 
 InstanceIdTest::InstanceIdTest() {
-  auto cuttlefish_instance = GetParam().cuttlefish_instance;
-  if (cuttlefish_instance) {
-    envs_[kCuttlefishInstanceEnvVarName] = cuttlefish_instance.value();
-  }
   cmd_args_ = absl::StrSplit(GetParam().cmd_args, ' ', absl::SkipEmpty());
   selector_opts_ = GetParam().selector_opts;
   expected_ids_ = GetParam().expected_ids;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/parser_ids_helper.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/parser_ids_helper.h
@@ -15,7 +15,6 @@
 
 #pragma once
 
-#include <optional>
 #include <string>
 #include <vector>
 
@@ -30,7 +29,6 @@ namespace selector {
 struct InstanceIdTestInput {
   std::string cmd_args;
   SelectorOptions selector_opts;
-  std::optional<std::string> cuttlefish_instance;
   std::vector<unsigned> expected_ids;
   unsigned requested_num_instances;
   bool expected_result;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/parser_ids_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/parser_ids_test.cpp
@@ -15,8 +15,8 @@
 
 #include <gtest/gtest.h>
 
-#include "cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/parser_ids_helper.h"
+#include "cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.h"
 
 namespace cuttlefish {
 namespace selector {
@@ -36,42 +36,26 @@ TEST_P(InstanceIdTest, InstanceIdCalculation) {
 INSTANTIATE_TEST_SUITE_P(
     CvdParser, InstanceIdTest,
     testing::Values(
-        InstanceIdTestInput{.cuttlefish_instance = std::nullopt,
-                            .expected_ids = {},
-                            .requested_num_instances = 1,
-                            .expected_result = true},
-        InstanceIdTestInput{.cuttlefish_instance = "8",
-                            .expected_ids = std::vector<unsigned>{8},
+        InstanceIdTestInput{.expected_ids = {},
                             .requested_num_instances = 1,
                             .expected_result = true},
         InstanceIdTestInput{.cmd_args = "--num_instances=2",
                             .expected_ids = {},
                             .requested_num_instances = 2,
                             .expected_result = true},
-        InstanceIdTestInput{.cmd_args = "--num_instances=2",
-                            .cuttlefish_instance = "8",
-                            .expected_ids = std::vector<unsigned>{8, 9},
-                            .requested_num_instances = 2,
-                            .expected_result = true},
-        InstanceIdTestInput{
-            .cmd_args = "--base_instance_num=10 --num_instances=2",
-            .cuttlefish_instance = "8",
-            .expected_ids = std::vector<unsigned>{10, 11},
-            .requested_num_instances = 2,
-            .expected_result = true},
         InstanceIdTestInput{.cmd_args = "--instance_nums 2",
-                            .cuttlefish_instance = std::nullopt,
+
                             .expected_ids = std::vector<unsigned>{2},
                             .requested_num_instances = 1,
                             .expected_result = true},
         InstanceIdTestInput{.cmd_args = "--instance_nums 2,5,6",
-                            .cuttlefish_instance = std::nullopt,
+
                             .expected_ids = std::vector<unsigned>{2, 5, 6},
                             .requested_num_instances = 3,
                             .expected_result = true},
         InstanceIdTestInput{
             .cmd_args = "--instance_nums 2,5,6 --num_instances=3",
-            .cuttlefish_instance = std::nullopt,
+
             .expected_ids = std::vector<unsigned>{2, 5, 6},
             .requested_num_instances = 3,
             .expected_result = true},
@@ -80,7 +64,7 @@ INSTANTIATE_TEST_SUITE_P(
             .selector_opts = SelectorOptions{.instance_names =
                                                  std::vector<std::string>{
                                                      "c-1", "c-2", "c-3"}},
-            .cuttlefish_instance = std::nullopt,
+
             .expected_ids = std::vector<unsigned>{2, 5, 6},
             .requested_num_instances = 3,
             .expected_result = true},
@@ -88,21 +72,21 @@ INSTANTIATE_TEST_SUITE_P(
             .selector_opts = SelectorOptions{.instance_names =
                                                  std::vector<std::string>{
                                                      "c-1", "c-3", "c-5"}},
-            .cuttlefish_instance = std::nullopt,
+
             .expected_ids = {},
             .requested_num_instances = 3,
             .expected_result = true},
         // CUTTLEFISH_INSTANCE should be ignored
         InstanceIdTestInput{
             .cmd_args = "--instance_nums 2,5,6 --num_instances=3",
-            .cuttlefish_instance = "8",
+
             .expected_ids = std::vector<unsigned>{2, 5, 6},
             .requested_num_instances = 3,
             .expected_result = true},
         // instance_nums and num_instances mismatch
         InstanceIdTestInput{
             .cmd_args = "--instance_nums 2,5,6 --num_instances=7",
-            .cuttlefish_instance = std::nullopt,
+
             .expected_ids = std::vector<unsigned>{2, 5, 6},
             .requested_num_instances = 3,
             .expected_result = false},
@@ -112,14 +96,14 @@ INSTANTIATE_TEST_SUITE_P(
             .selector_opts =
                 SelectorOptions{
                     .instance_names = std::vector<std::string>{"c-1", "c-3"}},
-            .cuttlefish_instance = std::nullopt,
+
             .expected_ids = std::vector<unsigned>{2, 5, 6},
             .requested_num_instances = 3,
             .expected_result = false},
         // --base_instance_num is not allowed with --instance_nums
         InstanceIdTestInput{
             .cmd_args = "--instance_nums 2,5,6 --base_instance_num=7",
-            .cuttlefish_instance = std::nullopt,
+
             .expected_ids = std::vector<unsigned>{2, 5, 6},
             .requested_num_instances = 3,
             .expected_result = false}));

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/parser_ids_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/parser_ids_test.cpp
@@ -23,7 +23,7 @@ namespace selector {
 
 TEST_P(InstanceIdTest, InstanceIdCalculation) {
   auto parser = StartSelectorParser::ConductSelectFlagsParser(
-      selector_opts_, cmd_args_, envs_);
+      selector_opts_.instance_names, cmd_args_, envs_);
 
   ASSERT_EQ(parser.ok(), expected_result_);
   if (!expected_result_) {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector_option_parser_utils.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector_option_parser_utils.h
@@ -32,24 +32,14 @@ namespace selector {
  * @return any parsing successfully and actually happened
  */
 template <typename T>
-Result<void> FilterSelectorFlag(std::vector<std::string>& args,
-                                const std::string& flag_name,
-                                std::optional<T>& value_opt) {
-  value_opt = std::nullopt;
-  const size_t args_initial_size = args.size();
-  if (args_initial_size == 0) {
-    return {};
-  }
-
-  T value;
-  CF_EXPECT(ConsumeFlags({GflagsCompatFlag(flag_name, value)}, args),
+Result<std::optional<T>> FilterSelectorFlag(std::vector<std::string>& args,
+                                            const std::string& flag_name) {
+  std::optional<T> value_opt;
+  CF_EXPECT(ConsumeFlags(
+                {GflagsCompatFlag(flag_name, value_opt, CoerceToNullopt::None)},
+                args),
             "Failed to parse --" << flag_name);
-  if (args.size() == args_initial_size) {
-    // not consumed
-    return {};
-  }
-  value_opt = value;
-  return {};
+  return value_opt;
 }
 
 }  // namespace selector

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.cpp
@@ -226,10 +226,6 @@ StartSelectorParser::HandleInstanceIds(
 }
 
 Result<void> StartSelectorParser::ParseOptions() {
-  std::optional<bool> use_cvdalloc;
-  CF_EXPECT(FilterSelectorFlag(cmd_args_, "use_cvdalloc", use_cvdalloc));
-  use_cvdalloc_ = use_cvdalloc.value_or(false);
-
   std::optional<std::string> num_instances;
   std::optional<std::string> instance_nums;
   std::optional<std::string> base_instance_num;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.cpp
@@ -226,14 +226,13 @@ StartSelectorParser::HandleInstanceIds(
 }
 
 Result<void> StartSelectorParser::ParseOptions() {
-  std::optional<std::string> num_instances;
-  std::optional<std::string> instance_nums;
-  std::optional<std::string> base_instance_num;
-  // set num_instances as std::nullptr or the value of --num_instances
-  CF_EXPECT(FilterSelectorFlag(cmd_args_, "num_instances", num_instances));
-  CF_EXPECT(FilterSelectorFlag(cmd_args_, "instance_nums", instance_nums));
-  CF_EXPECT(
-      FilterSelectorFlag(cmd_args_, "base_instance_num", base_instance_num));
+  // set num_instances as std::nullopt or the value of --num_instances
+  std::optional<std::string> num_instances =
+      CF_EXPECT(FilterSelectorFlag<std::string>(cmd_args_, "num_instances"));
+  std::optional<std::string> instance_nums =
+      CF_EXPECT(FilterSelectorFlag<std::string>(cmd_args_, "instance_nums"));
+  std::optional<std::string> base_instance_num = CF_EXPECT(
+      FilterSelectorFlag<std::string>(cmd_args_, "base_instance_num"));
 
   InstanceIdsParams instance_nums_param{
       .num_instances = std::move(num_instances),

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.cpp
@@ -31,7 +31,6 @@
 #include "absl/strings/numbers.h"
 
 #include "cuttlefish/common/libs/utils/contains.h"
-#include "cuttlefish/host/commands/cvd/cli/selector/selector_common_parser.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector_option_parser_utils.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/host/libs/config/config_constants.h"
@@ -53,25 +52,20 @@ static Result<unsigned> ParsePositiveNumber(std::string_view token) {
 }
 
 Result<StartSelectorParser> StartSelectorParser::ConductSelectFlagsParser(
-    const SelectorOptions& selector_options, const cvd_common::Args& cmd_args,
-    const cvd_common::Envs& envs) {
-  StartSelectorParser parser(selector_options, cmd_args, envs);
+    const std::optional<std::vector<std::string>>& instance_names_opt,
+    const cvd_common::Args& cmd_args, const cvd_common::Envs& envs) {
+  StartSelectorParser parser(instance_names_opt, cmd_args, envs);
   CF_EXPECT(parser.ParseOptions(), "selector option flag parsing failed.");
   return {std::move(parser)};
 }
 
 StartSelectorParser::StartSelectorParser(
-    const SelectorOptions& selector_options, const cvd_common::Args& cmd_args,
-    const cvd_common::Envs& envs)
-    : selector_options_(selector_options), cmd_args_(cmd_args), envs_(envs) {}
-
-std::optional<std::string> StartSelectorParser::GroupName() const {
-  return selector_options_.group_name;
-}
-
-std::optional<std::vector<std::string>> StartSelectorParser::PerInstanceNames()
-    const {
-  return selector_options_.instance_names;
+    const std::optional<std::vector<std::string>>& instance_names_opt,
+    const cvd_common::Args& cmd_args, const cvd_common::Envs& envs)
+    : cmd_args_(cmd_args), envs_(envs) {
+  if (instance_names_opt) {
+    num_instance_names_opt_ = instance_names_opt->size();
+  }
 }
 
 namespace {
@@ -123,15 +117,15 @@ Result<unsigned> StartSelectorParser::VerifyNumOfInstances(
     const VerifyNumOfInstancesParam& params,
     const unsigned default_n_instances) const {
   const auto& num_instances_flag = params.num_instances_flag;
-  const auto& instance_names = params.instance_names;
+  const auto& num_instance_names = params.num_instance_names;
   const auto& instance_nums_flag = params.instance_nums_flag;
 
   std::optional<unsigned> num_instances;
   if (num_instances_flag) {
     num_instances = CF_EXPECT(ParsePositiveNumber(*num_instances_flag));
   }
-  if (instance_names && !instance_names->empty()) {
-    auto implied_n_instances = instance_names->size();
+  if (num_instance_names.value_or(0) > 0) {
+    auto implied_n_instances = *num_instance_names;
     if (num_instances) {
       CF_EXPECT_EQ(*num_instances, static_cast<unsigned>(implied_n_instances),
                    "The number of instances requested by --num_instances "
@@ -182,7 +176,7 @@ StartSelectorParser::HandleInstanceIds(
   unsigned num_instances =
       CF_EXPECT(VerifyNumOfInstances(VerifyNumOfInstancesParam{
           .num_instances_flag = instance_id_params.num_instances,
-          .instance_names = PerInstanceNames(),
+          .num_instance_names = num_instance_names_opt_,
           .instance_nums_flag = instance_nums}));
 
   if (!instance_nums && !base_instance_num) {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.cpp
@@ -89,7 +89,6 @@ std::optional<std::vector<unsigned>>
 StartSelectorParser::InstanceFromEnvironment(
     const InstanceFromEnvParam& params) {
   const auto& cuttlefish_instance_env = params.cuttlefish_instance_env;
-  const auto& vsoc_suffix = params.vsoc_suffix;
   const auto& num_instances = params.num_instances;
 
   // see the logic in cuttlefish::InstanceFromEnvironment()
@@ -98,9 +97,6 @@ StartSelectorParser::InstanceFromEnvironment(
   std::optional<unsigned> base;
   if (cuttlefish_instance_env) {
     base = *cuttlefish_instance_env;
-  }
-  if (!base && vsoc_suffix) {
-    base = *vsoc_suffix;
   }
   if (!base) {
     return {};
@@ -170,7 +166,6 @@ StartSelectorParser::HandleInstanceIds(
   const auto& base_instance_num = instance_id_params.base_instance_num;
   const auto& cuttlefish_instance_env =
       instance_id_params.cuttlefish_instance_env;
-  const auto& vsoc_suffix = instance_id_params.vsoc_suffix;
 
   // calculate and/or verify the number of instances
   unsigned num_instances =
@@ -185,7 +180,6 @@ StartSelectorParser::HandleInstanceIds(
     // std::nullopt is returned.
     auto instance_ids = InstanceFromEnvironment(
         {.cuttlefish_instance_env = cuttlefish_instance_env,
-         .vsoc_suffix = vsoc_suffix,
          .num_instances = num_instances});
     if (instance_ids) {
       return ParsedInstanceIdsOpt(*instance_ids);

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.cpp
@@ -22,7 +22,6 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -30,10 +29,8 @@
 #include "absl/strings/str_split.h"
 #include "absl/strings/numbers.h"
 
-#include "cuttlefish/common/libs/utils/contains.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector_option_parser_utils.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
-#include "cuttlefish/host/libs/config/config_constants.h"
 #include "cuttlefish/host/libs/config/instance_nums.h"
 
 namespace cuttlefish {
@@ -66,47 +63,6 @@ StartSelectorParser::StartSelectorParser(
   if (instance_names_opt) {
     num_instance_names_opt_ = instance_names_opt->size();
   }
-}
-
-namespace {
-
-std::optional<unsigned> TryFromCuttlefishInstance(
-    const cvd_common::Envs& envs) {
-  if (!Contains(envs, kCuttlefishInstanceEnvVarName)) {
-    return std::nullopt;
-  }
-  const auto cuttlefish_instance = envs.at(kCuttlefishInstanceEnvVarName);
-  if (cuttlefish_instance.empty()) {
-    return std::nullopt;
-  }
-  auto parsed = ParsePositiveNumber(cuttlefish_instance);
-  return parsed.ok() ? std::optional(*parsed) : std::nullopt;
-}
-
-}  // namespace
-
-std::optional<std::vector<unsigned>>
-StartSelectorParser::InstanceFromEnvironment(
-    const InstanceFromEnvParam& params) {
-  const auto& cuttlefish_instance_env = params.cuttlefish_instance_env;
-  const auto& num_instances = params.num_instances;
-
-  // see the logic in cuttlefish::InstanceFromEnvironment()
-  // defined in host/libs/config/cuttlefish_config.cpp
-  std::vector<unsigned> nums;
-  std::optional<unsigned> base;
-  if (cuttlefish_instance_env) {
-    base = *cuttlefish_instance_env;
-  }
-  if (!base) {
-    return {};
-  }
-  // this is guaranteed by the caller
-  // assert(num_instances != std::nullopt);
-  for (unsigned i = 0; i != *num_instances; i++) {
-    nums.emplace_back(base.value() + i);
-  }
-  return nums;
 }
 
 Result<unsigned> StartSelectorParser::VerifyNumOfInstances(
@@ -164,8 +120,6 @@ StartSelectorParser::HandleInstanceIds(
     const InstanceIdsParams& instance_id_params) {
   const auto& instance_nums = instance_id_params.instance_nums;
   const auto& base_instance_num = instance_id_params.base_instance_num;
-  const auto& cuttlefish_instance_env =
-      instance_id_params.cuttlefish_instance_env;
 
   // calculate and/or verify the number of instances
   unsigned num_instances =
@@ -175,15 +129,6 @@ StartSelectorParser::HandleInstanceIds(
           .instance_nums_flag = instance_nums}));
 
   if (!instance_nums && !base_instance_num) {
-    // num_instances is given. if non-std::nullopt is returned,
-    // the base is also figured out. If base can't be figured out,
-    // std::nullopt is returned.
-    auto instance_ids = InstanceFromEnvironment(
-        {.cuttlefish_instance_env = cuttlefish_instance_env,
-         .num_instances = num_instances});
-    if (instance_ids) {
-      return ParsedInstanceIdsOpt(*instance_ids);
-    }
     // the return value, n_instances is the "desired/requested" instances
     // When instance_ids set isn't figured out, n_instances is not meant to
     // be always zero; it could be any natural number.
@@ -226,7 +171,7 @@ Result<void> StartSelectorParser::ParseOptions() {
       .num_instances = std::move(num_instances),
       .instance_nums = std::move(instance_nums),
       .base_instance_num = std::move(base_instance_num),
-      .cuttlefish_instance_env = TryFromCuttlefishInstance(envs_)};
+  };
   auto parsed_ids = CF_EXPECT(HandleInstanceIds(instance_nums_param));
   requested_num_instances_ = parsed_ids.GetNumOfInstances();
   instance_ids_ = parsed_ids.GetInstanceIds();

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.cpp
@@ -65,6 +65,8 @@ StartSelectorParser::StartSelectorParser(
   }
 }
 
+// Verify that, if given, the number of instances is the same accross
+// --num_instances, --instance_names and --instance_nums.
 Result<unsigned> StartSelectorParser::VerifyNumOfInstances(
     const VerifyNumOfInstancesParam& params,
     const unsigned default_n_instances) const {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.cpp
@@ -31,7 +31,6 @@
 #include "absl/strings/numbers.h"
 
 #include "cuttlefish/common/libs/utils/contains.h"
-#include "cuttlefish/common/libs/utils/users.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector_common_parser.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector_option_parser_utils.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
@@ -56,21 +55,15 @@ static Result<unsigned> ParsePositiveNumber(std::string_view token) {
 Result<StartSelectorParser> StartSelectorParser::ConductSelectFlagsParser(
     const SelectorOptions& selector_options, const cvd_common::Args& cmd_args,
     const cvd_common::Envs& envs) {
-  const std::string system_wide_home = CF_EXPECT(SystemWideUserHome());
-  StartSelectorParser parser(system_wide_home, selector_options, cmd_args,
-                             envs);
+  StartSelectorParser parser(selector_options, cmd_args, envs);
   CF_EXPECT(parser.ParseOptions(), "selector option flag parsing failed.");
   return {std::move(parser)};
 }
 
 StartSelectorParser::StartSelectorParser(
-    const std::string& system_wide_user_home,
     const SelectorOptions& selector_options, const cvd_common::Args& cmd_args,
     const cvd_common::Envs& envs)
-    : client_user_home_{system_wide_user_home},
-      selector_options_(selector_options),
-      cmd_args_(cmd_args),
-      envs_(envs) {}
+    : selector_options_(selector_options), cmd_args_(cmd_args), envs_(envs) {}
 
 std::optional<std::string> StartSelectorParser::GroupName() const {
   return selector_options_.group_name;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.h
@@ -62,7 +62,6 @@ class StartSelectorParser {
     std::optional<std::string> instance_nums;
     std::optional<std::string> base_instance_num;
     std::optional<unsigned> cuttlefish_instance_env;
-    std::optional<unsigned> vsoc_suffix;
   };
 
   class ParsedInstanceIdsOpt {
@@ -88,7 +87,6 @@ class StartSelectorParser {
 
   struct InstanceFromEnvParam {
     std::optional<unsigned> cuttlefish_instance_env;
-    std::optional<unsigned> vsoc_suffix;
     std::optional<unsigned> num_instances;
   };
   std::optional<std::vector<unsigned>> InstanceFromEnvironment(

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.h
@@ -61,7 +61,6 @@ class StartSelectorParser {
     std::optional<std::string> num_instances;
     std::optional<std::string> instance_nums;
     std::optional<std::string> base_instance_num;
-    std::optional<unsigned> cuttlefish_instance_env;
   };
 
   class ParsedInstanceIdsOpt {
@@ -84,13 +83,6 @@ class StartSelectorParser {
    */
   Result<ParsedInstanceIdsOpt> HandleInstanceIds(
       const InstanceIdsParams& instance_id_params);
-
-  struct InstanceFromEnvParam {
-    std::optional<unsigned> cuttlefish_instance_env;
-    std::optional<unsigned> num_instances;
-  };
-  std::optional<std::vector<unsigned>> InstanceFromEnvironment(
-      const InstanceFromEnvParam& params);
 
   struct VerifyNumOfInstancesParam {
     std::optional<std::string> num_instances_flag;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.h
@@ -56,8 +56,7 @@ class StartSelectorParser {
   bool UseCvdalloc() const { return use_cvdalloc_; }
 
  private:
-  StartSelectorParser(const std::string& system_wide_user_home,
-                      const SelectorOptions& selector_options,
+  StartSelectorParser(const SelectorOptions& selector_options,
                       const cvd_common::Args& cmd_args,
                       const cvd_common::Envs& envs);
 
@@ -139,7 +138,6 @@ class StartSelectorParser {
   bool use_cvdalloc_;
 
   // temporarily keeps the leftover of the input cmd_args
-  const std::string client_user_home_;
   SelectorOptions selector_options_;
   cvd_common::Args cmd_args_;
   cvd_common::Envs envs_;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <stddef.h>
 #include <sys/types.h>
 
 #include <optional>
@@ -23,7 +24,6 @@
 #include <utility>
 #include <vector>
 
-#include "cuttlefish/host/commands/cvd/cli/selector/selector_common_parser.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/result/result.h"
 
@@ -45,19 +45,15 @@ namespace selector {
 class StartSelectorParser {
  public:
   static Result<StartSelectorParser> ConductSelectFlagsParser(
-      const SelectorOptions& selector_options, const cvd_common::Args& cmd_args,
-      const cvd_common::Envs& envs);
-  std::optional<std::string> GroupName() const;
-  std::optional<std::vector<std::string>> PerInstanceNames() const;
-  const std::vector<unsigned>& InstanceIds() const {
-    return instance_ids_;
-  }
+      const std::optional<std::vector<std::string>>& instance_names_opt,
+      const cvd_common::Args& cmd_args, const cvd_common::Envs& envs);
+  const std::vector<unsigned>& InstanceIds() const { return instance_ids_; }
   unsigned RequestedNumInstances() const { return requested_num_instances_; }
 
  private:
-  StartSelectorParser(const SelectorOptions& selector_options,
-                      const cvd_common::Args& cmd_args,
-                      const cvd_common::Envs& envs);
+  StartSelectorParser(
+      const std::optional<std::vector<std::string>>& instance_names_opt,
+      const cvd_common::Args& cmd_args, const cvd_common::Envs& envs);
 
   Result<void> ParseOptions();
 
@@ -100,7 +96,7 @@ class StartSelectorParser {
 
   struct VerifyNumOfInstancesParam {
     std::optional<std::string> num_instances_flag;
-    std::optional<std::vector<std::string>> instance_names;
+    std::optional<size_t> num_instance_names;
     std::optional<std::string> instance_nums_flag;
   };
 
@@ -123,8 +119,7 @@ class StartSelectorParser {
   std::vector<unsigned> instance_ids_;
   unsigned requested_num_instances_;
 
-  SelectorOptions selector_options_;
-
+  std::optional<size_t> num_instance_names_opt_;
   // temporarily keeps the leftover of the input cmd_args
   cvd_common::Args cmd_args_;
   cvd_common::Envs envs_;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.h
@@ -85,19 +85,7 @@ class StartSelectorParser {
   };
 
   /*
-   * CF_ERR is meant to be an error:
-   *  For example, --num_instances != |--instance_nums|.
-   *
-   * On the contrary, std::nullopt inside Result is not necessary one.
-   * std::nullopt inside Result means that with the given information,
-   * the instance_ids_ cannot be yet figured out, so the task is deferred
-   * to CreationAnaylizer or so, which has more contexts. For example,
-   * if no option at all is given, it is not an error; however, the
-   * StartSelectorParser alone cannot figure out the list of instance ids. The
-   * InstanceDatabase, UniqueResourceAllocator, InstanceLockFileManager will be
-   * involved to automatically generate the valid, numeric instance ids.
-   * If that's the case, Result{std::nullopt} could be returned.
-   *
+   * Returns the number of instances and maybe the instance ids.
    */
   Result<ParsedInstanceIdsOpt> HandleInstanceIds(
       const InstanceIdsParams& instance_id_params);
@@ -135,8 +123,9 @@ class StartSelectorParser {
   std::vector<unsigned> instance_ids_;
   unsigned requested_num_instances_;
 
-  // temporarily keeps the leftover of the input cmd_args
   SelectorOptions selector_options_;
+
+  // temporarily keeps the leftover of the input cmd_args
   cvd_common::Args cmd_args_;
   cvd_common::Envs envs_;
 };

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/start_selector_parser.h
@@ -53,7 +53,6 @@ class StartSelectorParser {
     return instance_ids_;
   }
   unsigned RequestedNumInstances() const { return requested_num_instances_; }
-  bool UseCvdalloc() const { return use_cvdalloc_; }
 
  private:
   StartSelectorParser(const SelectorOptions& selector_options,
@@ -135,7 +134,6 @@ class StartSelectorParser {
    */
   std::vector<unsigned> instance_ids_;
   unsigned requested_num_instances_;
-  bool use_cvdalloc_;
 
   // temporarily keeps the leftover of the input cmd_args
   SelectorOptions selector_options_;

--- a/base/cvd/cuttlefish/host/libs/config/instance_nums.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/instance_nums.cpp
@@ -222,11 +222,11 @@ Result<std::vector<int32_t>> InstanceNumsCalculator::CalculateFromFlags() {
     instance_nums_opt = instance_nums_;
   }
   // exactly one of these two should be given
-  CF_EXPECT(!instance_nums_opt || !base_instance_num_,
+  CF_EXPECT(!(instance_nums_opt && base_instance_num_),
+            "InstanceNums and BaseInstanceNum are mutually exclusive");
+  CF_EXPECT(instance_nums_opt || base_instance_num_,
             "At least one of --instance_nums or --base_instance_num"
                 << "should be given to call CalculateFromFlags()");
-  CF_EXPECT(instance_nums_opt || base_instance_num_,
-            "InstanceNums and BaseInstanceNum are mutually exclusive");
 
   if (instance_nums_opt) {
     if (num_instances_) {


### PR DESCRIPTION
Most of the simplification is done in StartSelectorParser.

The most significant change is that it no longer considers the `$CUTTLEFISH_INSTANCE` environment variable when trying to figure the number of instances and its ids. `cvd_internal_start` never expected the user to set that variable, expecting the user to use flags instead. That variable is unconditionally set by `cvd_internal_start` so `run_cvd` and its children know which instance they are running.

NOTE TO REVIEWER: reviewing each commit separately is going to be a lot easier than the entire PR at once.
