### PR TITLE
Enable clang-format for common/libs/transport

### DIFF
--- a/base/cvd/cuttlefish/common/libs/transport/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/transport/BUILD.bazel
@@ -14,6 +14,7 @@ cf_cc_library(
         "channel.h",
         "channel_sharedfd.h",
     ],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/result",

--- a/base/cvd/cuttlefish/common/libs/transport/channel.cpp
+++ b/base/cvd/cuttlefish/common/libs/transport/channel.cpp
@@ -28,11 +28,13 @@ void MessageDestroyer::operator()(RawMessage* ptr) {
  * Allocates memory for a RawMessage carrying a message of size
  * `payload_size`.
  */
-Result<ManagedMessage> CreateMessage(uint32_t command, bool is_response, size_t payload_size) {
+Result<ManagedMessage> CreateMessage(uint32_t command, bool is_response,
+                                     size_t payload_size) {
   const auto bytes_to_allocate = sizeof(RawMessage) + payload_size;
   auto memory = std::malloc(bytes_to_allocate);
-  CF_EXPECT(memory != nullptr,
-            "Cannot allocate " << bytes_to_allocate << " bytes for secure_env RPC message");
+  CF_EXPECT(memory != nullptr, "Cannot allocate "
+                                   << bytes_to_allocate
+                                   << " bytes for secure_env RPC message");
   auto message = reinterpret_cast<RawMessage*>(memory);
   message->command = command;
   message->is_response = is_response;


### PR DESCRIPTION
Assisted-by: Gemini:Next
Bug: b/512215781
TAG=agy
CONV=7aca3351-9aca-4ef1-a4e3-10e50737d7b2