### PR TITLE
Use only appended partitions during raw disk build

### DIFF
--- a/base/cvd/cuttlefish/host/libs/image_aggregator/image_aggregator.cc
+++ b/base/cvd/cuttlefish/host/libs/image_aggregator/image_aggregator.cc
@@ -116,6 +116,8 @@ class CompositeDiskBuilder {
  public:
   CompositeDiskBuilder(bool read_only) : read_only_(read_only) {}
 
+  const std::vector<PartitionInfo>& Partitions() const { return partitions_; }
+
   Result<void> AppendPartition(ImagePartition source) {
     uint64_t size = CF_EXPECT(ExpandedStorageSize(source.image_file_path));
     auto aligned_size = AlignToPartitionSize(size);
@@ -329,7 +331,8 @@ Result<void> AggregateImage(const std::vector<ImagePartition>& partitions,
              "Could not write GPT beginning to '{}': {}", output_path,
              output->StrError());
 
-  for (auto& disk : partitions) {
+  for (const auto& partition_info : builder.Partitions()) {
+    const auto& disk = partition_info.source;
     SharedFD disk_fd = SharedFD::Open(disk.image_file_path, O_RDONLY);
     CF_EXPECTF(disk_fd->IsOpen(), "{}", disk_fd->StrError());
 


### PR DESCRIPTION
Along with the final partition images, the Android build system places some temporary images into target output folder (e.g `dtb.img`, `ramdisk.img`, `vendor-bootconfig.img`, `vendor_ramdisk.img`), which are then getting picked during the `assemble_cvd` disk build process. Currently, we implicitly filter out these temporary image files by checking their size alignment (line 323 where we just ignore error). However, even after an image is filtered out, the further logic still attempts to write it to the disk, which results in a corrupted GPT.

The proper long-term fix is to avoid relying on image file alignment to decide whether or not a file should be included. For now, correctly respecting and skipping these filtered images is enough to restore functionality.