### PR TITLE
Enforce clang-format and include cleaner in cuttlefish/io

### DIFF
--- a/base/cvd/BUILD.bazel
+++ b/base/cvd/BUILD.bazel
@@ -27,6 +27,7 @@ filegroup(
     name = "clang_tidy_config",
     srcs = [
         ".clang-tidy",
+        "//cuttlefish/io:.clang-tidy",
         "//cuttlefish/common/libs/key_equals_value:.clang-tidy",
         "//cuttlefish/host/commands/assemble_cvd/android_build:.clang-tidy",
         "//cuttlefish/host/commands/cvd/cli/commands:.clang-tidy",

--- a/base/cvd/cuttlefish/io/.clang-tidy
+++ b/base/cvd/cuttlefish/io/.clang-tidy
@@ -1,0 +1,1 @@
+../../clang_tidy_configs/with_include_cleaner

--- a/base/cvd/cuttlefish/io/BUILD.bazel
+++ b/base/cvd/cuttlefish/io/BUILD.bazel
@@ -10,6 +10,7 @@ cf_cc_library(
     name = "chroot",
     srcs = ["chroot.cc"],
     hdrs = ["chroot.h"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:filesystem",
@@ -22,6 +23,7 @@ cf_cc_library(
 cf_cc_test(
     name = "chroot_test",
     srcs = ["chroot_test.cc"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:chroot",
@@ -37,6 +39,7 @@ cf_cc_library(
     name = "concat",
     srcs = ["concat.cc"],
     hdrs = ["concat.h"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:fake_seek",
@@ -49,6 +52,7 @@ cf_cc_library(
 cf_cc_test(
     name = "concat_test",
     srcs = ["concat_test.cc"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:concat",
@@ -62,6 +66,7 @@ cf_cc_library(
     name = "copy",
     srcs = ["copy.cc"],
     hdrs = ["copy.h"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/result:expect",
@@ -72,6 +77,7 @@ cf_cc_library(
 cf_cc_test(
     name = "copy_test",
     srcs = ["copy_test.cc"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:copy",
@@ -85,6 +91,7 @@ cf_cc_library(
     name = "cpio",
     srcs = ["cpio.cc"],
     hdrs = ["cpio.h"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/common/libs/utils:size_utils",
         "//cuttlefish/io",
@@ -99,6 +106,7 @@ cf_cc_library(
 cf_cc_test(
     name = "cpio_test",
     srcs = ["cpio_test.cc"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io:cpio",
         "//cuttlefish/io:in_memory",
@@ -112,6 +120,7 @@ cf_cc_library(
     name = "default_visitor",
     srcs = ["default_visitor.cc"],
     hdrs = ["default_visitor.h"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:concat",
@@ -126,6 +135,7 @@ cf_cc_library(
     name = "disjoint_range_set",
     srcs = ["disjoint_range_set.cc"],
     hdrs = ["disjoint_range_set.h"],
+    clang_format_enabled = True,
     deps = [
         "//libbase",
         "@abseil-cpp//absl/log:check",
@@ -145,6 +155,7 @@ proto_library(
 cf_cc_test(
     name = "disjoint_range_set_test",
     srcs = ["disjoint_range_set_test.cc"],
+    clang_format_enabled = True,
     deps = ["//cuttlefish/io:disjoint_range_set"],
 )
 
@@ -152,6 +163,7 @@ cf_cc_library(
     name = "fake_pread_pwrite",
     srcs = ["fake_pread_pwrite.cc"],
     hdrs = ["fake_pread_pwrite.h"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/result:expect",
@@ -163,6 +175,7 @@ cf_cc_library(
     name = "fake_seek",
     srcs = ["fake_seek.cc"],
     hdrs = ["fake_seek.h"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/result:expect",
@@ -173,6 +186,7 @@ cf_cc_library(
 cf_cc_test(
     name = "fake_seek_test",
     srcs = ["fake_seek_test.cc"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io:fake_seek",
         "//cuttlefish/result:result_matchers",
@@ -183,6 +197,7 @@ cf_cc_test(
 cf_cc_library(
     name = "filesystem",
     hdrs = ["filesystem.h"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/result:result_type",
@@ -193,6 +208,7 @@ cf_cc_library(
     name = "in_memory",
     srcs = ["in_memory.cc"],
     hdrs = ["in_memory.h"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:filesystem",
@@ -204,6 +220,7 @@ cf_cc_library(
 cf_cc_test(
     name = "in_memory_test",
     srcs = ["in_memory_test.cc"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io:in_memory",
         "//cuttlefish/result:result_matchers",
@@ -216,6 +233,7 @@ cf_cc_library(
     name = "io",
     srcs = ["io.cc"],
     hdrs = ["io.h"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/result:expect",
         "//cuttlefish/result:result_type",
@@ -226,6 +244,7 @@ cf_cc_library(
     name = "lazily_loaded_file",
     srcs = ["lazily_loaded_file.cc"],
     hdrs = ["lazily_loaded_file.h"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",
@@ -241,6 +260,7 @@ cf_cc_library(
     name = "length",
     srcs = ["length.cc"],
     hdrs = ["length.h"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/result:expect",
@@ -251,6 +271,7 @@ cf_cc_library(
 cf_cc_test(
     name = "length_test",
     srcs = ["length_test.cc"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:in_memory",
@@ -263,6 +284,7 @@ cf_cc_library(
     name = "lz4_legacy",
     srcs = ["lz4_legacy.cc"],
     hdrs = ["lz4_legacy.h"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:read_exact",
@@ -276,6 +298,7 @@ cf_cc_library(
 cf_cc_test(
     name = "lz4_legacy_test",
     srcs = ["lz4_legacy_test.cc"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io:filesystem",
         "//cuttlefish/io:in_memory",
@@ -291,6 +314,7 @@ cf_cc_library(
     name = "native_filesystem",
     srcs = ["native_filesystem.cc"],
     hdrs = ["native_filesystem.h"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/io",
@@ -306,6 +330,7 @@ cf_cc_library(
     name = "read_exact",
     srcs = ["read_exact.cc"],
     hdrs = ["read_exact.h"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/result:expect",
@@ -317,6 +342,7 @@ cf_cc_library(
     name = "read_window_view",
     srcs = ["read_window_view.cc"],
     hdrs = ["read_window_view.h"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io:fake_seek",
         "//cuttlefish/result:expect",
@@ -327,6 +353,7 @@ cf_cc_library(
 cf_cc_test(
     name = "read_window_view_test",
     srcs = ["read_window_view_test.cc"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:in_memory",
@@ -341,6 +368,7 @@ cf_cc_library(
     name = "serialize_disjoint_range_set",
     srcs = ["serialize_disjoint_range_set.cc"],
     hdrs = ["serialize_disjoint_range_set.h"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io:disjoint_range_set",
         "//cuttlefish/io:disjoint_range_set_cc_proto",
@@ -351,6 +379,7 @@ cf_cc_library(
 cf_cc_test(
     name = "serialize_disjoint_range_set_test",
     srcs = ["serialize_disjoint_range_set_test.cc"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io:disjoint_range_set",
         "//cuttlefish/io:serialize_disjoint_range_set",
@@ -363,6 +392,7 @@ cf_cc_library(
     name = "shared_fd",
     srcs = ["shared_fd.cc"],
     hdrs = ["shared_fd.h"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/io",
@@ -375,6 +405,7 @@ cf_cc_library(
     name = "string",
     srcs = ["string.cc"],
     hdrs = ["string.h"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/result:expect",
@@ -386,6 +417,7 @@ cf_cc_library(
     name = "write_exact",
     srcs = ["write_exact.cc"],
     hdrs = ["write_exact.h"],
+    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/result:expect",

--- a/base/cvd/cuttlefish/io/BUILD.bazel
+++ b/base/cvd/cuttlefish/io/BUILD.bazel
@@ -6,6 +6,8 @@ package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
+exports_files([".clang-tidy"])
+
 cf_cc_library(
     name = "chroot",
     srcs = ["chroot.cc"],
@@ -31,6 +33,7 @@ cf_cc_test(
         "//cuttlefish/io:filesystem",
         "//cuttlefish/io:in_memory",
         "//cuttlefish/io:string",
+        "//cuttlefish/result",
         "//cuttlefish/result:result_matchers",
     ],
 )
@@ -58,6 +61,7 @@ cf_cc_test(
         "//cuttlefish/io:concat",
         "//cuttlefish/io:in_memory",
         "//cuttlefish/io:string",
+        "//cuttlefish/result",
         "//cuttlefish/result:result_matchers",
     ],
 )
@@ -108,10 +112,12 @@ cf_cc_test(
     srcs = ["cpio_test.cc"],
     clang_format_enabled = True,
     deps = [
+        "//cuttlefish/io",
         "//cuttlefish/io:cpio",
         "//cuttlefish/io:in_memory",
         "//cuttlefish/io:read_exact",
         "//cuttlefish/io:string",
+        "//cuttlefish/result",
         "//cuttlefish/result:result_matchers",
     ],
 )
@@ -222,6 +228,7 @@ cf_cc_test(
     srcs = ["in_memory_test.cc"],
     clang_format_enabled = True,
     deps = [
+        "//cuttlefish/io",
         "//cuttlefish/io:in_memory",
         "//cuttlefish/result:result_matchers",
         "//cuttlefish/result:result_type",
@@ -300,12 +307,14 @@ cf_cc_test(
     srcs = ["lz4_legacy_test.cc"],
     clang_format_enabled = True,
     deps = [
+        "//cuttlefish/io",
         "//cuttlefish/io:filesystem",
         "//cuttlefish/io:in_memory",
         "//cuttlefish/io:lz4_legacy",
         "//cuttlefish/io:read_exact",
         "//cuttlefish/io:string",
         "//cuttlefish/io:write_exact",
+        "//cuttlefish/result",
         "//cuttlefish/result:result_matchers",
     ],
 )
@@ -344,6 +353,7 @@ cf_cc_library(
     hdrs = ["read_window_view.h"],
     clang_format_enabled = True,
     deps = [
+        "//cuttlefish/io",
         "//cuttlefish/io:fake_seek",
         "//cuttlefish/result:expect",
         "//cuttlefish/result:result_type",

--- a/base/cvd/cuttlefish/io/chroot.cc
+++ b/base/cvd/cuttlefish/io/chroot.cc
@@ -18,6 +18,7 @@
 #include <stdint.h>
 
 #include <list>
+#include <memory>
 #include <string>
 #include <string_view>
 

--- a/base/cvd/cuttlefish/io/chroot.h
+++ b/base/cvd/cuttlefish/io/chroot.h
@@ -15,13 +15,12 @@
 
 #pragma once
 
-#include "cuttlefish/io/filesystem.h"
-
 #include <stdint.h>
 
 #include <string>
 #include <string_view>
 
+#include "cuttlefish/io/filesystem.h"
 #include "cuttlefish/io/io.h"
 #include "cuttlefish/result/result_type.h"
 

--- a/base/cvd/cuttlefish/io/chroot_test.cc
+++ b/base/cvd/cuttlefish/io/chroot_test.cc
@@ -15,16 +15,18 @@
 
 #include "cuttlefish/io/chroot.h"
 
-#include <string>
+#include <memory>
 #include <string_view>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 #include "cuttlefish/io/copy.h"
+#include "cuttlefish/io/filesystem.h"
 #include "cuttlefish/io/in_memory.h"
 #include "cuttlefish/io/io.h"
 #include "cuttlefish/io/string.h"
+#include "cuttlefish/result/result.h"
 #include "cuttlefish/result/result_matchers.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/io/concat.cc
+++ b/base/cvd/cuttlefish/io/concat.cc
@@ -15,8 +15,11 @@
 
 #include "cuttlefish/io/concat.h"
 
+#include <stdint.h>
+
 #include <map>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "cuttlefish/io/fake_seek.h"

--- a/base/cvd/cuttlefish/io/concat_test.cc
+++ b/base/cvd/cuttlefish/io/concat_test.cc
@@ -15,8 +15,10 @@
 
 #include "cuttlefish/io/concat.h"
 
-#include <string>
+#include <memory>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -24,6 +26,7 @@
 #include "cuttlefish/io/in_memory.h"
 #include "cuttlefish/io/io.h"
 #include "cuttlefish/io/string.h"
+#include "cuttlefish/result/result.h"
 #include "cuttlefish/result/result_matchers.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/io/copy.cc
+++ b/base/cvd/cuttlefish/io/copy.cc
@@ -18,6 +18,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <array>
 #include <memory>
 
 #include "cuttlefish/io/io.h"

--- a/base/cvd/cuttlefish/io/copy_test.cc
+++ b/base/cvd/cuttlefish/io/copy_test.cc
@@ -16,13 +16,13 @@
 #include "cuttlefish/io/copy.h"
 
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "gmock/gmock-matchers.h"
 #include "gtest/gtest.h"
 
 #include "cuttlefish/io/in_memory.h"
+#include "cuttlefish/io/io.h"
 #include "cuttlefish/io/read_exact.h"
 #include "cuttlefish/result/result_matchers.h"
 

--- a/base/cvd/cuttlefish/io/cpio.cc
+++ b/base/cvd/cuttlefish/io/cpio.cc
@@ -16,12 +16,19 @@
 #include "cuttlefish/io/cpio.h"
 
 #include <endian.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <string.h>
 
 #include <charconv>
+#include <memory>
+#include <string>
 #include <string_view>
+#include <system_error>
+#include <utility>
 
 #include "cuttlefish/common/libs/utils/size_utils.h"
+#include "cuttlefish/io/io.h"
 #include "cuttlefish/io/read_exact.h"
 #include "cuttlefish/io/read_window_view.h"
 #include "cuttlefish/result/expect.h"

--- a/base/cvd/cuttlefish/io/cpio.cc
+++ b/base/cvd/cuttlefish/io/cpio.cc
@@ -146,7 +146,8 @@ Result<CpioReader::EntriesMap> CpioReader::Parse(const ReaderSeeker& reader) {
   }
 }
 
-Result<CpioReader::EntriesMap> CpioReader::ParseNewc(const ReaderSeeker& reader) {
+Result<CpioReader::EntriesMap> CpioReader::ParseNewc(
+    const ReaderSeeker& reader) {
   EntriesMap entries;
   uint64_t offset = 0;
   while (true) {
@@ -189,7 +190,8 @@ Result<CpioReader::EntriesMap> CpioReader::ParseNewc(const ReaderSeeker& reader)
   return entries;
 }
 
-Result<CpioReader::EntriesMap> CpioReader::ParseOdc(const ReaderSeeker& reader) {
+Result<CpioReader::EntriesMap> CpioReader::ParseOdc(
+    const ReaderSeeker& reader) {
   EntriesMap entries;
   uint64_t offset = 0;
   while (true) {

--- a/base/cvd/cuttlefish/io/cpio_test.cc
+++ b/base/cvd/cuttlefish/io/cpio_test.cc
@@ -15,14 +15,20 @@
 
 #include "cuttlefish/io/cpio.h"
 
-#include <gtest/gtest.h>
+#include <stdint.h>
+
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
 #include "cuttlefish/io/in_memory.h"
-#include "cuttlefish/io/read_exact.h"
+#include "cuttlefish/io/io.h"
 #include "cuttlefish/io/string.h"
+#include "cuttlefish/result/result.h"
 #include "cuttlefish/result/result_matchers.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/io/default_visitor.cc
+++ b/base/cvd/cuttlefish/io/default_visitor.cc
@@ -15,8 +15,6 @@
 
 #include "cuttlefish/io/default_visitor.h"
 
-#include <stdint.h>
-
 #include "cuttlefish/io/concat.h"
 #include "cuttlefish/io/io.h"
 #include "cuttlefish/io/read_window_view.h"

--- a/base/cvd/cuttlefish/io/fake_pread_pwrite.cc
+++ b/base/cvd/cuttlefish/io/fake_pread_pwrite.cc
@@ -22,7 +22,8 @@
 
 namespace cuttlefish {
 
-Result<uint64_t> FakePRead(ReaderSeeker& reader_seeker, void* buf, uint64_t count, uint64_t offset) {
+Result<uint64_t> FakePRead(ReaderSeeker& reader_seeker, void* buf,
+                           uint64_t count, uint64_t offset) {
   size_t original_offset = CF_EXPECT(reader_seeker.SeekCur(0));
   CF_EXPECT(reader_seeker.SeekSet(offset));
   Result<size_t> read_res = reader_seeker.Read(buf, count);

--- a/base/cvd/cuttlefish/io/fake_pread_pwrite.cc
+++ b/base/cvd/cuttlefish/io/fake_pread_pwrite.cc
@@ -13,10 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "cuttlefish/io/io.h"
-
+#include <stddef.h>
 #include <stdint.h>
 
+#include <utility>
+
+#include "cuttlefish/io/io.h"
 #include "cuttlefish/result/expect.h"
 #include "cuttlefish/result/result_type.h"
 

--- a/base/cvd/cuttlefish/io/fake_pread_pwrite.h
+++ b/base/cvd/cuttlefish/io/fake_pread_pwrite.h
@@ -26,7 +26,8 @@ namespace cuttlefish {
  *
  * Will not call PRead() on the ReaderSeeker instance.
  */
-Result<uint64_t> FakePRead(ReaderSeeker&, void* buf, uint64_t count, uint64_t offset);
+Result<uint64_t> FakePRead(ReaderSeeker&, void* buf, uint64_t count,
+                           uint64_t offset);
 /**
  * Best-effort fake pwrite(2) using Write() and Seek*() calls.
  *

--- a/base/cvd/cuttlefish/io/fake_pread_pwrite.h
+++ b/base/cvd/cuttlefish/io/fake_pread_pwrite.h
@@ -13,10 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "cuttlefish/io/io.h"
-
 #include <stdint.h>
 
+#include "cuttlefish/io/io.h"
 #include "cuttlefish/result/result_type.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/io/fake_seek_test.cc
+++ b/base/cvd/cuttlefish/io/fake_seek_test.cc
@@ -15,8 +15,11 @@
 
 #include "cuttlefish/io/fake_seek.h"
 
-#include <string>
-#include <string_view>
+#include <stdint.h>
+#include <string.h>
+
+#include <algorithm>
+#include <vector>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/base/cvd/cuttlefish/io/filesystem.h
+++ b/base/cvd/cuttlefish/io/filesystem.h
@@ -15,12 +15,11 @@
 
 #pragma once
 
-#include "cuttlefish/io/io.h"
-
 #include <stdint.h>
 
 #include <string_view>
 
+#include "cuttlefish/io/io.h"
 #include "cuttlefish/result/result_type.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/io/in_memory.cc
+++ b/base/cvd/cuttlefish/io/in_memory.cc
@@ -21,11 +21,16 @@
 #include <algorithm>
 #include <functional>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
+#include "cuttlefish/io/filesystem.h"
+#include "cuttlefish/io/io.h"
 #include "cuttlefish/result/expect.h"
 #include "cuttlefish/result/result_type.h"
 

--- a/base/cvd/cuttlefish/io/in_memory_test.cc
+++ b/base/cvd/cuttlefish/io/in_memory_test.cc
@@ -15,6 +15,7 @@
 
 #include "cuttlefish/io/in_memory.h"
 
+#include <memory>
 #include <string>
 #include <string_view>
 
@@ -22,6 +23,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#include "cuttlefish/io/io.h"
 #include "cuttlefish/result/result_matchers.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/io/lz4_legacy.cc
+++ b/base/cvd/cuttlefish/io/lz4_legacy.cc
@@ -17,6 +17,7 @@
 
 #include <endian.h>
 #include <stdint.h>
+#include <string.h>
 
 #include <algorithm>
 #include <memory>

--- a/base/cvd/cuttlefish/io/lz4_legacy_test.cc
+++ b/base/cvd/cuttlefish/io/lz4_legacy_test.cc
@@ -15,17 +15,22 @@
 
 #include "cuttlefish/io/lz4_legacy.h"
 
+#include <stddef.h>
+
 #include <memory>
 #include <string>
-#include <vector>
+#include <string_view>
+#include <utility>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "cuttlefish/io/filesystem.h"
 #include "cuttlefish/io/in_memory.h"
-#include "cuttlefish/io/read_exact.h"
+#include "cuttlefish/io/io.h"
 #include "cuttlefish/io/string.h"
 #include "cuttlefish/io/write_exact.h"
+#include "cuttlefish/result/result.h"
 #include "cuttlefish/result/result_matchers.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/io/native_filesystem.cc
+++ b/base/cvd/cuttlefish/io/native_filesystem.cc
@@ -16,12 +16,17 @@
 #include "cuttlefish/io/native_filesystem.h"
 
 #include <errno.h>
+#include <fcntl.h>
 #include <stdint.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
+#include <memory>
+#include <string>
 #include <string_view>
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/io/io.h"
 #include "cuttlefish/io/shared_fd.h"
 #include "cuttlefish/posix/strerror.h"
 #include "cuttlefish/result/expect.h"

--- a/base/cvd/cuttlefish/io/read_exact.cc
+++ b/base/cvd/cuttlefish/io/read_exact.cc
@@ -15,6 +15,7 @@
 
 #include "cuttlefish/io/read_exact.h"
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "cuttlefish/io/io.h"

--- a/base/cvd/cuttlefish/io/read_exact.h
+++ b/base/cvd/cuttlefish/io/read_exact.h
@@ -33,7 +33,8 @@ Result<T> ReadExactBinary(Reader& reader) {
   return data;
 }
 
-Result<void> PReadExact(const ReaderSeeker&, char* buf, size_t size, uint64_t offset);
+Result<void> PReadExact(const ReaderSeeker&, char* buf, size_t size,
+                        uint64_t offset);
 
 template <typename T>
 Result<T> PReadExactBinary(const ReaderSeeker& reader, uint64_t offset) {

--- a/base/cvd/cuttlefish/io/read_window_view.cc
+++ b/base/cvd/cuttlefish/io/read_window_view.cc
@@ -20,6 +20,7 @@
 #include <algorithm>
 
 #include "cuttlefish/io/fake_seek.h"
+#include "cuttlefish/io/io.h"
 #include "cuttlefish/result/expect.h"
 #include "cuttlefish/result/result_type.h"
 

--- a/base/cvd/cuttlefish/io/read_window_view_test.cc
+++ b/base/cvd/cuttlefish/io/read_window_view_test.cc
@@ -15,7 +15,7 @@
 
 #include "cuttlefish/io/read_window_view.h"
 
-#include <string>
+#include <memory>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -24,7 +24,6 @@
 #include "cuttlefish/io/io.h"
 #include "cuttlefish/io/string.h"
 #include "cuttlefish/result/result_matchers.h"
-#include "cuttlefish/result/result_type.h"
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/io/shared_fd.cc
+++ b/base/cvd/cuttlefish/io/shared_fd.cc
@@ -16,11 +16,12 @@
 #include "cuttlefish/io/shared_fd.h"
 
 #include <stdint.h>
-#include <unistd.h>
+#include <stdio.h>
 
 #include <utility>
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/io/io.h"
 #include "cuttlefish/result/expect.h"
 #include "cuttlefish/result/result_type.h"
 

--- a/base/cvd/cuttlefish/io/string.cc
+++ b/base/cvd/cuttlefish/io/string.cc
@@ -15,10 +15,12 @@
 
 #include "cuttlefish/io/string.h"
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include "cuttlefish/io/io.h"
 #include "cuttlefish/result/expect.h"

--- a/base/cvd/cuttlefish/io/write_exact.cc
+++ b/base/cvd/cuttlefish/io/write_exact.cc
@@ -15,7 +15,7 @@
 
 #include "cuttlefish/io/write_exact.h"
 
-#include <stdint.h>
+#include <stddef.h>
 
 #include "cuttlefish/io/io.h"
 #include "cuttlefish/result/expect.h"


### PR DESCRIPTION
Assisted-by: Gemini:Next
Bug: b/512215781