### PR TITLE
Reapply "Treat all monitored subprocesses as critical."

### DIFF
--- a/base/cvd/cuttlefish/host/libs/feature/command_source.h
+++ b/base/cvd/cuttlefish/host/libs/feature/command_source.h
@@ -30,7 +30,7 @@ struct MonitorCommand {
   Command command;
   bool is_critical;
 
-  MonitorCommand(Command command, bool is_critical = false)
+  MonitorCommand(Command command, bool is_critical = true)
       : command(std::move(command)), is_critical(is_critical) {}
 };
 


### PR DESCRIPTION
This reverts commit bdc7b896a7ca4311468270b5e13971cd6d5ce6bd.

-- 

Reverts #2600 and re-land #2592. I could not reproduce the issue that informed reverting in the first place. 

Bug: 508320217