### PR TITLE
Omnibus for changes to kvm and cvdnetwork checks.

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/users.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/users.cpp
@@ -126,4 +126,12 @@ Result<std::string> CurrentUserName() {
   return std::string(pwd.pw_name);
 }
 
+bool IsKvmAccessible() {
+#ifdef __linux__
+  return access("/dev/kvm", R_OK | W_OK) == 0 || InGroup("kvm");
+#else
+  return false;
+#endif
+}
+
 } // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/users.h
+++ b/base/cvd/cuttlefish/common/libs/utils/users.h
@@ -25,6 +25,7 @@ namespace cuttlefish {
 
 gid_t GroupIdFromName(const std::string& group_name);
 bool InGroup(const std::string& group);
+bool IsKvmAccessible();
 
 /**
  * returns the user's home defined by the system

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
@@ -186,6 +186,7 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:gflags_xml_parser",
+        "//cuttlefish/common/libs/utils:in_sandbox",
         "//cuttlefish/common/libs/utils:subprocess",
         "//cuttlefish/common/libs/utils:subprocess_managed_stdio",
         "//cuttlefish/common/libs/utils:users",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
@@ -38,6 +38,7 @@
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/gflags_xml_parser.h"
 #include "cuttlefish/common/libs/utils/subprocess_managed_stdio.h"
+#include "cuttlefish/common/libs/utils/in_sandbox.h"
 #include "cuttlefish/common/libs/utils/users.h"
 #include "cuttlefish/host/commands/cvd/instances/config_path.h"
 #include "cuttlefish/host/commands/cvd/utils/common.h"
@@ -63,7 +64,12 @@ Result<void> CheckProcessExitedNormally(siginfo_t infop,
 
 static Command FixGroupsIfNecessary(const std::string& command_name,
                                     const std::string& bin_path) {
-  if (InGroup("cvdnetwork") && InGroup("kvm")) {
+#ifndef __linux__
+  return Command(command_name).SetExecutable(bin_path);
+#endif
+  const bool has_net = InSandbox() || InGroup("cvdnetwork");
+  const bool has_kvm = IsKvmAccessible();
+  if (has_net && has_kvm) {
     return Command(command_name).SetExecutable(bin_path);
   }
   const std::string refresh_groups =

--- a/base/cvd/cuttlefish/host/libs/vm_manager/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/BUILD.bazel
@@ -37,6 +37,7 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:environment",
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:host_info",
+        "//cuttlefish/common/libs/utils:in_sandbox",
         "//cuttlefish/common/libs/utils:json",
         "//cuttlefish/common/libs/utils:network",
         "//cuttlefish/common/libs/utils:subprocess",

--- a/base/cvd/cuttlefish/host/libs/vm_manager/host_configuration.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/host_configuration.cpp
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "cuttlefish/common/libs/utils/container.h"
+#include "cuttlefish/common/libs/utils/in_sandbox.h"
 #include "cuttlefish/common/libs/utils/users.h"
 
 namespace cuttlefish {
@@ -98,7 +99,9 @@ Result<std::vector<HostConfigurationAction>> ValidateHostConfiguration() {
 
   // the check for cvdnetwork needs to happen even if the user is not in kvm, so
   // we can't just say UserInGroup("kvm") && UserInGroup("cvdnetwork")
-  PushOptional(actions, CF_EXPECT(PutUserInGroup("cvdnetwork")));
+  if (!InSandbox()) {
+    PushOptional(actions, CF_EXPECT(PutUserInGroup("cvdnetwork")));
+  }
 
   // if we're in the virtaccess group this is likely to be a CrOS environment.
   bool is_cros = InGroup("virtaccess");
@@ -109,7 +112,9 @@ Result<std::vector<HostConfigurationAction>> ValidateHostConfiguration() {
   } else {
     // this is regular Linux, so use the Debian group name and be more
     // conservative with the kernel version check.
-    PushOptional(actions, CF_EXPECT(PutUserInGroup("kvm")));
+    if (!IsKvmAccessible()) {
+      PushOptional(actions, CF_EXPECT(PutUserInGroup("kvm")));
+    }
     PushOptional(actions, CF_EXPECT(EnforceLinuxVersionAtLeast(version, 4, 8)));
   }
 #endif


### PR DESCRIPTION
Let's expand on the concept of a sandboxed environment to something more
general. Call the environment in which a platform runs, whether it be a
sandboxed environment or an environment with restricted networking a
_domain_.

We may want to run in domains where the ability to modify the networking
setup or add new tap devices is restricted, so that we want to run with
--enable_tap_devices being false. If we are running with this flag,
then we don't need the cvdnetwork membership check. However, we don't
have easy access to the enable_tap_devices flag where we check for the
group membership.

Instead, we add a new domain for this case. We can't easily infer the
domain like we can for the sandbox or container cases, so for now,
we'll assert we're in the restricted networking domain by checking for
an environment variable.

Also, some execution domains may have the kvm device already
read-writable without the user explicitly needing to be in the kvm
group. Test that the device is read-writable, and if it isn't, then
require membership in the group.