### PR TITLE
Revert "Reapply "Set up shared library targets.""

### DIFF
--- a/base/cvd/BUILD.bazel
+++ b/base/cvd/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:cc_import.bzl", "cc_import")
-load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package_group(
     name = "android_cuttlefish",
@@ -77,46 +77,4 @@ cc_import(
     name = "gfxstream_backend_import",
     shared_library = ":gfxstream_backend",
     visibility = ["//visibility:public"],
-)
-
-cc_shared_library(
-    name = "absl_shared",
-    exports_filter = [
-        "@abseil-cpp//:__subpackages__",
-    ],
-    shared_lib_name = "libcuttlefish_absl.so",
-    deps = [
-        "@abseil-cpp//absl/base",
-        "@abseil-cpp//absl/cleanup",
-        "@abseil-cpp//absl/container:flat_hash_map",
-        "@abseil-cpp//absl/container:flat_hash_set",
-        "@abseil-cpp//absl/debugging:stacktrace",
-        "@abseil-cpp//absl/debugging:symbolize",
-        "@abseil-cpp//absl/flags:flag",
-        "@abseil-cpp//absl/flags:parse",
-        "@abseil-cpp//absl/hash",
-        "@abseil-cpp//absl/log",
-        "@abseil-cpp//absl/log:check",
-        "@abseil-cpp//absl/log:globals",
-        "@abseil-cpp//absl/log:initialize",
-        "@abseil-cpp//absl/numeric:int128",
-        "@abseil-cpp//absl/status",
-        "@abseil-cpp//absl/status:statusor",
-        "@abseil-cpp//absl/strings",
-        "@abseil-cpp//absl/strings:cord",
-        "@abseil-cpp//absl/strings:str_format",
-        "@abseil-cpp//absl/synchronization",
-        "@abseil-cpp//absl/time",
-    ],
-)
-
-cc_shared_library(
-    name = "fmt_shared",
-    exports_filter = [
-        "@fmt//:__subpackages__",
-    ],
-    shared_lib_name = "libcuttlefish_fmt.so",
-    deps = [
-        "@fmt",
-    ],
 )

--- a/base/cvd/build_variables.bzl
+++ b/base/cvd/build_variables.bzl
@@ -6,6 +6,4 @@ COPTS = [
 ]
 
 LINKOPTS = [
-    "-Wl,-rpath,$ORIGIN/../lib64",
-    "-Wl,-rpath,$ORIGIN/../lib",
 ]

--- a/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("//cuttlefish/bazel:rules.bzl", "cf_cc_library", "cf_cc_test")
 
 package(
@@ -15,23 +14,6 @@ cf_cc_library(
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/result",
-    ],
-)
-
-cc_shared_library(
-    name = "fs_shared",
-    dynamic_deps = [
-        "//:absl_shared",
-        "//cuttlefish/result:result_shared",
-    ],
-    shared_lib_name = "libcuttlefish_fs.so",
-    user_link_flags = [
-        "-Wl,-rpath,$ORIGIN/",
-    ],
-    deps = [
-        ":fs",
-        "//cuttlefish/common/libs/utils:environment",
-        "//cuttlefish/posix:strerror",
     ],
 )
 

--- a/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("//cuttlefish/bazel:rules.bzl", "cf_cc_library", "cf_cc_test")
 
 package(
@@ -103,22 +102,6 @@ cf_cc_test(
     deps = [
         ":environment",
         "@abseil-cpp//absl/cleanup",
-    ],
-)
-
-cc_shared_library(
-    name = "files_shared",
-    dynamic_deps = ["//cuttlefish/common/libs/fs:fs_shared"],
-    shared_lib_name = "libcuttlefish_files.so",
-    user_link_flags = [
-        "-Wl,-rpath,$ORIGIN/",
-    ],
-    deps = [
-        ":files",
-        ":users",
-        "//cuttlefish/common/libs/utils:in_sandbox",
-        "//cuttlefish/posix:rename",
-        "//cuttlefish/posix:symlink",
     ],
 )
 

--- a/base/cvd/cuttlefish/package/BUILD.bazel
+++ b/base/cvd/cuttlefish/package/BUILD.bazel
@@ -133,11 +133,6 @@ package_files(
         "cuttlefish-common/usr/share/webrtc/assets/js/gamepad.js": "//cuttlefish/host/frontend/webrtc/html_client:js/gamepad.js",
         "cuttlefish-common/usr/share/webrtc/assets/js/rootcanal.js": "//cuttlefish/host/frontend/webrtc/html_client:js/rootcanal.js",
         "cuttlefish-common/usr/share/webrtc/assets/js/touch.js": "//cuttlefish/host/frontend/webrtc/html_client:js/touch.js",
-        "cuttlefish-common/lib64/libcuttlefish_result.so": "//cuttlefish/result:result_shared",
-        "cuttlefish-common/lib64/libcuttlefish_files.so": "//cuttlefish/common/libs/utils:files_shared",
-        "cuttlefish-common/lib64/libcuttlefish_fs.so": "//cuttlefish/common/libs/fs:fs_shared",
-        "cuttlefish-common/lib64/libcuttlefish_absl.so": "//:absl_shared",
-        "cuttlefish-common/lib64/libcuttlefish_fmt.so": "//:fmt_shared",
     },
     visibility = ["//:android_cuttlefish"],
 )

--- a/base/cvd/cuttlefish/result/BUILD.bazel
+++ b/base/cvd/cuttlefish/result/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("//cuttlefish/bazel:rules.bzl", "cf_cc_library", "cf_cc_test")
 
 package(
@@ -25,26 +24,6 @@ cf_cc_library(
         "//libbase",
         "@abseil-cpp//absl/log",
         "@fmt",
-    ],
-)
-
-cc_shared_library(
-    name = "result_shared",
-    dynamic_deps = [
-        "//:absl_shared",
-        "//:fmt_shared",
-    ],
-    exports_filter = [
-        "//libbase:libbase",
-        "//libbase:libbase_posix_strerror",
-    ],
-    shared_lib_name = "libcuttlefish_result.so",
-    user_link_flags = [
-        "-Wl,-rpath,$ORIGIN/",
-    ],
-    deps = [
-        ":error_type",
-        ":result",
     ],
 )
 

--- a/base/cvd/libbase/BUILD.bazel
+++ b/base/cvd/libbase/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
-load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
+
 load("//:build_variables.bzl", "COPTS")
 
 package(


### PR DESCRIPTION
This reverts commit 058061f19983fb7513ba78a337208ab31121fbc6.

Reverting again; even though nothing is actually wired up to these
targets, it may still be having unintended side-effects.