### PR TITLE
Fix ReadFile crash on empty files

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/files.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/files.cpp
@@ -490,7 +490,9 @@ std::string ReadFile(const std::string& file) {
   }
   contents.resize(in.tellg());
   in.seekg(0, std::ios::beg);
-  in.read(&contents[0], contents.size());
+  if (!contents.empty()) {
+    in.read(&contents[0], contents.size());
+  }
   in.close();
   return(contents);
 }


### PR DESCRIPTION
Found and fixed downstream by https://github.com/aidanwolter3 in ag/40206421

ReadFile crashed on 0-sized or empty files on environments with AVX-512 and specific glibc/libc assertions.

When the file size is 0, contents.resize(0) is called. In some C++ standard library implementations, &contents[0] returns nullptr or similar invalid address for an empty string. Passing this pointer to in.read(&contents[0], 0) then attempts to read into a NULL/invalid pointer, causing a segmentation fault inside the underlying glibc/libc memcpy/fread.

Protect the read call with a !contents.empty() check.

Bug: 496643640
Test: See ag/40206421