### PR TITLE
Fix the gpu mode ordering in the non-opt'ing path

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/graphics_flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/graphics_flags.cc
@@ -456,8 +456,8 @@ std::vector<GpuMode> GetGpuModeCandidates(const GuestConfig& guest_config) {
     gpu_mode_candidates.push_back(GpuMode::GfxstreamGuestAngleHostLavapipe);
     gpu_mode_candidates.push_back(GpuMode::GuestSwiftshader);
   } else {
-    gpu_mode_candidates.push_back(GpuMode::GuestSwiftshader);
     gpu_mode_candidates.push_back(GpuMode::Gfxstream);
+    gpu_mode_candidates.push_back(GpuMode::GuestSwiftshader);
     gpu_mode_candidates.push_back(GpuMode::GfxstreamGuestAngle);
     gpu_mode_candidates.push_back(GpuMode::GfxstreamGuestAngleHostSwiftshader);
     gpu_mode_candidates.push_back(GpuMode::GfxstreamGuestAngleHostLavapipe);

--- a/e2etests/cvd/graphics_detector_tests/main_test.go
+++ b/e2etests/cvd/graphics_detector_tests/main_test.go
@@ -44,15 +44,15 @@ func TestLaunchingWithAutoEnablesGfxstream(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get EGL sysprop: %w", err)
 	}
-	if gl_driver != "angle" {
-		t.Errorf(`"ro.hardware.egl" was "%s"; expected "angle"`, gl_driver)
+	if gl_driver != "emulation" {
+		t.Errorf(`"ro.hardware.egl" was "%s"; expected "emulation"`, gl_driver)
 	}
 
 	vk_driver, err := c.GetSyspropString("ro.hardware.vulkan")
 	if err != nil {
 		t.Fatalf("failed to get Vulkan sysprop: %w", err)
 	}
-	if vk_driver != "pastel" {
-		t.Errorf(`"ro.hardware.vulkan" was "%s"; expected "pastel"`, vk_driver)
+	if vk_driver != "ranchu" {
+		t.Errorf(`"ro.hardware.vulkan" was "%s"; expected "ranchu"`, vk_driver)
 	}
 }


### PR DESCRIPTION
https://github.com/google/android-cuttlefish/pull/2611 was incorrect. The previous behavior was to prefer `--gpu_mode=gfxstream` over `--gpu_mode=guest_swiftshader` prior to the Jolt changes.

Bug: b/513229182