### PR TITLE
Migrate hinge angle injection to sensors simulator

### DIFF
--- a/base/cvd/cuttlefish/common/libs/sensors/sensors.h
+++ b/base/cvd/cuttlefish/common/libs/sensors/sensors.h
@@ -57,6 +57,7 @@ inline constexpr char OUTER_DELIM = ' ';
 inline constexpr int kUpdateRotationVec = 0;
 inline constexpr int kGetSensorsData = 1;
 inline constexpr int kUpdateHal = 2;
+inline constexpr int kUpdateHingeAngle = 3;
 
 using SensorsCmd = int;
 

--- a/base/cvd/cuttlefish/host/commands/sensors_simulator/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/sensors_simulator/main.cpp
@@ -60,7 +60,13 @@ Result<void> ProcessWebrtcRequest(transport::SharedFdChannel& channel,
       CF_EXPECT((ss >> y >> delimiter) && (delimiter == INNER_DELIM),
                 kReqMisFormatted);
       CF_EXPECT(static_cast<bool>(ss >> z), kReqMisFormatted);
-      sensors_simulator.RefreshSensors(x, y, z);
+      sensors_simulator.SetMotion(x, y, z);
+      break;
+    }
+    case kUpdateHingeAngle: {
+      float angle;
+      CF_EXPECT(static_cast<bool>(ss >> angle), kReqMisFormatted);
+      sensors_simulator.SetHingeAngle(angle);
       break;
     }
     case kGetSensorsData: {

--- a/base/cvd/cuttlefish/host/commands/sensors_simulator/sensors_hal_proxy.cpp
+++ b/base/cvd/cuttlefish/host/commands/sensors_simulator/sensors_hal_proxy.cpp
@@ -16,6 +16,9 @@
 
 #include "cuttlefish/host/commands/sensors_simulator/sensors_hal_proxy.h"
 
+#include <mutex>
+#include <string>
+
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 
@@ -34,6 +37,13 @@ static constexpr SensorsMask kContinuousModeSensors =
     (1 << kAccelerationId) | (1 << kGyroscopeId) | (1 << kMagneticId) |
     (1 << kPressureId) | (1 << kUncalibGyroscopeId) |
     (1 << kUncalibAccelerationId) | (1 << kLightId);
+
+/*
+  On-change sensors are only reported to the guest when their value changes
+  (and once after the guest HAL (re)starts), instead of being streamed every
+  cycle like the continuous mode sensors above.
+*/
+static constexpr SensorsMask kOnChangeSensors = (1 << kHingeAngle0Id);
 
 Result<std::string> SensorIdToName(int id) {
   switch (id) {
@@ -72,10 +82,10 @@ Result<std::string> SensorIdToName(int id) {
 
 Result<void> SendResponseHelper(transport::SharedFdChannel& channel,
                                 const std::string& msg) {
-  auto size = msg.size();
-  auto cmd = sensors::kUpdateHal;
-  auto response = CF_EXPECT(transport::CreateMessage(cmd, msg.size()),
-                            "Failed to allocate message.");
+  size_t size = msg.size();
+  int cmd = sensors::kUpdateHal;
+  transport::ManagedMessage response = CF_EXPECT(
+      transport::CreateMessage(cmd, msg.size()), "Failed to allocate message.");
   std::memcpy(response->payload, msg.data(), size);
   CF_EXPECT(channel.SendResponse(*response), "Can't update sensor HAL.");
   return {};
@@ -84,12 +94,12 @@ Result<void> SendResponseHelper(transport::SharedFdChannel& channel,
 Result<void> ProcessHalRequest(transport::SharedFdChannel& channel,
                                std::atomic<bool>& hal_activated,
                                uint32_t mask) {
-  auto request =
+  transport::ManagedMessage request =
       CF_EXPECT(channel.ReceiveMessage(), "Couldn't receive message.");
   std::string payload(reinterpret_cast<const char*>(request->payload),
                       request->payload_size);
   if (payload.rfind("list-sensors", 0) == 0) {
-    auto msg = std::to_string(mask) + END_OF_MSG;
+    std::string msg = std::to_string(mask) + END_OF_MSG;
     CF_EXPECT(SendResponseHelper(channel, msg));
     hal_activated = true;
   }
@@ -107,7 +117,7 @@ Result<void> UpdateSensorsHal(const std::string& sensors_data,
   while (mask) {
     if (mask & 1) {
       CF_EXPECT(static_cast<bool>(sensors_data_stream >> report));
-      auto result = SensorIdToName(id);
+      Result<std::string> result = SensorIdToName(id);
       if (result.ok()) {
         reports.push_back(result.value() + INNER_DELIM + report + END_OF_MSG);
       }
@@ -162,6 +172,10 @@ SensorsHalProxy::SensorsHalProxy(SharedFD control_from_guest_fd,
       sensors_simulator_(sensors_simulator) {
   const SensorsMask host_enabled_sensors = HostEnabledSensors(device_type);
 
+  sensors_simulator_.SetSensorsChangedCallback(
+      host_enabled_sensors & kOnChangeSensors,
+      [this](SensorsMask changed) { ReportToGuest(changed); });
+
   req_responder_thread_ = std::thread([this, host_enabled_sensors] {
     while (running_) {
       auto result = ProcessHalRequest(control_channel_, hal_activated_,
@@ -174,24 +188,14 @@ SensorsHalProxy::SensorsHalProxy(SharedFD control_from_guest_fd,
   });
   data_reporter_thread_ = std::thread([this, host_enabled_sensors] {
     while (running_) {
-      if (hal_activated_) {
-        SensorsMask host_update_sensors =
-            host_enabled_sensors & kContinuousModeSensors;
-        auto sensors_data =
-            sensors_simulator_.GetSensorsData(host_update_sensors);
-        auto result =
-            UpdateSensorsHal(sensors_data, data_channel_, host_update_sensors);
-        if (!result.ok()) {
-          running_ = false;
-          LOG(ERROR) << result.error();
-        }
-      }
+      ReportToGuest(host_enabled_sensors & kContinuousModeSensors);
       std::this_thread::sleep_for(std::chrono::milliseconds(kIntervalMs));
     }
   });
   reboot_monitor_thread_ = std::thread([this] {
     while (kernel_events_fd_->IsOpen()) {
-      auto read_result = monitor::ReadEvent(kernel_events_fd_);
+      Result<std::optional<monitor::ReadEventResult>> read_result =
+          monitor::ReadEvent(kernel_events_fd_);
       CHECK(read_result.ok()) << read_result.error();
       CHECK(read_result->has_value()) << "EOF in kernel log monitor";
       if ((*read_result)->event == monitor::Event::BootloaderLoaded) {
@@ -199,6 +203,19 @@ SensorsHalProxy::SensorsHalProxy(SharedFD control_from_guest_fd,
       }
     }
   });
+}
+
+void SensorsHalProxy::ReportToGuest(SensorsMask mask) {
+  if (!hal_activated_ || !mask) {
+    return;
+  }
+  std::string sensors_data = sensors_simulator_.GetSensorsData(mask);
+  std::lock_guard<std::mutex> lock(report_mtx_);
+  Result<void> result = UpdateSensorsHal(sensors_data, data_channel_, mask);
+  if (!result.ok()) {
+    running_ = false;
+    LOG(ERROR) << result.error();
+  }
 }
 
 }  // namespace sensors

--- a/base/cvd/cuttlefish/host/commands/sensors_simulator/sensors_hal_proxy.h
+++ b/base/cvd/cuttlefish/host/commands/sensors_simulator/sensors_hal_proxy.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <atomic>
+#include <mutex>
 #include <thread>
 
 #include "cuttlefish/common/libs/sensors/sensors.h"
@@ -37,6 +38,8 @@ class SensorsHalProxy {
                   SensorsSimulator& sensors_simulator, DeviceType device_type);
 
  private:
+  void ReportToGuest(SensorsMask mask);
+
   std::thread req_responder_thread_;
   std::thread data_reporter_thread_;
   std::thread reboot_monitor_thread_;
@@ -46,6 +49,7 @@ class SensorsHalProxy {
   SensorsSimulator& sensors_simulator_;
   std::atomic<bool> hal_activated_ = false;
   std::atomic<bool> running_ = true;
+  std::mutex report_mtx_;
 };
 
 }  // namespace sensors

--- a/base/cvd/cuttlefish/host/commands/sensors_simulator/sensors_simulator.cpp
+++ b/base/cvd/cuttlefish/host/commands/sensors_simulator/sensors_simulator.cpp
@@ -17,6 +17,7 @@
 #include "cuttlefish/host/commands/sensors_simulator/sensors_simulator.h"
 
 #include <cmath>
+#include <utility>
 
 namespace cuttlefish {
 namespace sensors {
@@ -28,7 +29,7 @@ constexpr float kLight = 1000.0f;       // lux
 constexpr float kPressure = 1013.25f;   // hpa
 constexpr float kHumidity = 40.0f;      // percent
 constexpr float kHingeAngle0 = 180.0f;  // degree
-constexpr double kG = 9.80665;  // meter per second^2
+constexpr double kG = 9.80665;          // meter per second^2
 const Eigen::Vector3d kMagneticField{0, 5.9, -48.4};
 inline double ToRadians(double x) { return x * M_PI / 180; }
 
@@ -96,7 +97,7 @@ SensorsSimulator::SensorsSimulator(bool is_auto)
       last_event_timestamp_(std::chrono::high_resolution_clock::now()),
       is_auto_(is_auto) {
   // Initialize sensors_data_ based on rotation vector = (0, 0, 0)
-  RefreshSensors(0, 0, 0);
+  SetMotion(0, 0, 0);
   // Set constant values for the sensors that are independent of rotation vector
   sensors_data_[kTemperatureId].f = kTemperature;
   sensors_data_[kProximityId].f = kProximity;
@@ -106,30 +107,61 @@ SensorsSimulator::SensorsSimulator(bool is_auto)
   sensors_data_[kHingeAngle0Id].f = kHingeAngle0;
 }
 
-void SensorsSimulator::RefreshSensors(double x, double y, double z) {
-  auto rotation_matrix_update = GetRotationMatrix(x, y, z);
-  auto acc_update = CalculateAcceleration(rotation_matrix_update, is_auto_);
-  auto mgn_update = CalculateMagnetometer(rotation_matrix_update);
+void SensorsSimulator::SetSensorsChangedCallback(
+    SensorsMask mask, SensorsChangedCallback callback) {
+  sensors_changed_mask_ = mask;
+  sensors_changed_callback_ = std::move(callback);
+}
 
-  std::lock_guard<std::mutex> lock(sensors_data_mtx_);
-  auto current_time = std::chrono::high_resolution_clock::now();
-  auto duration = current_time - last_event_timestamp_;
-  last_event_timestamp_ = current_time;
+void SensorsSimulator::NotifySensorsChanged(SensorsMask changed) {
+  SensorsMask relevant = changed & sensors_changed_mask_;
+  if (sensors_changed_callback_ && relevant) {
+    sensors_changed_callback_(relevant);
+  }
+}
 
-  auto gyro_update = CalculateGyroscope(duration, current_rotation_matrix_,
-                                        rotation_matrix_update);
+void SensorsSimulator::SetMotion(double x, double y, double z) {
+  Eigen::Matrix3d rotation_matrix_update = GetRotationMatrix(x, y, z);
+  Eigen::Vector3d acc_update =
+      CalculateAcceleration(rotation_matrix_update, is_auto_);
+  Eigen::Vector3d mgn_update = CalculateMagnetometer(rotation_matrix_update);
 
-  current_rotation_matrix_ = rotation_matrix_update;
+  {
+    std::lock_guard<std::mutex> lock(sensors_data_mtx_);
+    auto current_time = std::chrono::high_resolution_clock::now();
+    auto duration = current_time - last_event_timestamp_;
+    last_event_timestamp_ = current_time;
 
-  sensors_data_[kRotationVecId].v << x, y, z;
-  sensors_data_[kAccelerationId].v = acc_update;
-  sensors_data_[kGyroscopeId].v = gyro_update;
-  sensors_data_[kMagneticId].v = mgn_update;
+    Eigen::Vector3d gyro_update = CalculateGyroscope(
+        duration, current_rotation_matrix_, rotation_matrix_update);
 
-  // Copy the calibrated sensor data over for uncalibrated sensor support
-  sensors_data_[kUncalibAccelerationId].v = acc_update;
-  sensors_data_[kUncalibGyroscopeId].v = gyro_update;
-  sensors_data_[kUncalibMagneticId].v = mgn_update;
+    current_rotation_matrix_ = rotation_matrix_update;
+
+    sensors_data_[kRotationVecId].v << x, y, z;
+    sensors_data_[kAccelerationId].v = acc_update;
+    sensors_data_[kGyroscopeId].v = gyro_update;
+    sensors_data_[kMagneticId].v = mgn_update;
+
+    // Copy the calibrated sensor data over for uncalibrated sensor support
+    sensors_data_[kUncalibAccelerationId].v = acc_update;
+    sensors_data_[kUncalibGyroscopeId].v = gyro_update;
+    sensors_data_[kUncalibMagneticId].v = mgn_update;
+  }
+  NotifySensorsChanged((1 << kRotationVecId) | (1 << kAccelerationId) |
+                       (1 << kGyroscopeId) | (1 << kMagneticId) |
+                       (1 << kUncalibAccelerationId) |
+                       (1 << kUncalibGyroscopeId) | (1 << kUncalibMagneticId));
+}
+
+void SensorsSimulator::SetHingeAngle(float angle) {
+  {
+    std::lock_guard<std::mutex> lock(sensors_data_mtx_);
+    if (sensors_data_[kHingeAngle0Id].f == angle) {
+      return;
+    }
+    sensors_data_[kHingeAngle0Id].f = angle;
+  }
+  NotifySensorsChanged(1 << kHingeAngle0Id);
 }
 
 std::string SensorsSimulator::GetSensorsData(const SensorsMask mask) {

--- a/base/cvd/cuttlefish/host/commands/sensors_simulator/sensors_simulator.h
+++ b/base/cvd/cuttlefish/host/commands/sensors_simulator/sensors_simulator.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <chrono>
+#include <functional>
 #include <mutex>
 #include <string>
 
@@ -37,8 +38,15 @@ struct SensorsData {
 class SensorsSimulator {
  public:
   SensorsSimulator(bool is_auto);
-  // Update sensor values based on new rotation status.
-  void RefreshSensors(double x, double y, double z);
+
+  using SensorsChangedCallback = std::function<void(SensorsMask)>;
+  // Registers a callback invoked whenever one or more sensors in |mask| are
+  // updated.
+  void SetSensorsChangedCallback(SensorsMask mask,
+                                 SensorsChangedCallback callback);
+
+  void SetMotion(double x, double y, double z);
+  void SetHingeAngle(float angle);
 
   // Return a string with serialized sensors data in ascending order of
   // sensor id. A bitmask is used to specify which sensors to include.
@@ -49,7 +57,11 @@ class SensorsSimulator {
   std::string GetSensorsData(const SensorsMask mask);
 
  private:
+  void NotifySensorsChanged(SensorsMask changed);
+
   std::mutex sensors_data_mtx_;
+  SensorsMask sensors_changed_mask_ = 0;
+  SensorsChangedCallback sensors_changed_callback_;
   SensorsData sensors_data_[kMaxSensorId + 1];
   Eigen::Matrix3d current_rotation_matrix_;
   std::chrono::time_point<std::chrono::high_resolution_clock>

--- a/base/cvd/cuttlefish/host/frontend/webrtc/connection_observer.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/connection_observer.cpp
@@ -178,9 +178,11 @@ class ConnectionObserverImpl : public webrtc_streaming::ConnectionObserver {
     CF_EXPECT(OnSwitchEvent(SW_LID, !lid_open));
     return {};
   }
-  void OnHingeAngleChange(int /*hinge_angle*/) override {
-    // TODO(b/181157794) Propagate hinge angle sensor data using a custom
-    // Sensor HAL.
+  void OnHingeAngleChange(int hinge_angle) override {
+    Result<void> result = sensors_handler_.SetHingeAngle(hinge_angle);
+    if (!result.ok()) {
+      LOG(ERROR) << "Failed to set hinge angle: " << result.error();
+    }
   }
   Result<void> OnPowerButton(bool button_down) override {
     CF_EXPECT(OnKeyboardEvent(KEY_POWER, button_down));
@@ -239,12 +241,12 @@ class ConnectionObserverImpl : public webrtc_streaming::ConnectionObserver {
   void OnSensorsChannelOpen(std::function<bool(const uint8_t *, size_t)>
                                 sensors_message_sender) override {
     sensors_subscription_id =
-        sensors_handler_.Subscribe(sensors_message_sender);
+        sensors_handler_.AddMotionUpdatedCallback(sensors_message_sender);
     VLOG(1) << "Sensors channel open";
   }
 
   void OnSensorsChannelClosed() override {
-    sensors_handler_.UnSubscribe(sensors_subscription_id);
+    sensors_handler_.RemoveMotionUpdatedCallback(sensors_subscription_id);
   }
 
   void OnSensorsMessage(const uint8_t *msg, size_t size) override {
@@ -264,7 +266,10 @@ class ConnectionObserverImpl : public webrtc_streaming::ConnectionObserver {
         << "Y rotation value must be a double";
     CHECK(absl::SimpleAtod(xyz.at(2), &z))
         << "Z rotation value must be a double";
-    sensors_handler_.HandleMessage(x, y, z);
+    Result<void> result = sensors_handler_.SetMotion(x, y, z);
+    if (!result.ok()) {
+      LOG(ERROR) << "Failed to set motion: " << result.error();
+    }
   }
 
   void OnLightsChannelOpen(

--- a/base/cvd/cuttlefish/host/frontend/webrtc/html_client/js/app.js
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/html_client/js/app.js
@@ -183,14 +183,14 @@ class DeviceControlApp {
         document.getElementById('record_video_btn'),
         enabled => this.#onVideoCaptureToggle(enabled));
 
+    this.#showDeviceUI();
+
     // Enable non-ADB buttons, these buttons use data channels to communicate
     // with the host, so they're ready to go as soon as the webrtc connection is
     // established.
     this.#getControlPanelButtons()
         .filter(b => !b.dataset.adb)
         .forEach(b => b.disabled = false);
-
-    this.#showDeviceUI();
   }
 
   #addAudioStream(stream_id, audioPlaybackCtrl) {
@@ -352,18 +352,10 @@ class DeviceControlApp {
               'control-panel-custom-buttons');
           element.dataset.adb = true;
         } else if (button.device_states) {
-          // This button corresponds to variable hardware device state(s).
-          let element = createControlPanelButton(
+          createControlPanelButton(
               button.title, button.icon_name,
               this.#getCustomDeviceStateButtonCb(button.device_states),
               'control-panel-custom-buttons');
-          for (const device_state of button.device_states) {
-            // hinge_angle is currently injected via an adb shell command that
-            // triggers a guest binary.
-            if ('hinge_angle_value' in device_state) {
-              element.dataset.adb = true;
-            }
-          }
         } else {
           // This button's command is handled by custom action server.
           createControlPanelButton(
@@ -738,8 +730,6 @@ class DeviceControlApp {
     let index = 0;
     return e => {
       if (e.type == 'mousedown') {
-        // Reset any overridden device state.
-        adbShell('cmd device_state state reset');
         // Send a device_state message for the current state.
         let message = {
           command: 'device_state',
@@ -754,11 +744,6 @@ class DeviceControlApp {
         let hingeAngle = null;
         if ('hinge_angle_value' in states[index]) {
           hingeAngle = states[index].hinge_angle_value;
-          // TODO(b/181157794): Use a custom Sensor HAL for hinge_angle
-          // injection instead of this guest binary.
-          adbShell(
-              '/vendor/bin/cuttlefish_sensor_injection hinge_angle ' +
-              states[index].hinge_angle_value);
         }
         // Update the Device Details view.
         this.#updateDeviceStateDetails(lidSwitchOpen, hingeAngle);

--- a/base/cvd/cuttlefish/host/frontend/webrtc/sensors_handler.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/sensors_handler.cpp
@@ -21,6 +21,7 @@
 #include <mutex>
 #include <sstream>
 #include <string>
+#include <string_view>
 
 #include "absl/log/log.h"
 
@@ -30,100 +31,88 @@ namespace cuttlefish {
 namespace webrtc_streaming {
 
 namespace {
-static constexpr sensors::SensorsMask kUiSupportedSensors =
+static constexpr sensors::SensorsMask kMotionSensors =
     (1 << sensors::kAccelerationId) | (1 << sensors::kGyroscopeId) |
     (1 << sensors::kMagneticId) | (1 << sensors::kRotationVecId);
 }  // namespace
 
 SensorsHandler::SensorsHandler(SharedFD sensors_fd)
-    : channel_(transport::SharedFdChannel(sensors_fd, sensors_fd)) {
-  auto refresh_result = RefreshSensors(0, 0, 0);
-  if (!refresh_result.ok()) {
-    LOG(ERROR) << "Failed to refresh sensors: " << refresh_result.error();
-  }
-}
+    : channel_(transport::SharedFdChannel(sensors_fd, sensors_fd)) {}
 
 SensorsHandler::~SensorsHandler() {}
 
-Result<void> SensorsHandler::RefreshSensors(const double x, const double y,
-                                            const double z) {
-  std::stringstream ss;
-  ss << x << sensors::INNER_DELIM << y << sensors::INNER_DELIM << z;
-  auto msg = ss.str();
-  auto size = msg.size();
-  auto cmd = sensors::kUpdateRotationVec;
-  auto request = CF_EXPECT(transport::CreateMessage(cmd, size),
-                           "Failed to allocate message for cmd: "
-                               << cmd << " with size: " << size << " bytes. ");
-  memcpy(request->payload, msg.data(), size);
+Result<void> SensorsHandler::SendCommand(uint32_t cmd,
+                                         std::string_view payload) {
+  size_t size = payload.size();
+  transport::ManagedMessage request = CF_EXPECT(
+      transport::CreateMessage(cmd, size),
+      "Failed to allocate message for cmd: " << cmd << " with size: " << size
+                                             << " bytes. ");
+  memcpy(request->payload, payload.data(), size);
   CF_EXPECT(channel_.SendRequest(*request),
             "Can't send request for cmd: " << cmd);
   return {};
 }
 
-Result<std::string> SensorsHandler::GetSensorsData() {
-  auto msg = std::to_string(kUiSupportedSensors);
-  auto size = msg.size();
-  auto cmd = sensors::kGetSensorsData;
-  auto request = CF_EXPECT(transport::CreateMessage(cmd, size),
-                           "Failed to allocate message for cmd: "
-                               << cmd << " with size: " << size << " bytes. ");
-  memcpy(request->payload, msg.data(), size);
-  CF_EXPECT(channel_.SendRequest(*request),
-            "Can't send request for cmd: " << cmd);
-  auto response =
+Result<void> SensorsHandler::SetMotion(const double x, const double y,
+                                       const double z) {
+  std::stringstream ss;
+  ss << x << sensors::INNER_DELIM << y << sensors::INNER_DELIM << z;
+  CF_EXPECT(SendCommand(sensors::kUpdateRotationVec, ss.str()));
+  NotifyMotionUpdated();
+  return {};
+}
+
+Result<void> SensorsHandler::SetHingeAngle(const double angle) {
+  CF_EXPECT(SendCommand(sensors::kUpdateHingeAngle, std::to_string(angle)));
+  return {};
+}
+
+Result<std::string> SensorsHandler::GetSensorsData(sensors::SensorsMask mask) {
+  CF_EXPECT(SendCommand(sensors::kGetSensorsData, std::to_string(mask)));
+  transport::ManagedMessage response =
       CF_EXPECT(channel_.ReceiveMessage(), "Couldn't receive message.");
-  cmd = response->command;
-  auto is_response = response->is_response;
+  uint32_t cmd = response->command;
+  bool is_response = response->is_response;
   CF_EXPECT((cmd == sensors::kGetSensorsData) && is_response,
             "Unexpected cmd: " << cmd << ", response: " << is_response);
   return std::string(reinterpret_cast<const char*>(response->payload),
                      response->payload_size);
 }
 
-// Get new sensor values and send them to client.
-void SensorsHandler::HandleMessage(const double x, const double y, const double z) {
-  auto refresh_result = RefreshSensors(x, y, z);
-  if (!refresh_result.ok()) {
-    LOG(ERROR) << "Failed to refresh sensors: " << refresh_result.error();
-    return;
-  }
-  UpdateSensorsUi();
-}
-
-int SensorsHandler::Subscribe(std::function<void(const uint8_t*, size_t)> send_to_client) {
+int SensorsHandler::AddMotionUpdatedCallback(MotionUpdatedCallback callback) {
   int subscriber_id = ++last_client_channel_id_;
   {
     std::lock_guard<std::mutex> lock(subscribers_mtx_);
-    client_channels_[subscriber_id] = send_to_client;
+    client_channels_[subscriber_id] = callback;
   }
 
   // Send device's initial state to the new client.
-  auto result = GetSensorsData();
+  Result<std::string> result = GetSensorsData(kMotionSensors);
   if (!result.ok()) {
     LOG(ERROR) << "Failed to get sensors data: " << result.error();
     return subscriber_id;
   }
-  auto new_sensors_data = std::move(result.value());
+  std::string new_sensors_data = std::move(result.value());
   const uint8_t* message =
       reinterpret_cast<const uint8_t*>(new_sensors_data.c_str());
-  send_to_client(message, new_sensors_data.size());
+  callback(message, new_sensors_data.size());
 
   return subscriber_id;
 }
 
-void SensorsHandler::UnSubscribe(int subscriber_id) {
+void SensorsHandler::RemoveMotionUpdatedCallback(int subscriber_id) {
   std::lock_guard<std::mutex> lock(subscribers_mtx_);
   client_channels_.erase(subscriber_id);
 }
 
-void SensorsHandler::UpdateSensorsUi() {
-  auto result = GetSensorsData();
+void SensorsHandler::NotifyMotionUpdated() {
+  Result<std::string> result = GetSensorsData(kMotionSensors);
   if (!result.ok()) {
     LOG(ERROR) << "Failed to get sensors data: " << result.error();
     return;
   }
-  auto new_sensors_data = std::move(result.value());
+  std::string new_sensors_data = std::move(result.value());
   const uint8_t* message =
       reinterpret_cast<const uint8_t*>(new_sensors_data.c_str());
   std::lock_guard<std::mutex> lock(subscribers_mtx_);

--- a/base/cvd/cuttlefish/host/frontend/webrtc/sensors_handler.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/sensors_handler.h
@@ -18,8 +18,10 @@
 
 #include <functional>
 #include <mutex>
+#include <string_view>
 #include <unordered_map>
 
+#include "cuttlefish/common/libs/sensors/sensors.h"
 #include "cuttlefish/common/libs/transport/channel_sharedfd.h"
 
 namespace cuttlefish {
@@ -27,19 +29,23 @@ namespace webrtc_streaming {
 
 class SensorsHandler {
  public:
+  using MotionUpdatedCallback = std::function<void(const uint8_t*, size_t)>;
+
   explicit SensorsHandler(SharedFD sensors_fd);
   ~SensorsHandler();
 
-  void HandleMessage(double x, double y, double z);
-  int Subscribe(std::function<void(const uint8_t*, size_t)> send_to_client);
-  void UnSubscribe(int subscriber_id);
+  Result<void> SetMotion(double x, double y, double z);
+  Result<void> SetHingeAngle(double angle);
+
+  int AddMotionUpdatedCallback(MotionUpdatedCallback callback);
+  void RemoveMotionUpdatedCallback(int subscriber_id);
 
  private:
-  Result<void> RefreshSensors(double x, double y, double z);
-  Result<std::string> GetSensorsData();
-  void UpdateSensorsUi();
+  Result<void> SendCommand(uint32_t cmd, std::string_view payload);
+  Result<std::string> GetSensorsData(sensors::SensorsMask mask);
+  void NotifyMotionUpdated();
 
-  std::unordered_map<int, std::function<void(const uint8_t*, size_t)>> client_channels_;
+  std::unordered_map<int, MotionUpdatedCallback> client_channels_;
   int last_client_channel_id_ = -1;
   std::mutex subscribers_mtx_;
   transport::SharedFdChannel channel_;


### PR DESCRIPTION
The cuttlefish_sensor_injection tool does not work with goldfish multihal sensors, meaning hinge angle changes currently have no effect

To fix this, redirect WebRTC hinge angle updates to the sensors simulator instead.

Test: hinge angle is updated from web ui
Bug: 517370262