### PR TITLE
Route per-instance start API

### DIFF
--- a/frontend/src/host_orchestrator/orchestrator/controller.go
+++ b/frontend/src/host_orchestrator/orchestrator/controller.go
@@ -80,7 +80,7 @@ func (c *Controller) AddRoutes(router *mux.Router) {
 	router.Handle("/cvds/{group}/{name}",
 		httpHandler(newExecCVDGroupCommandHandler(c.Config, c.OperationManager, &removeCvdCommand{}))).Methods("DELETE")
 	router.Handle("/cvds/{group}/{name}/:start",
-		httpHandler(newStartCVDHandler(c.Config, c.OperationManager))).Methods("POST")
+		httpHandler(newStartCVDInstanceHandler(c.Config, c.OperationManager))).Methods("POST")
 	router.Handle("/cvds/{group}/{name}/:stop",
 		httpHandler(newExecCVDInstanceCommandHandler(c.Config, c.OperationManager, &stopCvdInstanceCommand{}))).Methods("POST")
 	router.Handle("/cvds/{group}/{name}/:powerwash",
@@ -502,16 +502,16 @@ func (h *displayScreenshotHandler) Handle(r *http.Request) (interface{}, error) 
 	return NewDisplayScreenshotAction(opts).Run()
 }
 
-type startCVDHandler struct {
+type startCVDInstanceHandler struct {
 	Config Config
 	OM     OperationManager
 }
 
-func newStartCVDHandler(c Config, om OperationManager) *startCVDHandler {
-	return &startCVDHandler{Config: c, OM: om}
+func newStartCVDInstanceHandler(c Config, om OperationManager) *startCVDInstanceHandler {
+	return &startCVDInstanceHandler{Config: c, OM: om}
 }
 
-func (h *startCVDHandler) Handle(r *http.Request) (interface{}, error) {
+func (h *startCVDInstanceHandler) Handle(r *http.Request) (interface{}, error) {
 	req := &apiv1.StartCVDRequest{}
 	err := json.NewDecoder(r.Body).Decode(req)
 	if err != nil {
@@ -519,14 +519,15 @@ func (h *startCVDHandler) Handle(r *http.Request) (interface{}, error) {
 	}
 	vars := mux.Vars(r)
 	group := vars["group"]
-	opts := StartCVDActionOpts{
+	name := vars["name"]
+	opts := StartCVDInstanceActionOpts{
 		Request:          req,
-		Selector:         cvd.GroupSelector{Name: group},
+		Selector:         cvd.InstanceSelector{GroupName: group, Name: name},
 		Paths:            h.Config.Paths,
 		OperationManager: h.OM,
 		ExecContext:      exec.CommandContext,
 	}
-	return NewStartCVDAction(opts).Run()
+	return NewStartCVDInstanceAction(opts).Run()
 }
 
 type getCVDLogsHandler struct {

--- a/frontend/src/host_orchestrator/orchestrator/cvd/cvd.go
+++ b/frontend/src/host_orchestrator/orchestrator/cvd/cvd.go
@@ -390,6 +390,14 @@ func (i *Instance) Stop() error {
 	return err
 }
 
+func (i *Instance) Start(opts StartOptions) error {
+	args := i.selectorArgs()
+	args = append(args, "start", "--report_anonymous_usage_stats=y")
+	args = append(args, opts.toArgs()...)
+	_, err := i.cli.exec(CVDBin, args...)
+	return err
+}
+
 type DisplayAddOpts struct {
 	Width         int
 	Height        int

--- a/frontend/src/host_orchestrator/orchestrator/startcvdaction.go
+++ b/frontend/src/host_orchestrator/orchestrator/startcvdaction.go
@@ -25,24 +25,24 @@ import (
 	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
 )
 
-type StartCVDActionOpts struct {
+type StartCVDInstanceActionOpts struct {
 	Request          *apiv1.StartCVDRequest
-	Selector         cvd.GroupSelector
+	Selector         cvd.InstanceSelector
 	Paths            IMPaths
 	OperationManager OperationManager
 	ExecContext      exec.ExecContext
 }
 
-type StartCVDAction struct {
+type StartCVDInstanceAction struct {
 	req      *apiv1.StartCVDRequest
-	selector cvd.GroupSelector
+	selector cvd.InstanceSelector
 	paths    IMPaths
 	om       OperationManager
 	cvdCLI   *cvd.CLI
 }
 
-func NewStartCVDAction(opts StartCVDActionOpts) *StartCVDAction {
-	return &StartCVDAction{
+func NewStartCVDInstanceAction(opts StartCVDInstanceActionOpts) *StartCVDInstanceAction {
+	return &StartCVDInstanceAction{
 		req:      opts.Request,
 		selector: opts.Selector,
 		paths:    opts.Paths,
@@ -51,7 +51,7 @@ func NewStartCVDAction(opts StartCVDActionOpts) *StartCVDAction {
 	}
 }
 
-func (a *StartCVDAction) Run() (apiv1.Operation, error) {
+func (a *StartCVDInstanceAction) Run() (apiv1.Operation, error) {
 	if err := ValidateStartCVDRequest(a.req); err != nil {
 		return apiv1.Operation{}, err
 	}
@@ -77,8 +77,8 @@ func (a *StartCVDAction) Run() (apiv1.Operation, error) {
 	return op, nil
 }
 
-func (a *StartCVDAction) exec(opts cvd.StartOptions) (*apiv1.EmptyResponse, error) {
-	if err := a.cvdCLI.LazySelectGroup(a.selector).Start(opts); err != nil {
+func (a *StartCVDInstanceAction) exec(opts cvd.StartOptions) (*apiv1.EmptyResponse, error) {
+	if err := a.cvdCLI.LazySelectInstance(a.selector).Start(opts); err != nil {
 		return nil, operator.NewInternalError("cvd start failed", err)
 	}
 	return &apiv1.EmptyResponse{}, nil


### PR DESCRIPTION
### **Summary**
Exposes per-instance start functionality through the HO API. This change ensures that users can start a specific stopped instance, with support for passing a SnapshotID in the request body to boot the instance from a snapshot.

### **Key Changes**
Dedicated Handler: Implemented newStartCVDInstanceHandler and startCVDInstanceHandler in controller.go. This handler correctly decodes the apiv1.StartCVDRequest from the POST request body.
StartCVDInstanceAction: Added StartCVDInstanceAction in startcvdaction.go to handle the logic. It validates the request, locates the snapshot if provided, and invokes cvdCLI.LazySelectInstance().Start(opts).
Route Redirection: Updated controller.go to map /cvds/{group}/{name}/:start to newStartCVDInstanceHandler instead of the group instance command handler.

### **Bug**
b/459780275

### **Document**
go/cuttlefish-per-instance-control

### **Backend pr**
https://github.com/google/android-cuttlefish/pull/2617