### PR TITLE
Ahead of #2608, mark operator_proxy noncritical.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/streamer.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/streamer.cpp
@@ -233,7 +233,7 @@ class WebRtcServer : public virtual CommandSource,
     // legacy port.
     Command sig_proxy(WebRtcSigServerProxyBinary());
     sig_proxy.AddParameter("-server_port=", config_.sig_server_proxy_port());
-    commands.emplace_back(std::move(sig_proxy));
+    commands.emplace_back(std::move(sig_proxy), /* is_critical= */ false);
 
     auto stopper = [webrtc_controller = webrtc_controller_]() mutable {
       (void)webrtc_controller.SendStopRecordingCommand();


### PR DESCRIPTION
Empirical testing indicates that operator_proxy unexpectedly exiting does not seem to prevent the instance from booting.