### PR TITLE
Use INADDR_LOOPBACK for adb serial

### DIFF
--- a/base/cvd/cuttlefish/host/libs/config/adb/launch.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/adb/launch.cpp
@@ -48,7 +48,7 @@ class AdbHelper {
   }
 
   std::string ConnectorTcpArg() const {
-    return "0.0.0.0:" + std::to_string(instance_.adb_host_port());
+    return "127.0.0.1:" + std::to_string(instance_.adb_host_port());
   }
 
   std::string ConnectorVsockArg() const {


### PR DESCRIPTION
Instead of INADDR_ANY. INADDR_ANY is still used on the host side proxy to accept connections on all network interfaces.

When issuing the `adb connect` command though, the loopback address is used as it's more specific.

The loopback address is also more likely to be used when the user (or an agent on their behalf) executes the `adb connect` command. If the user tries to connect to the same port with a different address, the adb server will create a new connection with the device and list it separately from the one created by adb_connection_maintainer.

Bug: b/516816243