### PR TITLE
Resolve race condition for unlinking file on base/cvd/cuttlefish/host/commands/cvd/fetch/substitute.cc

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/substitute.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/substitute.cc
@@ -64,9 +64,8 @@ Result<void> Substitute(const std::string& target,
 
   CF_EXPECT(EnsureDirectoryExists(android::base::Dirname(full_link_name)));
 
-  if (FileExists(full_link_name)) {
-    CF_EXPECTF(unlink(full_link_name.c_str()) == 0, "{}", StrError(errno));
-  }
+  int unlink_res = unlink(full_link_name.c_str());
+  CF_EXPECTF(unlink_res == 0 || errno == ENOENT, "{}", StrError(errno));
 
   CF_EXPECT(Symlink(target, full_link_name));
   return {};


### PR DESCRIPTION
While launching multiple Cuttlefish instances simultaneously by `cvdr create`, I observed ENOENT error could be observed from the given line though it's guarded by `FileExists`. So it makes paralleled execution of `cvdr create` being flaky. This commit fixes the issue by just trying to do unlink and throw an error only when the error is not ENOENT.