### PR TITLE
Enforce `misc-include-cleaner` and `clang-format` on `key_equals_value`

### DIFF
--- a/base/cvd/BUILD.bazel
+++ b/base/cvd/BUILD.bazel
@@ -27,6 +27,7 @@ filegroup(
     name = "clang_tidy_config",
     srcs = [
         ".clang-tidy",
+        "//cuttlefish/common/libs/key_equals_value:.clang-tidy",
         "//cuttlefish/host/commands/assemble_cvd/android_build:.clang-tidy",
         "//cuttlefish/host/commands/cvd/cli/commands:.clang-tidy",
         "//cuttlefish/host/commands/kernel_log_monitor:.clang-tidy",

--- a/base/cvd/cuttlefish/common/libs/key_equals_value/.clang-tidy
+++ b/base/cvd/cuttlefish/common/libs/key_equals_value/.clang-tidy
@@ -1,0 +1,1 @@
+../../../../clang_tidy_configs/with_include_cleaner

--- a/base/cvd/cuttlefish/common/libs/key_equals_value/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/key_equals_value/BUILD.bazel
@@ -4,6 +4,8 @@ package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
+exports_files([".clang-tidy"])
+
 cf_cc_library(
     name = "key_equals_value",
     srcs = ["key_equals_value.cc"],

--- a/base/cvd/cuttlefish/common/libs/key_equals_value/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/key_equals_value/BUILD.bazel
@@ -10,6 +10,7 @@ cf_cc_library(
     name = "key_equals_value",
     srcs = ["key_equals_value.cc"],
     hdrs = ["key_equals_value.h"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:contains",
@@ -21,6 +22,7 @@ cf_cc_library(
 cf_cc_test(
     name = "key_equals_value_test",
     srcs = ["key_equals_value_test.cc"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/common/libs/key_equals_value",
         "//cuttlefish/result",

--- a/base/cvd/cuttlefish/common/libs/key_equals_value/key_equals_value_test.cc
+++ b/base/cvd/cuttlefish/common/libs/key_equals_value/key_equals_value_test.cc
@@ -15,6 +15,8 @@
 
 #include "cuttlefish/common/libs/key_equals_value/key_equals_value.h"
 
+#include <functional>
+#include <map>
 #include <string>
 
 #include "gmock/gmock-matchers.h"


### PR DESCRIPTION
This PR applies the `with_include_cleaner` clang-tidy configuration to the `key_equals_value` directory and enables `clang-format` enforcement for its targets.

Assisted-by: Gemini:Flash-Preview