### PR TITLE
Prevent a fetcher_config error message from being printed

### DIFF
--- a/base/cvd/cuttlefish/host/libs/config/fetcher_configs.cc
+++ b/base/cvd/cuttlefish/host/libs/config/fetcher_configs.cc
@@ -61,7 +61,7 @@ FetcherConfigs FetcherConfigs::ReadFromDirectories(
 
     std::string path = absl::StrCat(real, "/", kFetcherConfigFile);
 
-    if (!it->second.LoadFromFile(path)) {
+    if (FileExists(path) && !it->second.LoadFromFile(path)) {
       VLOG(0) << "No valid fetcher_config in '" << path
               << "', falling back to default";
     }


### PR DESCRIPTION
The following message is always printed when calling `cvd create`:

Could not read config file /mnt/external_ssd/main/out/target/product/vsoc_x86_64/fetcher_config.json: * Line 1, Column 1
  Syntax error: value, object or array expected.

However, this file never exists (at least in my development setup). So add a check to ensure the file exists first before trying to parse it.

Bug: 519542446
Test: cvd create