### PR TITLE
Implement GET /cvds/{group}/{name} endpoint

### DIFF
--- a/frontend/src/host_orchestrator/orchestrator/controller.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller.go
@@ -68,6 +68,7 @@ func (c *Controller) AddRoutes(router *mux.Router) {
 		httpHandler(newCreateCVDHandler(c.Config, c.OperationManager, c.UserArtifactsManager))).Methods("POST")
 	router.Handle("/cvds", httpHandler(&listCVDsHandlerAll{Config: c.Config})).Methods("GET")
 	router.Handle("/cvds/{group}", httpHandler(&listCVDsHandler{Config: c.Config})).Methods("GET")
+	router.Handle("/cvds/{group}/{name}", httpHandler(&listCVDsHandler{Config: c.Config})).Methods("GET")
 	router.PathPrefix("/cvds/{group}/{name}/logs").Handler(&getCVDLogsHandler{Config: c.Config}).Methods("GET")
 	router.Handle("/cvds/{group}/:start",
 		httpHandler(newExecCVDGroupCommandHandler(c.Config, c.OperationManager, &startCvdCommand{}))).Methods("POST")
@@ -296,6 +297,7 @@ func (h *listCVDsHandler) Handle(r *http.Request) (interface{}, error) {
 	vars := mux.Vars(r)
 	opts := ListCVDsActionOpts{
 		Group:       vars["group"],
+		Name:        vars["name"],
 		Paths:       h.Config.Paths,
 		ExecContext: exec.CommandContext,
 	}

--- a/frontend/src/host_orchestrator/orchestrator/controller_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller_test.go
@@ -66,6 +66,21 @@ func TestGetCVDLogsIsHandled(t *testing.T) {
 	}
 }
 
+func TestGetCVDIsHandled(t *testing.T) {
+	rr := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/cvds/foo/bar", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller := Controller{}
+
+	makeRequest(rr, req, &controller)
+
+	if rr.Code == http.StatusNotFound && rr.Body.String() == pageNotFoundErrMsg {
+		t.Errorf("request was not handled. This failure implies an API breaking change.")
+	}
+}
+
 func TestGetOperationIsHandled(t *testing.T) {
 	rr := httptest.NewRecorder()
 	req, err := http.NewRequest("GET", "/operations/foo", nil)

--- a/frontend/src/host_orchestrator/orchestrator/listcvdsaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/listcvdsaction.go
@@ -25,12 +25,14 @@ import (
 
 type ListCVDsActionOpts struct {
 	Group       string
+	Name        string
 	Paths       IMPaths
 	ExecContext exec.ExecContext
 }
 
 type ListCVDsAction struct {
 	group  string
+	name   string
 	paths  IMPaths
 	cvdCLI *cvd.CLI
 }
@@ -38,6 +40,7 @@ type ListCVDsAction struct {
 func NewListCVDsAction(opts ListCVDsActionOpts) *ListCVDsAction {
 	return &ListCVDsAction{
 		group:  opts.Group,
+		name:   opts.Name,
 		paths:  opts.Paths,
 		cvdCLI: cvd.NewCLI(opts.ExecContext),
 	}
@@ -56,8 +59,19 @@ func (a *ListCVDsAction) Run() (*apiv1.ListCVDsResponse, error) {
 		groups = []*cvd.Group{g}
 	}
 	cvds := []*apiv1.CVD{}
-	for _, g := range groups {
-		cvds = append(cvds, CvdGroupToAPIObject(g)...)
+	if a.name != "" {
+		if len(groups) == 0 {
+			return nil, operator.NewNotFoundError(fmt.Sprintf("CVD %q not found", a.name), nil)
+		}
+		found, ins := findInstance(groups[0], a.name)
+		if !found {
+			return nil, operator.NewNotFoundError(fmt.Sprintf("CVD %q not found in group %q", a.name, a.group), nil)
+		}
+		cvds = []*apiv1.CVD{CvdInstanceToAPIObject(ins, a.group)}
+	} else {
+		for _, g := range groups {
+			cvds = append(cvds, CvdGroupToAPIObject(g)...)
+		}
 	}
 	return &apiv1.ListCVDsResponse{CVDs: cvds}, nil
 }

--- a/frontend/src/host_orchestrator/orchestrator/listcvdsaction_test.go
+++ b/frontend/src/host_orchestrator/orchestrator/listcvdsaction_test.go
@@ -105,29 +105,63 @@ func TestListCVDsSucceeds(t *testing.T) {
 		},
 	}
 	var tests = []struct {
-		group string
-		want  *apiv1.ListCVDsResponse
+		nameDesc string
+		group    string
+		name     string
+		want     *apiv1.ListCVDsResponse
+		wantErr  bool
 	}{
 		{
-			group: "",
-			want:  &apiv1.ListCVDsResponse{CVDs: cvds},
+			nameDesc: "list all",
+			group:    "",
+			name:     "",
+			want:     &apiv1.ListCVDsResponse{CVDs: cvds},
 		},
 		{
-			group: "foo",
-			want:  &apiv1.ListCVDsResponse{CVDs: []*apiv1.CVD{cvds[0]}},
+			nameDesc: "list group foo",
+			group:    "foo",
+			name:     "",
+			want:     &apiv1.ListCVDsResponse{CVDs: []*apiv1.CVD{cvds[0]}},
+		},
+		{
+			nameDesc: "get cvd 1 in group foo",
+			group:    "foo",
+			name:     "1",
+			want:     &apiv1.ListCVDsResponse{CVDs: []*apiv1.CVD{cvds[0]}},
+		},
+		{
+			nameDesc: "get cvd 2 in group foo (not found)",
+			group:    "foo",
+			name:     "2",
+			wantErr:  true,
+		},
+		{
+			nameDesc: "get cvd 1 in non-existent group (not found)",
+			group:    "baz",
+			name:     "1",
+			wantErr:  true,
 		},
 	}
 	for _, test := range tests {
-		opts := ListCVDsActionOpts{
-			Group:       test.group,
-			ExecContext: execContext,
-		}
-		action := NewListCVDsAction(opts)
+		t.Run(test.nameDesc, func(t *testing.T) {
+			opts := ListCVDsActionOpts{
+				Group:       test.group,
+				Name:        test.name,
+				ExecContext: execContext,
+			}
+			action := NewListCVDsAction(opts)
 
-		res, _ := action.Run()
+			res, err := action.Run()
 
-		if diff := cmp.Diff(test.want, res); diff != "" {
-			t.Errorf("response mismatch (-want +got):\n%s", diff)
-		}
+			if (err != nil) != test.wantErr {
+				t.Errorf("wantErr %v, got %v", test.wantErr, err)
+			}
+			if test.wantErr {
+				return
+			}
+			if diff := cmp.Diff(test.want, res); diff != "" {
+				t.Errorf("response mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Implement the `GET /cvds/{group}/{name}` endpoint in the host orchestrator to allow retrieving a specific CVD instance by its group and name.

This is achieved by:
- Extending `ListCVDsActionOpts` and `ListCVDsAction` to support filtering by CVD name.
- Updating `listCVDsHandler.Handle` to extract the `name` variable from the request and pass it to `ListCVDsActionOpts`.
- Registering the `GET /cvds/{group}/{name}` route in `Controller.AddRoutes` using `listCVDsHandler`.
- Adding unit tests in `listcvdsaction_test.go` to verify the filtering logic and error handling (404 when not found).
- Adding a routing test in `controller_test.go` to ensure the new endpoint is correctly registered.
  
This change preserves the original behavior of `GET /cvds` and `GET /cvds/{group}`.