### PR TITLE
Build CF host debian packages in parallel

### DIFF
--- a/.github/actions/build-debian-packages/action.yaml
+++ b/.github/actions/build-debian-packages/action.yaml
@@ -25,16 +25,29 @@ runs:
       INPUTS_DEBIAN_VERSION: ${{ inputs.debian-version }}
   - name: Build CF debian packages
     run: |
+      sudo docker build --file "tools/buildutils/cw/Containerfile" --tag "android-cuttlefish-build" .
+      sudo docker run -v=$PWD:/mnt/build -w /mnt/build -v=$HOME/bazel-disk-cache:/root/bazel-disk-cache android-cuttlefish-build base -d /root/bazel-disk-cache &
+      PID_BASE=$!
       IMAGE_OPT=""
       if [ -n "${INPUTS_IMAGE_VERSION}" ]; then
         IMAGE_OPT="-e container_image_name=us-docker.pkg.dev/android-cuttlefish-artifacts/cuttlefish-orchestration/cuttlefish-orchestration:${INPUTS_IMAGE_VERSION}"
+      fi      
+      sudo docker run ${IMAGE_OPT} -v=$PWD:/mnt/build -w /mnt/build android-cuttlefish-build container &
+      PID_CONTAINER=$!
+      sudo docker run -v=$PWD:/mnt/build -w /mnt/build android-cuttlefish-build frontend &
+      PID_FRONTEND=$!
+      sudo docker run -v=$PWD:/mnt/build -w /mnt/build android-cuttlefish-build cuttlefish-integration-gigabyte-arm64 &
+      PID_GIGABYTE=$!
+      # Wait for all background jobs and collect exit codes
+      exit_code=0
+      wait $PID_BASE || exit_code=$?
+      wait $PID_CONTAINER || exit_code=$?
+      wait $PID_FRONTEND || exit_code=$?
+      wait $PID_GIGABYTE || exit_code=$?
+      if [ $exit_code -ne 0 ]; then
+        echo "One or more builds failed."
+        exit $exit_code
       fi
-
-      sudo docker build --file "tools/buildutils/cw/Containerfile" --tag "android-cuttlefish-build" .
-      sudo docker run -v=$PWD:/mnt/build -w /mnt/build -v=$HOME/bazel-disk-cache:/root/bazel-disk-cache android-cuttlefish-build base -d /root/bazel-disk-cache
-      sudo docker run ${IMAGE_OPT} -v=$PWD:/mnt/build -w /mnt/build android-cuttlefish-build container
-      sudo docker run -v=$PWD:/mnt/build -w /mnt/build android-cuttlefish-build frontend
-      sudo docker run -v=$PWD:/mnt/build -w /mnt/build android-cuttlefish-build cuttlefish-integration-gigabyte-arm64
     shell: bash
     env:
       INPUTS_IMAGE_VERSION: ${{ inputs.image-version }}


### PR DESCRIPTION
In `build-debian-package-{arch}` GitHub workflow job, it tries to build debian packages for each directory in a row. This PR suggests to build CF host debian packages in parallel, and wait until all build procedure is done. I expect we can reduce presubmit/postsubmit workflow time with applying this PR.

However, you can see the elapsed time of `build-debian-package-{arch}` is huge. This is intended behavior, as the bazel cache is invalidated by changing corresponding GitHub action code. Once it's merged to the main branch and writing bazel cache via postsubmit procedure, I expect it would be reduced as intended.