### PR TITLE
Show progress when pulling podman image

### DIFF
--- a/container/src/libcfcontainer/cuttlefish_container.go
+++ b/container/src/libcfcontainer/cuttlefish_container.go
@@ -26,8 +26,10 @@ import (
 	"dario.cat/mergo"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/moby/term"
 )
 
 type CuttlefishContainerManager interface {
@@ -35,7 +37,7 @@ type CuttlefishContainerManager interface {
 	// Check whether an image with the given name exists on the container engine or not
 	ImageExists(ctx context.Context, name string) (bool, error)
 	// Pull the container image
-	PullImage(ctx context.Context, name string) error
+	PullImage(ctx context.Context, name string, progressWriter io.Writer) error
 	// Create and start a container instance
 	CreateAndStartContainer(ctx context.Context, additionalConfig *container.Config, additionalHostConfig *container.HostConfig, name string) (string, error)
 	// Execute a command on a running container instance
@@ -89,15 +91,24 @@ func (m *CuttlefishContainerManagerImpl) ImageExists(ctx context.Context, name s
 	return false, nil
 }
 
-func (m *CuttlefishContainerManagerImpl) PullImage(ctx context.Context, name string) error {
+func (m *CuttlefishContainerManagerImpl) PullImage(ctx context.Context, name string, progressWriter io.Writer) error {
 	reader, err := m.cli.ImagePull(ctx, name, image.PullOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to request pulling docker image %q: %w", name, err)
 	}
 	defer reader.Close()
-	// Caller of ImagePull should handle its output to complete actual ImagePull operation.
-	// Details in https://pkg.go.dev/github.com/docker/docker/client#Client.ImagePull.
-	if _, err := io.Copy(io.Discard, reader); err != nil {
+
+	if progressWriter == nil {
+		progressWriter = io.Discard
+	}
+	var fd uintptr
+	var isTerminal bool
+	if f, ok := progressWriter.(interface{ Fd() uintptr }); ok {
+		fd = f.Fd()
+		isTerminal = term.IsTerminal(fd)
+	}
+	err = jsonmessage.DisplayJSONMessagesStream(reader, progressWriter, fd, isTerminal, nil)
+	if err != nil {
 		return fmt.Errorf("failed to pull docker image %q: %w", name, err)
 	}
 	return nil

--- a/container/src/libcfcontainer/go.mod
+++ b/container/src/libcfcontainer/go.mod
@@ -7,9 +7,11 @@ toolchain go1.24.8
 require (
 	dario.cat/mergo v1.0.2
 	github.com/docker/docker v28.5.2+incompatible
+	github.com/moby/term v0.5.2
 )
 
 require (
+	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
@@ -23,7 +25,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/sys/atomicwriter v0.1.0 // indirect
-	github.com/moby/term v0.5.2 // indirect
 	github.com/morikuni/aec v1.1.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect

--- a/container/src/libcfcontainer/go.sum
+++ b/container/src/libcfcontainer/go.sum
@@ -14,6 +14,8 @@ github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151X
 github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
+github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
@@ -81,6 +83,7 @@ go.opentelemetry.io/proto/otlp v1.9.0 h1:l706jCMITVouPOqEnii2fIAuO3IVGBRPV5ICjce
 go.opentelemetry.io/proto/otlp v1.9.0/go.mod h1:xE+Cx5E/eEHw+ISFkwPLwCZefwVjY+pqKg1qcK03+/4=
 golang.org/x/net v0.47.0 h1:Mx+4dIFzqraBXUugkia1OOvlD6LemFo1ALMHjrXDOhY=
 golang.org/x/net v0.47.0/go.mod h1:/jNxtkgq5yWUGYkaZGqo27cfGZ1c5Nen03aYrrKpVRU=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.31.0 h1:aC8ghyu4JhP8VojJ2lEHBnochRno1sgL6nEi9WGFGMM=

--- a/container/src/podcvd/go.mod
+++ b/container/src/podcvd/go.mod
@@ -33,6 +33,8 @@ require (
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
+	github.com/moby/term v0.5.2 // indirect
+	github.com/morikuni/aec v1.1.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/container/src/podcvd/go.sum
+++ b/container/src/podcvd/go.sum
@@ -14,6 +14,8 @@ github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151X
 github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
+github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=

--- a/container/src/podcvd/internal/host.go
+++ b/container/src/podcvd/internal/host.go
@@ -173,7 +173,8 @@ func pullContainerImage(ccm libcfcontainer.CuttlefishContainerManager) error {
 	} else if exists {
 		return nil
 	}
-	return ccm.PullImage(context.Background(), imageName)
+	log.Printf("Pulling container image %q...\n", imageName)
+	return ccm.PullImage(context.Background(), imageName, os.Stderr)
 }
 
 func cvdDataHome() (string, error) {


### PR DESCRIPTION
When using `podcvd` for the first time, it takes seconds for downloading podman image. As there's no logs, users can easily misunderstand that it's not working properly. I believe it can confuse AI agents either. Not to confuse users from doubting functionality of `podcvd`, I added some logs in case of downloading podman image.