### PR TITLE
Fix 1 ClangTidyReadability finding:

### DIFF
--- a/base/cvd/cuttlefish/host/frontend/webrtc/audio_handler.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/audio_handler.cpp
@@ -77,7 +77,7 @@ virtio_snd_chmap_info GetVirtioSndChmapInfo(
   return info;
 }
 
-inline constexpr const char* GetDirectionString(
+constexpr const char* GetDirectionString(
     AudioStreamSettings::Direction direction) {
   switch (direction) {
     case AudioStreamSettings::Direction::Capture:


### PR DESCRIPTION
'GetDirectionString' has inline specifier but is implicitly inlined.