### PR TITLE
Route per-instance stop API to instance-level stop

### DIFF
--- a/frontend/src/host_orchestrator/orchestrator/controller.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller.go
@@ -84,7 +84,7 @@ func (c *Controller) AddRoutes(router *mux.Router) {
 	router.Handle("/cvds/{group}/{name}/:start",
 		httpHandler(newStartCVDHandler(c.Config, c.OperationManager))).Methods("POST")
 	router.Handle("/cvds/{group}/{name}/:stop",
-		httpHandler(newExecCVDGroupCommandHandler(c.Config, c.OperationManager, &stopCvdCommand{}))).Methods("POST")
+		httpHandler(newExecCVDInstanceCommandHandler(c.Config, c.OperationManager, &stopCvdInstanceCommand{}))).Methods("POST")
 	router.Handle("/cvds/{group}/{name}/:powerwash",
 		httpHandler(newExecCVDInstanceCommandHandler(c.Config, c.OperationManager, &powerwashCvdCommand{}))).Methods("POST")
 	router.Handle("/cvds/{group}/{name}/:powerbtn",

--- a/frontend/src/host_orchestrator/orchestrator/cvd/cvd.go
+++ b/frontend/src/host_orchestrator/orchestrator/cvd/cvd.go
@@ -383,6 +383,13 @@ func (i *Instance) ADBPort() uint32 {
 	return i.instance.ADBPort
 }
 
+func (i *Instance) Stop() error {
+	args := i.selectorArgs()
+	args = append(args, "stop")
+	_, err := i.cli.exec(CVDBin, args...)
+	return err
+}
+
 type DisplayAddOpts struct {
 	Width         int
 	Height        int

--- a/frontend/src/host_orchestrator/orchestrator/execcvdcommandaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/execcvdcommandaction.go
@@ -84,6 +84,12 @@ type execCvdInstanceCommand interface {
 	exec(cvd *cvd.CLI, sel cvd.InstanceSelector) error
 }
 
+type stopCvdInstanceCommand struct{}
+
+func (a *stopCvdInstanceCommand) exec(cvdCLI *cvd.CLI, sel cvd.InstanceSelector) error {
+	return cvdCLI.LazySelectInstance(sel).Stop()
+}
+
 type powerwashCvdCommand struct{}
 
 func (a *powerwashCvdCommand) exec(cvd *cvd.CLI, sel cvd.InstanceSelector) error {


### PR DESCRIPTION
### **Summary**
Exposes the backend per-instance stop functionality through the Host Orchestrator's REST API. Previously, stopping an instance via the frontend API routed to a group-level stop, which terminated all instances in the group.

### **Key Changes**
Route Redirection: Modified controller.go to route the POST request /cvds/{group}/{name}/:stop to newExecCVDInstanceCommandHandler using &stopCvdInstanceCommand{}. Instance.Stop() Method: Added a native Stop() method to the Instance struct in cvd.go. 

### **Bug**
b/459780275

### **Document**
go/cuttlefish-per-instance-control

### **Backend pr**
https://github.com/google/android-cuttlefish/pull/2614
