### PR TITLE
Use C++20 default comparison operators across Cuttlefish host code

### DIFF
--- a/base/cvd/allocd/BUILD.bazel
+++ b/base/cvd/allocd/BUILD.bazel
@@ -11,17 +11,17 @@ string_flag(
 )
 
 config_setting(
-  name = "netlink",
-  flag_values = {
-    ":driver": "netlink"
-  }
+    name = "netlink",
+    flag_values = {
+        ":driver": "netlink",
+    },
 )
 
 config_setting(
-  name = "iproute2",
-  flag_values = {
-    ":driver": "iproute2"
-  }
+    name = "iproute2",
+    flag_values = {
+        ":driver": "iproute2",
+    },
 )
 
 cc_library(
@@ -32,6 +32,7 @@ cc_library(
     hdrs = [
         "alloc_utils.h",
     ],
+    copts = ["-std=c++20"],
     deps = select({
         ":netlink": [":alloc_netlink"],
         "//conditions:default": [":alloc_iproute2"],
@@ -58,12 +59,13 @@ cc_library(
     hdrs = [
         "alloc_driver.h",
     ],
+    copts = ["-std=c++20"],
     deps = [
-        "//cuttlefish/result",
         "//cuttlefish/common/libs/utils:subprocess",
+        "//cuttlefish/result",
+        "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/strings:str_format",
-        "@abseil-cpp//absl/log",
     ],
 )
 
@@ -75,6 +77,7 @@ cc_library(
     hdrs = [
         "alloc_driver.h",
     ],
+    copts = ["-std=c++20"],
     deps = [
         "//allocd/net:netlink",
         "//cuttlefish/common/libs/fs",

--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd.h
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd.h
@@ -35,6 +35,7 @@
 #include <sys/un.h>
 
 #include <chrono>
+#include <compare>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -205,17 +206,7 @@ class SharedFD {
   static std::string GetVhostUserVsockClientAddr(int cid);
 #endif
 
-  bool operator==(const SharedFD& rhs) const { return value_ == rhs.value_; }
-
-  bool operator!=(const SharedFD& rhs) const { return value_ != rhs.value_; }
-
-  bool operator<(const SharedFD& rhs) const { return value_ < rhs.value_; }
-
-  bool operator<=(const SharedFD& rhs) const { return value_ <= rhs.value_; }
-
-  bool operator>(const SharedFD& rhs) const { return value_ > rhs.value_; }
-
-  bool operator>=(const SharedFD& rhs) const { return value_ >= rhs.value_; }
+  auto operator<=>(const SharedFD&) const = default;
 
   std::shared_ptr<FileInstance> operator->() const { return value_; }
 

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/android_build/identify_build.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/android_build/identify_build.cc
@@ -45,16 +45,6 @@ AndroidBuildKey::AndroidBuildKey(std::string system_image_dir,
       fetcher_config(&fetcher_config),
       source(source) {}
 
-bool operator<(const AndroidBuildKey& left, const AndroidBuildKey& right) {
-  if (left.system_image_dir != right.system_image_dir) {
-    return left.system_image_dir < right.system_image_dir;
-  }
-  if (left.fetcher_config != right.fetcher_config) {
-    return left.fetcher_config < right.fetcher_config;
-  }
-  return left.source < right.source;
-}
-
 Result<std::unique_ptr<AndroidBuild>> IdentifyAndroidBuild(
     const std::string& system_image_dir, const FetcherConfig& config,
     FileSource source) {

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/android_build/identify_build.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/android_build/identify_build.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <compare>
 #include <memory>
 #include <string>
 
@@ -33,9 +34,9 @@ struct AndroidBuildKey {
   std::string system_image_dir;
   const FetcherConfig* fetcher_config;
   FileSource source;
-};
 
-bool operator<(const AndroidBuildKey&, const AndroidBuildKey&);
+  auto operator<=>(const AndroidBuildKey&) const = default;
+};
 
 Result<std::unique_ptr<AndroidBuild>> IdentifyAndroidBuild(
     const std::string& system_image_dir, const FetcherConfig& config,

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/client.cc
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/client.cc
@@ -29,10 +29,6 @@ ClientId::ClientId() {
   next_id_++;
 }
 
-bool ClientId::operator==(const ClientId& other) const {
-  return id_ == other.id_;
-}
-
 Client::Client(SharedFD fd) : client_read_fd_(fd), client_write_fd_(fd) {}
 
 Client::Client(SharedFD read, SharedFD write)

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/client.h
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/client.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <compare>
 #include <mutex>
 #include <vector>
 
@@ -31,7 +32,7 @@ class ClientId {
  public:
   ClientId();
 
-  bool operator==(const ClientId&) const;
+  auto operator<=>(const ClientId&) const = default;
 
  private:
   static size_t next_id_;

--- a/base/cvd/cuttlefish/host/libs/web/android_build_string.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_string.cpp
@@ -109,32 +109,12 @@ std::ostream& operator<<(std::ostream& out,
   return out;
 }
 
-bool operator==(const DeviceBuildString& lhs, const DeviceBuildString& rhs) {
-  return lhs.branch_or_id == rhs.branch_or_id && lhs.target == rhs.target &&
-         lhs.filepath == rhs.filepath;
-}
-
-bool operator!=(const DeviceBuildString& lhs, const DeviceBuildString& rhs) {
-  return !(lhs == rhs);
-}
-
 std::ostream& operator<<(std::ostream& out,
                          const DirectoryBuildString& build_string) {
   fmt::print(out, "(paths=\"{}\", target=\"{}\", filepath=\"{}\")",
              fmt::join(build_string.paths, ":"), build_string.target,
              build_string.filepath.value_or(""));
   return out;
-}
-
-bool operator==(const DirectoryBuildString& lhs,
-                const DirectoryBuildString& rhs) {
-  return lhs.paths == rhs.paths && lhs.target == rhs.target &&
-         lhs.filepath == rhs.filepath;
-}
-
-bool operator!=(const DirectoryBuildString& lhs,
-                const DirectoryBuildString& rhs) {
-  return !(lhs == rhs);
 }
 
 std::ostream& operator<<(std::ostream& out, const BuildString& build_string) {

--- a/base/cvd/cuttlefish/host/libs/web/android_build_string.h
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_string.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <compare>
 #include <optional>
 #include <string>
 #include <variant>
@@ -30,25 +31,23 @@ struct DeviceBuildString {
   std::string branch_or_id;
   std::optional<std::string> target;
   std::optional<std::string> filepath;
+
+  auto operator<=>(const DeviceBuildString&) const = default;
 };
 
 std::ostream& operator<<(std::ostream& out,
                          const DeviceBuildString& build_string);
-bool operator==(const DeviceBuildString& lhs, const DeviceBuildString& rhs);
-bool operator!=(const DeviceBuildString& lhs, const DeviceBuildString& rhs);
 
 struct DirectoryBuildString {
   std::vector<std::string> paths;
   std::string target;
   std::optional<std::string> filepath;
+
+  auto operator<=>(const DirectoryBuildString&) const = default;
 };
 
 std::ostream& operator<<(std::ostream& out,
                          const DirectoryBuildString& build_string);
-bool operator==(const DirectoryBuildString& lhs,
-                const DirectoryBuildString& rhs);
-bool operator!=(const DirectoryBuildString& lhs,
-                const DirectoryBuildString& rhs);
 
 using BuildString = std::variant<DeviceBuildString, DirectoryBuildString>;
 

--- a/base/cvd/cuttlefish/io/disjoint_range_set.cc
+++ b/base/cvd/cuttlefish/io/disjoint_range_set.cc
@@ -50,9 +50,7 @@ class Range {
     return start_ < other.start_ ||
            (start_ == other.start_ && end_ > other.end_);
   }
-  bool operator==(const Range& other) const {
-    return start_ == other.start_ && end_ == other.end_;
-  }
+  bool operator==(const Range&) const = default;
 
   std::pair<uint64_t, uint64_t> AsPair() const {
     return std::make_pair(start_, end_);


### PR DESCRIPTION
Replaces manually defined relational and equality comparison overloads in SharedFD, AndroidBuildKey, DeviceBuildString, DirectoryBuildString, ClientId, and Range with C++20 defaulted comparison operators (= default) and the three-way comparison operator (operator<=>). It also updates the underlying allocd build rules to use `-std=c++20`.

Assisted-by: Gemini:Next
Bug: b/520128494