### PR TITLE
Support multi-VM extra_bootconfig_args with single-instance backward compatibility

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
@@ -48,7 +48,7 @@ DEFINE_string(refresh_rate_hz, "60", "Screen refresh rate in Hertz");
 DEFINE_string(overlays, "",
               "List of displays to overlay. Format is: 'vm_index:display_index "
               "vm_index2:display_index2 [...]'");
-DEFINE_string(extra_bootconfig_args, CF_DEFAULTS_EXTRA_BOOTCONFIG_ARGS,
+DEFINE_vec(extra_bootconfig_args, CF_DEFAULTS_EXTRA_BOOTCONFIG_ARGS,
               "Space-separated list of extra bootconfig args. "
               "Note: overwriting an existing bootconfig argument "
               "requires ':=' instead of '='.");

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -259,6 +259,9 @@ Result<std::vector<std::string>> GetFlagStrValueForInstances(
     const std::string& flag_values, int32_t instances_size,
     const std::string& flag_name,
     const std::map<std::string, std::string>& name_to_default_value) {
+  if (instances_size == 1) {
+    return std::vector<std::string>{flag_values};
+  }
   std::vector<std::string_view> flag_vec = absl::StrSplit(flag_values, ",");
   std::vector<std::string> value_vec(instances_size);
 
@@ -549,6 +552,8 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
 
   std::vector<std::string> extra_bootconfig_args_base64_vec =
       CF_EXPECT(GET_FLAG_STR_VALUE(extra_bootconfig_args_base64));
+  std::vector<std::string> extra_bootconfig_args_vec =
+      CF_EXPECT(GET_FLAG_STR_VALUE(extra_bootconfig_args));
 
   std::vector<bool> record_screen_vec = CF_EXPECT(GET_FLAG_BOOL_VALUE(
       record_screen));
@@ -811,7 +816,8 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
     instance.set_enable_gnss_grpc_proxy(start_gnss_proxy_vec[instance_index]);
     instance.set_enable_bootanimation(enable_bootanimation_vec[instance_index]);
 
-    instance.set_extra_bootconfig_args(FLAGS_extra_bootconfig_args);
+    instance.set_extra_bootconfig_args(
+        extra_bootconfig_args_vec[instance_index]);
     if (!extra_bootconfig_args_base64_vec[instance_index].empty()) {
       std::vector<uint8_t> decoded_args = CF_EXPECT(
           DecodeBase64(extra_bootconfig_args_base64_vec[instance_index]));


### PR DESCRIPTION
### **Summary**
Addresses a limitation where --extra_bootconfig_args treated its value as a single string applying only to the first instance, unlike other instanced flags.

### **Key Changes**
Instanced Flag Migration: Modified assemble_cvd/flags.cc to parse extra_bootconfig_args as a vector flag using GET_FLAG_STR_VALUE and assign the corresponding index to each instance.
Backward Compatibility Safeguard: Modified GetFlagStrValueForInstances in flags.cc to immediately return the unsplit flag value if instances_size == 1.

### **Bug**
b/459780275

### **Document**
go/cuttlefish-per-instance-control