### PR TITLE
Invert clang-format default for cuttlefish packages

### DIFF
--- a/base/cvd/allocd/net/BUILD.bazel
+++ b/base/cvd/allocd/net/BUILD.bazel
@@ -14,6 +14,7 @@ cf_cc_library(
         "netlink_client.h",
         "netlink_request.h",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "@abseil-cpp//absl/log",

--- a/base/cvd/cuttlefish/bazel/rules.bzl
+++ b/base/cvd/cuttlefish/bazel/rules.bzl
@@ -50,7 +50,7 @@ def _cf_cc_binary_implementation(name, clang_format_enabled, clang_tidy_enabled,
 cf_cc_binary = macro(
     inherit_attrs = cc_binary,
     attrs = {
-        "clang_format_enabled": attr.bool(configurable = False, default = False, doc = "Decide if a corresponding format_test target is generated"),
+        "clang_format_enabled": attr.bool(configurable = False, default = True, doc = "Decide if a corresponding format_test target is generated"),
         "clang_tidy_enabled": attr.bool(configurable = False, default = True, doc = "Decide if a corresponding clang_tidy_test target is generated"),
         "copts": attr.string_list(configurable = False, default = []),
         "linkopts": attr.string_list(configurable = False, default = []),
@@ -85,7 +85,7 @@ def _cf_cc_library_implementation(name, clang_format_enabled, clang_tidy_enabled
 cf_cc_library = macro(
     inherit_attrs = cc_library,
     attrs = {
-        "clang_format_enabled": attr.bool(configurable = False, default = False, doc = "Decide if a corresponding format_test target is generated"),
+        "clang_format_enabled": attr.bool(configurable = False, default = True, doc = "Decide if a corresponding format_test target is generated"),
         "clang_tidy_enabled": attr.bool(configurable = False, default = True, doc = "Decide if a corresponding clang_tidy_test target is generated"),
         "copts": attr.string_list(configurable = False, default = []),
     },
@@ -123,7 +123,7 @@ def _cf_cc_test_implementation(name, clang_format_enabled, clang_tidy_enabled, c
 cf_cc_test = macro(
     inherit_attrs = cc_test,
     attrs = {
-        "clang_format_enabled": attr.bool(configurable = False, default = False, doc = "Decide if a corresponding format_test target is generated"),
+        "clang_format_enabled": attr.bool(configurable = False, default = True, doc = "Decide if a corresponding format_test target is generated"),
         "clang_tidy_enabled": attr.bool(configurable = False, default = True, doc = "Decide if a corresponding clang_tidy_test target is generated"),
         "copts": attr.string_list(configurable = False, default = []),
         "deps": attr.label_list(configurable = False),

--- a/base/cvd/cuttlefish/common/frontend/socket_vsock_proxy/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/frontend/socket_vsock_proxy/BUILD.bazel
@@ -13,6 +13,7 @@ cf_cc_binary(
         "server.h",
         "socket_vsock_proxy.cpp",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:contains",

--- a/base/cvd/cuttlefish/common/libs/confui/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/confui/BUILD.bazel
@@ -20,6 +20,7 @@ cf_cc_library(
         "protocol_types.h",
         "utils.h",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:contains",

--- a/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
@@ -28,6 +28,7 @@ cf_cc_library(
         "shared_fd.h",
         "shared_select.h",
     ],
+    clang_format_enabled = False,
     linkopts = select({
         "@platforms//os:linux": ["-lrt"],
         "//conditions:default": [],
@@ -48,6 +49,7 @@ cf_cc_test(
     srcs = [
         "shared_fd_test.cpp",
     ],
+    clang_format_enabled = False,
     deps = [
         ":fs",
         "//libbase",
@@ -58,6 +60,7 @@ cf_cc_library(
     name = "shared_fd_stream",
     srcs = ["shared_fd_stream.cpp"],
     hdrs = ["shared_fd_stream.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
     ],

--- a/base/cvd/cuttlefish/common/libs/key_equals_value/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/key_equals_value/BUILD.bazel
@@ -10,7 +10,6 @@ cf_cc_library(
     name = "key_equals_value",
     srcs = ["key_equals_value.cc"],
     hdrs = ["key_equals_value.h"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:contains",
@@ -22,7 +21,6 @@ cf_cc_library(
 cf_cc_test(
     name = "key_equals_value_test",
     srcs = ["key_equals_value_test.cc"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/common/libs/key_equals_value",
         "//cuttlefish/result",

--- a/base/cvd/cuttlefish/common/libs/transport/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/transport/BUILD.bazel
@@ -14,7 +14,6 @@ cf_cc_library(
         "channel.h",
         "channel_sharedfd.h",
     ],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/result",

--- a/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
@@ -8,6 +8,7 @@ cf_cc_library(
     name = "archive",
     srcs = ["archive.cpp"],
     hdrs = ["archive.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:subprocess",
         "//cuttlefish/common/libs/utils:subprocess_managed_stdio",
@@ -32,6 +33,7 @@ cf_cc_library(
 cf_cc_test(
     name = "base64_test",
     srcs = ["base64_test.cpp"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:base64",
         "//cuttlefish/result:result_matchers",
@@ -72,6 +74,7 @@ cf_cc_library(
     name = "disk_usage",
     srcs = ["disk_usage.cpp"],
     hdrs = ["disk_usage.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:subprocess",
         "//cuttlefish/common/libs/utils:subprocess_managed_stdio",
@@ -109,6 +112,7 @@ cf_cc_library(
     name = "files",
     srcs = ["files.cpp"],
     hdrs = ["files.h"],
+    clang_format_enabled = False,
     target_compatible_with = [
         "@platforms//os:linux",  # SEEK_DATA
     ],
@@ -176,6 +180,7 @@ cf_cc_library(
     name = "host_info",
     srcs = ["host_info.cpp"],
     hdrs = ["host_info.h"],
+    clang_format_enabled = False,
     deps = [
         "//libbase",
         "@abseil-cpp//absl/base:no_destructor",
@@ -227,6 +232,7 @@ cf_cc_library(
     name = "network",
     srcs = ["network.cpp"],
     hdrs = ["network.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:subprocess",
@@ -288,6 +294,7 @@ cf_cc_library(
     hdrs = [
         "random.h",
     ],
+    clang_format_enabled = False,
 )
 
 cf_cc_library(
@@ -315,6 +322,7 @@ cf_cc_library(
     name = "signals",
     srcs = ["signals.cpp"],
     hdrs = ["signals.h"],
+    clang_format_enabled = False,
     deps = [
         "//libbase",
         "@abseil-cpp//absl/log:check",
@@ -330,6 +338,7 @@ cf_cc_library(
     name = "socket2socket_proxy",
     srcs = ["socket2socket_proxy.cpp"],
     hdrs = ["socket2socket_proxy.h"],
+    clang_format_enabled = False,
     target_compatible_with = [
         "@platforms//os:linux",
     ],
@@ -360,6 +369,7 @@ cf_cc_library(
     name = "subprocess_managed_stdio",
     srcs = ["subprocess_managed_stdio.cc"],
     hdrs = ["subprocess_managed_stdio.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:subprocess",
@@ -373,6 +383,7 @@ cf_cc_library(
     name = "tee_logging",
     srcs = ["tee_logging.cpp"],
     hdrs = ["tee_logging.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:contains",
@@ -438,6 +449,7 @@ cf_cc_library(
     name = "users",
     srcs = ["users.cpp"],
     hdrs = ["users.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/result",
@@ -450,6 +462,7 @@ cf_cc_library(
     name = "vsock_connection",
     srcs = ["vsock_connection.cpp"],
     hdrs = ["vsock_connection.h"],
+    clang_format_enabled = False,
     clang_tidy_enabled = False,  # TODO: b/403278821 - fix warnings and re-enable after migration work
     target_compatible_with = [
         "@platforms//os:linux",
@@ -479,6 +492,7 @@ cf_cc_library(
     name = "wait_for_unix_socket",
     srcs = ["wait_for_unix_socket.cpp"],
     hdrs = ["wait_for_unix_socket.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:subprocess",

--- a/base/cvd/cuttlefish/flag_parser/BUILD.bazel
+++ b/base/cvd/cuttlefish/flag_parser/BUILD.bazel
@@ -14,6 +14,7 @@ cf_cc_library(
         "flag.h",
         "gflags_compat.h",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/result",
         "//libbase",
@@ -27,6 +28,7 @@ cf_cc_library(
 cf_cc_test(
     name = "flag_parser_test",
     srcs = ["flag_parser_test.cpp"],
+    clang_format_enabled = False,
     # `layering_check` conflicts with the combination of the clang prebuilt and
     # the cmake build rules used for @libxml2.
     features = ["-layering_check"],

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -10,6 +10,7 @@ cf_cc_library(
     name = "alloc",
     srcs = ["alloc.cc"],
     hdrs = ["alloc.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/host/commands/cvdalloc:interface",
@@ -23,6 +24,7 @@ cf_cc_library(
 cf_cc_binary(
     name = "assemble_cvd",
     srcs = ["assemble_cvd.cc"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:contains",
@@ -85,6 +87,7 @@ cf_cc_library(
     name = "boot_config",
     srcs = ["boot_config.cc"],
     hdrs = ["boot_config.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:size_utils",
@@ -109,6 +112,7 @@ cf_cc_library(
     name = "boot_image_utils",
     srcs = ["boot_image_utils.cc"],
     hdrs = ["boot_image_utils.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",
@@ -145,6 +149,7 @@ cf_cc_library(
     name = "bootconfig_args",
     srcs = ["bootconfig_args.cpp"],
     hdrs = ["bootconfig_args.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:json",
@@ -162,6 +167,7 @@ cf_cc_library(
     name = "clean",
     srcs = ["clean.cc"],
     hdrs = ["clean.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:in_sandbox",
@@ -250,6 +256,7 @@ cf_cc_library(
     name = "disk_image_flags_vectorization",
     srcs = ["disk_image_flags_vectorization.cc"],
     hdrs = ["disk_image_flags_vectorization.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/assemble_cvd:assemble_cvd_flags",
         "//cuttlefish/host/commands/assemble_cvd:super_image_mixer",
@@ -274,6 +281,7 @@ cf_cc_library(
     name = "display",
     srcs = ["display.cpp"],
     hdrs = ["display.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/flag_parser",
         "//cuttlefish/host/libs/config:config_flag",
@@ -290,6 +298,7 @@ cf_cc_library(
     name = "flag_feature",
     srcs = ["flag_feature.cpp"],
     hdrs = ["flag_feature.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/libs/config:config_flag",
         "//cuttlefish/host/libs/feature",
@@ -304,6 +313,7 @@ cf_cc_library(
     name = "flags",
     srcs = ["flags.cc"],
     hdrs = ["flags.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:base64",
         "//cuttlefish/common/libs/utils:container",
@@ -388,6 +398,7 @@ cf_cc_library(
     name = "guest_config",
     srcs = ["guest_config.cc"],
     hdrs = ["guest_config.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/key_equals_value",
         "//cuttlefish/common/libs/utils:device_type",
@@ -421,6 +432,7 @@ cf_cc_library(
     name = "graphics_flags",
     srcs = ["graphics_flags.cc"],
     hdrs = ["graphics_flags.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:files",
@@ -507,6 +519,7 @@ cf_cc_library(
     name = "misc_info",
     srcs = ["misc_info.cc"],
     hdrs = ["misc_info.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:contains",
@@ -548,6 +561,7 @@ cf_cc_library(
     name = "resolve_instance_files",
     srcs = ["resolve_instance_files.cc"],
     hdrs = ["resolve_instance_files.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/assemble_cvd:assemble_cvd_flags",
         "//cuttlefish/host/commands/assemble_cvd/flags:boot_image",
@@ -568,6 +582,7 @@ cf_cc_library(
     name = "super_image_mixer",
     srcs = ["super_image_mixer.cc"],
     hdrs = ["super_image_mixer.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/key_equals_value",
         "//cuttlefish/common/libs/utils:archive",
@@ -592,6 +607,7 @@ cf_cc_library(
     name = "touchpad",
     srcs = ["touchpad.cpp"],
     hdrs = ["touchpad.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/flag_parser",
         "//cuttlefish/host/libs/config:config_flag",
@@ -607,6 +623,7 @@ cf_cc_library(
     name = "vendor_dlkm_utils",
     srcs = ["vendor_dlkm_utils.cc"],
     hdrs = ["vendor_dlkm_utils.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:contains",
@@ -636,6 +653,7 @@ cf_cc_library(
     hdrs = [
         "assemble_cvd_flags.h",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:environment",
         "//cuttlefish/host/commands/assemble_cvd:flags_defaults",
@@ -652,6 +670,7 @@ cf_cc_library(
     name = "media",
     srcs = ["media.cpp"],
     hdrs = ["media.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/flag_parser",
         "//cuttlefish/host/libs/config:config_flag",

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/android_build/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/android_build/BUILD.bazel
@@ -10,6 +10,7 @@ cf_cc_library(
     name = "android_build",
     srcs = ["android_build.cc"],
     hdrs = ["android_build.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/pretty",
         "//cuttlefish/pretty:struct",
@@ -150,6 +151,7 @@ cf_cc_library(
     name = "identify_build",
     srcs = ["identify_build.cc"],
     hdrs = ["identify_build.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/commands/assemble_cvd/android_build",
@@ -211,6 +213,7 @@ cf_cc_library(
     name = "physical_partitions",
     srcs = ["physical_partitions.cc"],
     hdrs = ["physical_partitions.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/assemble_cvd/android_build",
         "//cuttlefish/pretty:result",
@@ -224,6 +227,7 @@ cf_cc_library(
     name = "super_image",
     srcs = ["super_image.cc"],
     hdrs = ["super_image.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/host/commands/assemble_cvd/android_build",

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/BUILD.bazel
@@ -81,6 +81,7 @@ cf_cc_library(
     name = "chromeos_state",
     srcs = ["chromeos_state.cc"],
     hdrs = ["chromeos_state.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/libs/config:boot_flow",
@@ -146,6 +147,7 @@ cf_cc_library(
     name = "generate_persistent_bootconfig",
     srcs = ["generate_persistent_bootconfig.cpp"],
     hdrs = ["generate_persistent_bootconfig.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/key_equals_value",
@@ -271,6 +273,7 @@ cf_cc_library(
     name = "misc_image",
     srcs = ["misc_image.cc"],
     hdrs = ["misc_image.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/commands/assemble_cvd/disk:image_file",

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/BUILD.bazel
@@ -68,6 +68,7 @@ cf_cc_library(
     name = "bootloader",
     srcs = ["bootloader.cc"],
     hdrs = ["bootloader.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/commands/assemble_cvd:flags_defaults",
@@ -192,6 +193,7 @@ cf_cc_library(
     name = "from_gflags",
     srcs = ["from_gflags.cc"],
     hdrs = ["from_gflags.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/assemble_cvd/flags:flag_base",
         "//cuttlefish/host/commands/assemble_cvd/flags:parser",
@@ -234,6 +236,7 @@ cf_cc_library(
     name = "initramfs_path",
     srcs = ["initramfs_path.cc"],
     hdrs = ["initramfs_path.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/assemble_cvd:flags_defaults",
         "//cuttlefish/host/libs/config:fetcher_config",
@@ -249,6 +252,7 @@ cf_cc_library(
     name = "kernel_path",
     srcs = ["kernel_path.cc"],
     hdrs = ["kernel_path.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/assemble_cvd:flags_defaults",
         "//cuttlefish/host/libs/config:fetcher_config",
@@ -264,6 +268,7 @@ cf_cc_library(
     name = "mcu_config_path",
     srcs = ["mcu_config_path.cc"],
     hdrs = ["mcu_config_path.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:json",
@@ -293,6 +298,7 @@ cf_cc_library(
     name = "restart_subprocesses",
     srcs = ["restart_subprocesses.cc"],
     hdrs = ["restart_subprocesses.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/assemble_cvd:flags_defaults",
         "//cuttlefish/host/commands/assemble_cvd/flags:flag_base",
@@ -306,6 +312,7 @@ cf_cc_library(
     name = "super_image",
     srcs = ["super_image.cc"],
     hdrs = ["super_image.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/assemble_cvd:flags_defaults",
         "//cuttlefish/host/commands/assemble_cvd/flags:system_image_dir",
@@ -319,6 +326,7 @@ cf_cc_library(
     name = "system_image_dir",
     srcs = ["system_image_dir.cc"],
     hdrs = ["system_image_dir.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/assemble_cvd:flags_defaults",
         "//cuttlefish/host/commands/assemble_cvd/flags:flag_base",
@@ -333,6 +341,7 @@ cf_cc_library(
     name = "use_cvdalloc",
     srcs = ["use_cvdalloc.cc"],
     hdrs = ["use_cvdalloc.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/assemble_cvd:flags_defaults",
         "//cuttlefish/host/commands/assemble_cvd/flags:flag_base",
@@ -347,6 +356,7 @@ cf_cc_library(
     name = "vendor_boot_image",
     srcs = ["vendor_boot_image.cc"],
     hdrs = ["vendor_boot_image.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/assemble_cvd:flags_defaults",
         "//cuttlefish/host/commands/assemble_cvd/flags:system_image_dir",
@@ -360,6 +370,7 @@ cf_cc_library(
     name = "vm_manager",
     srcs = ["vm_manager.cc"],
     hdrs = ["vm_manager.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/assemble_cvd:flags_defaults",
         "//cuttlefish/host/commands/assemble_cvd:guest_config",

--- a/base/cvd/cuttlefish/host/commands/casimir_control_server/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/casimir_control_server/BUILD.bazel
@@ -12,6 +12,7 @@ cf_cc_binary(
     srcs = [
         "main.cpp",
     ],
+    clang_format_enabled = False,
     deps = [
         ":libcasimir",
         ":libcasimir_control_server",
@@ -44,6 +45,7 @@ cf_cc_library(
         "packet_runtime.h",
         "rf_packets.h",
     ],
+    clang_format_enabled = False,
     deps = [
         ":libcasimir_control_server",
         "//cuttlefish/common/libs/fs",

--- a/base/cvd/cuttlefish/host/commands/console_forwarder/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/console_forwarder/BUILD.bazel
@@ -9,6 +9,7 @@ cf_cc_binary(
     srcs = [
         "main.cpp",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/host/commands/kernel_log_monitor:kernel_log_monitor_utils",

--- a/base/cvd/cuttlefish/host/commands/cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/BUILD.bazel
@@ -28,6 +28,7 @@ cf_cc_library(
 cf_cc_binary(
     name = "cvd",
     srcs = ["main.cc"],
+    clang_format_enabled = False,
     deps = [
         ":libcvd",
         "//cuttlefish/common/libs/utils:environment",

--- a/base/cvd/cuttlefish/host/commands/cvd/cache/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cache/BUILD.bazel
@@ -9,6 +9,7 @@ cf_cc_library(
     name = "cache",
     srcs = ["cache.cpp"],
     hdrs = ["cache.h"],
+    clang_format_enabled = False,
     copts = COPTS + ["-Werror=sign-compare"],
     deps = [
         "//cuttlefish/common/libs/utils:disk_usage",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
@@ -8,6 +8,7 @@ cf_cc_library(
     name = "command_request",
     srcs = ["command_request.cpp"],
     hdrs = ["command_request.h"],
+    clang_format_enabled = False,
     deps = [
         ":types",
         "//cuttlefish/flag_parser",
@@ -44,6 +45,7 @@ cf_cc_library(
     name = "help_format",
     srcs = ["help_format.cpp"],
     hdrs = ["help_format.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/flag_parser",
         "@abseil-cpp//absl/log",
@@ -69,7 +71,6 @@ cf_cc_library(
     name = "log_files",
     srcs = ["log_files.cpp"],
     hdrs = ["log_files.h"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/commands/cvd/utils",
@@ -82,7 +83,6 @@ cf_cc_library(
 cf_cc_test(
     name = "log_files_test",
     srcs = ["log_files_test.cpp"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/commands/cvd/cli:log_files",
@@ -107,6 +107,7 @@ cf_cc_library(
         "//cuttlefish/host/commands/cvd/cli/commands:help.h",
         "//cuttlefish/host/commands/cvd/cli/commands:load_configs.h",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:contains",
@@ -177,6 +178,7 @@ cf_cc_library(
     name = "utils",
     srcs = ["utils.cpp"],
     hdrs = ["utils.h"],
+    clang_format_enabled = False,
     deps = [
         ":command_request",
         ":types",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
@@ -18,6 +18,7 @@ cf_cc_library(
     name = "bugreport",
     srcs = ["bugreport.cpp"],
     hdrs = ["bugreport.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:subprocess",
@@ -95,6 +96,7 @@ cf_cc_library(
     name = "display",
     srcs = ["display.cpp"],
     hdrs = ["display.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:subprocess",
@@ -181,6 +183,7 @@ cf_cc_library(
     name = "host_tool_target",
     srcs = ["host_tool_target.cpp"],
     hdrs = ["host_tool_target.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:subprocess",
@@ -211,6 +214,7 @@ cf_cc_library(
     name = "login",
     srcs = ["login.cpp"],
     hdrs = ["login.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:environment",
         "//cuttlefish/common/libs/utils:is_google_corp",
@@ -250,6 +254,7 @@ cf_cc_library(
     name = "power_btn",
     srcs = ["power_btn.cpp"],
     hdrs = ["power_btn.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/flag_parser",
         "//cuttlefish/host/commands/cvd/cli:command_request",
@@ -383,6 +388,7 @@ cf_cc_library(
     name = "start",
     srcs = ["start.cpp"],
     hdrs = ["start.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:files",
@@ -465,6 +471,7 @@ cf_cc_library(
     name = "version",
     srcs = ["version.cpp"],
     hdrs = ["version.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:proto",
         "//cuttlefish/flag_parser",
@@ -483,6 +490,7 @@ cf_cc_library(
     name = "setup",
     srcs = ["setup.cc"],
     hdrs = ["setup.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:subprocess",
         "//cuttlefish/host/commands/cvd/cli:command_request",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/BUILD.bazel
@@ -8,7 +8,6 @@ cf_cc_library(
     name = "ansi_codes",
     srcs = ["ansi_codes.cc"],
     hdrs = ["ansi_codes.h"],
-    clang_format_enabled = True,
     deps = [
         "@abseil-cpp//absl/strings",
     ],
@@ -18,7 +17,6 @@ cf_cc_library(
     name = "command_handler",
     srcs = ["command_handler.cc"],
     hdrs = ["command_handler.h"],
-    clang_format_enabled = True,
     deps = [
         ":ansi_codes",
         ":display",
@@ -42,7 +40,6 @@ cf_cc_library(
     name = "display",
     srcs = ["display.cc"],
     hdrs = ["display.h"],
-    clang_format_enabled = True,
     deps = [
         ":kernel",
         ":launcher",
@@ -63,7 +60,6 @@ cf_cc_library(
 cf_cc_test(
     name = "display_test",
     srcs = ["display_test.cc"],
-    clang_format_enabled = True,
     deps = [
         ":display",
         "//cuttlefish/common/libs/fs",
@@ -76,7 +72,6 @@ cf_cc_library(
     name = "kernel",
     srcs = ["kernel.cc"],
     hdrs = ["kernel.h"],
-    clang_format_enabled = True,
     deps = [
         ":ansi_codes",
         "//cuttlefish/result",
@@ -87,7 +82,6 @@ cf_cc_library(
 cf_cc_test(
     name = "kernel_test",
     srcs = ["kernel_test.cc"],
-    clang_format_enabled = True,
     deps = [
         ":kernel",
         "//cuttlefish/result:result_matchers",
@@ -98,7 +92,6 @@ cf_cc_library(
     name = "launcher",
     srcs = ["launcher.cc"],
     hdrs = ["launcher.h"],
-    clang_format_enabled = True,
     deps = [
         ":ansi_codes",
         ":verbosity",
@@ -110,7 +103,6 @@ cf_cc_library(
 cf_cc_test(
     name = "launcher_test",
     srcs = ["launcher_test.cc"],
-    clang_format_enabled = True,
     deps = [
         ":launcher",
         "//cuttlefish/result:result_matchers",
@@ -121,7 +113,6 @@ cf_cc_library(
     name = "log_tee",
     srcs = ["log_tee.cc"],
     hdrs = ["log_tee.h"],
-    clang_format_enabled = True,
     deps = [
         ":ansi_codes",
         ":verbosity",
@@ -133,7 +124,6 @@ cf_cc_library(
 cf_cc_test(
     name = "log_tee_test",
     srcs = ["log_tee_test.cc"],
-    clang_format_enabled = True,
     deps = [
         ":log_tee",
         "//cuttlefish/result:result_matchers",
@@ -144,7 +134,6 @@ cf_cc_library(
     name = "logcat",
     srcs = ["logcat.cc"],
     hdrs = ["logcat.h"],
-    clang_format_enabled = True,
     deps = [
         ":ansi_codes",
         ":verbosity",
@@ -157,7 +146,6 @@ cf_cc_library(
     name = "truncate",
     srcs = ["truncate.cc"],
     hdrs = ["truncate.h"],
-    clang_format_enabled = True,
     deps = [
         ":ansi_codes",
         "@abseil-cpp//absl/strings",
@@ -167,7 +155,6 @@ cf_cc_library(
 cf_cc_test(
     name = "truncate_test",
     srcs = ["truncate_test.cc"],
-    clang_format_enabled = True,
     deps = [
         ":ansi_codes",
         ":truncate",
@@ -178,7 +165,6 @@ cf_cc_test(
 cf_cc_test(
     name = "logcat_test",
     srcs = ["logcat_test.cc"],
-    clang_format_enabled = True,
     deps = [
         ":logcat",
         "//cuttlefish/result:result_matchers",
@@ -189,7 +175,6 @@ cf_cc_library(
     name = "verbosity",
     srcs = ["verbosity.cc"],
     hdrs = ["verbosity.h"],
-    clang_format_enabled = True,
     deps = [
         ":ansi_codes",
     ],

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/BUILD.bazel
@@ -75,6 +75,7 @@ cf_cc_library(
     name = "fetch_config_parser",
     srcs = ["fetch_config_parser.cpp"],
     hdrs = ["fetch_config_parser.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/cvd/cli/parser:cf_configs_common",
         "//cuttlefish/host/commands/cvd/cli/parser:load_config_cc_proto",
@@ -88,6 +89,7 @@ cf_cc_library(
 cf_cc_test(
     name = "flags_parser_test",
     srcs = ["flags_parser_test.cc"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/flag_parser",
         "//cuttlefish/host/commands/cvd/cli/parser:load_configs_parser",
@@ -101,6 +103,7 @@ cf_cc_library(
     name = "launch_cvd_parser",
     srcs = ["launch_cvd_parser.cpp"],
     hdrs = ["launch_cvd_parser.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/cvd/cli/parser:cf_configs_common",
         "//cuttlefish/host/commands/cvd/cli/parser:cf_configs_instances",
@@ -117,6 +120,7 @@ cf_cc_library(
     name = "launch_cvd_templates",
     srcs = ["launch_cvd_templates.cpp"],
     hdrs = ["launch_cvd_templates.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:json",
         "//cuttlefish/host/commands/cvd/cli/parser:cf_configs_common",
@@ -150,6 +154,7 @@ cf_cc_library(
     name = "load_configs_parser",
     srcs = ["load_configs_parser.cpp"],
     hdrs = ["load_configs_parser.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:json",
@@ -189,6 +194,7 @@ cf_cc_library(
     name = "selector_parser",
     srcs = ["selector_parser.cpp"],
     hdrs = ["selector_parser.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/cvd/cli/parser:load_config_cc_proto",
         "//cuttlefish/host/commands/cvd/cli/selector:selector_common_parser",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/BUILD.bazel
@@ -50,6 +50,7 @@ cf_cc_library(
     name = "cf_graphics_configs",
     srcs = ["cf_graphics_configs.cpp"],
     hdrs = ["cf_graphics_configs.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:base64",
         "//cuttlefish/host/commands/assemble_cvd:flags_defaults",
@@ -103,6 +104,7 @@ cf_cc_library(
 cf_cc_test(
     name = "disk_configs_test",
     srcs = ["disk_configs_test.cc"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/cvd/cli/parser:test_common",
         "@jsoncpp",
@@ -112,6 +114,7 @@ cf_cc_test(
 cf_cc_test(
     name = "graphics_configs_test",
     srcs = ["graphics_configs_test.cc"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:base64",
         "//cuttlefish/common/libs/utils:json",
@@ -128,6 +131,7 @@ cf_cc_test(
 cf_cc_test(
     name = "vm_configs_test",
     srcs = ["vm_configs_test.cc"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:json",
         "//cuttlefish/host/commands/cvd/cli/parser:test_common",

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/BUILD.bazel
@@ -199,6 +199,7 @@ cf_cc_library(
     name = "fetch_cvd",
     srcs = ["fetch_cvd.cc"],
     hdrs = ["fetch_cvd.h"],
+    clang_format_enabled = False,
     copts = COPTS + ["-Werror=sign-compare"],
     deps = [
         "//cuttlefish/common/libs/utils:archive",
@@ -240,6 +241,7 @@ cf_cc_library(
     name = "fetch_cvd_parser",
     srcs = ["fetch_cvd_parser.cc"],
     hdrs = ["fetch_cvd_parser.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:tee_logging",
@@ -316,6 +318,7 @@ cf_cc_library(
     name = "substitute",
     srcs = ["substitute.cc"],
     hdrs = ["substitute.h"],
+    clang_format_enabled = False,
     deps = [
         ":host_pkg_migration_cc_proto",
         "//cuttlefish/common/libs/utils:environment",
@@ -344,6 +347,7 @@ cf_cc_library(
     name = "vector_flags",
     srcs = ["vector_flags.cc"],
     hdrs = ["vector_flags.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/flag_parser",
         "//cuttlefish/host/libs/web:android_build_string",

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/BUILD.bazel
@@ -31,6 +31,7 @@ cf_cc_library(
     name = "data_viewer",
     srcs = ["data_viewer.cpp"],
     hdrs = ["data_viewer.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:signals",
@@ -56,6 +57,7 @@ cf_cc_library(
     testonly = True,
     srcs = ["instance_database_helper.cpp"],
     hdrs = ["instance_database_helper.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",
@@ -97,6 +99,7 @@ cf_cc_library(
         "operator_client.h",
         "status_fetcher.h",
     ],
+    clang_format_enabled = False,
     deps = [
         ":cvd_persistent_data",
         "//cuttlefish/common/libs/fs",
@@ -144,6 +147,7 @@ cf_cc_library(
     hdrs = [
         "instance_manager.h",
     ],
+    clang_format_enabled = False,
     deps = [
         ":cvd_persistent_data",
         ":instances",
@@ -204,6 +208,7 @@ cf_cc_library(
     name = "run_cvd_proc_collector",
     srcs = ["run_cvd_proc_collector.cpp"],
     hdrs = ["run_cvd_proc_collector.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:files",
@@ -222,6 +227,7 @@ cf_cc_library(
     name = "stop",
     srcs = ["stop.cpp"],
     hdrs = ["stop.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:files",

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/lock/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/lock/BUILD.bazel
@@ -15,6 +15,7 @@ cf_cc_library(
         "instance_lock.h",
         "lock_file.h",
     ],
+    clang_format_enabled = False,
     copts = COPTS + ["-Werror=sign-compare"],
     deps = [
         "//cuttlefish/common/libs/fs",

--- a/base/cvd/cuttlefish/host/commands/cvd/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/utils/BUILD.bazel
@@ -9,6 +9,7 @@ cf_cc_library(
     name = "common",
     srcs = ["common.cpp"],
     hdrs = ["common.h"],
+    clang_format_enabled = False,
     copts = COPTS + ["-Werror=sign-compare"],
     deps = [
         "//cuttlefish/common/libs/utils:contains",
@@ -38,6 +39,7 @@ cf_cc_library(
     name = "interrupt_listener",
     srcs = ["interrupt_listener.cpp"],
     hdrs = ["interrupt_listener.h"],
+    clang_format_enabled = False,
     copts = COPTS + ["-Werror=sign-compare"],
     deps = [
         "//cuttlefish/common/libs/utils:signals",

--- a/base/cvd/cuttlefish/host/commands/cvd_env/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd_env/BUILD.bazel
@@ -9,6 +9,7 @@ cf_cc_binary(
     srcs = [
         "main.cc",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:tee_logging",
         "//cuttlefish/host/libs/config:cuttlefish_config",

--- a/base/cvd/cuttlefish/host/commands/cvd_import_locations/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd_import_locations/BUILD.bazel
@@ -9,6 +9,7 @@ cf_cc_binary(
     srcs = [
         "main.cc",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:tee_logging",

--- a/base/cvd/cuttlefish/host/commands/cvd_send_id_disclosure/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd_send_id_disclosure/BUILD.bazel
@@ -9,6 +9,7 @@ cf_cc_binary(
     srcs = [
         "main.cc",
     ],
+    clang_format_enabled = False,
     deps = [
         ":libcvd_id_disclosure_builder",
         "//cuttlefish/common/libs/fs",
@@ -28,6 +29,7 @@ cf_cc_library(
     hdrs = [
         "cellular_identifier_disclosure_command_builder.h",
     ],
+    clang_format_enabled = False,
     deps = [
         "@fmt",
     ],

--- a/base/cvd/cuttlefish/host/commands/cvd_update_location/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd_update_location/BUILD.bazel
@@ -9,6 +9,7 @@ cf_cc_binary(
     srcs = [
         "main.cc",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:tee_logging",
         "//cuttlefish/host/libs/config:cuttlefish_config",

--- a/base/cvd/cuttlefish/host/commands/cvd_update_security_algorithm/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd_update_security_algorithm/BUILD.bazel
@@ -9,6 +9,7 @@ cf_cc_binary(
     srcs = [
         "main.cc",
     ],
+    clang_format_enabled = False,
     deps = [
         ":libcvd_update_security_algorithm_builder",
         "//cuttlefish/common/libs/fs",

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/BUILD.bazel
@@ -10,6 +10,7 @@ cf_cc_library(
         "interface.cpp",
     ],
     hdrs = ["interface.h"],
+    clang_format_enabled = False,
     deps = [
         "@abseil-cpp//absl/strings:str_format",
     ],
@@ -30,10 +31,7 @@ cf_cc_library(
 
 cf_cc_library(
     name = "privilege",
-    srcs = [
-        "privilege.cpp",
-        "privilege.h",
-    ],
+    srcs = ["privilege.cpp"],
     hdrs = ["privilege.h"],
     deps = [
         "//cuttlefish/posix:strerror",
@@ -48,6 +46,7 @@ cf_cc_binary(
     srcs = [
         "cvdalloc.cpp",
     ],
+    clang_format_enabled = False,
     deps = [
         ":interface",
         ":privilege",

--- a/base/cvd/cuttlefish/host/commands/defaults/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/defaults/BUILD.bazel
@@ -9,6 +9,7 @@ cf_cc_binary(
     srcs = [
         "defaults.cpp",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/key_equals_value",
         "//cuttlefish/host/libs/web/http_client:curl_http_client",

--- a/base/cvd/cuttlefish/host/commands/display/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/display/BUILD.bazel
@@ -9,6 +9,7 @@ cf_cc_binary(
     srcs = [
         "main.cpp",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",

--- a/base/cvd/cuttlefish/host/commands/gnss_grpc_proxy/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/gnss_grpc_proxy/BUILD.bazel
@@ -12,6 +12,7 @@ cf_cc_binary(
     srcs = [
         "gnss_grpc_proxy.cpp",
     ],
+    clang_format_enabled = False,
     deps = [
         ":libcvd_gnss_grpc_proxy",
         "//cuttlefish/common/libs/fs",

--- a/base/cvd/cuttlefish/host/commands/host_bugreport/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/host_bugreport/BUILD.bazel
@@ -7,6 +7,7 @@ package(
 cf_cc_binary(
     name = "cvd_internal_host_bugreport",
     srcs = ["main.cc"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:environment",

--- a/base/cvd/cuttlefish/host/commands/kernel_log_monitor/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/kernel_log_monitor/BUILD.bazel
@@ -11,7 +11,6 @@ cf_cc_binary(
     srcs = [
         "main.cc",
     ],
-    clang_format_enabled = True,
     deps = [
         ":kernel_log_monitor_utils",
         "//cuttlefish/common/libs/fs",
@@ -39,7 +38,6 @@ cf_cc_library(
         "kernel_log_server.h",
         "utils.h",
     ],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:json",

--- a/base/cvd/cuttlefish/host/commands/log_tee/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/log_tee/BUILD.bazel
@@ -9,6 +9,7 @@ cf_cc_binary(
     srcs = [
         "log_tee.cpp",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:tee_logging",

--- a/base/cvd/cuttlefish/host/commands/logcat_receiver/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/logcat_receiver/BUILD.bazel
@@ -9,6 +9,7 @@ cf_cc_binary(
     srcs = [
         "main.cpp",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/host/libs/config:config_instance_derived",

--- a/base/cvd/cuttlefish/host/commands/metrics/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/metrics/BUILD.bazel
@@ -31,6 +31,7 @@ cf_cc_library(
     name = "events",
     srcs = ["events.cc"],
     hdrs = ["events.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/metrics:clearcut_protos",
         "//cuttlefish/host/commands/metrics:send",

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/BUILD.bazel
@@ -10,6 +10,7 @@ cf_cc_library(
     name = "channel_monitor",
     srcs = ["channel_monitor.cpp"],
     hdrs = ["channel_monitor.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/host/commands/modem_simulator:client",
@@ -35,6 +36,7 @@ cf_cc_library(
     name = "command_parser",
     srcs = ["command_parser.cpp"],
     hdrs = ["command_parser.h"],
+    clang_format_enabled = False,
     deps = [
         "//libbase",
         "@abseil-cpp//absl/strings",
@@ -44,6 +46,7 @@ cf_cc_library(
 cf_cc_test(
     name = "command_parser_test",
     srcs = ["unittest/command_parser_test.cpp"],
+    clang_format_enabled = False,
     deps = ["//cuttlefish/host/commands/modem_simulator:command_parser"],
 )
 
@@ -51,6 +54,7 @@ cf_cc_library(
     name = "data_service",
     srcs = ["data_service.cpp"],
     hdrs = ["data_service.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/modem_simulator:device_config",
         "//cuttlefish/host/commands/modem_simulator:modem_service",
@@ -62,6 +66,7 @@ cf_cc_library(
     name = "device_config",
     srcs = ["cf_device_config.cpp"],
     hdrs = ["device_config.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/libs/config:cuttlefish_config",
     ],
@@ -71,6 +76,7 @@ cf_cc_library(
     name = "misc_service",
     srcs = ["misc_service.cpp"],
     hdrs = ["misc_service.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/modem_simulator:device_config",
         "//cuttlefish/host/commands/modem_simulator:modem_service",
@@ -81,6 +87,7 @@ cf_cc_library(
     name = "modem_service",
     srcs = ["modem_service.cpp"],
     hdrs = ["modem_service.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/modem_simulator:channel_monitor",
         "//cuttlefish/host/commands/modem_simulator:command_parser",
@@ -95,6 +102,7 @@ cf_cc_library(
     name = "modem_simulator_class",
     srcs = ["modem_simulator.cpp"],
     hdrs = ["modem_simulator.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/modem_simulator:channel_monitor",
         "//cuttlefish/host/commands/modem_simulator:data_service",
@@ -126,6 +134,7 @@ cf_cc_library(
         "sms_service.h",
         "stk_service.h",
     ],
+    clang_format_enabled = False,
     clang_tidy_enabled = False,  # TODO(b/405163202): Enable back once migration is completed.
     copts = [
         "-Wall",
@@ -162,6 +171,7 @@ cf_cc_binary(
     srcs = [
         "main.cpp",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:tee_logging",
@@ -191,6 +201,7 @@ cf_cc_library(
     name = "nvram_config",
     srcs = ["nvram_config.cpp"],
     hdrs = ["nvram_config.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/commands/modem_simulator:device_config",
@@ -205,11 +216,13 @@ cf_cc_library(
     name = "pdu_parser",
     srcs = ["pdu_parser.cpp"],
     hdrs = ["pdu_parser.h"],
+    clang_format_enabled = False,
 )
 
 cf_cc_test(
     name = "pdu_parser_test",
     srcs = ["unittest/pdu_parser_test.cpp"],
+    clang_format_enabled = False,
     deps = ["//cuttlefish/host/commands/modem_simulator:pdu_parser"],
 )
 
@@ -219,6 +232,7 @@ cf_cc_test(
         "unittest/iccfile.h",
         "unittest/service_test.cpp",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",
@@ -239,6 +253,7 @@ cf_cc_library(
     name = "sup_service",
     srcs = ["sup_service.cpp"],
     hdrs = ["sup_service.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/modem_simulator:modem_service",
     ],
@@ -248,6 +263,7 @@ cf_cc_library(
     name = "thread_looper",
     srcs = ["thread_looper.cpp"],
     hdrs = ["thread_looper.h"],
+    clang_format_enabled = False,
     deps = [
         "//libbase",
         "@abseil-cpp//absl/log",

--- a/base/cvd/cuttlefish/host/commands/powerwash_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/powerwash_cvd/BUILD.bazel
@@ -9,6 +9,7 @@ cf_cc_binary(
     srcs = [
         "powerwash_cvd.cc",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:tee_logging",

--- a/base/cvd/cuttlefish/host/commands/restart_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/restart_cvd/BUILD.bazel
@@ -9,6 +9,7 @@ cf_cc_binary(
     srcs = [
         "restart_cvd.cc",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:tee_logging",

--- a/base/cvd/cuttlefish/host/commands/run_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/BUILD.bazel
@@ -10,6 +10,7 @@ cf_cc_library(
     name = "boot_state_machine",
     srcs = ["boot_state_machine.cc"],
     hdrs = ["boot_state_machine.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",
@@ -128,6 +129,7 @@ cf_cc_library(
         "server_loop_impl_webrtc.cpp",
     ],
     hdrs = ["server_loop.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:contains",
@@ -164,6 +166,7 @@ cf_cc_library(
     name = "validate",
     srcs = ["validate.cpp"],
     hdrs = ["validate.h"],
+    clang_format_enabled = False,
     deps = [
         "//allocd:alloc_utils",
         "//cuttlefish/common/libs/utils:in_sandbox",

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
@@ -75,6 +75,7 @@ cf_cc_library(
     name = "enable_multitouch",
     srcs = ["enable_multitouch.cpp"],
     hdrs = ["enable_multitouch.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:guest_os",
@@ -115,6 +116,7 @@ cf_cc_library(
     name = "cvdalloc",
     srcs = ["cvdalloc.cpp"],
     hdrs = ["cvdalloc.h"],
+    clang_format_enabled = False,
     deps = [
         "//allocd:alloc_utils",
         "//cuttlefish/common/libs/fs",
@@ -175,6 +177,7 @@ cf_cc_library(
     name = "kernel_log_monitor",
     srcs = ["kernel_log_monitor.cpp"],
     hdrs = ["kernel_log_monitor.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:subprocess",
         "//cuttlefish/host/commands/run_cvd:reporting",
@@ -225,6 +228,7 @@ cf_cc_library(
     name = "mcu",
     srcs = ["mcu.cpp"],
     hdrs = ["mcu.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:subprocess",
@@ -306,6 +310,7 @@ cf_cc_library(
     name = "open_wrt",
     srcs = ["open_wrt.cpp"],
     hdrs = ["open_wrt.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:json",
         "//cuttlefish/host/commands/run_cvd/launch:cvdalloc",
@@ -445,6 +450,7 @@ cf_cc_library(
     name = "streamer",
     srcs = ["streamer.cpp"],
     hdrs = ["streamer.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",
@@ -566,6 +572,7 @@ cf_cc_library(
     name = "vhost_input_devices",
     srcs = ["vhost_input_devices.cpp"],
     hdrs = ["input_connections_provider.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",
@@ -588,6 +595,7 @@ cf_cc_library(
     name = "vhost_user_media_devices",
     srcs = ["vhost_user_media_devices.cpp"],
     hdrs = ["vhost_user_media_devices.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",

--- a/base/cvd/cuttlefish/host/commands/secure_env/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/secure_env/BUILD.bazel
@@ -7,6 +7,7 @@ package(
 cf_cc_binary(
     name = "secure_env",
     srcs = ["secure_env_only_oemlock.cpp"],
+    clang_format_enabled = False,
     deps = [
         ":suspend_resume_handler",
         ":worker_thread_loop_body",

--- a/base/cvd/cuttlefish/host/commands/secure_env/oemlock/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/secure_env/oemlock/BUILD.bazel
@@ -8,6 +8,7 @@ cf_cc_library(
     name = "oemlock",
     srcs = ["oemlock.cpp"],
     hdrs = ["oemlock.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/secure_env/storage",
         "//cuttlefish/result",

--- a/base/cvd/cuttlefish/host/commands/secure_env/storage/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/secure_env/storage/BUILD.bazel
@@ -8,6 +8,7 @@ cf_cc_library(
     name = "insecure_json_storage",
     srcs = ["insecure_json_storage.cpp"],
     hdrs = ["insecure_json_storage.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:base64",
         "//cuttlefish/common/libs/utils:files",
@@ -23,6 +24,7 @@ cf_cc_library(
     name = "storage",
     srcs = ["storage.cpp"],
     hdrs = ["storage.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/result",
     ],

--- a/base/cvd/cuttlefish/host/commands/sensors_simulator/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/sensors_simulator/BUILD.bazel
@@ -12,6 +12,7 @@ cf_cc_library(
     hdrs = [
         "sensors_simulator.h",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/sensors",
         "//libbase",
@@ -45,6 +46,7 @@ cf_cc_binary(
     srcs = [
         "main.cpp",
     ],
+    clang_format_enabled = False,
     deps = [
         ":libsensors_hal_proxy",
         ":libsensors_simulator",

--- a/base/cvd/cuttlefish/host/commands/snapshot_util_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/snapshot_util_cvd/BUILD.bazel
@@ -13,6 +13,7 @@ cf_cc_binary(
         "snapshot_taker.cc",
         "snapshot_taker.h",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:contains",

--- a/base/cvd/cuttlefish/host/commands/start/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/start/BUILD.bazel
@@ -17,6 +17,7 @@ cf_cc_binary(
         "validate_metrics_confirmation.cpp",
         "validate_metrics_confirmation.h",
     ],
+    clang_format_enabled = False,
     # `layering_check` conflicts with the combination of the clang prebuilt and
     # the cmake build rules used for @libxml2.
     features = ["-layering_check"],

--- a/base/cvd/cuttlefish/host/commands/status/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/status/BUILD.bazel
@@ -9,6 +9,7 @@ cf_cc_binary(
     srcs = [
         "main.cc",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",

--- a/base/cvd/cuttlefish/host/commands/stop/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/stop/BUILD.bazel
@@ -9,6 +9,7 @@ cf_cc_binary(
     srcs = [
         "main.cc",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:environment",

--- a/base/cvd/cuttlefish/host/commands/tombstone_receiver/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/tombstone_receiver/BUILD.bazel
@@ -9,6 +9,7 @@ cf_cc_binary(
     srcs = [
         "main.cpp",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/flag_parser",

--- a/base/cvd/cuttlefish/host/example_custom_actions/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/example_custom_actions/BUILD.bazel
@@ -15,6 +15,7 @@ cf_cc_binary(
     srcs = [
         "main.cpp",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/host/libs/config:cuttlefish_config",

--- a/base/cvd/cuttlefish/host/frontend/adb_connector/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/frontend/adb_connector/BUILD.bazel
@@ -11,6 +11,7 @@ cf_cc_binary(
         "adb_connection_maintainer.h",
         "main.cpp",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:environment",

--- a/base/cvd/cuttlefish/host/frontend/webrtc/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/BUILD.bazel
@@ -32,6 +32,7 @@ cf_cc_library(
     name = "libcuttlefish_webrtc_adb_handler",
     srcs = ["adb_handler.cpp"],
     hdrs = ["adb_handler.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//libbase",
@@ -48,6 +49,7 @@ cf_cc_library(
     name = "libcuttlefish_webrtc_audio_handler",
     srcs = ["audio_handler.cpp"],
     hdrs = ["audio_handler.h"],
+    clang_format_enabled = False,
     deps = [
         ":libcuttlefish_webrtc_audio_mixer",
         ":libcuttlefish_webrtc_audio_settings",
@@ -69,6 +71,7 @@ cf_cc_library(
     name = "libcuttlefish_webrtc_audio_mixer",
     srcs = ["audio_mixer.cpp"],
     hdrs = ["audio_mixer.h"],
+    clang_format_enabled = False,
     deps = [
         ":libcuttlefish_webrtc_audio_settings",
         "//cuttlefish/host/frontend/webrtc/libdevice:audio_sink",
@@ -91,6 +94,7 @@ cf_cc_library(
     name = "libcuttlefish_webrtc_bluetooth_handler",
     srcs = ["bluetooth_handler.cpp"],
     hdrs = ["bluetooth_handler.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//libbase",
@@ -107,6 +111,7 @@ cf_cc_library(
     name = "libcuttlefish_webrtc_client_server",
     srcs = ["client_server.cpp"],
     hdrs = ["client_server.h"],
+    clang_format_enabled = False,
     deps = [
         "//libbase",
         "@abseil-cpp//absl/log",
@@ -123,6 +128,7 @@ cf_cc_library(
     name = "libcuttlefish_webrtc_connection_observer",
     srcs = ["connection_observer.cpp"],
     hdrs = ["connection_observer.h"],
+    clang_format_enabled = False,
     deps = [
         ":libcuttlefish_webrtc_adb_handler",
         ":libcuttlefish_webrtc_bluetooth_handler",
@@ -158,6 +164,7 @@ cf_cc_library(
     name = "libcuttlefish_webrtc_cvd_video_frame_buffer",
     srcs = ["cvd_video_frame_buffer.cpp"],
     hdrs = ["cvd_video_frame_buffer.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:size_utils",
         "//cuttlefish/host/libs/screen_connector:video_frame_buffer",
@@ -198,6 +205,7 @@ cf_cc_library(
     name = "libcuttlefish_webrtc_gpx_locations_handler",
     srcs = ["gpx_locations_handler.cpp"],
     hdrs = ["gpx_locations_handler.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/location",
@@ -217,6 +225,7 @@ cf_cc_library(
     name = "libcuttlefish_webrtc_kernel_log_events_handler",
     srcs = ["kernel_log_events_handler.cpp"],
     hdrs = ["kernel_log_events_handler.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/host/commands/kernel_log_monitor:kernel_log_monitor_utils",
@@ -237,6 +246,7 @@ cf_cc_library(
     name = "libcuttlefish_webrtc_kml_locations_handler",
     srcs = ["kml_locations_handler.cpp"],
     hdrs = ["kml_locations_handler.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/location",
@@ -255,6 +265,7 @@ cf_cc_library(
     name = "libcuttlefish_webrtc_location_handler",
     srcs = ["location_handler.cpp"],
     hdrs = ["location_handler.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/location",
@@ -296,6 +307,7 @@ cf_cc_library(
     name = "libcuttlefish_webrtc_sensors_handler",
     srcs = ["sensors_handler.cpp"],
     hdrs = ["sensors_handler.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/sensors",
         "//cuttlefish/common/libs/transport",

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/BUILD.bazel
@@ -8,6 +8,7 @@ cf_cc_library(
     name = "audio_device",
     srcs = ["audio_device.cpp"],
     hdrs = ["audio_device.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/frontend/webrtc/libcommon:audio_source",
         "//libbase",
@@ -42,6 +43,7 @@ cf_cc_library(
     name = "peer_connection_utils",
     srcs = ["peer_connection_utils.cpp"],
     hdrs = ["peer_connection_utils.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/frontend/webrtc/libcommon:audio_device",
         "//cuttlefish/host/frontend/webrtc/libcommon:vp8only_encoder_factory",
@@ -78,6 +80,7 @@ cf_cc_library(
     name = "vp8only_encoder_factory",
     srcs = ["vp8only_encoder_factory.cpp"],
     hdrs = ["vp8only_encoder_factory.h"],
+    clang_format_enabled = False,
     deps = [
         "@libwebrtc",
     ],

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/BUILD.bazel
@@ -15,6 +15,7 @@ cf_cc_library(
 cf_cc_library(
     name = "audio_sink",
     hdrs = ["audio_sink.h"],
+    clang_format_enabled = False,
     deps = [
         ":audio_frame_buffer",
     ],
@@ -24,6 +25,7 @@ cf_cc_library(
     name = "audio_track_source_impl",
     srcs = ["audio_track_source_impl.cpp"],
     hdrs = ["audio_track_source_impl.h"],
+    clang_format_enabled = False,
     deps = [
         ":audio_sink",
         "//cuttlefish/host/frontend/webrtc/libcommon:audio_source",
@@ -60,6 +62,7 @@ cf_cc_library(
     name = "client_handler",
     srcs = ["client_handler.cpp"],
     hdrs = ["client_handler.h"],
+    clang_format_enabled = False,
     deps = [
         ":connection_observer",
         ":data_channels",
@@ -77,6 +80,7 @@ cf_cc_library(
 cf_cc_library(
     name = "connection_observer",
     hdrs = ["connection_observer.h"],
+    clang_format_enabled = False,
     deps = [
         ":camera_controller",
         ":lights_observer",
@@ -90,6 +94,7 @@ cf_cc_library(
     name = "data_channels",
     srcs = ["data_channels.cpp"],
     hdrs = ["data_channels.h"],
+    clang_format_enabled = False,
     deps = [
         ":connection_observer",
         ":gamepad",
@@ -109,6 +114,7 @@ cf_cc_library(
     name = "gamepad",
     srcs = ["gamepad.cpp"],
     hdrs = ["gamepad.h"],
+    clang_format_enabled = False,
     deps = [
         "//libbase",
     ],
@@ -139,6 +145,7 @@ cf_cc_library(
     name = "local_recorder",
     srcs = ["local_recorder.cpp"],
     hdrs = ["local_recorder.h"],
+    clang_format_enabled = False,
     linkopts = [
         "-lopus",
     ],
@@ -158,6 +165,7 @@ cf_cc_library(
     name = "recording_manager",
     srcs = ["recording_manager.cpp"],
     hdrs = ["recording_manager.h"],
+    clang_format_enabled = False,
     deps = [
         ":local_recorder",
         "//cuttlefish/host/libs/config:cuttlefish_config",
@@ -172,6 +180,7 @@ cf_cc_library(
     name = "server_connection",
     srcs = ["server_connection.cpp"],
     hdrs = ["server_connection.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:json",
@@ -189,6 +198,7 @@ cf_cc_library(
     name = "streamer",
     srcs = ["streamer.cpp"],
     hdrs = ["streamer.h"],
+    clang_format_enabled = False,
     deps = [
         ":audio_sink",
         ":audio_track_source_impl",
@@ -229,6 +239,7 @@ cf_cc_library(
     name = "video_track_source_impl",
     srcs = ["video_track_source_impl.cpp"],
     hdrs = ["video_track_source_impl.h"],
+    clang_format_enabled = False,
     deps = [
         ":video_sink",
         "@libwebrtc",

--- a/base/cvd/cuttlefish/host/graphics/mem_overrides/BUILD
+++ b/base/cvd/cuttlefish/host/graphics/mem_overrides/BUILD
@@ -14,6 +14,7 @@ cf_cc_binary(
             "mem_overrides_noop.cpp",
         ],
     }),
+    clang_format_enabled = False,
     copts = [
         "-fPIC",
     ],

--- a/base/cvd/cuttlefish/host/graphics_detector/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/graphics_detector/BUILD.bazel
@@ -47,6 +47,7 @@ cf_cc_binary(
         "vulkan.cpp",
         "vulkan.h",
     ],
+    clang_format_enabled = False,
     clang_tidy_enabled = False,
     copts = COPTS + [
         "-DVULKAN_HPP_ASSERT_ON_RESULT=",

--- a/base/cvd/cuttlefish/host/graphics_detector/shaders/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/graphics_detector/shaders/BUILD.bazel
@@ -11,5 +11,6 @@ cf_cc_binary(
 
 cf_cc_library(
     name = "graphics_detector_shaders",
+    clang_format_enabled = False,
     textual_hdrs = glob(["*.inl"]),
 )

--- a/base/cvd/cuttlefish/host/libs/audio_connector/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/audio_connector/BUILD.bazel
@@ -17,6 +17,7 @@ cf_cc_library(
         "server.h",
         "shm_layout.h",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:cf_endian",

--- a/base/cvd/cuttlefish/host/libs/avb/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/avb/BUILD.bazel
@@ -12,6 +12,7 @@ cf_cc_library(
     hdrs = [
         "avb.h",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",

--- a/base/cvd/cuttlefish/host/libs/command_util/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/command_util/BUILD.bazel
@@ -28,6 +28,7 @@ cf_cc_library(
         "snapshot_utils.h",
         "util.h",
     ],
+    clang_format_enabled = False,
     deps = [
         ":libcuttlefish_run_cvd_proto",
         "//cuttlefish/common/libs/fs",

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -19,12 +19,14 @@ cf_cc_library(
 cf_cc_library(
     name = "config_constants",
     hdrs = ["config_constants.h"],
+    clang_format_enabled = False,
 )
 
 cf_cc_library(
     name = "config_flag",
     srcs = ["config_flag.cpp"],
     hdrs = ["config_flag.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/key_equals_value",
         "//cuttlefish/common/libs/utils:files",
@@ -55,6 +57,7 @@ cf_cc_library(
     name = "config_instance_derived",
     srcs = ["config_instance_derived.cc"],
     hdrs = ["config_instance_derived.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/libs/config:cuttlefish_config",
@@ -66,6 +69,7 @@ cf_cc_library(
     name = "config_utils",
     srcs = ["config_utils.cpp"],
     hdrs = ["config_utils.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:environment",
@@ -85,6 +89,7 @@ cf_cc_library(
     name = "custom_actions",
     srcs = ["custom_actions.cpp"],
     hdrs = ["custom_actions.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:json",
@@ -111,6 +116,7 @@ cf_cc_library(
         "cuttlefish_config_instance.cpp",
     ],
     hdrs = ["cuttlefish_config.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:device_type",
         "//cuttlefish/common/libs/utils:environment",
@@ -147,6 +153,7 @@ cf_cc_library(
     name = "data_image",
     srcs = ["data_image.cpp"],
     hdrs = ["data_image.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",
@@ -182,6 +189,7 @@ cf_cc_library(
     name = "display",
     srcs = ["display.cpp"],
     hdrs = ["display.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/flag_parser",
@@ -197,6 +205,7 @@ cf_cc_library(
     name = "esp",
     srcs = ["esp.cpp"],
     hdrs = ["esp.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",
@@ -223,6 +232,7 @@ cf_cc_library(
     name = "build_archive",
     srcs = ["build_archive.cc"],
     hdrs = ["build_archive.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/libs/config:fetcher_config",
@@ -249,6 +259,7 @@ cf_cc_library(
     name = "fetcher_config",
     srcs = ["fetcher_config.cpp"],
     hdrs = ["fetcher_config.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/libs/config:file_source",
@@ -331,6 +342,7 @@ cf_cc_library(
     name = "host_tools_version",
     srcs = ["host_tools_version.cpp"],
     hdrs = ["host_tools_version.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/libs/config:config_utils",
@@ -344,6 +356,7 @@ cf_cc_library(
     name = "instance_nums",
     srcs = ["instance_nums.cpp"],
     hdrs = ["instance_nums.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/flag_parser",
@@ -359,6 +372,7 @@ cf_cc_library(
     name = "kernel_args",
     srcs = ["kernel_args.cpp"],
     hdrs = ["kernel_args.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:host_info",
         "//cuttlefish/host/libs/config:cuttlefish_config",
@@ -369,6 +383,7 @@ cf_cc_library(
     name = "known_paths",
     srcs = ["known_paths.cpp"],
     hdrs = ["known_paths.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/libs/config:config_utils",
@@ -391,6 +406,7 @@ cf_cc_library(
     name = "logging",
     srcs = ["logging.cpp"],
     hdrs = ["logging.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:tee_logging",
         "//cuttlefish/host/libs/config:cuttlefish_config",
@@ -441,6 +457,7 @@ cf_cc_library(
     name = "touchpad",
     srcs = ["touchpad.cpp"],
     hdrs = ["touchpad.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/flag_parser",
@@ -455,6 +472,7 @@ cf_cc_library(
     name = "vmm_mode",
     srcs = ["vmm_mode.cc"],
     hdrs = ["vmm_mode.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/result",
         "@abseil-cpp//absl/strings",
@@ -465,6 +483,7 @@ cf_cc_library(
     name = "media",
     srcs = ["media.cpp"],
     hdrs = ["media.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/flag_parser",

--- a/base/cvd/cuttlefish/host/libs/config/adb/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/adb/BUILD.bazel
@@ -16,6 +16,7 @@ cf_cc_library(
     hdrs = [
         "adb.h",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:container",
         "//cuttlefish/common/libs/utils:subprocess",
@@ -41,6 +42,7 @@ cf_cc_test(
     srcs = [
         "test.cpp",
     ],
+    clang_format_enabled = False,
     deps = [
         ":adb",
         "//cuttlefish/host/libs/config:config_flag",

--- a/base/cvd/cuttlefish/host/libs/config/defaults/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/defaults/BUILD.bazel
@@ -12,6 +12,7 @@ cf_cc_library(
     hdrs = [
         "defaults.h",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/key_equals_value",
         "//cuttlefish/common/libs/utils:files",

--- a/base/cvd/cuttlefish/host/libs/config/fastboot/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/fastboot/BUILD.bazel
@@ -15,6 +15,7 @@ cf_cc_library(
     hdrs = [
         "fastboot.h",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:subprocess",
         "//cuttlefish/flag_parser",

--- a/base/cvd/cuttlefish/host/libs/confui/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/confui/BUILD.bazel
@@ -71,6 +71,7 @@ cf_cc_library(
         "sign.h",
         "sign_utils.h",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/concurrency",
         "//cuttlefish/common/libs/confui",

--- a/base/cvd/cuttlefish/host/libs/control_env/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/control_env/BUILD.bazel
@@ -10,6 +10,7 @@ cf_cc_library(
         "grpc_service_handler.cc",
     ],
     hdrs = ["grpc_service_handler.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/result",

--- a/base/cvd/cuttlefish/host/libs/feature/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/feature/BUILD.bazel
@@ -14,6 +14,7 @@ cf_cc_library(
         "feature.h",
         "kernel_log_pipe_provider.h",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:subprocess",

--- a/base/cvd/cuttlefish/host/libs/image_aggregator/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/image_aggregator/BUILD.bazel
@@ -20,6 +20,7 @@ cf_cc_library(
     name = "composite_disk",
     srcs = ["composite_disk.cc"],
     hdrs = ["composite_disk.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/host/libs/image_aggregator:cdisk_spec_cc_proto",
@@ -63,6 +64,7 @@ cf_cc_library(
     name = "image_from_file",
     srcs = ["image_from_file.cc"],
     hdrs = ["image_from_file.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",
@@ -126,6 +128,7 @@ cf_cc_library(
     name = "sparse_image",
     srcs = ["sparse_image.cc"],
     hdrs = ["sparse_image.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",
@@ -164,6 +167,7 @@ cf_cc_library(
     name = "qcow2",
     srcs = ["qcow2.cc"],
     hdrs = ["qcow2.h"],
+    clang_format_enabled = False,
     copts = COPTS + [
         "-Wno-packed-non-pod",
     ],

--- a/base/cvd/cuttlefish/host/libs/input_connector/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/input_connector/BUILD.bazel
@@ -18,6 +18,7 @@ cf_cc_library(
         "input_connector.h",
         "input_devices.h",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:cf_endian",

--- a/base/cvd/cuttlefish/host/libs/location/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/location/BUILD.bazel
@@ -17,6 +17,7 @@ cf_cc_library(
         "GpxParser.h",
         "KmlParser.h",
     ],
+    clang_format_enabled = False,
     # `layering_check` conflicts with the combination of the clang prebuilt and
     # the cmake build rules used for @libxml2.
     features = ["-layering_check"],

--- a/base/cvd/cuttlefish/host/libs/metrics/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/metrics/BUILD.bazel
@@ -195,6 +195,7 @@ cf_cc_library(
     hdrs = [
         "metrics_receiver.h",
     ],
+    clang_format_enabled = False,
     deps = [
         ":metrics_headers",
         "//cuttlefish/common/libs/fs",
@@ -264,6 +265,7 @@ cf_cc_library(
         "metrics_configs.h",
         "metrics_defs.h",
     ],
+    clang_format_enabled = False,
 )
 
 cf_cc_library(

--- a/base/cvd/cuttlefish/host/libs/screen_connector/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/screen_connector/BUILD.bazel
@@ -44,6 +44,7 @@ cf_cc_library(
         "screen_connector_queue.h",
         "wayland_screen_connector.h",
     ],
+    clang_format_enabled = False,
     deps = [
         ":screen_connector_common",
         ":video_frame_buffer",

--- a/base/cvd/cuttlefish/host/libs/screen_recording_controls/BUILD
+++ b/base/cvd/cuttlefish/host/libs/screen_recording_controls/BUILD
@@ -12,6 +12,7 @@ cf_cc_library(
     hdrs = [
         "screen_recording_controls.h",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/host/libs/command_util",

--- a/base/cvd/cuttlefish/host/libs/version/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/version/BUILD.bazel
@@ -27,4 +27,5 @@ cf_cc_library(
     hdrs = [
         ":build_version_header",
     ],
+    clang_format_enabled = False,
 )

--- a/base/cvd/cuttlefish/host/libs/vm_manager/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/BUILD.bazel
@@ -30,6 +30,7 @@ cf_cc_library(
         "vhost_user.h",
         "vm_manager.h",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:container",

--- a/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
@@ -30,6 +30,7 @@ cf_cc_library(
         "wayland_utils.h",
         "wayland_virtio_gpu_metadata.h",
     ],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//libbase",

--- a/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
@@ -21,6 +21,7 @@ cf_cc_library(
     name = "android_build_api",
     srcs = ["android_build_api.cpp"],
     hdrs = ["android_build_api.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:environment",
@@ -60,6 +61,7 @@ cf_cc_library(
     name = "android_build_string",
     srcs = ["android_build_string.cpp"],
     hdrs = ["android_build_string.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/flag_parser",
         "//cuttlefish/result",
@@ -84,6 +86,7 @@ cf_cc_library(
     name = "android_build_url",
     srcs = ["android_build_url.cpp"],
     hdrs = ["android_build_url.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/libs/web/http_client:url_escape",
         "//cuttlefish/result",
@@ -120,6 +123,7 @@ cf_cc_library(
     name = "caching_build_api",
     srcs = ["caching_build_api.cpp"],
     hdrs = ["caching_build_api.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/libs/web:android_build",
@@ -143,6 +147,7 @@ cf_cc_library(
     name = "chrome_os_build_string",
     srcs = ["chrome_os_build_string.cpp"],
     hdrs = ["chrome_os_build_string.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/flag_parser",
         "//cuttlefish/result",
@@ -156,6 +161,7 @@ cf_cc_library(
     name = "credential_source",
     srcs = ["credential_source.cc"],
     hdrs = ["credential_source.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:base64",
         "//cuttlefish/common/libs/utils:json",
@@ -174,6 +180,7 @@ cf_cc_library(
     name = "luci_build_api",
     srcs = ["luci_build_api.cpp"],
     hdrs = ["luci_build_api.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:json",
         "//cuttlefish/host/libs/web:chrome_os_build_string",
@@ -194,6 +201,7 @@ cf_cc_library(
     name = "oauth2_consent",
     srcs = ["oauth2_consent.cpp"],
     hdrs = ["oauth2_consent.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:contains",

--- a/base/cvd/cuttlefish/host/libs/web/cas/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/web/cas/BUILD.bazel
@@ -8,6 +8,7 @@ cf_cc_library(
     name = "cas_downloader",
     srcs = ["cas_downloader.cpp"],
     hdrs = ["cas_downloader.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:environment",
@@ -55,6 +56,7 @@ cf_cc_library(
     name = "cas_flags",
     srcs = ["cas_flags.cc"],
     hdrs = ["cas_flags.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/flag_parser",

--- a/base/cvd/cuttlefish/host/libs/web/http_client/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/BUILD.bazel
@@ -15,6 +15,7 @@ cf_cc_library(
     name = "curl_http_client",
     srcs = ["curl_http_client.cc"],
     hdrs = ["curl_http_client.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/libs/web/http_client",
         "//cuttlefish/host/libs/web/http_client:scrub_secrets",
@@ -53,6 +54,7 @@ cf_cc_library(
     name = "http_client",
     srcs = ["http_client.cc"],
     hdrs = ["http_client.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/result",
         "@fmt",

--- a/base/cvd/cuttlefish/host/libs/zip/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/zip/BUILD.bazel
@@ -66,6 +66,7 @@ cf_cc_library(
     name = "remote_zip",
     srcs = ["remote_zip.cc"],
     hdrs = ["remote_zip.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/libs/web/http_client",
         "//cuttlefish/host/libs/zip/libzip_cc:seekable_source",
@@ -100,6 +101,7 @@ cf_cc_library(
     name = "zip_file",
     srcs = ["zip_file.cc"],
     hdrs = ["zip_file.h"],
+    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/libs/zip/libzip_cc:archive",

--- a/base/cvd/cuttlefish/host/libs/zip/libzip_cc/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/zip/libzip_cc/BUILD.bazel
@@ -10,6 +10,7 @@ cf_cc_library(
     name = "archive",
     srcs = ["archive.cc"],
     hdrs = ["archive.h"],
+    clang_format_enabled = False,
     features = ["-layering_check"],  # libzip
     linkopts = ["-llzma"],  # libzip
     linkstatic = True,  # libzip
@@ -56,6 +57,7 @@ cf_cc_library(
     name = "readable_source",
     srcs = ["readable_source.cc"],
     hdrs = ["readable_source.h"],
+    clang_format_enabled = False,
     features = ["-layering_check"],  # libzip
     linkopts = ["-llzma"],  # libzip
     linkstatic = True,  # libzip
@@ -75,6 +77,7 @@ cf_cc_library(
     name = "seekable_source",
     srcs = ["seekable_source.cc"],
     hdrs = ["seekable_source.h"],
+    clang_format_enabled = False,
     features = ["-layering_check"],  # libzip
     linkopts = ["-llzma"],  # libzip
     linkstatic = True,  # libzip

--- a/base/cvd/cuttlefish/io/BUILD.bazel
+++ b/base/cvd/cuttlefish/io/BUILD.bazel
@@ -12,7 +12,6 @@ cf_cc_library(
     name = "chroot",
     srcs = ["chroot.cc"],
     hdrs = ["chroot.h"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:filesystem",
@@ -25,7 +24,6 @@ cf_cc_library(
 cf_cc_test(
     name = "chroot_test",
     srcs = ["chroot_test.cc"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:chroot",
@@ -42,7 +40,6 @@ cf_cc_library(
     name = "concat",
     srcs = ["concat.cc"],
     hdrs = ["concat.h"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:fake_seek",
@@ -55,7 +52,6 @@ cf_cc_library(
 cf_cc_test(
     name = "concat_test",
     srcs = ["concat_test.cc"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:concat",
@@ -70,7 +66,6 @@ cf_cc_library(
     name = "copy",
     srcs = ["copy.cc"],
     hdrs = ["copy.h"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/result:expect",
@@ -81,7 +76,6 @@ cf_cc_library(
 cf_cc_test(
     name = "copy_test",
     srcs = ["copy_test.cc"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:copy",
@@ -95,7 +89,6 @@ cf_cc_library(
     name = "cpio",
     srcs = ["cpio.cc"],
     hdrs = ["cpio.h"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/common/libs/utils:size_utils",
         "//cuttlefish/io",
@@ -110,7 +103,6 @@ cf_cc_library(
 cf_cc_test(
     name = "cpio_test",
     srcs = ["cpio_test.cc"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:cpio",
@@ -126,7 +118,6 @@ cf_cc_library(
     name = "default_visitor",
     srcs = ["default_visitor.cc"],
     hdrs = ["default_visitor.h"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:concat",
@@ -141,7 +132,6 @@ cf_cc_library(
     name = "disjoint_range_set",
     srcs = ["disjoint_range_set.cc"],
     hdrs = ["disjoint_range_set.h"],
-    clang_format_enabled = True,
     deps = [
         "//libbase",
         "@abseil-cpp//absl/log:check",
@@ -161,7 +151,6 @@ proto_library(
 cf_cc_test(
     name = "disjoint_range_set_test",
     srcs = ["disjoint_range_set_test.cc"],
-    clang_format_enabled = True,
     deps = ["//cuttlefish/io:disjoint_range_set"],
 )
 
@@ -169,7 +158,6 @@ cf_cc_library(
     name = "fake_pread_pwrite",
     srcs = ["fake_pread_pwrite.cc"],
     hdrs = ["fake_pread_pwrite.h"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/result:expect",
@@ -181,7 +169,6 @@ cf_cc_library(
     name = "fake_seek",
     srcs = ["fake_seek.cc"],
     hdrs = ["fake_seek.h"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/result:expect",
@@ -192,7 +179,6 @@ cf_cc_library(
 cf_cc_test(
     name = "fake_seek_test",
     srcs = ["fake_seek_test.cc"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io:fake_seek",
         "//cuttlefish/result:result_matchers",
@@ -203,7 +189,6 @@ cf_cc_test(
 cf_cc_library(
     name = "filesystem",
     hdrs = ["filesystem.h"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/result:result_type",
@@ -214,7 +199,6 @@ cf_cc_library(
     name = "in_memory",
     srcs = ["in_memory.cc"],
     hdrs = ["in_memory.h"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:filesystem",
@@ -226,7 +210,6 @@ cf_cc_library(
 cf_cc_test(
     name = "in_memory_test",
     srcs = ["in_memory_test.cc"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:in_memory",
@@ -240,7 +223,6 @@ cf_cc_library(
     name = "io",
     srcs = ["io.cc"],
     hdrs = ["io.h"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/result:expect",
         "//cuttlefish/result:result_type",
@@ -251,7 +233,6 @@ cf_cc_library(
     name = "lazily_loaded_file",
     srcs = ["lazily_loaded_file.cc"],
     hdrs = ["lazily_loaded_file.h"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",
@@ -267,7 +248,6 @@ cf_cc_library(
     name = "length",
     srcs = ["length.cc"],
     hdrs = ["length.h"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/result:expect",
@@ -278,7 +258,6 @@ cf_cc_library(
 cf_cc_test(
     name = "length_test",
     srcs = ["length_test.cc"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:in_memory",
@@ -291,7 +270,6 @@ cf_cc_library(
     name = "lz4_legacy",
     srcs = ["lz4_legacy.cc"],
     hdrs = ["lz4_legacy.h"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:read_exact",
@@ -305,7 +283,6 @@ cf_cc_library(
 cf_cc_test(
     name = "lz4_legacy_test",
     srcs = ["lz4_legacy_test.cc"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:filesystem",
@@ -323,7 +300,6 @@ cf_cc_library(
     name = "native_filesystem",
     srcs = ["native_filesystem.cc"],
     hdrs = ["native_filesystem.h"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/io",
@@ -339,7 +315,6 @@ cf_cc_library(
     name = "read_exact",
     srcs = ["read_exact.cc"],
     hdrs = ["read_exact.h"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/result:expect",
@@ -351,7 +326,6 @@ cf_cc_library(
     name = "read_window_view",
     srcs = ["read_window_view.cc"],
     hdrs = ["read_window_view.h"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:fake_seek",
@@ -363,7 +337,6 @@ cf_cc_library(
 cf_cc_test(
     name = "read_window_view_test",
     srcs = ["read_window_view_test.cc"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:in_memory",
@@ -378,7 +351,6 @@ cf_cc_library(
     name = "serialize_disjoint_range_set",
     srcs = ["serialize_disjoint_range_set.cc"],
     hdrs = ["serialize_disjoint_range_set.h"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io:disjoint_range_set",
         "//cuttlefish/io:disjoint_range_set_cc_proto",
@@ -389,7 +361,6 @@ cf_cc_library(
 cf_cc_test(
     name = "serialize_disjoint_range_set_test",
     srcs = ["serialize_disjoint_range_set_test.cc"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io:disjoint_range_set",
         "//cuttlefish/io:serialize_disjoint_range_set",
@@ -402,7 +373,6 @@ cf_cc_library(
     name = "shared_fd",
     srcs = ["shared_fd.cc"],
     hdrs = ["shared_fd.h"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/io",
@@ -415,7 +385,6 @@ cf_cc_library(
     name = "string",
     srcs = ["string.cc"],
     hdrs = ["string.h"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/result:expect",
@@ -427,7 +396,6 @@ cf_cc_library(
     name = "write_exact",
     srcs = ["write_exact.cc"],
     hdrs = ["write_exact.h"],
-    clang_format_enabled = True,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/result:expect",


### PR DESCRIPTION
- Change the default of `clang_format_enabled` to `True` in `rules.bzl`.
- Remove explicit `clang_format_enabled = True` from compliant targets.
- Set `clang_format_enabled = False` for non-compliant targets across the workspace.

Also fix a duplicate header in cvdalloc/BUILD.bazel.

Bug: b/512215781
Assisted-by: gemini-next:current