### PR TITLE
e2etests: enhance CF host presubmit to cover SDV and IVI use cases

### DIFF
--- a/e2etests/cvd/cvd_create_tests/main_test.go
+++ b/e2etests/cvd/cvd_create_tests/main_test.go
@@ -38,6 +38,14 @@ func TestCvdCreate(t *testing.T) {
 			branch: "git_main-throttled-nightly",
 			target: "aosp_cf_x86_64_auto-trunk_staging-userdebug",
 		},
+		{
+			branch: "git_main",
+			target: "aosp_cf_x86_64_sdv_media-trunk_staging-userdebug",
+		},
+		{
+			branch: "git_main",
+			target: "aosp_cf_x86_64_sdv_core-trunk_staging-userdebug",
+		},
 	}
 	c := e2etests.TestContext{}
 	for _, tc := range testcases {

--- a/e2etests/cvd/cvd_load_tests/main_test.go
+++ b/e2etests/cvd/cvd_load_tests/main_test.go
@@ -135,6 +135,44 @@ func TestCvdLoad(t *testing.T) {
   }
 }`,
 		},
+		{
+			name: "GitMainSDVMULTI",
+			loadconfig: `
+{
+  "instances": [
+    {
+      "name": "core",
+      "disk": {
+        "default_build": "@ab\/git_main\/aosp_cf_x86_64_sdv_core-trunk_staging-userdebug"
+      },
+      "vm": {
+        "cpus": 2,
+        "memory_mb": 4096
+      },
+      "graphics": {
+        "displays": [],
+        "record_screen": false
+      }
+    },
+    {
+      "name": "media",
+      "disk": {
+        "default_build": "@ab\/git_main\/aosp_cf_x86_64_sdv_media-trunk_staging-userdebug"
+      },
+      "vm": {
+        "cpus": 2,
+        "memory_mb": 4096
+      }
+    }
+  ],
+  "metrics": {
+    "enable": true
+  },
+  "common": {
+    "host_package": "@ab\/git_main\/aosp_cf_x86_64_only_phone-trunk_staging-userdebug"
+  }
+}`,
+		},
 	}
 	c := e2etests.TestContext{}
 	for _, tc := range testcases {

--- a/e2etests/cvd/launch_cvd_tests/main_test.go
+++ b/e2etests/cvd/launch_cvd_tests/main_test.go
@@ -32,6 +32,21 @@ func TestLaunchCvd(t *testing.T) {
 			target: "aosp_cf_x86_64_only_phone-trunk_staging-userdebug",
 		},
 		{
+			name:   "GitMainSDVMedia",
+			branch: "git_main",
+			target: "aosp_cf_x86_64_sdv_media-trunk_staging-userdebug",
+		},
+		{
+			name:   "GitMainSDVCore",
+			branch: "git_main",
+			target: "aosp_cf_x86_64_sdv_core-trunk_staging-userdebug",
+		},
+		{
+			name:   "GitMainAuto",
+			branch: "git_main",
+			target: "aosp_cf_x86_64_auto-trunk_staging-userdebug",
+		},
+		{
 			name:   "AospMainPhone",
 			branch: "aosp-android-latest-release",
 			target: "aosp_cf_x86_64_only_phone-userdebug",


### PR DESCRIPTION
Enhance the existing CVD end-to-end test suite to cover Software Defined Vehicle (SDV) and In-Vehicle Infotainment (IVI) use cases.

Changes:
- Add aosp_cf_x86_64_sdv_media to cvd_create_tests.
- Add SDVMedia and Auto (IVI proxy) to launch_cvd_tests.
- Add a multi-instance sdv_core + sdv_media simultaneous launch test case to cvd_load_tests.

These tests use Tip of Tree (@ab/git_main) artifacts to ensure 3p accessibility and alignment with standard presubmit patterns.

Bug: 507906785