### PR TITLE
Fix unstable channel workflow trigger

### DIFF
--- a/.github/workflows/unstable-channel.yaml
+++ b/.github/workflows/unstable-channel.yaml
@@ -3,7 +3,8 @@ name: Unstable channel
 on:
   push:
     branches:
-      - 'version-[0-9]+.[0-9]+-dev'
+      - 'version-*-dev'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Update the branch pattern to 'version-*-dev' to support 3-digit version branches like 'version-1.54.1-dev'. Also add 'workflow_dispatch' to support manual triggering.