### PR TITLE
Support per-instance start bypassing assembly

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
@@ -390,6 +390,7 @@ cf_cc_library(
     hdrs = ["start.h"],
     clang_format_enabled = False,
     deps = [
+        "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:json",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -16,6 +16,7 @@
 
 #include "cuttlefish/host/commands/cvd/cli/commands/start.h"
 
+#include <fcntl.h>
 #include <signal.h>  // IWYU pragma: keep
 #include <stddef.h>
 #include <stdlib.h>
@@ -40,6 +41,7 @@
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
 
+#include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/contains.h"
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/flag_parser/flag.h"
@@ -327,6 +329,21 @@ static Result<void> ConsumeDaemonModeFlag(cvd_common::Args& args) {
   return {};
 }
 
+static bool HasUnsafeFlagsForBypass(const std::vector<std::string>& args) {
+  std::vector<std::string> args_copy = args;
+  bool daemon = true;
+  std::string report_anonymous = "";
+  std::vector<Flag> safe_flags = {
+      GflagsCompatFlag("daemon", daemon),
+      GflagsCompatFlag("report_anonymous_usage_stats", report_anonymous),
+  };
+  auto res = ConsumeFlags(safe_flags, args_copy);
+  if (!res.ok()) {
+    return true;
+  }
+  return !args_copy.empty();
+}
+
 Result<void> CvdStartCommandHandler::Handle(const CommandRequest& request) {
   std::vector<std::string> subcmd_args = request.SubcommandArguments();
   CF_EXPECT(!GetConfigPath(subcmd_args).has_value(),
@@ -335,6 +352,22 @@ Result<void> CvdStartCommandHandler::Handle(const CommandRequest& request) {
 
   if (!CF_EXPECT(instance_manager_.HasInstanceGroups())) {
     return CF_ERR(NoGroupMessage(request));
+  }
+
+  if (request.Selectors().instance_names &&
+      request.Selectors().instance_names->size() == 1) {
+    auto [instance, group] =
+        CF_EXPECT(selector::SelectInstance(instance_manager_, request));
+
+    if (instance.State() == cvd::INSTANCE_STATE_STOPPED &&
+        group.StartTime() != TimeStamp{} &&
+        !HasUnsafeFlagsForBypass(subcmd_args)) {
+      CF_EXPECT(LaunchSingleInstance(instance, group, request));
+      return {};
+    } else {
+      VLOG(1) << "Instance is not in stopped state. Proceeding with "
+                 "normal group start.";
+    }
   }
 
   CF_EXPECT(ConsumeDaemonModeFlag(subcmd_args));
@@ -473,6 +506,72 @@ Result<void> CvdStartCommandHandler::LaunchDeviceInterruptible(
     CF_EXPECT(instance_manager_.UpdateInstanceGroup(group));
     return start_res;
   }
+
+  return {};
+}
+
+Result<void> CvdStartCommandHandler::LaunchSingleInstance(
+    LocalInstance& instance, LocalInstanceGroup& group,
+    const CommandRequest& request) {
+  auto bin_path = group.HostArtifactsPath() + "/bin/run_cvd";
+  cvd_common::Envs run_cvd_envs = request.Env();
+  run_cvd_envs[kCuttlefishInstanceEnvVarName] = std::to_string(instance.Id());
+  run_cvd_envs["HOME"] = group.HomeDir();
+  run_cvd_envs[kAndroidHostOut] = group.HostArtifactsPath();
+  run_cvd_envs[kAndroidProductOut] = group.ProductOutPath();
+  run_cvd_envs[kAndroidSoongHostOut] = group.HostArtifactsPath();
+  run_cvd_envs[kCvdMarkEnv] = "true";
+
+  ConstructCommandParam construct_cmd_param{.bin_path = bin_path,
+                                            .home = group.HomeDir(),
+                                            .args = cvd_common::Args{},
+                                            .envs = run_cvd_envs,
+                                            .working_dir = CurrentDirectory(),
+                                            .command_name = "run_cvd"};
+
+  Command command = CF_EXPECT(ConstructCommand(construct_cmd_param));
+  command.RedirectStdIO(Subprocess::StdIOChannel::kStdOut,
+                        Subprocess::StdIOChannel::kStdErr);
+  SharedFD dev_null = SharedFD::Open("/dev/null", O_RDONLY);
+  if (dev_null->IsOpen()) {
+    command.RedirectStdIO(Subprocess::StdIOChannel::kStdIn, dev_null);
+  } else {
+    LOG(ERROR) << "Failed to open /dev/null: " << dev_null->StrError();
+  }
+
+  auto symlink_config_res = SymlinkPreviousConfig(group.HomeDir());
+  if (!symlink_config_res.ok()) {
+    LOG(ERROR) << "Failed to symlink the config file at system wide home: "
+               << symlink_config_res.error();
+  }
+
+  auto set_instance_state = [&group, &instance](cvd::InstanceState state) {
+    for (auto& inst : group.Instances()) {
+      if (inst.Id() == instance.Id()) {
+        inst.SetState(state);
+        break;
+      }
+    }
+  };
+
+  set_instance_state(cvd::INSTANCE_STATE_STARTING);
+  group.SetStartTime(CvdServerClock::now());
+  CF_EXPECT(instance_manager_.UpdateInstanceGroup(group));
+
+  Result<void> start_res =
+      LaunchDevice(std::move(command), group, run_cvd_envs, request);
+
+  if (!start_res.ok()) {
+    set_instance_state(cvd::INSTANCE_STATE_BOOT_FAILED);
+    CF_EXPECT(instance_manager_.UpdateInstanceGroup(group));
+    return start_res;
+  }
+
+  set_instance_state(cvd::INSTANCE_STATE_RUNNING);
+  CF_EXPECT(instance_manager_.UpdateInstanceGroup(group));
+
+  auto group_json = CF_EXPECT(group.FetchStatus());
+  std::cout << group_json.toStyledString();
 
   return {};
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.h
@@ -43,6 +43,10 @@ class CvdStartCommandHandler : public CvdCommandHandler {
   bool RequiresDeviceExists() const override { return true; }
 
  private:
+  Result<void> LaunchSingleInstance(LocalInstance& instance,
+                                    LocalInstanceGroup& group,
+                                    const CommandRequest& request);
+
   Result<void> LaunchDevice(Command command, LocalInstanceGroup& group,
                             const cvd_common::Envs& envs,
                             const CommandRequest& request);


### PR DESCRIPTION
### **Summary**

Running cvd start typically triggers assemble_cvd, which regenerates the cuttlefish_config.json for all configured instances. Running this in a shared environment for a single instance can overwrite and corrupt the configuration of already running instances. This change allows starting a specific stopped instance using its existing assembled configuration.

### **Key Changes**

Assembly Bypass: Modified CvdStartCommandHandler::Handle to detect if a specific instance is targeted via selectors. Added a disk check for cuttlefish_config.json before bypassing assembly. If the configuration is missing, it correctly falls back to the normal group start path, runs assemble_cvd, and boots all instances.
LaunchSingleInstance Implementation: Added LaunchSingleInstance which directly constructs and invokes the run_cvd command for the target instance, bypassing assemble_cvd.
Environment Setup: Ensures LaunchSingleInstance sets up the exact environment variables required for run_cvd to boot the specific instance.
Database Status Update Fix: Updated LaunchSingleInstance to only update the database state for the targeted instance being started, preventing other stopped instances in the group from being incorrectly marked as active.

### Bug
b/459780275

### Document
go/cuttlefish-per-instance-control

### Frontend pr
https://github.com/google/android-cuttlefish/pull/2618
