### PR TITLE
Enable clang-format enforcement for targets not touched in 2026

### DIFF
--- a/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
@@ -49,7 +49,6 @@ cf_cc_test(
     srcs = [
         "shared_fd_test.cpp",
     ],
-    clang_format_enabled = False,
     deps = [
         ":fs",
         "//libbase",

--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd_test.cpp
@@ -16,8 +16,8 @@
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 
-#include <unistd.h>
 #include <gtest/gtest.h>
+#include <unistd.h>
 
 namespace cuttlefish {
 
@@ -28,10 +28,11 @@ TEST(SendFD, Basic) {
   SharedFD::Pipe(fds, fds + 1);
   EXPECT_TRUE(fds[0]->IsOpen());
   EXPECT_TRUE(fds[1]->IsOpen());
-  EXPECT_EQ(sizeof(pipe_message), fds[1]->Write(pipe_message, sizeof(pipe_message)));
+  EXPECT_EQ(sizeof(pipe_message),
+            fds[1]->Write(pipe_message, sizeof(pipe_message)));
   char buf[80];
   EXPECT_EQ(sizeof(pipe_message), fds[0]->Read(buf, sizeof(buf)));
   EXPECT_EQ(0, strcmp(buf, pipe_message));
 }
 
-}
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
@@ -294,7 +294,6 @@ cf_cc_library(
     hdrs = [
         "random.h",
     ],
-    clang_format_enabled = False,
 )
 
 cf_cc_library(
@@ -322,7 +321,6 @@ cf_cc_library(
     name = "signals",
     srcs = ["signals.cpp"],
     hdrs = ["signals.h"],
-    clang_format_enabled = False,
     deps = [
         "//libbase",
         "@abseil-cpp//absl/log:check",
@@ -338,7 +336,6 @@ cf_cc_library(
     name = "socket2socket_proxy",
     srcs = ["socket2socket_proxy.cpp"],
     hdrs = ["socket2socket_proxy.h"],
-    clang_format_enabled = False,
     target_compatible_with = [
         "@platforms//os:linux",
     ],
@@ -462,7 +459,6 @@ cf_cc_library(
     name = "vsock_connection",
     srcs = ["vsock_connection.cpp"],
     hdrs = ["vsock_connection.h"],
-    clang_format_enabled = False,
     clang_tidy_enabled = False,  # TODO: b/403278821 - fix warnings and re-enable after migration work
     target_compatible_with = [
         "@platforms//os:linux",
@@ -492,7 +488,6 @@ cf_cc_library(
     name = "wait_for_unix_socket",
     srcs = ["wait_for_unix_socket.cpp"],
     hdrs = ["wait_for_unix_socket.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:subprocess",

--- a/base/cvd/cuttlefish/common/libs/utils/random.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/random.cpp
@@ -27,9 +27,9 @@ std::string GenerateRandomString(const std::string& alphabet,
                                  const int length) {
   std::srand(std::time(0));
   std::vector<char> result(length);
-  for(int i = 0; i < length; i++){
+  for (int i = 0; i < length; i++) {
     result[i] = alphabet[std::rand() % alphabet.size()];
   }
   return std::string(result.begin(), result.end());
 }
-}
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/signals.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/signals.cpp
@@ -44,7 +44,7 @@ void ChangeSignalHandlers(void (*handler)(int), std::vector<int> signals) {
   struct sigaction act;
   act.sa_handler = handler;
   sigemptyset(&act.sa_mask);
-  for (auto signal: signals) {
+  for (auto signal : signals) {
     sigaddset(&act.sa_mask, signal);
   }
   act.sa_flags = 0;
@@ -55,4 +55,3 @@ void ChangeSignalHandlers(void (*handler)(int), std::vector<int> signals) {
 }
 
 }  // namespace cuttlefish
-

--- a/base/cvd/cuttlefish/common/libs/utils/signals.h
+++ b/base/cvd/cuttlefish/common/libs/utils/signals.h
@@ -43,6 +43,6 @@ class SignalMasker {
   sigset_t old_mask_;
 };
 
-void ChangeSignalHandlers(void(*handler)(int), std::vector<int> signals);
+void ChangeSignalHandlers(void (*handler)(int), std::vector<int> signals);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/socket2socket_proxy.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/socket2socket_proxy.cpp
@@ -17,8 +17,8 @@
 #include "cuttlefish/common/libs/utils/socket2socket_proxy.h"
 
 #include <poll.h>
-#include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/types.h>
 
 #include <atomic>
 #include <cstring>
@@ -37,8 +37,7 @@ namespace {
 
 class ProxyPair {
  public:
-  ProxyPair()
-      : stop_fd_(SharedFD::Event()) {
+  ProxyPair() : stop_fd_(SharedFD::Event()) {
     if (!stop_fd_->IsOpen()) {
       LOG(FATAL) << "Failed to open eventfd: " << stop_fd_->StrError();
       return;
@@ -80,9 +79,7 @@ class ProxyPair {
                        std::ref(t2c_running_));
   }
 
-  bool Running() {
-    return c2t_running_ || t2c_running_;
-  }
+  bool Running() { return c2t_running_ || t2c_running_; }
 
  private:
   void Forward(const std::string& label, SharedFD from, SharedFD to,
@@ -112,22 +109,22 @@ class ProxyPair {
 
 }  // namespace
 
-ProxyServer::ProxyServer(SharedFD server, std::function<SharedFD()> clients_factory)
+ProxyServer::ProxyServer(SharedFD server,
+                         std::function<SharedFD()> clients_factory)
     : stop_fd_(SharedFD::Event()) {
   if (!stop_fd_->IsOpen()) {
     LOG(FATAL) << "Failed to open eventfd: " << stop_fd_->StrError();
     return;
   }
   server_ = std::thread([&, server_fd = std::move(server),
-                            clients_factory = std::move(clients_factory)]() {
+                         clients_factory = std::move(clients_factory)]() {
     constexpr ssize_t SERVER = 0;
     constexpr ssize_t STOP = 1;
     std::list<ProxyPair> watched;
 
     std::vector<PollSharedFd> server_poll = {
-      {.fd = server_fd, .events = POLLIN},
-      {.fd = stop_fd_, .events = POLLIN}
-    };
+        {.fd = server_fd, .events = POLLIN},
+        {.fd = stop_fd_, .events = POLLIN}};
 
     while (server_fd->IsOpen()) {
       server_poll[SERVER].revents = 0;
@@ -151,7 +148,8 @@ ProxyServer::ProxyServer(SharedFD server, std::function<SharedFD()> clients_fact
       // connection without blocking on that
       auto client = SharedFD::Accept(*server_fd);
       if (!client->IsOpen()) {
-        LOG(ERROR) << "Failed to accept incoming connection: " << client->StrError();
+        LOG(ERROR) << "Failed to accept incoming connection: "
+                   << client->StrError();
         continue;
       }
       auto target = clients_factory();
@@ -163,13 +161,15 @@ ProxyServer::ProxyServer(SharedFD server, std::function<SharedFD()> clients_fact
             << "Proxy is launched. Amount of currently tracked proxy pairs: "
             << watched.size();
       } else {
-        LOG(ERROR) << "Cannot connect to the target to setup proxying: " << target->StrError();
+        LOG(ERROR) << "Cannot connect to the target to setup proxying: "
+                   << target->StrError();
       }
       // Unwatch completed proxy pairs
       watched.remove_if([](ProxyPair& proxy) { return !proxy.Running(); });
     }
 
-    // Making sure all launched proxy pairs are finished by triggering their destructor
+    // Making sure all launched proxy pairs are finished by triggering their
+    // destructor
     VLOG(0) << "Waiting for proxy threads to turn down";
     watched.clear();
     VLOG(0) << "Proxy threads are successfully turned down";
@@ -194,8 +194,10 @@ void Proxy(SharedFD server, std::function<SharedFD()> conn_factory) {
   proxy.Join();
 }
 
-std::unique_ptr<ProxyServer> ProxyAsync(SharedFD server, std::function<SharedFD()> conn_factory) {
-  return std::make_unique<ProxyServer>(std::move(server), std::move(conn_factory));
+std::unique_ptr<ProxyServer> ProxyAsync(
+    SharedFD server, std::function<SharedFD()> conn_factory) {
+  return std::make_unique<ProxyServer>(std::move(server),
+                                       std::move(conn_factory));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/socket2socket_proxy.h
+++ b/base/cvd/cuttlefish/common/libs/utils/socket2socket_proxy.h
@@ -44,6 +44,7 @@ class ProxyServer {
 // behavior for SIGPIPE before calling this function, otherwise it runs the risk
 // or crashing the process when a connection breaks.
 void Proxy(SharedFD server, std::function<SharedFD()> conn_factory);
-std::unique_ptr<ProxyServer> ProxyAsync(SharedFD server, std::function<SharedFD()> conn_factory);
+std::unique_ptr<ProxyServer> ProxyAsync(SharedFD server,
+                                        std::function<SharedFD()> conn_factory);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/vsock_connection.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/vsock_connection.cpp
@@ -16,9 +16,9 @@
 
 #include "cuttlefish/common/libs/utils/vsock_connection.h"
 
-#include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/time.h>
+#include <sys/types.h>
 
 #include <functional>
 #include <future>

--- a/base/cvd/cuttlefish/common/libs/utils/wait_for_unix_socket.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/wait_for_unix_socket.cpp
@@ -102,4 +102,4 @@ Result<void> WaitForUnixSocketListeningWithoutConnect(const std::string& path,
   return CF_ERR("This shouldn't be executed");
 }
 
-}
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/utils/wait_for_unix_socket.h
+++ b/base/cvd/cuttlefish/common/libs/utils/wait_for_unix_socket.h
@@ -28,4 +28,4 @@ Result<void> WaitForUnixSocketListeningWithoutConnect(const std::string& path,
                                                       int timeoutSec);
 #endif
 
-}
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/casimir_control_server/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/casimir_control_server/BUILD.bazel
@@ -45,7 +45,6 @@ cf_cc_library(
         "packet_runtime.h",
         "rf_packets.h",
     ],
-    clang_format_enabled = False,
     deps = [
         ":libcasimir_control_server",
         "//cuttlefish/common/libs/fs",

--- a/base/cvd/cuttlefish/host/commands/casimir_control_server/packet_runtime.h
+++ b/base/cvd/cuttlefish/host/commands/casimir_control_server/packet_runtime.h
@@ -15,8 +15,8 @@
  */
 
 /*
-* TODO: b/416777029 - Stop using this copy of the file
-*/
+ * TODO: b/416777029 - Stop using this copy of the file
+ */
 
 #pragma once
 

--- a/base/cvd/cuttlefish/host/commands/casimir_control_server/rf_packets.h
+++ b/base/cvd/cuttlefish/host/commands/casimir_control_server/rf_packets.h
@@ -15,18 +15,19 @@
  */
 
 // File generated from <stdin>, with the command:
-//  /mnt/disks/build-disk/src/android/main/out/soong/.temp/sbox/9a296958a3bd30ec1088ce7729bb85fe3b298ceb/tools/out/bin/pdl_cxx_generator --namespace casimir::rf --output ./out/rf_packets.h
+//  /mnt/disks/build-disk/src/android/main/out/soong/.temp/sbox/9a296958a3bd30ec1088ce7729bb85fe3b298ceb/tools/out/bin/pdl_cxx_generator
+//  --namespace casimir::rf --output ./out/rf_packets.h
 // /!\ Do not edit by hand
 
 /*
-* TODO: b/416777029 - Stop using this file and generate it at compile time
-*/
+ * TODO: b/416777029 - Stop using this file and generate it at compile time
+ */
 
 #pragma once
 
 #include <cstdint>
-#include <string>
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -55,1797 +56,1840 @@ class DeactivateNotificationView;
 class DataView;
 
 enum class Technology : uint8_t {
-    NFC_A = 0x0,
-    NFC_B = 0x1,
-    NFC_F = 0x2,
-    NFC_V = 0x3,
-    RAW = 0x7,
+  NFC_A = 0x0,
+  NFC_B = 0x1,
+  NFC_F = 0x2,
+  NFC_V = 0x3,
+  RAW = 0x7,
 };
 
 inline std::string TechnologyText(Technology tag) {
-    switch (tag) {
-        case Technology::NFC_A: return "NFC_A";
-        case Technology::NFC_B: return "NFC_B";
-        case Technology::NFC_F: return "NFC_F";
-        case Technology::NFC_V: return "NFC_V";
-        case Technology::RAW: return "RAW";
-        default:
-            return std::string("Unknown Technology: " +
-                   std::to_string(static_cast<uint64_t>(tag)));
-    }
+  switch (tag) {
+    case Technology::NFC_A:
+      return "NFC_A";
+    case Technology::NFC_B:
+      return "NFC_B";
+    case Technology::NFC_F:
+      return "NFC_F";
+    case Technology::NFC_V:
+      return "NFC_V";
+    case Technology::RAW:
+      return "RAW";
+    default:
+      return std::string("Unknown Technology: " +
+                         std::to_string(static_cast<uint64_t>(tag)));
+  }
 }
 
 enum class BitRate : uint8_t {
-    BIT_RATE_106_KBIT_S = 0x0,
-    BIT_RATE_212_KBIT_S = 0x1,
-    BIT_RATE_424_KBIT_S = 0x2,
-    BIT_RATE_848_KBIT_S = 0x3,
-    BIT_RATE_1695_KBIT_S = 0x4,
-    BIT_RATE_3390_KBIT_S = 0x5,
-    BIT_RATE_6780_KBIT_S = 0x6,
-    BIT_RATE_26_KBIT_S = 0x20,
+  BIT_RATE_106_KBIT_S = 0x0,
+  BIT_RATE_212_KBIT_S = 0x1,
+  BIT_RATE_424_KBIT_S = 0x2,
+  BIT_RATE_848_KBIT_S = 0x3,
+  BIT_RATE_1695_KBIT_S = 0x4,
+  BIT_RATE_3390_KBIT_S = 0x5,
+  BIT_RATE_6780_KBIT_S = 0x6,
+  BIT_RATE_26_KBIT_S = 0x20,
 };
 
 inline std::string BitRateText(BitRate tag) {
-    switch (tag) {
-        case BitRate::BIT_RATE_106_KBIT_S: return "BIT_RATE_106_KBIT_S";
-        case BitRate::BIT_RATE_212_KBIT_S: return "BIT_RATE_212_KBIT_S";
-        case BitRate::BIT_RATE_424_KBIT_S: return "BIT_RATE_424_KBIT_S";
-        case BitRate::BIT_RATE_848_KBIT_S: return "BIT_RATE_848_KBIT_S";
-        case BitRate::BIT_RATE_1695_KBIT_S: return "BIT_RATE_1695_KBIT_S";
-        case BitRate::BIT_RATE_3390_KBIT_S: return "BIT_RATE_3390_KBIT_S";
-        case BitRate::BIT_RATE_6780_KBIT_S: return "BIT_RATE_6780_KBIT_S";
-        case BitRate::BIT_RATE_26_KBIT_S: return "BIT_RATE_26_KBIT_S";
-        default:
-            return std::string("Unknown BitRate: " +
-                   std::to_string(static_cast<uint64_t>(tag)));
-    }
+  switch (tag) {
+    case BitRate::BIT_RATE_106_KBIT_S:
+      return "BIT_RATE_106_KBIT_S";
+    case BitRate::BIT_RATE_212_KBIT_S:
+      return "BIT_RATE_212_KBIT_S";
+    case BitRate::BIT_RATE_424_KBIT_S:
+      return "BIT_RATE_424_KBIT_S";
+    case BitRate::BIT_RATE_848_KBIT_S:
+      return "BIT_RATE_848_KBIT_S";
+    case BitRate::BIT_RATE_1695_KBIT_S:
+      return "BIT_RATE_1695_KBIT_S";
+    case BitRate::BIT_RATE_3390_KBIT_S:
+      return "BIT_RATE_3390_KBIT_S";
+    case BitRate::BIT_RATE_6780_KBIT_S:
+      return "BIT_RATE_6780_KBIT_S";
+    case BitRate::BIT_RATE_26_KBIT_S:
+      return "BIT_RATE_26_KBIT_S";
+    default:
+      return std::string("Unknown BitRate: " +
+                         std::to_string(static_cast<uint64_t>(tag)));
+  }
 }
 
 enum class Protocol : uint8_t {
-    UNDETERMINED = 0x0,
-    T1T = 0x1,
-    T2T = 0x2,
-    T3T = 0x3,
-    ISO_DEP = 0x4,
-    NFC_DEP = 0x5,
-    T5T = 0x6,
-    NDEF = 0x7,
+  UNDETERMINED = 0x0,
+  T1T = 0x1,
+  T2T = 0x2,
+  T3T = 0x3,
+  ISO_DEP = 0x4,
+  NFC_DEP = 0x5,
+  T5T = 0x6,
+  NDEF = 0x7,
 };
 
 inline std::string ProtocolText(Protocol tag) {
-    switch (tag) {
-        case Protocol::UNDETERMINED: return "UNDETERMINED";
-        case Protocol::T1T: return "T1T";
-        case Protocol::T2T: return "T2T";
-        case Protocol::T3T: return "T3T";
-        case Protocol::ISO_DEP: return "ISO_DEP";
-        case Protocol::NFC_DEP: return "NFC_DEP";
-        case Protocol::T5T: return "T5T";
-        case Protocol::NDEF: return "NDEF";
-        default:
-            return std::string("Unknown Protocol: " +
-                   std::to_string(static_cast<uint64_t>(tag)));
-    }
+  switch (tag) {
+    case Protocol::UNDETERMINED:
+      return "UNDETERMINED";
+    case Protocol::T1T:
+      return "T1T";
+    case Protocol::T2T:
+      return "T2T";
+    case Protocol::T3T:
+      return "T3T";
+    case Protocol::ISO_DEP:
+      return "ISO_DEP";
+    case Protocol::NFC_DEP:
+      return "NFC_DEP";
+    case Protocol::T5T:
+      return "T5T";
+    case Protocol::NDEF:
+      return "NDEF";
+    default:
+      return std::string("Unknown Protocol: " +
+                         std::to_string(static_cast<uint64_t>(tag)));
+  }
 }
 
 enum class RfPacketType : uint8_t {
-    DATA = 0x0,
-    POLL_COMMAND = 0x1,
-    POLL_RESPONSE = 0x2,
-    SELECT_COMMAND = 0x3,
-    SELECT_RESPONSE = 0x4,
-    DEACTIVATE_NOTIFICATION = 0x5,
-    FIELD_INFO = 0x6,
+  DATA = 0x0,
+  POLL_COMMAND = 0x1,
+  POLL_RESPONSE = 0x2,
+  SELECT_COMMAND = 0x3,
+  SELECT_RESPONSE = 0x4,
+  DEACTIVATE_NOTIFICATION = 0x5,
+  FIELD_INFO = 0x6,
 };
 
 inline std::string RfPacketTypeText(RfPacketType tag) {
-    switch (tag) {
-        case RfPacketType::DATA: return "DATA";
-        case RfPacketType::POLL_COMMAND: return "POLL_COMMAND";
-        case RfPacketType::POLL_RESPONSE: return "POLL_RESPONSE";
-        case RfPacketType::SELECT_COMMAND: return "SELECT_COMMAND";
-        case RfPacketType::SELECT_RESPONSE: return "SELECT_RESPONSE";
-        case RfPacketType::DEACTIVATE_NOTIFICATION: return "DEACTIVATE_NOTIFICATION";
-        case RfPacketType::FIELD_INFO: return "FIELD_INFO";
-        default:
-            return std::string("Unknown RfPacketType: " +
-                   std::to_string(static_cast<uint64_t>(tag)));
-    }
+  switch (tag) {
+    case RfPacketType::DATA:
+      return "DATA";
+    case RfPacketType::POLL_COMMAND:
+      return "POLL_COMMAND";
+    case RfPacketType::POLL_RESPONSE:
+      return "POLL_RESPONSE";
+    case RfPacketType::SELECT_COMMAND:
+      return "SELECT_COMMAND";
+    case RfPacketType::SELECT_RESPONSE:
+      return "SELECT_RESPONSE";
+    case RfPacketType::DEACTIVATE_NOTIFICATION:
+      return "DEACTIVATE_NOTIFICATION";
+    case RfPacketType::FIELD_INFO:
+      return "FIELD_INFO";
+    default:
+      return std::string("Unknown RfPacketType: " +
+                         std::to_string(static_cast<uint64_t>(tag)));
+  }
 }
 
 class RfPacketView {
-public:
-    static RfPacketView Create(pdl::packet::slice const& parent) {
-        return RfPacketView(parent);
-    }
+ public:
+  static RfPacketView Create(pdl::packet::slice const& parent) {
+    return RfPacketView(parent);
+  }
 
-    uint16_t GetSender() const {
-        _ASSERT_VALID(valid_);
-        return sender_;
-    }
-    
-    uint16_t GetReceiver() const {
-        _ASSERT_VALID(valid_);
-        return receiver_;
-    }
-    
-    Technology GetTechnology() const {
-        _ASSERT_VALID(valid_);
-        return technology_;
-    }
-    
-    Protocol GetProtocol() const {
-        _ASSERT_VALID(valid_);
-        return protocol_;
-    }
-    
-    RfPacketType GetPacketType() const {
-        _ASSERT_VALID(valid_);
-        return packet_type_;
-    }
-    
-    BitRate GetBitrate() const {
-        _ASSERT_VALID(valid_);
-        return bitrate_;
-    }
-    
-    uint8_t GetPowerLevel() const {
-        _ASSERT_VALID(valid_);
-        return power_level_;
-    }
-    
-    std::vector<uint8_t> GetPayload() const {
-        _ASSERT_VALID(valid_);
-        return payload_.bytes();
-    }
-    
-    
-    std::string ToString() const {
-        return "";
-    }
-    
+  uint16_t GetSender() const {
+    _ASSERT_VALID(valid_);
+    return sender_;
+  }
 
-    bool IsValid() const {
-        return valid_;
+  uint16_t GetReceiver() const {
+    _ASSERT_VALID(valid_);
+    return receiver_;
+  }
+
+  Technology GetTechnology() const {
+    _ASSERT_VALID(valid_);
+    return technology_;
+  }
+
+  Protocol GetProtocol() const {
+    _ASSERT_VALID(valid_);
+    return protocol_;
+  }
+
+  RfPacketType GetPacketType() const {
+    _ASSERT_VALID(valid_);
+    return packet_type_;
+  }
+
+  BitRate GetBitrate() const {
+    _ASSERT_VALID(valid_);
+    return bitrate_;
+  }
+
+  uint8_t GetPowerLevel() const {
+    _ASSERT_VALID(valid_);
+    return power_level_;
+  }
+
+  std::vector<uint8_t> GetPayload() const {
+    _ASSERT_VALID(valid_);
+    return payload_.bytes();
+  }
+
+  std::string ToString() const { return ""; }
+
+  bool IsValid() const { return valid_; }
+
+  pdl::packet::slice bytes() const { return bytes_; }
+
+ protected:
+  explicit RfPacketView(pdl::packet::slice const& parent) : bytes_(parent) {
+    valid_ = Parse(parent);
+  }
+
+  bool Parse(pdl::packet::slice const& parent) {
+    // Parse packet field values.
+    pdl::packet::slice span = parent;
+    if (span.size() < 9) {
+      return false;
     }
+    sender_ = span.read_le<uint16_t, 2>();
+    receiver_ = span.read_le<uint16_t, 2>();
+    technology_ = Technology(span.read_le<uint8_t, 1>());
+    protocol_ = Protocol(span.read_le<uint8_t, 1>());
+    packet_type_ = RfPacketType(span.read_le<uint8_t, 1>());
+    bitrate_ = BitRate(span.read_le<uint8_t, 1>());
+    power_level_ = span.read_le<uint8_t, 1>();
+    payload_ = span;
+    span.clear();
+    return true;
+  }
 
-    pdl::packet::slice bytes() const {
-        return bytes_;
-    }
+  bool valid_{false};
+  pdl::packet::slice bytes_;
+  uint16_t sender_{0};
+  uint16_t receiver_{0};
+  Technology technology_{Technology::NFC_A};
+  Protocol protocol_{Protocol::UNDETERMINED};
+  RfPacketType packet_type_{RfPacketType::DATA};
+  BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
+  uint8_t power_level_{0};
+  pdl::packet::slice payload_;
 
-protected:
-    explicit RfPacketView(pdl::packet::slice const& parent)
-          : bytes_(parent) {
-        valid_ = Parse(parent);
-    }
-
-    bool Parse(pdl::packet::slice const& parent) {
-        // Parse packet field values.
-        pdl::packet::slice span = parent;
-        if (span.size() < 9) {
-            return false;
-        }
-        sender_ = span.read_le<uint16_t, 2>();
-        receiver_ = span.read_le<uint16_t, 2>();
-        technology_ = Technology(span.read_le<uint8_t, 1>());
-        protocol_ = Protocol(span.read_le<uint8_t, 1>());
-        packet_type_ = RfPacketType(span.read_le<uint8_t, 1>());
-        bitrate_ = BitRate(span.read_le<uint8_t, 1>());
-        power_level_ = span.read_le<uint8_t, 1>();
-        payload_ = span;
-        span.clear();
-        return true;
-    }
-
-    bool valid_{false};
-    pdl::packet::slice bytes_;
-    uint16_t sender_{0};
-    uint16_t receiver_{0};
-    Technology technology_{Technology::NFC_A};
-    Protocol protocol_{Protocol::UNDETERMINED};
-    RfPacketType packet_type_{RfPacketType::DATA};
-    BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
-    uint8_t power_level_{0};
-    pdl::packet::slice payload_;
-
-    friend class PollCommandView;
-    friend class FieldInfoView;
-    friend class NfcAPollResponseView;
-    friend class T4ATSelectCommandView;
-    friend class T4ATSelectResponseView;
-    friend class NfcDepSelectCommandView;
-    friend class NfcDepSelectResponseView;
-    friend class SelectCommandView;
-    friend class DeactivateNotificationView;
-    friend class DataView;
+  friend class PollCommandView;
+  friend class FieldInfoView;
+  friend class NfcAPollResponseView;
+  friend class T4ATSelectCommandView;
+  friend class T4ATSelectResponseView;
+  friend class NfcDepSelectCommandView;
+  friend class NfcDepSelectResponseView;
+  friend class SelectCommandView;
+  friend class DeactivateNotificationView;
+  friend class DataView;
 };
 
 class RfPacketBuilder : public pdl::packet::Builder {
-public:
-    ~RfPacketBuilder() override = default;
-    RfPacketBuilder() = default;
-    RfPacketBuilder(RfPacketBuilder const&) = default;
-    RfPacketBuilder(RfPacketBuilder&&) = default;
-    RfPacketBuilder& operator=(RfPacketBuilder const&) = default;
-        RfPacketBuilder(uint16_t sender, uint16_t receiver, Technology technology, Protocol protocol, RfPacketType packet_type, BitRate bitrate, uint8_t power_level, std::vector<uint8_t> payload)
-        : sender_(sender), receiver_(receiver), technology_(technology), protocol_(protocol), packet_type_(packet_type), bitrate_(bitrate), power_level_(power_level), payload_(std::move(payload)) {
-    
-}
-    static std::unique_ptr<RfPacketBuilder> Create(uint16_t sender, uint16_t receiver, Technology technology, Protocol protocol, RfPacketType packet_type, BitRate bitrate, uint8_t power_level, std::vector<uint8_t> payload) {
-    return std::make_unique<RfPacketBuilder>(sender, receiver, technology, protocol, packet_type, bitrate, power_level, std::move(payload));
-}
+ public:
+  ~RfPacketBuilder() override = default;
+  RfPacketBuilder() = default;
+  RfPacketBuilder(RfPacketBuilder const&) = default;
+  RfPacketBuilder(RfPacketBuilder&&) = default;
+  RfPacketBuilder& operator=(RfPacketBuilder const&) = default;
+  RfPacketBuilder(uint16_t sender, uint16_t receiver, Technology technology,
+                  Protocol protocol, RfPacketType packet_type, BitRate bitrate,
+                  uint8_t power_level, std::vector<uint8_t> payload)
+      : sender_(sender),
+        receiver_(receiver),
+        technology_(technology),
+        protocol_(protocol),
+        packet_type_(packet_type),
+        bitrate_(bitrate),
+        power_level_(power_level),
+        payload_(std::move(payload)) {}
+  static std::unique_ptr<RfPacketBuilder> Create(
+      uint16_t sender, uint16_t receiver, Technology technology,
+      Protocol protocol, RfPacketType packet_type, BitRate bitrate,
+      uint8_t power_level, std::vector<uint8_t> payload) {
+    return std::make_unique<RfPacketBuilder>(sender, receiver, technology,
+                                             protocol, packet_type, bitrate,
+                                             power_level, std::move(payload));
+  }
 
-    void Serialize(std::vector<uint8_t>& output) const override {
-        pdl::packet::Builder::write_le<uint16_t, 2>(output, (static_cast<uint16_t>(sender_ & 0xffff) << 0));
-        pdl::packet::Builder::write_le<uint16_t, 2>(output, (static_cast<uint16_t>(receiver_ & 0xffff) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(technology_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(protocol_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(packet_type_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(bitrate_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(power_level_ & 0xff) << 0));
-        output.insert(output.end(), payload_.begin(), payload_.end());
-    }
+  void Serialize(std::vector<uint8_t>& output) const override {
+    pdl::packet::Builder::write_le<uint16_t, 2>(
+        output, (static_cast<uint16_t>(sender_ & 0xffff) << 0));
+    pdl::packet::Builder::write_le<uint16_t, 2>(
+        output, (static_cast<uint16_t>(receiver_ & 0xffff) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(technology_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(protocol_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(packet_type_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(bitrate_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(power_level_ & 0xff) << 0));
+    output.insert(output.end(), payload_.begin(), payload_.end());
+  }
 
-    size_t GetSize() const override {
-        return payload_.size() + 9;
-    }
+  size_t GetSize() const override { return payload_.size() + 9; }
 
-    
-    uint16_t sender_{0};
-    uint16_t receiver_{0};
-    Technology technology_{Technology::NFC_A};
-    Protocol protocol_{Protocol::UNDETERMINED};
-    RfPacketType packet_type_{RfPacketType::DATA};
-    BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
-    uint8_t power_level_{0};
-    std::vector<uint8_t> payload_;
+  uint16_t sender_{0};
+  uint16_t receiver_{0};
+  Technology technology_{Technology::NFC_A};
+  Protocol protocol_{Protocol::UNDETERMINED};
+  RfPacketType packet_type_{RfPacketType::DATA};
+  BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
+  uint8_t power_level_{0};
+  std::vector<uint8_t> payload_;
 };
 
 enum class PollingFrameFormat : uint8_t {
-    SHORT = 0x0,
-    LONG = 0x1,
+  SHORT = 0x0,
+  LONG = 0x1,
 };
 
 inline std::string PollingFrameFormatText(PollingFrameFormat tag) {
-    switch (tag) {
-        case PollingFrameFormat::SHORT: return "SHORT";
-        case PollingFrameFormat::LONG: return "LONG";
-        default:
-            return std::string("Unknown PollingFrameFormat: " +
-                   std::to_string(static_cast<uint64_t>(tag)));
-    }
+  switch (tag) {
+    case PollingFrameFormat::SHORT:
+      return "SHORT";
+    case PollingFrameFormat::LONG:
+      return "LONG";
+    default:
+      return std::string("Unknown PollingFrameFormat: " +
+                         std::to_string(static_cast<uint64_t>(tag)));
+  }
 }
 
 class PollCommandView {
-public:
-    static PollCommandView Create(RfPacketView const& parent) {
-        return PollCommandView(parent);
+ public:
+  static PollCommandView Create(RfPacketView const& parent) {
+    return PollCommandView(parent);
+  }
+
+  uint16_t GetSender() const {
+    _ASSERT_VALID(valid_);
+    return sender_;
+  }
+
+  uint16_t GetReceiver() const {
+    _ASSERT_VALID(valid_);
+    return receiver_;
+  }
+
+  Technology GetTechnology() const {
+    _ASSERT_VALID(valid_);
+    return technology_;
+  }
+
+  Protocol GetProtocol() const {
+    _ASSERT_VALID(valid_);
+    return protocol_;
+  }
+
+  BitRate GetBitrate() const {
+    _ASSERT_VALID(valid_);
+    return bitrate_;
+  }
+
+  uint8_t GetPowerLevel() const {
+    _ASSERT_VALID(valid_);
+    return power_level_;
+  }
+
+  PollingFrameFormat GetFormat() const {
+    _ASSERT_VALID(valid_);
+    return format_;
+  }
+
+  std::vector<uint8_t> GetPayload() const {
+    _ASSERT_VALID(valid_);
+    return payload_.bytes();
+  }
+
+  RfPacketType GetPacketType() const { return RfPacketType::POLL_COMMAND; }
+
+  std::string ToString() const { return ""; }
+
+  bool IsValid() const { return valid_; }
+
+  pdl::packet::slice bytes() const { return bytes_; }
+
+ protected:
+  explicit PollCommandView(RfPacketView const& parent) : bytes_(parent.bytes_) {
+    valid_ = Parse(parent);
+  }
+
+  bool Parse(RfPacketView const& parent) {
+    // Check validity of parent packet.
+    if (!parent.IsValid()) {
+      return false;
     }
 
-    uint16_t GetSender() const {
-        _ASSERT_VALID(valid_);
-        return sender_;
-    }
-    
-    uint16_t GetReceiver() const {
-        _ASSERT_VALID(valid_);
-        return receiver_;
-    }
-    
-    Technology GetTechnology() const {
-        _ASSERT_VALID(valid_);
-        return technology_;
-    }
-    
-    Protocol GetProtocol() const {
-        _ASSERT_VALID(valid_);
-        return protocol_;
-    }
-    
-    BitRate GetBitrate() const {
-        _ASSERT_VALID(valid_);
-        return bitrate_;
-    }
-    
-    uint8_t GetPowerLevel() const {
-        _ASSERT_VALID(valid_);
-        return power_level_;
-    }
-    
-    PollingFrameFormat GetFormat() const {
-        _ASSERT_VALID(valid_);
-        return format_;
-    }
-    
-    std::vector<uint8_t> GetPayload() const {
-        _ASSERT_VALID(valid_);
-        return payload_.bytes();
-    }
-    
-    RfPacketType GetPacketType() const {
-        return RfPacketType::POLL_COMMAND;
-    }
-    
-    
-    std::string ToString() const {
-        return "";
-    }
-    
+    // Copy parent field values.
+    sender_ = parent.sender_;
+    receiver_ = parent.receiver_;
+    technology_ = parent.technology_;
+    protocol_ = parent.protocol_;
+    bitrate_ = parent.bitrate_;
+    power_level_ = parent.power_level_;
 
-    bool IsValid() const {
-        return valid_;
+    if (parent.packet_type_ != RfPacketType::POLL_COMMAND) {
+      return false;
     }
 
-    pdl::packet::slice bytes() const {
-        return bytes_;
+    // Parse packet field values.
+    pdl::packet::slice span = parent.payload_;
+    if (span.size() < 1) {
+      return false;
     }
+    uint8_t chunk0 = span.read_le<uint8_t, 1>();
+    format_ = PollingFrameFormat((chunk0 >> 0) & 0x1);
+    payload_ = span;
+    span.clear();
+    return true;
+  }
 
-protected:
-    explicit PollCommandView(RfPacketView const& parent)
-          : bytes_(parent.bytes_) {
-        valid_ = Parse(parent);
-    }
-
-    bool Parse(RfPacketView const& parent) {
-        // Check validity of parent packet.
-        if (!parent.IsValid()) {
-            return false;
-        }
-        
-        // Copy parent field values.
-        sender_ = parent.sender_;
-        receiver_ = parent.receiver_;
-        technology_ = parent.technology_;
-        protocol_ = parent.protocol_;
-        bitrate_ = parent.bitrate_;
-        power_level_ = parent.power_level_;
-        
-        if (parent.packet_type_ != RfPacketType::POLL_COMMAND) {
-            return false;
-        }
-        
-        // Parse packet field values.
-        pdl::packet::slice span = parent.payload_;
-        if (span.size() < 1) {
-            return false;
-        }
-        uint8_t chunk0 = span.read_le<uint8_t, 1>();
-        format_ = PollingFrameFormat((chunk0 >> 0) & 0x1);
-        payload_ = span;
-        span.clear();
-        return true;
-    }
-
-    bool valid_{false};
-    pdl::packet::slice bytes_;
-    uint16_t sender_{0};
-    uint16_t receiver_{0};
-    Technology technology_{Technology::NFC_A};
-    Protocol protocol_{Protocol::UNDETERMINED};
-    BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
-    uint8_t power_level_{0};
-    PollingFrameFormat format_{PollingFrameFormat::SHORT};
-    pdl::packet::slice payload_;
-
-    
+  bool valid_{false};
+  pdl::packet::slice bytes_;
+  uint16_t sender_{0};
+  uint16_t receiver_{0};
+  Technology technology_{Technology::NFC_A};
+  Protocol protocol_{Protocol::UNDETERMINED};
+  BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
+  uint8_t power_level_{0};
+  PollingFrameFormat format_{PollingFrameFormat::SHORT};
+  pdl::packet::slice payload_;
 };
 
 class PollCommandBuilder : public RfPacketBuilder {
-public:
-    ~PollCommandBuilder() override = default;
-    PollCommandBuilder() = default;
-    PollCommandBuilder(PollCommandBuilder const&) = default;
-    PollCommandBuilder(PollCommandBuilder&&) = default;
-    PollCommandBuilder& operator=(PollCommandBuilder const&) = default;
-        PollCommandBuilder(uint16_t sender, uint16_t receiver, Technology technology, Protocol protocol, BitRate bitrate, uint8_t power_level, PollingFrameFormat format, std::vector<uint8_t> payload)
-        : RfPacketBuilder(sender, receiver, technology, protocol, RfPacketType::POLL_COMMAND, bitrate, power_level, std::vector<uint8_t>{}), format_(format) {
+ public:
+  ~PollCommandBuilder() override = default;
+  PollCommandBuilder() = default;
+  PollCommandBuilder(PollCommandBuilder const&) = default;
+  PollCommandBuilder(PollCommandBuilder&&) = default;
+  PollCommandBuilder& operator=(PollCommandBuilder const&) = default;
+  PollCommandBuilder(uint16_t sender, uint16_t receiver, Technology technology,
+                     Protocol protocol, BitRate bitrate, uint8_t power_level,
+                     PollingFrameFormat format, std::vector<uint8_t> payload)
+      : RfPacketBuilder(sender, receiver, technology, protocol,
+                        RfPacketType::POLL_COMMAND, bitrate, power_level,
+                        std::vector<uint8_t>{}),
+        format_(format) {
     payload_ = std::move(payload);
-}
-    static std::unique_ptr<PollCommandBuilder> Create(uint16_t sender, uint16_t receiver, Technology technology, Protocol protocol, BitRate bitrate, uint8_t power_level, PollingFrameFormat format, std::vector<uint8_t> payload) {
-    return std::make_unique<PollCommandBuilder>(sender, receiver, technology, protocol, bitrate, power_level, format, std::move(payload));
-}
+  }
+  static std::unique_ptr<PollCommandBuilder> Create(
+      uint16_t sender, uint16_t receiver, Technology technology,
+      Protocol protocol, BitRate bitrate, uint8_t power_level,
+      PollingFrameFormat format, std::vector<uint8_t> payload) {
+    return std::make_unique<PollCommandBuilder>(sender, receiver, technology,
+                                                protocol, bitrate, power_level,
+                                                format, std::move(payload));
+  }
 
-    void Serialize(std::vector<uint8_t>& output) const override {
-        pdl::packet::Builder::write_le<uint16_t, 2>(output, (static_cast<uint16_t>(sender_ & 0xffff) << 0));
-        pdl::packet::Builder::write_le<uint16_t, 2>(output, (static_cast<uint16_t>(receiver_ & 0xffff) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(technology_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(protocol_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(RfPacketType::POLL_COMMAND) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(bitrate_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(power_level_ & 0xff) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(format_) << 0));
-        output.insert(output.end(), payload_.begin(), payload_.end());
-    }
+  void Serialize(std::vector<uint8_t>& output) const override {
+    pdl::packet::Builder::write_le<uint16_t, 2>(
+        output, (static_cast<uint16_t>(sender_ & 0xffff) << 0));
+    pdl::packet::Builder::write_le<uint16_t, 2>(
+        output, (static_cast<uint16_t>(receiver_ & 0xffff) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(technology_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(protocol_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(RfPacketType::POLL_COMMAND) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(bitrate_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(power_level_ & 0xff) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(format_) << 0));
+    output.insert(output.end(), payload_.begin(), payload_.end());
+  }
 
-    size_t GetSize() const override {
-        return payload_.size() + 10;
-    }
+  size_t GetSize() const override { return payload_.size() + 10; }
 
-    
-    PollingFrameFormat format_{PollingFrameFormat::SHORT};
+  PollingFrameFormat format_{PollingFrameFormat::SHORT};
 };
 
 enum class FieldStatus : uint8_t {
-    FieldOff = 0x0,
-    FieldOn = 0x1,
+  FieldOff = 0x0,
+  FieldOn = 0x1,
 };
 
 inline std::string FieldStatusText(FieldStatus tag) {
-    switch (tag) {
-        case FieldStatus::FieldOff: return "FieldOff";
-        case FieldStatus::FieldOn: return "FieldOn";
-        default:
-            return std::string("Unknown FieldStatus: " +
-                   std::to_string(static_cast<uint64_t>(tag)));
-    }
+  switch (tag) {
+    case FieldStatus::FieldOff:
+      return "FieldOff";
+    case FieldStatus::FieldOn:
+      return "FieldOn";
+    default:
+      return std::string("Unknown FieldStatus: " +
+                         std::to_string(static_cast<uint64_t>(tag)));
+  }
 }
 
 class FieldInfoView {
-public:
-    static FieldInfoView Create(RfPacketView const& parent) {
-        return FieldInfoView(parent);
+ public:
+  static FieldInfoView Create(RfPacketView const& parent) {
+    return FieldInfoView(parent);
+  }
+
+  uint16_t GetSender() const {
+    _ASSERT_VALID(valid_);
+    return sender_;
+  }
+
+  uint16_t GetReceiver() const {
+    _ASSERT_VALID(valid_);
+    return receiver_;
+  }
+
+  Technology GetTechnology() const {
+    _ASSERT_VALID(valid_);
+    return technology_;
+  }
+
+  Protocol GetProtocol() const {
+    _ASSERT_VALID(valid_);
+    return protocol_;
+  }
+
+  BitRate GetBitrate() const {
+    _ASSERT_VALID(valid_);
+    return bitrate_;
+  }
+
+  uint8_t GetPowerLevel() const {
+    _ASSERT_VALID(valid_);
+    return power_level_;
+  }
+
+  FieldStatus GetFieldStatus() const {
+    _ASSERT_VALID(valid_);
+    return field_status_;
+  }
+
+  RfPacketType GetPacketType() const { return RfPacketType::FIELD_INFO; }
+
+  std::string ToString() const { return ""; }
+
+  bool IsValid() const { return valid_; }
+
+  pdl::packet::slice bytes() const { return bytes_; }
+
+ protected:
+  explicit FieldInfoView(RfPacketView const& parent) : bytes_(parent.bytes_) {
+    valid_ = Parse(parent);
+  }
+
+  bool Parse(RfPacketView const& parent) {
+    // Check validity of parent packet.
+    if (!parent.IsValid()) {
+      return false;
     }
 
-    uint16_t GetSender() const {
-        _ASSERT_VALID(valid_);
-        return sender_;
-    }
-    
-    uint16_t GetReceiver() const {
-        _ASSERT_VALID(valid_);
-        return receiver_;
-    }
-    
-    Technology GetTechnology() const {
-        _ASSERT_VALID(valid_);
-        return technology_;
-    }
-    
-    Protocol GetProtocol() const {
-        _ASSERT_VALID(valid_);
-        return protocol_;
-    }
-    
-    BitRate GetBitrate() const {
-        _ASSERT_VALID(valid_);
-        return bitrate_;
-    }
-    
-    uint8_t GetPowerLevel() const {
-        _ASSERT_VALID(valid_);
-        return power_level_;
-    }
-    
-    FieldStatus GetFieldStatus() const {
-        _ASSERT_VALID(valid_);
-        return field_status_;
-    }
-    
-    RfPacketType GetPacketType() const {
-        return RfPacketType::FIELD_INFO;
-    }
-    
-    
-    std::string ToString() const {
-        return "";
-    }
-    
+    // Copy parent field values.
+    sender_ = parent.sender_;
+    receiver_ = parent.receiver_;
+    technology_ = parent.technology_;
+    protocol_ = parent.protocol_;
+    bitrate_ = parent.bitrate_;
+    power_level_ = parent.power_level_;
 
-    bool IsValid() const {
-        return valid_;
+    if (parent.packet_type_ != RfPacketType::FIELD_INFO) {
+      return false;
     }
 
-    pdl::packet::slice bytes() const {
-        return bytes_;
+    // Parse packet field values.
+    pdl::packet::slice span = parent.payload_;
+    if (span.size() < 1) {
+      return false;
     }
+    field_status_ = FieldStatus(span.read_le<uint8_t, 1>());
+    return true;
+  }
 
-protected:
-    explicit FieldInfoView(RfPacketView const& parent)
-          : bytes_(parent.bytes_) {
-        valid_ = Parse(parent);
-    }
-
-    bool Parse(RfPacketView const& parent) {
-        // Check validity of parent packet.
-        if (!parent.IsValid()) {
-            return false;
-        }
-        
-        // Copy parent field values.
-        sender_ = parent.sender_;
-        receiver_ = parent.receiver_;
-        technology_ = parent.technology_;
-        protocol_ = parent.protocol_;
-        bitrate_ = parent.bitrate_;
-        power_level_ = parent.power_level_;
-        
-        if (parent.packet_type_ != RfPacketType::FIELD_INFO) {
-            return false;
-        }
-        
-        // Parse packet field values.
-        pdl::packet::slice span = parent.payload_;
-        if (span.size() < 1) {
-            return false;
-        }
-        field_status_ = FieldStatus(span.read_le<uint8_t, 1>());
-        return true;
-    }
-
-    bool valid_{false};
-    pdl::packet::slice bytes_;
-    uint16_t sender_{0};
-    uint16_t receiver_{0};
-    Technology technology_{Technology::NFC_A};
-    Protocol protocol_{Protocol::UNDETERMINED};
-    BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
-    uint8_t power_level_{0};
-    FieldStatus field_status_{FieldStatus::FieldOff};
-
-    
+  bool valid_{false};
+  pdl::packet::slice bytes_;
+  uint16_t sender_{0};
+  uint16_t receiver_{0};
+  Technology technology_{Technology::NFC_A};
+  Protocol protocol_{Protocol::UNDETERMINED};
+  BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
+  uint8_t power_level_{0};
+  FieldStatus field_status_{FieldStatus::FieldOff};
 };
 
 class FieldInfoBuilder : public RfPacketBuilder {
-public:
-    ~FieldInfoBuilder() override = default;
-    FieldInfoBuilder() = default;
-    FieldInfoBuilder(FieldInfoBuilder const&) = default;
-    FieldInfoBuilder(FieldInfoBuilder&&) = default;
-    FieldInfoBuilder& operator=(FieldInfoBuilder const&) = default;
-        FieldInfoBuilder(uint16_t sender, uint16_t receiver, Technology technology, Protocol protocol, BitRate bitrate, uint8_t power_level, FieldStatus field_status)
-        : RfPacketBuilder(sender, receiver, technology, protocol, RfPacketType::FIELD_INFO, bitrate, power_level, std::vector<uint8_t>{}), field_status_(field_status) {
-    
-}
-    static std::unique_ptr<FieldInfoBuilder> Create(uint16_t sender, uint16_t receiver, Technology technology, Protocol protocol, BitRate bitrate, uint8_t power_level, FieldStatus field_status) {
-    return std::make_unique<FieldInfoBuilder>(sender, receiver, technology, protocol, bitrate, power_level, field_status);
-}
+ public:
+  ~FieldInfoBuilder() override = default;
+  FieldInfoBuilder() = default;
+  FieldInfoBuilder(FieldInfoBuilder const&) = default;
+  FieldInfoBuilder(FieldInfoBuilder&&) = default;
+  FieldInfoBuilder& operator=(FieldInfoBuilder const&) = default;
+  FieldInfoBuilder(uint16_t sender, uint16_t receiver, Technology technology,
+                   Protocol protocol, BitRate bitrate, uint8_t power_level,
+                   FieldStatus field_status)
+      : RfPacketBuilder(sender, receiver, technology, protocol,
+                        RfPacketType::FIELD_INFO, bitrate, power_level,
+                        std::vector<uint8_t>{}),
+        field_status_(field_status) {}
+  static std::unique_ptr<FieldInfoBuilder> Create(
+      uint16_t sender, uint16_t receiver, Technology technology,
+      Protocol protocol, BitRate bitrate, uint8_t power_level,
+      FieldStatus field_status) {
+    return std::make_unique<FieldInfoBuilder>(sender, receiver, technology,
+                                              protocol, bitrate, power_level,
+                                              field_status);
+  }
 
-    void Serialize(std::vector<uint8_t>& output) const override {
-        pdl::packet::Builder::write_le<uint16_t, 2>(output, (static_cast<uint16_t>(sender_ & 0xffff) << 0));
-        pdl::packet::Builder::write_le<uint16_t, 2>(output, (static_cast<uint16_t>(receiver_ & 0xffff) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(technology_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(protocol_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(RfPacketType::FIELD_INFO) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(bitrate_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(power_level_ & 0xff) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(field_status_) << 0));
-    }
+  void Serialize(std::vector<uint8_t>& output) const override {
+    pdl::packet::Builder::write_le<uint16_t, 2>(
+        output, (static_cast<uint16_t>(sender_ & 0xffff) << 0));
+    pdl::packet::Builder::write_le<uint16_t, 2>(
+        output, (static_cast<uint16_t>(receiver_ & 0xffff) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(technology_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(protocol_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(RfPacketType::FIELD_INFO) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(bitrate_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(power_level_ & 0xff) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(field_status_) << 0));
+  }
 
-    size_t GetSize() const override {
-        return 10;
-    }
+  size_t GetSize() const override { return 10; }
 
-    
-    FieldStatus field_status_{FieldStatus::FieldOff};
+  FieldStatus field_status_{FieldStatus::FieldOff};
 };
 
 class NfcAPollResponseView {
-public:
-    static NfcAPollResponseView Create(RfPacketView const& parent) {
-        return NfcAPollResponseView(parent);
+ public:
+  static NfcAPollResponseView Create(RfPacketView const& parent) {
+    return NfcAPollResponseView(parent);
+  }
+
+  uint16_t GetSender() const {
+    _ASSERT_VALID(valid_);
+    return sender_;
+  }
+
+  uint16_t GetReceiver() const {
+    _ASSERT_VALID(valid_);
+    return receiver_;
+  }
+
+  Protocol GetProtocol() const {
+    _ASSERT_VALID(valid_);
+    return protocol_;
+  }
+
+  BitRate GetBitrate() const {
+    _ASSERT_VALID(valid_);
+    return bitrate_;
+  }
+
+  uint8_t GetPowerLevel() const {
+    _ASSERT_VALID(valid_);
+    return power_level_;
+  }
+
+  std::vector<uint8_t> GetNfcid1() const {
+    _ASSERT_VALID(valid_);
+    pdl::packet::slice span = nfcid1_;
+    std::vector<uint8_t> elements;
+    while (span.size() >= 1) {
+      elements.push_back(span.read_le<uint8_t, 1>());
+    }
+    return elements;
+  }
+
+  uint8_t GetIntProtocol() const {
+    _ASSERT_VALID(valid_);
+    return int_protocol_;
+  }
+
+  uint8_t GetBitFrameSdd() const {
+    _ASSERT_VALID(valid_);
+    return bit_frame_sdd_;
+  }
+
+  Technology GetTechnology() const { return Technology::NFC_A; }
+
+  RfPacketType GetPacketType() const { return RfPacketType::POLL_RESPONSE; }
+
+  std::string ToString() const { return ""; }
+
+  bool IsValid() const { return valid_; }
+
+  pdl::packet::slice bytes() const { return bytes_; }
+
+ protected:
+  explicit NfcAPollResponseView(RfPacketView const& parent)
+      : bytes_(parent.bytes_) {
+    valid_ = Parse(parent);
+  }
+
+  bool Parse(RfPacketView const& parent) {
+    // Check validity of parent packet.
+    if (!parent.IsValid()) {
+      return false;
     }
 
-    uint16_t GetSender() const {
-        _ASSERT_VALID(valid_);
-        return sender_;
-    }
-    
-    uint16_t GetReceiver() const {
-        _ASSERT_VALID(valid_);
-        return receiver_;
-    }
-    
-    Protocol GetProtocol() const {
-        _ASSERT_VALID(valid_);
-        return protocol_;
-    }
-    
-    BitRate GetBitrate() const {
-        _ASSERT_VALID(valid_);
-        return bitrate_;
-    }
-    
-    uint8_t GetPowerLevel() const {
-        _ASSERT_VALID(valid_);
-        return power_level_;
-    }
-    
-    std::vector<uint8_t> GetNfcid1() const {
-        _ASSERT_VALID(valid_);
-        pdl::packet::slice span = nfcid1_;
-        std::vector<uint8_t> elements;
-        while (span.size() >= 1) {
-            elements.push_back(span.read_le<uint8_t, 1>());
-        }
-        return elements;
-    }
-    
-    uint8_t GetIntProtocol() const {
-        _ASSERT_VALID(valid_);
-        return int_protocol_;
-    }
-    
-    uint8_t GetBitFrameSdd() const {
-        _ASSERT_VALID(valid_);
-        return bit_frame_sdd_;
-    }
-    
-    Technology GetTechnology() const {
-        return Technology::NFC_A;
-    }
-    
-    RfPacketType GetPacketType() const {
-        return RfPacketType::POLL_RESPONSE;
-    }
-    
-    
-    std::string ToString() const {
-        return "";
-    }
-    
+    // Copy parent field values.
+    sender_ = parent.sender_;
+    receiver_ = parent.receiver_;
+    protocol_ = parent.protocol_;
+    bitrate_ = parent.bitrate_;
+    power_level_ = parent.power_level_;
 
-    bool IsValid() const {
-        return valid_;
+    if (parent.technology_ != Technology::NFC_A) {
+      return false;
     }
 
-    pdl::packet::slice bytes() const {
-        return bytes_;
+    if (parent.packet_type_ != RfPacketType::POLL_RESPONSE) {
+      return false;
     }
 
-protected:
-    explicit NfcAPollResponseView(RfPacketView const& parent)
-          : bytes_(parent.bytes_) {
-        valid_ = Parse(parent);
+    // Parse packet field values.
+    pdl::packet::slice span = parent.payload_;
+    uint8_t nfcid1_size;
+    if (span.size() < 1) {
+      return false;
     }
-
-    bool Parse(RfPacketView const& parent) {
-        // Check validity of parent packet.
-        if (!parent.IsValid()) {
-            return false;
-        }
-        
-        // Copy parent field values.
-        sender_ = parent.sender_;
-        receiver_ = parent.receiver_;
-        protocol_ = parent.protocol_;
-        bitrate_ = parent.bitrate_;
-        power_level_ = parent.power_level_;
-        
-        if (parent.technology_ != Technology::NFC_A) {
-            return false;
-        }
-        
-        if (parent.packet_type_ != RfPacketType::POLL_RESPONSE) {
-            return false;
-        }
-        
-        // Parse packet field values.
-        pdl::packet::slice span = parent.payload_;
-        uint8_t nfcid1_size;
-        if (span.size() < 1) {
-            return false;
-        }
-        nfcid1_size = span.read_le<uint8_t, 1>();
-        if (span.size() < nfcid1_size) {
-            return false;
-        }
-        nfcid1_ = span.subrange(0, nfcid1_size);
-        span.skip(nfcid1_size);
-        if (span.size() < 2) {
-            return false;
-        }
-        uint8_t chunk0 = span.read_le<uint8_t, 1>();
-        int_protocol_ = (chunk0 >> 0) & 0x3;
-        bit_frame_sdd_ = span.read_le<uint8_t, 1>();
-        return true;
+    nfcid1_size = span.read_le<uint8_t, 1>();
+    if (span.size() < nfcid1_size) {
+      return false;
     }
+    nfcid1_ = span.subrange(0, nfcid1_size);
+    span.skip(nfcid1_size);
+    if (span.size() < 2) {
+      return false;
+    }
+    uint8_t chunk0 = span.read_le<uint8_t, 1>();
+    int_protocol_ = (chunk0 >> 0) & 0x3;
+    bit_frame_sdd_ = span.read_le<uint8_t, 1>();
+    return true;
+  }
 
-    bool valid_{false};
-    pdl::packet::slice bytes_;
-    uint16_t sender_{0};
-    uint16_t receiver_{0};
-    Protocol protocol_{Protocol::UNDETERMINED};
-    BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
-    uint8_t power_level_{0};
-    pdl::packet::slice nfcid1_;
-    uint8_t int_protocol_{0};
-    uint8_t bit_frame_sdd_{0};
-
-    
+  bool valid_{false};
+  pdl::packet::slice bytes_;
+  uint16_t sender_{0};
+  uint16_t receiver_{0};
+  Protocol protocol_{Protocol::UNDETERMINED};
+  BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
+  uint8_t power_level_{0};
+  pdl::packet::slice nfcid1_;
+  uint8_t int_protocol_{0};
+  uint8_t bit_frame_sdd_{0};
 };
 
 class NfcAPollResponseBuilder : public RfPacketBuilder {
-public:
-    ~NfcAPollResponseBuilder() override = default;
-    NfcAPollResponseBuilder() = default;
-    NfcAPollResponseBuilder(NfcAPollResponseBuilder const&) = default;
-    NfcAPollResponseBuilder(NfcAPollResponseBuilder&&) = default;
-    NfcAPollResponseBuilder& operator=(NfcAPollResponseBuilder const&) = default;
-        NfcAPollResponseBuilder(uint16_t sender, uint16_t receiver, Protocol protocol, BitRate bitrate, uint8_t power_level, std::vector<uint8_t> nfcid1, uint8_t int_protocol, uint8_t bit_frame_sdd)
-        : RfPacketBuilder(sender, receiver, Technology::NFC_A, protocol, RfPacketType::POLL_RESPONSE, bitrate, power_level, std::vector<uint8_t>{}), nfcid1_(std::move(nfcid1)), int_protocol_(int_protocol), bit_frame_sdd_(bit_frame_sdd) {
-    
-}
-    static std::unique_ptr<NfcAPollResponseBuilder> Create(uint16_t sender, uint16_t receiver, Protocol protocol, BitRate bitrate, uint8_t power_level, std::vector<uint8_t> nfcid1, uint8_t int_protocol, uint8_t bit_frame_sdd) {
-    return std::make_unique<NfcAPollResponseBuilder>(sender, receiver, protocol, bitrate, power_level, std::move(nfcid1), int_protocol, bit_frame_sdd);
-}
+ public:
+  ~NfcAPollResponseBuilder() override = default;
+  NfcAPollResponseBuilder() = default;
+  NfcAPollResponseBuilder(NfcAPollResponseBuilder const&) = default;
+  NfcAPollResponseBuilder(NfcAPollResponseBuilder&&) = default;
+  NfcAPollResponseBuilder& operator=(NfcAPollResponseBuilder const&) = default;
+  NfcAPollResponseBuilder(uint16_t sender, uint16_t receiver, Protocol protocol,
+                          BitRate bitrate, uint8_t power_level,
+                          std::vector<uint8_t> nfcid1, uint8_t int_protocol,
+                          uint8_t bit_frame_sdd)
+      : RfPacketBuilder(sender, receiver, Technology::NFC_A, protocol,
+                        RfPacketType::POLL_RESPONSE, bitrate, power_level,
+                        std::vector<uint8_t>{}),
+        nfcid1_(std::move(nfcid1)),
+        int_protocol_(int_protocol),
+        bit_frame_sdd_(bit_frame_sdd) {}
+  static std::unique_ptr<NfcAPollResponseBuilder> Create(
+      uint16_t sender, uint16_t receiver, Protocol protocol, BitRate bitrate,
+      uint8_t power_level, std::vector<uint8_t> nfcid1, uint8_t int_protocol,
+      uint8_t bit_frame_sdd) {
+    return std::make_unique<NfcAPollResponseBuilder>(
+        sender, receiver, protocol, bitrate, power_level, std::move(nfcid1),
+        int_protocol, bit_frame_sdd);
+  }
 
-    void Serialize(std::vector<uint8_t>& output) const override {
-        pdl::packet::Builder::write_le<uint16_t, 2>(output, (static_cast<uint16_t>(sender_ & 0xffff) << 0));
-        pdl::packet::Builder::write_le<uint16_t, 2>(output, (static_cast<uint16_t>(receiver_ & 0xffff) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(Technology::NFC_A) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(protocol_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(RfPacketType::POLL_RESPONSE) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(bitrate_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(power_level_ & 0xff) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(GetNfcid1Size()) << 0));
-        output.insert(output.end(), nfcid1_.begin(), nfcid1_.end());
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(int_protocol_ & 0x3) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(bit_frame_sdd_ & 0xff) << 0));
-    }
+  void Serialize(std::vector<uint8_t>& output) const override {
+    pdl::packet::Builder::write_le<uint16_t, 2>(
+        output, (static_cast<uint16_t>(sender_ & 0xffff) << 0));
+    pdl::packet::Builder::write_le<uint16_t, 2>(
+        output, (static_cast<uint16_t>(receiver_ & 0xffff) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(Technology::NFC_A) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(protocol_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(RfPacketType::POLL_RESPONSE) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(bitrate_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(power_level_ & 0xff) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(GetNfcid1Size()) << 0));
+    output.insert(output.end(), nfcid1_.begin(), nfcid1_.end());
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(int_protocol_ & 0x3) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(bit_frame_sdd_ & 0xff) << 0));
+  }
 
-    size_t GetSize() const override {
-        return GetNfcid1Size() + 12;
-    }
+  size_t GetSize() const override { return GetNfcid1Size() + 12; }
 
-    size_t GetNfcid1Size() const {
-        return nfcid1_.size() * 1;
-    }
-    
-    std::vector<uint8_t> nfcid1_;
-    uint8_t int_protocol_{0};
-    uint8_t bit_frame_sdd_{0};
+  size_t GetNfcid1Size() const { return nfcid1_.size() * 1; }
+
+  std::vector<uint8_t> nfcid1_;
+  uint8_t int_protocol_{0};
+  uint8_t bit_frame_sdd_{0};
 };
 
 class T4ATSelectCommandView {
-public:
-    static T4ATSelectCommandView Create(RfPacketView const& parent) {
-        return T4ATSelectCommandView(parent);
+ public:
+  static T4ATSelectCommandView Create(RfPacketView const& parent) {
+    return T4ATSelectCommandView(parent);
+  }
+
+  uint16_t GetSender() const {
+    _ASSERT_VALID(valid_);
+    return sender_;
+  }
+
+  uint16_t GetReceiver() const {
+    _ASSERT_VALID(valid_);
+    return receiver_;
+  }
+
+  BitRate GetBitrate() const {
+    _ASSERT_VALID(valid_);
+    return bitrate_;
+  }
+
+  uint8_t GetPowerLevel() const {
+    _ASSERT_VALID(valid_);
+    return power_level_;
+  }
+
+  uint8_t GetParam() const {
+    _ASSERT_VALID(valid_);
+    return param_;
+  }
+
+  Technology GetTechnology() const { return Technology::NFC_A; }
+
+  Protocol GetProtocol() const { return Protocol::ISO_DEP; }
+
+  RfPacketType GetPacketType() const { return RfPacketType::SELECT_COMMAND; }
+
+  std::string ToString() const { return ""; }
+
+  bool IsValid() const { return valid_; }
+
+  pdl::packet::slice bytes() const { return bytes_; }
+
+ protected:
+  explicit T4ATSelectCommandView(RfPacketView const& parent)
+      : bytes_(parent.bytes_) {
+    valid_ = Parse(parent);
+  }
+
+  bool Parse(RfPacketView const& parent) {
+    // Check validity of parent packet.
+    if (!parent.IsValid()) {
+      return false;
     }
 
-    uint16_t GetSender() const {
-        _ASSERT_VALID(valid_);
-        return sender_;
-    }
-    
-    uint16_t GetReceiver() const {
-        _ASSERT_VALID(valid_);
-        return receiver_;
-    }
-    
-    BitRate GetBitrate() const {
-        _ASSERT_VALID(valid_);
-        return bitrate_;
-    }
-    
-    uint8_t GetPowerLevel() const {
-        _ASSERT_VALID(valid_);
-        return power_level_;
-    }
-    
-    uint8_t GetParam() const {
-        _ASSERT_VALID(valid_);
-        return param_;
-    }
-    
-    Technology GetTechnology() const {
-        return Technology::NFC_A;
-    }
-    
-    Protocol GetProtocol() const {
-        return Protocol::ISO_DEP;
-    }
-    
-    RfPacketType GetPacketType() const {
-        return RfPacketType::SELECT_COMMAND;
-    }
-    
-    
-    std::string ToString() const {
-        return "";
-    }
-    
+    // Copy parent field values.
+    sender_ = parent.sender_;
+    receiver_ = parent.receiver_;
+    bitrate_ = parent.bitrate_;
+    power_level_ = parent.power_level_;
 
-    bool IsValid() const {
-        return valid_;
+    if (parent.technology_ != Technology::NFC_A) {
+      return false;
     }
 
-    pdl::packet::slice bytes() const {
-        return bytes_;
+    if (parent.protocol_ != Protocol::ISO_DEP) {
+      return false;
     }
 
-protected:
-    explicit T4ATSelectCommandView(RfPacketView const& parent)
-          : bytes_(parent.bytes_) {
-        valid_ = Parse(parent);
+    if (parent.packet_type_ != RfPacketType::SELECT_COMMAND) {
+      return false;
     }
 
-    bool Parse(RfPacketView const& parent) {
-        // Check validity of parent packet.
-        if (!parent.IsValid()) {
-            return false;
-        }
-        
-        // Copy parent field values.
-        sender_ = parent.sender_;
-        receiver_ = parent.receiver_;
-        bitrate_ = parent.bitrate_;
-        power_level_ = parent.power_level_;
-        
-        if (parent.technology_ != Technology::NFC_A) {
-            return false;
-        }
-        
-        if (parent.protocol_ != Protocol::ISO_DEP) {
-            return false;
-        }
-        
-        if (parent.packet_type_ != RfPacketType::SELECT_COMMAND) {
-            return false;
-        }
-        
-        // Parse packet field values.
-        pdl::packet::slice span = parent.payload_;
-        if (span.size() < 1) {
-            return false;
-        }
-        param_ = span.read_le<uint8_t, 1>();
-        return true;
+    // Parse packet field values.
+    pdl::packet::slice span = parent.payload_;
+    if (span.size() < 1) {
+      return false;
     }
+    param_ = span.read_le<uint8_t, 1>();
+    return true;
+  }
 
-    bool valid_{false};
-    pdl::packet::slice bytes_;
-    uint16_t sender_{0};
-    uint16_t receiver_{0};
-    BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
-    uint8_t power_level_{0};
-    uint8_t param_{0};
-
-    
+  bool valid_{false};
+  pdl::packet::slice bytes_;
+  uint16_t sender_{0};
+  uint16_t receiver_{0};
+  BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
+  uint8_t power_level_{0};
+  uint8_t param_{0};
 };
 
 class T4ATSelectCommandBuilder : public RfPacketBuilder {
-public:
-    ~T4ATSelectCommandBuilder() override = default;
-    T4ATSelectCommandBuilder() = default;
-    T4ATSelectCommandBuilder(T4ATSelectCommandBuilder const&) = default;
-    T4ATSelectCommandBuilder(T4ATSelectCommandBuilder&&) = default;
-    T4ATSelectCommandBuilder& operator=(T4ATSelectCommandBuilder const&) = default;
-        T4ATSelectCommandBuilder(uint16_t sender, uint16_t receiver, BitRate bitrate, uint8_t power_level, uint8_t param)
-        : RfPacketBuilder(sender, receiver, Technology::NFC_A, Protocol::ISO_DEP, RfPacketType::SELECT_COMMAND, bitrate, power_level, std::vector<uint8_t>{}), param_(param) {
-    
-}
-    static std::unique_ptr<T4ATSelectCommandBuilder> Create(uint16_t sender, uint16_t receiver, BitRate bitrate, uint8_t power_level, uint8_t param) {
-    return std::make_unique<T4ATSelectCommandBuilder>(sender, receiver, bitrate, power_level, param);
-}
+ public:
+  ~T4ATSelectCommandBuilder() override = default;
+  T4ATSelectCommandBuilder() = default;
+  T4ATSelectCommandBuilder(T4ATSelectCommandBuilder const&) = default;
+  T4ATSelectCommandBuilder(T4ATSelectCommandBuilder&&) = default;
+  T4ATSelectCommandBuilder& operator=(T4ATSelectCommandBuilder const&) =
+      default;
+  T4ATSelectCommandBuilder(uint16_t sender, uint16_t receiver, BitRate bitrate,
+                           uint8_t power_level, uint8_t param)
+      : RfPacketBuilder(sender, receiver, Technology::NFC_A, Protocol::ISO_DEP,
+                        RfPacketType::SELECT_COMMAND, bitrate, power_level,
+                        std::vector<uint8_t>{}),
+        param_(param) {}
+  static std::unique_ptr<T4ATSelectCommandBuilder> Create(uint16_t sender,
+                                                          uint16_t receiver,
+                                                          BitRate bitrate,
+                                                          uint8_t power_level,
+                                                          uint8_t param) {
+    return std::make_unique<T4ATSelectCommandBuilder>(sender, receiver, bitrate,
+                                                      power_level, param);
+  }
 
-    void Serialize(std::vector<uint8_t>& output) const override {
-        pdl::packet::Builder::write_le<uint16_t, 2>(output, (static_cast<uint16_t>(sender_ & 0xffff) << 0));
-        pdl::packet::Builder::write_le<uint16_t, 2>(output, (static_cast<uint16_t>(receiver_ & 0xffff) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(Technology::NFC_A) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(Protocol::ISO_DEP) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(RfPacketType::SELECT_COMMAND) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(bitrate_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(power_level_ & 0xff) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(param_ & 0xff) << 0));
-    }
+  void Serialize(std::vector<uint8_t>& output) const override {
+    pdl::packet::Builder::write_le<uint16_t, 2>(
+        output, (static_cast<uint16_t>(sender_ & 0xffff) << 0));
+    pdl::packet::Builder::write_le<uint16_t, 2>(
+        output, (static_cast<uint16_t>(receiver_ & 0xffff) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(Technology::NFC_A) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(Protocol::ISO_DEP) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(RfPacketType::SELECT_COMMAND) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(bitrate_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(power_level_ & 0xff) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(param_ & 0xff) << 0));
+  }
 
-    size_t GetSize() const override {
-        return 10;
-    }
+  size_t GetSize() const override { return 10; }
 
-    
-    uint8_t param_{0};
+  uint8_t param_{0};
 };
 
 class T4ATSelectResponseView {
-public:
-    static T4ATSelectResponseView Create(RfPacketView const& parent) {
-        return T4ATSelectResponseView(parent);
+ public:
+  static T4ATSelectResponseView Create(RfPacketView const& parent) {
+    return T4ATSelectResponseView(parent);
+  }
+
+  uint16_t GetSender() const {
+    _ASSERT_VALID(valid_);
+    return sender_;
+  }
+
+  uint16_t GetReceiver() const {
+    _ASSERT_VALID(valid_);
+    return receiver_;
+  }
+
+  BitRate GetBitrate() const {
+    _ASSERT_VALID(valid_);
+    return bitrate_;
+  }
+
+  uint8_t GetPowerLevel() const {
+    _ASSERT_VALID(valid_);
+    return power_level_;
+  }
+
+  std::vector<uint8_t> GetRatsResponse() const {
+    _ASSERT_VALID(valid_);
+    pdl::packet::slice span = rats_response_;
+    std::vector<uint8_t> elements;
+    while (span.size() >= 1) {
+      elements.push_back(span.read_le<uint8_t, 1>());
+    }
+    return elements;
+  }
+
+  Technology GetTechnology() const { return Technology::NFC_A; }
+
+  Protocol GetProtocol() const { return Protocol::ISO_DEP; }
+
+  RfPacketType GetPacketType() const { return RfPacketType::SELECT_RESPONSE; }
+
+  std::string ToString() const { return ""; }
+
+  bool IsValid() const { return valid_; }
+
+  pdl::packet::slice bytes() const { return bytes_; }
+
+ protected:
+  explicit T4ATSelectResponseView(RfPacketView const& parent)
+      : bytes_(parent.bytes_) {
+    valid_ = Parse(parent);
+  }
+
+  bool Parse(RfPacketView const& parent) {
+    // Check validity of parent packet.
+    if (!parent.IsValid()) {
+      return false;
     }
 
-    uint16_t GetSender() const {
-        _ASSERT_VALID(valid_);
-        return sender_;
-    }
-    
-    uint16_t GetReceiver() const {
-        _ASSERT_VALID(valid_);
-        return receiver_;
-    }
-    
-    BitRate GetBitrate() const {
-        _ASSERT_VALID(valid_);
-        return bitrate_;
-    }
-    
-    uint8_t GetPowerLevel() const {
-        _ASSERT_VALID(valid_);
-        return power_level_;
-    }
-    
-    std::vector<uint8_t> GetRatsResponse() const {
-        _ASSERT_VALID(valid_);
-        pdl::packet::slice span = rats_response_;
-        std::vector<uint8_t> elements;
-        while (span.size() >= 1) {
-            elements.push_back(span.read_le<uint8_t, 1>());
-        }
-        return elements;
-    }
-    
-    Technology GetTechnology() const {
-        return Technology::NFC_A;
-    }
-    
-    Protocol GetProtocol() const {
-        return Protocol::ISO_DEP;
-    }
-    
-    RfPacketType GetPacketType() const {
-        return RfPacketType::SELECT_RESPONSE;
-    }
-    
-    
-    std::string ToString() const {
-        return "";
-    }
-    
+    // Copy parent field values.
+    sender_ = parent.sender_;
+    receiver_ = parent.receiver_;
+    bitrate_ = parent.bitrate_;
+    power_level_ = parent.power_level_;
 
-    bool IsValid() const {
-        return valid_;
+    if (parent.technology_ != Technology::NFC_A) {
+      return false;
     }
 
-    pdl::packet::slice bytes() const {
-        return bytes_;
+    if (parent.protocol_ != Protocol::ISO_DEP) {
+      return false;
     }
 
-protected:
-    explicit T4ATSelectResponseView(RfPacketView const& parent)
-          : bytes_(parent.bytes_) {
-        valid_ = Parse(parent);
+    if (parent.packet_type_ != RfPacketType::SELECT_RESPONSE) {
+      return false;
     }
 
-    bool Parse(RfPacketView const& parent) {
-        // Check validity of parent packet.
-        if (!parent.IsValid()) {
-            return false;
-        }
-        
-        // Copy parent field values.
-        sender_ = parent.sender_;
-        receiver_ = parent.receiver_;
-        bitrate_ = parent.bitrate_;
-        power_level_ = parent.power_level_;
-        
-        if (parent.technology_ != Technology::NFC_A) {
-            return false;
-        }
-        
-        if (parent.protocol_ != Protocol::ISO_DEP) {
-            return false;
-        }
-        
-        if (parent.packet_type_ != RfPacketType::SELECT_RESPONSE) {
-            return false;
-        }
-        
-        // Parse packet field values.
-        pdl::packet::slice span = parent.payload_;
-        uint8_t rats_response_size;
-        if (span.size() < 1) {
-            return false;
-        }
-        rats_response_size = span.read_le<uint8_t, 1>();
-        if (span.size() < rats_response_size) {
-            return false;
-        }
-        rats_response_ = span.subrange(0, rats_response_size);
-        span.skip(rats_response_size);
-        return true;
+    // Parse packet field values.
+    pdl::packet::slice span = parent.payload_;
+    uint8_t rats_response_size;
+    if (span.size() < 1) {
+      return false;
     }
+    rats_response_size = span.read_le<uint8_t, 1>();
+    if (span.size() < rats_response_size) {
+      return false;
+    }
+    rats_response_ = span.subrange(0, rats_response_size);
+    span.skip(rats_response_size);
+    return true;
+  }
 
-    bool valid_{false};
-    pdl::packet::slice bytes_;
-    uint16_t sender_{0};
-    uint16_t receiver_{0};
-    BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
-    uint8_t power_level_{0};
-    pdl::packet::slice rats_response_;
-
-    
+  bool valid_{false};
+  pdl::packet::slice bytes_;
+  uint16_t sender_{0};
+  uint16_t receiver_{0};
+  BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
+  uint8_t power_level_{0};
+  pdl::packet::slice rats_response_;
 };
 
 class T4ATSelectResponseBuilder : public RfPacketBuilder {
-public:
-    ~T4ATSelectResponseBuilder() override = default;
-    T4ATSelectResponseBuilder() = default;
-    T4ATSelectResponseBuilder(T4ATSelectResponseBuilder const&) = default;
-    T4ATSelectResponseBuilder(T4ATSelectResponseBuilder&&) = default;
-    T4ATSelectResponseBuilder& operator=(T4ATSelectResponseBuilder const&) = default;
-        T4ATSelectResponseBuilder(uint16_t sender, uint16_t receiver, BitRate bitrate, uint8_t power_level, std::vector<uint8_t> rats_response)
-        : RfPacketBuilder(sender, receiver, Technology::NFC_A, Protocol::ISO_DEP, RfPacketType::SELECT_RESPONSE, bitrate, power_level, std::vector<uint8_t>{}), rats_response_(std::move(rats_response)) {
-    
-}
-    static std::unique_ptr<T4ATSelectResponseBuilder> Create(uint16_t sender, uint16_t receiver, BitRate bitrate, uint8_t power_level, std::vector<uint8_t> rats_response) {
-    return std::make_unique<T4ATSelectResponseBuilder>(sender, receiver, bitrate, power_level, std::move(rats_response));
-}
+ public:
+  ~T4ATSelectResponseBuilder() override = default;
+  T4ATSelectResponseBuilder() = default;
+  T4ATSelectResponseBuilder(T4ATSelectResponseBuilder const&) = default;
+  T4ATSelectResponseBuilder(T4ATSelectResponseBuilder&&) = default;
+  T4ATSelectResponseBuilder& operator=(T4ATSelectResponseBuilder const&) =
+      default;
+  T4ATSelectResponseBuilder(uint16_t sender, uint16_t receiver, BitRate bitrate,
+                            uint8_t power_level,
+                            std::vector<uint8_t> rats_response)
+      : RfPacketBuilder(sender, receiver, Technology::NFC_A, Protocol::ISO_DEP,
+                        RfPacketType::SELECT_RESPONSE, bitrate, power_level,
+                        std::vector<uint8_t>{}),
+        rats_response_(std::move(rats_response)) {}
+  static std::unique_ptr<T4ATSelectResponseBuilder> Create(
+      uint16_t sender, uint16_t receiver, BitRate bitrate, uint8_t power_level,
+      std::vector<uint8_t> rats_response) {
+    return std::make_unique<T4ATSelectResponseBuilder>(
+        sender, receiver, bitrate, power_level, std::move(rats_response));
+  }
 
-    void Serialize(std::vector<uint8_t>& output) const override {
-        pdl::packet::Builder::write_le<uint16_t, 2>(output, (static_cast<uint16_t>(sender_ & 0xffff) << 0));
-        pdl::packet::Builder::write_le<uint16_t, 2>(output, (static_cast<uint16_t>(receiver_ & 0xffff) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(Technology::NFC_A) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(Protocol::ISO_DEP) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(RfPacketType::SELECT_RESPONSE) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(bitrate_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(power_level_ & 0xff) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(GetRatsResponseSize()) << 0));
-        output.insert(output.end(), rats_response_.begin(), rats_response_.end());
-    }
+  void Serialize(std::vector<uint8_t>& output) const override {
+    pdl::packet::Builder::write_le<uint16_t, 2>(
+        output, (static_cast<uint16_t>(sender_ & 0xffff) << 0));
+    pdl::packet::Builder::write_le<uint16_t, 2>(
+        output, (static_cast<uint16_t>(receiver_ & 0xffff) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(Technology::NFC_A) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(Protocol::ISO_DEP) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(RfPacketType::SELECT_RESPONSE) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(bitrate_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(power_level_ & 0xff) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(GetRatsResponseSize()) << 0));
+    output.insert(output.end(), rats_response_.begin(), rats_response_.end());
+  }
 
-    size_t GetSize() const override {
-        return GetRatsResponseSize() + 10;
-    }
+  size_t GetSize() const override { return GetRatsResponseSize() + 10; }
 
-    size_t GetRatsResponseSize() const {
-        return rats_response_.size() * 1;
-    }
-    
-    std::vector<uint8_t> rats_response_;
+  size_t GetRatsResponseSize() const { return rats_response_.size() * 1; }
+
+  std::vector<uint8_t> rats_response_;
 };
 
 class NfcDepSelectCommandView {
-public:
-    static NfcDepSelectCommandView Create(RfPacketView const& parent) {
-        return NfcDepSelectCommandView(parent);
+ public:
+  static NfcDepSelectCommandView Create(RfPacketView const& parent) {
+    return NfcDepSelectCommandView(parent);
+  }
+
+  uint16_t GetSender() const {
+    _ASSERT_VALID(valid_);
+    return sender_;
+  }
+
+  uint16_t GetReceiver() const {
+    _ASSERT_VALID(valid_);
+    return receiver_;
+  }
+
+  Technology GetTechnology() const {
+    _ASSERT_VALID(valid_);
+    return technology_;
+  }
+
+  BitRate GetBitrate() const {
+    _ASSERT_VALID(valid_);
+    return bitrate_;
+  }
+
+  uint8_t GetPowerLevel() const {
+    _ASSERT_VALID(valid_);
+    return power_level_;
+  }
+
+  uint8_t GetLr() const {
+    _ASSERT_VALID(valid_);
+    return lr_;
+  }
+
+  Protocol GetProtocol() const { return Protocol::NFC_DEP; }
+
+  RfPacketType GetPacketType() const { return RfPacketType::SELECT_COMMAND; }
+
+  std::string ToString() const { return ""; }
+
+  bool IsValid() const { return valid_; }
+
+  pdl::packet::slice bytes() const { return bytes_; }
+
+ protected:
+  explicit NfcDepSelectCommandView(RfPacketView const& parent)
+      : bytes_(parent.bytes_) {
+    valid_ = Parse(parent);
+  }
+
+  bool Parse(RfPacketView const& parent) {
+    // Check validity of parent packet.
+    if (!parent.IsValid()) {
+      return false;
     }
 
-    uint16_t GetSender() const {
-        _ASSERT_VALID(valid_);
-        return sender_;
-    }
-    
-    uint16_t GetReceiver() const {
-        _ASSERT_VALID(valid_);
-        return receiver_;
-    }
-    
-    Technology GetTechnology() const {
-        _ASSERT_VALID(valid_);
-        return technology_;
-    }
-    
-    BitRate GetBitrate() const {
-        _ASSERT_VALID(valid_);
-        return bitrate_;
-    }
-    
-    uint8_t GetPowerLevel() const {
-        _ASSERT_VALID(valid_);
-        return power_level_;
-    }
-    
-    uint8_t GetLr() const {
-        _ASSERT_VALID(valid_);
-        return lr_;
-    }
-    
-    Protocol GetProtocol() const {
-        return Protocol::NFC_DEP;
-    }
-    
-    RfPacketType GetPacketType() const {
-        return RfPacketType::SELECT_COMMAND;
-    }
-    
-    
-    std::string ToString() const {
-        return "";
-    }
-    
+    // Copy parent field values.
+    sender_ = parent.sender_;
+    receiver_ = parent.receiver_;
+    technology_ = parent.technology_;
+    bitrate_ = parent.bitrate_;
+    power_level_ = parent.power_level_;
 
-    bool IsValid() const {
-        return valid_;
+    if (parent.protocol_ != Protocol::NFC_DEP) {
+      return false;
     }
 
-    pdl::packet::slice bytes() const {
-        return bytes_;
+    if (parent.packet_type_ != RfPacketType::SELECT_COMMAND) {
+      return false;
     }
 
-protected:
-    explicit NfcDepSelectCommandView(RfPacketView const& parent)
-          : bytes_(parent.bytes_) {
-        valid_ = Parse(parent);
+    // Parse packet field values.
+    pdl::packet::slice span = parent.payload_;
+    if (span.size() < 1) {
+      return false;
     }
+    uint8_t chunk0 = span.read_le<uint8_t, 1>();
+    lr_ = (chunk0 >> 0) & 0x3;
+    return true;
+  }
 
-    bool Parse(RfPacketView const& parent) {
-        // Check validity of parent packet.
-        if (!parent.IsValid()) {
-            return false;
-        }
-        
-        // Copy parent field values.
-        sender_ = parent.sender_;
-        receiver_ = parent.receiver_;
-        technology_ = parent.technology_;
-        bitrate_ = parent.bitrate_;
-        power_level_ = parent.power_level_;
-        
-        if (parent.protocol_ != Protocol::NFC_DEP) {
-            return false;
-        }
-        
-        if (parent.packet_type_ != RfPacketType::SELECT_COMMAND) {
-            return false;
-        }
-        
-        // Parse packet field values.
-        pdl::packet::slice span = parent.payload_;
-        if (span.size() < 1) {
-            return false;
-        }
-        uint8_t chunk0 = span.read_le<uint8_t, 1>();
-        lr_ = (chunk0 >> 0) & 0x3;
-        return true;
-    }
-
-    bool valid_{false};
-    pdl::packet::slice bytes_;
-    uint16_t sender_{0};
-    uint16_t receiver_{0};
-    Technology technology_{Technology::NFC_A};
-    BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
-    uint8_t power_level_{0};
-    uint8_t lr_{0};
-
-    
+  bool valid_{false};
+  pdl::packet::slice bytes_;
+  uint16_t sender_{0};
+  uint16_t receiver_{0};
+  Technology technology_{Technology::NFC_A};
+  BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
+  uint8_t power_level_{0};
+  uint8_t lr_{0};
 };
 
 class NfcDepSelectCommandBuilder : public RfPacketBuilder {
-public:
-    ~NfcDepSelectCommandBuilder() override = default;
-    NfcDepSelectCommandBuilder() = default;
-    NfcDepSelectCommandBuilder(NfcDepSelectCommandBuilder const&) = default;
-    NfcDepSelectCommandBuilder(NfcDepSelectCommandBuilder&&) = default;
-    NfcDepSelectCommandBuilder& operator=(NfcDepSelectCommandBuilder const&) = default;
-        NfcDepSelectCommandBuilder(uint16_t sender, uint16_t receiver, Technology technology, BitRate bitrate, uint8_t power_level, uint8_t lr)
-        : RfPacketBuilder(sender, receiver, technology, Protocol::NFC_DEP, RfPacketType::SELECT_COMMAND, bitrate, power_level, std::vector<uint8_t>{}), lr_(lr) {
-    
-}
-    static std::unique_ptr<NfcDepSelectCommandBuilder> Create(uint16_t sender, uint16_t receiver, Technology technology, BitRate bitrate, uint8_t power_level, uint8_t lr) {
-    return std::make_unique<NfcDepSelectCommandBuilder>(sender, receiver, technology, bitrate, power_level, lr);
-}
+ public:
+  ~NfcDepSelectCommandBuilder() override = default;
+  NfcDepSelectCommandBuilder() = default;
+  NfcDepSelectCommandBuilder(NfcDepSelectCommandBuilder const&) = default;
+  NfcDepSelectCommandBuilder(NfcDepSelectCommandBuilder&&) = default;
+  NfcDepSelectCommandBuilder& operator=(NfcDepSelectCommandBuilder const&) =
+      default;
+  NfcDepSelectCommandBuilder(uint16_t sender, uint16_t receiver,
+                             Technology technology, BitRate bitrate,
+                             uint8_t power_level, uint8_t lr)
+      : RfPacketBuilder(sender, receiver, technology, Protocol::NFC_DEP,
+                        RfPacketType::SELECT_COMMAND, bitrate, power_level,
+                        std::vector<uint8_t>{}),
+        lr_(lr) {}
+  static std::unique_ptr<NfcDepSelectCommandBuilder> Create(
+      uint16_t sender, uint16_t receiver, Technology technology,
+      BitRate bitrate, uint8_t power_level, uint8_t lr) {
+    return std::make_unique<NfcDepSelectCommandBuilder>(
+        sender, receiver, technology, bitrate, power_level, lr);
+  }
 
-    void Serialize(std::vector<uint8_t>& output) const override {
-        pdl::packet::Builder::write_le<uint16_t, 2>(output, (static_cast<uint16_t>(sender_ & 0xffff) << 0));
-        pdl::packet::Builder::write_le<uint16_t, 2>(output, (static_cast<uint16_t>(receiver_ & 0xffff) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(technology_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(Protocol::NFC_DEP) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(RfPacketType::SELECT_COMMAND) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(bitrate_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(power_level_ & 0xff) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(lr_ & 0x3) << 0));
-    }
+  void Serialize(std::vector<uint8_t>& output) const override {
+    pdl::packet::Builder::write_le<uint16_t, 2>(
+        output, (static_cast<uint16_t>(sender_ & 0xffff) << 0));
+    pdl::packet::Builder::write_le<uint16_t, 2>(
+        output, (static_cast<uint16_t>(receiver_ & 0xffff) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(technology_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(Protocol::NFC_DEP) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(RfPacketType::SELECT_COMMAND) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(bitrate_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(power_level_ & 0xff) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(lr_ & 0x3) << 0));
+  }
 
-    size_t GetSize() const override {
-        return 10;
-    }
+  size_t GetSize() const override { return 10; }
 
-    
-    uint8_t lr_{0};
+  uint8_t lr_{0};
 };
 
 class NfcDepSelectResponseView {
-public:
-    static NfcDepSelectResponseView Create(RfPacketView const& parent) {
-        return NfcDepSelectResponseView(parent);
+ public:
+  static NfcDepSelectResponseView Create(RfPacketView const& parent) {
+    return NfcDepSelectResponseView(parent);
+  }
+
+  uint16_t GetSender() const {
+    _ASSERT_VALID(valid_);
+    return sender_;
+  }
+
+  uint16_t GetReceiver() const {
+    _ASSERT_VALID(valid_);
+    return receiver_;
+  }
+
+  Technology GetTechnology() const {
+    _ASSERT_VALID(valid_);
+    return technology_;
+  }
+
+  BitRate GetBitrate() const {
+    _ASSERT_VALID(valid_);
+    return bitrate_;
+  }
+
+  uint8_t GetPowerLevel() const {
+    _ASSERT_VALID(valid_);
+    return power_level_;
+  }
+
+  std::vector<uint8_t> GetAtrResponse() const {
+    _ASSERT_VALID(valid_);
+    pdl::packet::slice span = atr_response_;
+    std::vector<uint8_t> elements;
+    while (span.size() >= 1) {
+      elements.push_back(span.read_le<uint8_t, 1>());
+    }
+    return elements;
+  }
+
+  Protocol GetProtocol() const { return Protocol::NFC_DEP; }
+
+  RfPacketType GetPacketType() const { return RfPacketType::SELECT_RESPONSE; }
+
+  std::string ToString() const { return ""; }
+
+  bool IsValid() const { return valid_; }
+
+  pdl::packet::slice bytes() const { return bytes_; }
+
+ protected:
+  explicit NfcDepSelectResponseView(RfPacketView const& parent)
+      : bytes_(parent.bytes_) {
+    valid_ = Parse(parent);
+  }
+
+  bool Parse(RfPacketView const& parent) {
+    // Check validity of parent packet.
+    if (!parent.IsValid()) {
+      return false;
     }
 
-    uint16_t GetSender() const {
-        _ASSERT_VALID(valid_);
-        return sender_;
-    }
-    
-    uint16_t GetReceiver() const {
-        _ASSERT_VALID(valid_);
-        return receiver_;
-    }
-    
-    Technology GetTechnology() const {
-        _ASSERT_VALID(valid_);
-        return technology_;
-    }
-    
-    BitRate GetBitrate() const {
-        _ASSERT_VALID(valid_);
-        return bitrate_;
-    }
-    
-    uint8_t GetPowerLevel() const {
-        _ASSERT_VALID(valid_);
-        return power_level_;
-    }
-    
-    std::vector<uint8_t> GetAtrResponse() const {
-        _ASSERT_VALID(valid_);
-        pdl::packet::slice span = atr_response_;
-        std::vector<uint8_t> elements;
-        while (span.size() >= 1) {
-            elements.push_back(span.read_le<uint8_t, 1>());
-        }
-        return elements;
-    }
-    
-    Protocol GetProtocol() const {
-        return Protocol::NFC_DEP;
-    }
-    
-    RfPacketType GetPacketType() const {
-        return RfPacketType::SELECT_RESPONSE;
-    }
-    
-    
-    std::string ToString() const {
-        return "";
-    }
-    
+    // Copy parent field values.
+    sender_ = parent.sender_;
+    receiver_ = parent.receiver_;
+    technology_ = parent.technology_;
+    bitrate_ = parent.bitrate_;
+    power_level_ = parent.power_level_;
 
-    bool IsValid() const {
-        return valid_;
+    if (parent.protocol_ != Protocol::NFC_DEP) {
+      return false;
     }
 
-    pdl::packet::slice bytes() const {
-        return bytes_;
+    if (parent.packet_type_ != RfPacketType::SELECT_RESPONSE) {
+      return false;
     }
 
-protected:
-    explicit NfcDepSelectResponseView(RfPacketView const& parent)
-          : bytes_(parent.bytes_) {
-        valid_ = Parse(parent);
+    // Parse packet field values.
+    pdl::packet::slice span = parent.payload_;
+    uint8_t atr_response_size;
+    if (span.size() < 1) {
+      return false;
     }
-
-    bool Parse(RfPacketView const& parent) {
-        // Check validity of parent packet.
-        if (!parent.IsValid()) {
-            return false;
-        }
-        
-        // Copy parent field values.
-        sender_ = parent.sender_;
-        receiver_ = parent.receiver_;
-        technology_ = parent.technology_;
-        bitrate_ = parent.bitrate_;
-        power_level_ = parent.power_level_;
-        
-        if (parent.protocol_ != Protocol::NFC_DEP) {
-            return false;
-        }
-        
-        if (parent.packet_type_ != RfPacketType::SELECT_RESPONSE) {
-            return false;
-        }
-        
-        // Parse packet field values.
-        pdl::packet::slice span = parent.payload_;
-        uint8_t atr_response_size;
-        if (span.size() < 1) {
-            return false;
-        }
-        atr_response_size = span.read_le<uint8_t, 1>();
-        if (span.size() < atr_response_size) {
-            return false;
-        }
-        atr_response_ = span.subrange(0, atr_response_size);
-        span.skip(atr_response_size);
-        return true;
+    atr_response_size = span.read_le<uint8_t, 1>();
+    if (span.size() < atr_response_size) {
+      return false;
     }
+    atr_response_ = span.subrange(0, atr_response_size);
+    span.skip(atr_response_size);
+    return true;
+  }
 
-    bool valid_{false};
-    pdl::packet::slice bytes_;
-    uint16_t sender_{0};
-    uint16_t receiver_{0};
-    Technology technology_{Technology::NFC_A};
-    BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
-    uint8_t power_level_{0};
-    pdl::packet::slice atr_response_;
-
-    
+  bool valid_{false};
+  pdl::packet::slice bytes_;
+  uint16_t sender_{0};
+  uint16_t receiver_{0};
+  Technology technology_{Technology::NFC_A};
+  BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
+  uint8_t power_level_{0};
+  pdl::packet::slice atr_response_;
 };
 
 class NfcDepSelectResponseBuilder : public RfPacketBuilder {
-public:
-    ~NfcDepSelectResponseBuilder() override = default;
-    NfcDepSelectResponseBuilder() = default;
-    NfcDepSelectResponseBuilder(NfcDepSelectResponseBuilder const&) = default;
-    NfcDepSelectResponseBuilder(NfcDepSelectResponseBuilder&&) = default;
-    NfcDepSelectResponseBuilder& operator=(NfcDepSelectResponseBuilder const&) = default;
-        NfcDepSelectResponseBuilder(uint16_t sender, uint16_t receiver, Technology technology, BitRate bitrate, uint8_t power_level, std::vector<uint8_t> atr_response)
-        : RfPacketBuilder(sender, receiver, technology, Protocol::NFC_DEP, RfPacketType::SELECT_RESPONSE, bitrate, power_level, std::vector<uint8_t>{}), atr_response_(std::move(atr_response)) {
-    
-}
-    static std::unique_ptr<NfcDepSelectResponseBuilder> Create(uint16_t sender, uint16_t receiver, Technology technology, BitRate bitrate, uint8_t power_level, std::vector<uint8_t> atr_response) {
-    return std::make_unique<NfcDepSelectResponseBuilder>(sender, receiver, technology, bitrate, power_level, std::move(atr_response));
-}
+ public:
+  ~NfcDepSelectResponseBuilder() override = default;
+  NfcDepSelectResponseBuilder() = default;
+  NfcDepSelectResponseBuilder(NfcDepSelectResponseBuilder const&) = default;
+  NfcDepSelectResponseBuilder(NfcDepSelectResponseBuilder&&) = default;
+  NfcDepSelectResponseBuilder& operator=(NfcDepSelectResponseBuilder const&) =
+      default;
+  NfcDepSelectResponseBuilder(uint16_t sender, uint16_t receiver,
+                              Technology technology, BitRate bitrate,
+                              uint8_t power_level,
+                              std::vector<uint8_t> atr_response)
+      : RfPacketBuilder(sender, receiver, technology, Protocol::NFC_DEP,
+                        RfPacketType::SELECT_RESPONSE, bitrate, power_level,
+                        std::vector<uint8_t>{}),
+        atr_response_(std::move(atr_response)) {}
+  static std::unique_ptr<NfcDepSelectResponseBuilder> Create(
+      uint16_t sender, uint16_t receiver, Technology technology,
+      BitRate bitrate, uint8_t power_level, std::vector<uint8_t> atr_response) {
+    return std::make_unique<NfcDepSelectResponseBuilder>(
+        sender, receiver, technology, bitrate, power_level,
+        std::move(atr_response));
+  }
 
-    void Serialize(std::vector<uint8_t>& output) const override {
-        pdl::packet::Builder::write_le<uint16_t, 2>(output, (static_cast<uint16_t>(sender_ & 0xffff) << 0));
-        pdl::packet::Builder::write_le<uint16_t, 2>(output, (static_cast<uint16_t>(receiver_ & 0xffff) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(technology_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(Protocol::NFC_DEP) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(RfPacketType::SELECT_RESPONSE) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(bitrate_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(power_level_ & 0xff) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(GetAtrResponseSize()) << 0));
-        output.insert(output.end(), atr_response_.begin(), atr_response_.end());
-    }
+  void Serialize(std::vector<uint8_t>& output) const override {
+    pdl::packet::Builder::write_le<uint16_t, 2>(
+        output, (static_cast<uint16_t>(sender_ & 0xffff) << 0));
+    pdl::packet::Builder::write_le<uint16_t, 2>(
+        output, (static_cast<uint16_t>(receiver_ & 0xffff) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(technology_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(Protocol::NFC_DEP) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(RfPacketType::SELECT_RESPONSE) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(bitrate_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(power_level_ & 0xff) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(GetAtrResponseSize()) << 0));
+    output.insert(output.end(), atr_response_.begin(), atr_response_.end());
+  }
 
-    size_t GetSize() const override {
-        return GetAtrResponseSize() + 10;
-    }
+  size_t GetSize() const override { return GetAtrResponseSize() + 10; }
 
-    size_t GetAtrResponseSize() const {
-        return atr_response_.size() * 1;
-    }
-    
-    std::vector<uint8_t> atr_response_;
+  size_t GetAtrResponseSize() const { return atr_response_.size() * 1; }
+
+  std::vector<uint8_t> atr_response_;
 };
 
 class SelectCommandView {
-public:
-    static SelectCommandView Create(RfPacketView const& parent) {
-        return SelectCommandView(parent);
+ public:
+  static SelectCommandView Create(RfPacketView const& parent) {
+    return SelectCommandView(parent);
+  }
+
+  uint16_t GetSender() const {
+    _ASSERT_VALID(valid_);
+    return sender_;
+  }
+
+  uint16_t GetReceiver() const {
+    _ASSERT_VALID(valid_);
+    return receiver_;
+  }
+
+  Technology GetTechnology() const {
+    _ASSERT_VALID(valid_);
+    return technology_;
+  }
+
+  Protocol GetProtocol() const {
+    _ASSERT_VALID(valid_);
+    return protocol_;
+  }
+
+  BitRate GetBitrate() const {
+    _ASSERT_VALID(valid_);
+    return bitrate_;
+  }
+
+  uint8_t GetPowerLevel() const {
+    _ASSERT_VALID(valid_);
+    return power_level_;
+  }
+
+  RfPacketType GetPacketType() const { return RfPacketType::SELECT_COMMAND; }
+
+  std::string ToString() const { return ""; }
+
+  bool IsValid() const { return valid_; }
+
+  pdl::packet::slice bytes() const { return bytes_; }
+
+ protected:
+  explicit SelectCommandView(RfPacketView const& parent)
+      : bytes_(parent.bytes_) {
+    valid_ = Parse(parent);
+  }
+
+  bool Parse(RfPacketView const& parent) {
+    // Check validity of parent packet.
+    if (!parent.IsValid()) {
+      return false;
     }
 
-    uint16_t GetSender() const {
-        _ASSERT_VALID(valid_);
-        return sender_;
-    }
-    
-    uint16_t GetReceiver() const {
-        _ASSERT_VALID(valid_);
-        return receiver_;
-    }
-    
-    Technology GetTechnology() const {
-        _ASSERT_VALID(valid_);
-        return technology_;
-    }
-    
-    Protocol GetProtocol() const {
-        _ASSERT_VALID(valid_);
-        return protocol_;
-    }
-    
-    BitRate GetBitrate() const {
-        _ASSERT_VALID(valid_);
-        return bitrate_;
-    }
-    
-    uint8_t GetPowerLevel() const {
-        _ASSERT_VALID(valid_);
-        return power_level_;
-    }
-    
-    RfPacketType GetPacketType() const {
-        return RfPacketType::SELECT_COMMAND;
-    }
-    
-    
-    std::string ToString() const {
-        return "";
-    }
-    
+    // Copy parent field values.
+    sender_ = parent.sender_;
+    receiver_ = parent.receiver_;
+    technology_ = parent.technology_;
+    protocol_ = parent.protocol_;
+    bitrate_ = parent.bitrate_;
+    power_level_ = parent.power_level_;
 
-    bool IsValid() const {
-        return valid_;
+    if (parent.packet_type_ != RfPacketType::SELECT_COMMAND) {
+      return false;
     }
 
-    pdl::packet::slice bytes() const {
-        return bytes_;
-    }
+    return true;
+  }
 
-protected:
-    explicit SelectCommandView(RfPacketView const& parent)
-          : bytes_(parent.bytes_) {
-        valid_ = Parse(parent);
-    }
-
-    bool Parse(RfPacketView const& parent) {
-        // Check validity of parent packet.
-        if (!parent.IsValid()) {
-            return false;
-        }
-        
-        // Copy parent field values.
-        sender_ = parent.sender_;
-        receiver_ = parent.receiver_;
-        technology_ = parent.technology_;
-        protocol_ = parent.protocol_;
-        bitrate_ = parent.bitrate_;
-        power_level_ = parent.power_level_;
-        
-        if (parent.packet_type_ != RfPacketType::SELECT_COMMAND) {
-            return false;
-        }
-        
-        return true;
-    }
-
-    bool valid_{false};
-    pdl::packet::slice bytes_;
-    uint16_t sender_{0};
-    uint16_t receiver_{0};
-    Technology technology_{Technology::NFC_A};
-    Protocol protocol_{Protocol::UNDETERMINED};
-    BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
-    uint8_t power_level_{0};
-
-    
+  bool valid_{false};
+  pdl::packet::slice bytes_;
+  uint16_t sender_{0};
+  uint16_t receiver_{0};
+  Technology technology_{Technology::NFC_A};
+  Protocol protocol_{Protocol::UNDETERMINED};
+  BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
+  uint8_t power_level_{0};
 };
 
 class SelectCommandBuilder : public RfPacketBuilder {
-public:
-    ~SelectCommandBuilder() override = default;
-    SelectCommandBuilder() = default;
-    SelectCommandBuilder(SelectCommandBuilder const&) = default;
-    SelectCommandBuilder(SelectCommandBuilder&&) = default;
-    SelectCommandBuilder& operator=(SelectCommandBuilder const&) = default;
-        SelectCommandBuilder(uint16_t sender, uint16_t receiver, Technology technology, Protocol protocol, BitRate bitrate, uint8_t power_level)
-        : RfPacketBuilder(sender, receiver, technology, protocol, RfPacketType::SELECT_COMMAND, bitrate, power_level, std::vector<uint8_t>{}) {
-    
-}
-    static std::unique_ptr<SelectCommandBuilder> Create(uint16_t sender, uint16_t receiver, Technology technology, Protocol protocol, BitRate bitrate, uint8_t power_level) {
-    return std::make_unique<SelectCommandBuilder>(sender, receiver, technology, protocol, bitrate, power_level);
-}
+ public:
+  ~SelectCommandBuilder() override = default;
+  SelectCommandBuilder() = default;
+  SelectCommandBuilder(SelectCommandBuilder const&) = default;
+  SelectCommandBuilder(SelectCommandBuilder&&) = default;
+  SelectCommandBuilder& operator=(SelectCommandBuilder const&) = default;
+  SelectCommandBuilder(uint16_t sender, uint16_t receiver,
+                       Technology technology, Protocol protocol,
+                       BitRate bitrate, uint8_t power_level)
+      : RfPacketBuilder(sender, receiver, technology, protocol,
+                        RfPacketType::SELECT_COMMAND, bitrate, power_level,
+                        std::vector<uint8_t>{}) {}
+  static std::unique_ptr<SelectCommandBuilder> Create(
+      uint16_t sender, uint16_t receiver, Technology technology,
+      Protocol protocol, BitRate bitrate, uint8_t power_level) {
+    return std::make_unique<SelectCommandBuilder>(
+        sender, receiver, technology, protocol, bitrate, power_level);
+  }
 
-    void Serialize(std::vector<uint8_t>& output) const override {
-        pdl::packet::Builder::write_le<uint16_t, 2>(output, (static_cast<uint16_t>(sender_ & 0xffff) << 0));
-        pdl::packet::Builder::write_le<uint16_t, 2>(output, (static_cast<uint16_t>(receiver_ & 0xffff) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(technology_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(protocol_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(RfPacketType::SELECT_COMMAND) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(bitrate_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(power_level_ & 0xff) << 0));
-    }
+  void Serialize(std::vector<uint8_t>& output) const override {
+    pdl::packet::Builder::write_le<uint16_t, 2>(
+        output, (static_cast<uint16_t>(sender_ & 0xffff) << 0));
+    pdl::packet::Builder::write_le<uint16_t, 2>(
+        output, (static_cast<uint16_t>(receiver_ & 0xffff) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(technology_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(protocol_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(RfPacketType::SELECT_COMMAND) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(bitrate_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(power_level_ & 0xff) << 0));
+  }
 
-    size_t GetSize() const override {
-        return 9;
-    }
-
-    
-    
+  size_t GetSize() const override { return 9; }
 };
 
 enum class DeactivateType : uint8_t {
-    IDLE_MODE = 0x0,
-    SLEEP_MODE = 0x1,
-    SLEEP_AF_MODE = 0x2,
-    DISCOVERY = 0x3,
+  IDLE_MODE = 0x0,
+  SLEEP_MODE = 0x1,
+  SLEEP_AF_MODE = 0x2,
+  DISCOVERY = 0x3,
 };
 
 inline std::string DeactivateTypeText(DeactivateType tag) {
-    switch (tag) {
-        case DeactivateType::IDLE_MODE: return "IDLE_MODE";
-        case DeactivateType::SLEEP_MODE: return "SLEEP_MODE";
-        case DeactivateType::SLEEP_AF_MODE: return "SLEEP_AF_MODE";
-        case DeactivateType::DISCOVERY: return "DISCOVERY";
-        default:
-            return std::string("Unknown DeactivateType: " +
-                   std::to_string(static_cast<uint64_t>(tag)));
-    }
+  switch (tag) {
+    case DeactivateType::IDLE_MODE:
+      return "IDLE_MODE";
+    case DeactivateType::SLEEP_MODE:
+      return "SLEEP_MODE";
+    case DeactivateType::SLEEP_AF_MODE:
+      return "SLEEP_AF_MODE";
+    case DeactivateType::DISCOVERY:
+      return "DISCOVERY";
+    default:
+      return std::string("Unknown DeactivateType: " +
+                         std::to_string(static_cast<uint64_t>(tag)));
+  }
 }
 
 enum class DeactivateReason : uint8_t {
-    DH_REQUEST = 0x0,
-    ENDPOINT_REQUEST = 0x1,
-    RF_LINK_LOSS = 0x2,
-    NFC_B_BAD_AFI = 0x3,
-    DH_REQUEST_FAILED = 0x4,
+  DH_REQUEST = 0x0,
+  ENDPOINT_REQUEST = 0x1,
+  RF_LINK_LOSS = 0x2,
+  NFC_B_BAD_AFI = 0x3,
+  DH_REQUEST_FAILED = 0x4,
 };
 
 inline std::string DeactivateReasonText(DeactivateReason tag) {
-    switch (tag) {
-        case DeactivateReason::DH_REQUEST: return "DH_REQUEST";
-        case DeactivateReason::ENDPOINT_REQUEST: return "ENDPOINT_REQUEST";
-        case DeactivateReason::RF_LINK_LOSS: return "RF_LINK_LOSS";
-        case DeactivateReason::NFC_B_BAD_AFI: return "NFC_B_BAD_AFI";
-        case DeactivateReason::DH_REQUEST_FAILED: return "DH_REQUEST_FAILED";
-        default:
-            return std::string("Unknown DeactivateReason: " +
-                   std::to_string(static_cast<uint64_t>(tag)));
-    }
+  switch (tag) {
+    case DeactivateReason::DH_REQUEST:
+      return "DH_REQUEST";
+    case DeactivateReason::ENDPOINT_REQUEST:
+      return "ENDPOINT_REQUEST";
+    case DeactivateReason::RF_LINK_LOSS:
+      return "RF_LINK_LOSS";
+    case DeactivateReason::NFC_B_BAD_AFI:
+      return "NFC_B_BAD_AFI";
+    case DeactivateReason::DH_REQUEST_FAILED:
+      return "DH_REQUEST_FAILED";
+    default:
+      return std::string("Unknown DeactivateReason: " +
+                         std::to_string(static_cast<uint64_t>(tag)));
+  }
 }
 
 class DeactivateNotificationView {
-public:
-    static DeactivateNotificationView Create(RfPacketView const& parent) {
-        return DeactivateNotificationView(parent);
+ public:
+  static DeactivateNotificationView Create(RfPacketView const& parent) {
+    return DeactivateNotificationView(parent);
+  }
+
+  uint16_t GetSender() const {
+    _ASSERT_VALID(valid_);
+    return sender_;
+  }
+
+  uint16_t GetReceiver() const {
+    _ASSERT_VALID(valid_);
+    return receiver_;
+  }
+
+  Technology GetTechnology() const {
+    _ASSERT_VALID(valid_);
+    return technology_;
+  }
+
+  Protocol GetProtocol() const {
+    _ASSERT_VALID(valid_);
+    return protocol_;
+  }
+
+  BitRate GetBitrate() const {
+    _ASSERT_VALID(valid_);
+    return bitrate_;
+  }
+
+  uint8_t GetPowerLevel() const {
+    _ASSERT_VALID(valid_);
+    return power_level_;
+  }
+
+  DeactivateType GetType() const {
+    _ASSERT_VALID(valid_);
+    return type__;
+  }
+
+  DeactivateReason GetReason() const {
+    _ASSERT_VALID(valid_);
+    return reason_;
+  }
+
+  RfPacketType GetPacketType() const {
+    return RfPacketType::DEACTIVATE_NOTIFICATION;
+  }
+
+  std::string ToString() const { return ""; }
+
+  bool IsValid() const { return valid_; }
+
+  pdl::packet::slice bytes() const { return bytes_; }
+
+ protected:
+  explicit DeactivateNotificationView(RfPacketView const& parent)
+      : bytes_(parent.bytes_) {
+    valid_ = Parse(parent);
+  }
+
+  bool Parse(RfPacketView const& parent) {
+    // Check validity of parent packet.
+    if (!parent.IsValid()) {
+      return false;
     }
 
-    uint16_t GetSender() const {
-        _ASSERT_VALID(valid_);
-        return sender_;
-    }
-    
-    uint16_t GetReceiver() const {
-        _ASSERT_VALID(valid_);
-        return receiver_;
-    }
-    
-    Technology GetTechnology() const {
-        _ASSERT_VALID(valid_);
-        return technology_;
-    }
-    
-    Protocol GetProtocol() const {
-        _ASSERT_VALID(valid_);
-        return protocol_;
-    }
-    
-    BitRate GetBitrate() const {
-        _ASSERT_VALID(valid_);
-        return bitrate_;
-    }
-    
-    uint8_t GetPowerLevel() const {
-        _ASSERT_VALID(valid_);
-        return power_level_;
-    }
-    
-    DeactivateType GetType() const {
-        _ASSERT_VALID(valid_);
-        return type__;
-    }
-    
-    DeactivateReason GetReason() const {
-        _ASSERT_VALID(valid_);
-        return reason_;
-    }
-    
-    RfPacketType GetPacketType() const {
-        return RfPacketType::DEACTIVATE_NOTIFICATION;
-    }
-    
-    
-    std::string ToString() const {
-        return "";
-    }
-    
+    // Copy parent field values.
+    sender_ = parent.sender_;
+    receiver_ = parent.receiver_;
+    technology_ = parent.technology_;
+    protocol_ = parent.protocol_;
+    bitrate_ = parent.bitrate_;
+    power_level_ = parent.power_level_;
 
-    bool IsValid() const {
-        return valid_;
+    if (parent.packet_type_ != RfPacketType::DEACTIVATE_NOTIFICATION) {
+      return false;
     }
 
-    pdl::packet::slice bytes() const {
-        return bytes_;
+    // Parse packet field values.
+    pdl::packet::slice span = parent.payload_;
+    if (span.size() < 2) {
+      return false;
     }
+    type__ = DeactivateType(span.read_le<uint8_t, 1>());
+    reason_ = DeactivateReason(span.read_le<uint8_t, 1>());
+    return true;
+  }
 
-protected:
-    explicit DeactivateNotificationView(RfPacketView const& parent)
-          : bytes_(parent.bytes_) {
-        valid_ = Parse(parent);
-    }
-
-    bool Parse(RfPacketView const& parent) {
-        // Check validity of parent packet.
-        if (!parent.IsValid()) {
-            return false;
-        }
-        
-        // Copy parent field values.
-        sender_ = parent.sender_;
-        receiver_ = parent.receiver_;
-        technology_ = parent.technology_;
-        protocol_ = parent.protocol_;
-        bitrate_ = parent.bitrate_;
-        power_level_ = parent.power_level_;
-        
-        if (parent.packet_type_ != RfPacketType::DEACTIVATE_NOTIFICATION) {
-            return false;
-        }
-        
-        // Parse packet field values.
-        pdl::packet::slice span = parent.payload_;
-        if (span.size() < 2) {
-            return false;
-        }
-        type__ = DeactivateType(span.read_le<uint8_t, 1>());
-        reason_ = DeactivateReason(span.read_le<uint8_t, 1>());
-        return true;
-    }
-
-    bool valid_{false};
-    pdl::packet::slice bytes_;
-    uint16_t sender_{0};
-    uint16_t receiver_{0};
-    Technology technology_{Technology::NFC_A};
-    Protocol protocol_{Protocol::UNDETERMINED};
-    BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
-    uint8_t power_level_{0};
-    DeactivateType type__{DeactivateType::IDLE_MODE};
-    DeactivateReason reason_{DeactivateReason::DH_REQUEST};
-
-    
+  bool valid_{false};
+  pdl::packet::slice bytes_;
+  uint16_t sender_{0};
+  uint16_t receiver_{0};
+  Technology technology_{Technology::NFC_A};
+  Protocol protocol_{Protocol::UNDETERMINED};
+  BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
+  uint8_t power_level_{0};
+  DeactivateType type__{DeactivateType::IDLE_MODE};
+  DeactivateReason reason_{DeactivateReason::DH_REQUEST};
 };
 
 class DeactivateNotificationBuilder : public RfPacketBuilder {
-public:
-    ~DeactivateNotificationBuilder() override = default;
-    DeactivateNotificationBuilder() = default;
-    DeactivateNotificationBuilder(DeactivateNotificationBuilder const&) = default;
-    DeactivateNotificationBuilder(DeactivateNotificationBuilder&&) = default;
-    DeactivateNotificationBuilder& operator=(DeactivateNotificationBuilder const&) = default;
-        DeactivateNotificationBuilder(uint16_t sender, uint16_t receiver, Technology technology, Protocol protocol, BitRate bitrate, uint8_t power_level, DeactivateType type_, DeactivateReason reason)
-        : RfPacketBuilder(sender, receiver, technology, protocol, RfPacketType::DEACTIVATE_NOTIFICATION, bitrate, power_level, std::vector<uint8_t>{}), type__(type_), reason_(reason) {
-    
-}
-    static std::unique_ptr<DeactivateNotificationBuilder> Create(uint16_t sender, uint16_t receiver, Technology technology, Protocol protocol, BitRate bitrate, uint8_t power_level, DeactivateType type_, DeactivateReason reason) {
-    return std::make_unique<DeactivateNotificationBuilder>(sender, receiver, technology, protocol, bitrate, power_level, type_, reason);
-}
+ public:
+  ~DeactivateNotificationBuilder() override = default;
+  DeactivateNotificationBuilder() = default;
+  DeactivateNotificationBuilder(DeactivateNotificationBuilder const&) = default;
+  DeactivateNotificationBuilder(DeactivateNotificationBuilder&&) = default;
+  DeactivateNotificationBuilder& operator=(
+      DeactivateNotificationBuilder const&) = default;
+  DeactivateNotificationBuilder(uint16_t sender, uint16_t receiver,
+                                Technology technology, Protocol protocol,
+                                BitRate bitrate, uint8_t power_level,
+                                DeactivateType type_, DeactivateReason reason)
+      : RfPacketBuilder(sender, receiver, technology, protocol,
+                        RfPacketType::DEACTIVATE_NOTIFICATION, bitrate,
+                        power_level, std::vector<uint8_t>{}),
+        type__(type_),
+        reason_(reason) {}
+  static std::unique_ptr<DeactivateNotificationBuilder> Create(
+      uint16_t sender, uint16_t receiver, Technology technology,
+      Protocol protocol, BitRate bitrate, uint8_t power_level,
+      DeactivateType type_, DeactivateReason reason) {
+    return std::make_unique<DeactivateNotificationBuilder>(
+        sender, receiver, technology, protocol, bitrate, power_level, type_,
+        reason);
+  }
 
-    void Serialize(std::vector<uint8_t>& output) const override {
-        pdl::packet::Builder::write_le<uint16_t, 2>(output, (static_cast<uint16_t>(sender_ & 0xffff) << 0));
-        pdl::packet::Builder::write_le<uint16_t, 2>(output, (static_cast<uint16_t>(receiver_ & 0xffff) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(technology_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(protocol_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(RfPacketType::DEACTIVATE_NOTIFICATION) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(bitrate_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(power_level_ & 0xff) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(type__) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(reason_) << 0));
-    }
+  void Serialize(std::vector<uint8_t>& output) const override {
+    pdl::packet::Builder::write_le<uint16_t, 2>(
+        output, (static_cast<uint16_t>(sender_ & 0xffff) << 0));
+    pdl::packet::Builder::write_le<uint16_t, 2>(
+        output, (static_cast<uint16_t>(receiver_ & 0xffff) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(technology_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(protocol_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output,
+        (static_cast<uint8_t>(RfPacketType::DEACTIVATE_NOTIFICATION) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(bitrate_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(power_level_ & 0xff) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(type__) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(reason_) << 0));
+  }
 
-    size_t GetSize() const override {
-        return 11;
-    }
+  size_t GetSize() const override { return 11; }
 
-    
-    DeactivateType type__{DeactivateType::IDLE_MODE};
-    DeactivateReason reason_{DeactivateReason::DH_REQUEST};
+  DeactivateType type__{DeactivateType::IDLE_MODE};
+  DeactivateReason reason_{DeactivateReason::DH_REQUEST};
 };
 
 class DataView {
-public:
-    static DataView Create(RfPacketView const& parent) {
-        return DataView(parent);
+ public:
+  static DataView Create(RfPacketView const& parent) {
+    return DataView(parent);
+  }
+
+  uint16_t GetSender() const {
+    _ASSERT_VALID(valid_);
+    return sender_;
+  }
+
+  uint16_t GetReceiver() const {
+    _ASSERT_VALID(valid_);
+    return receiver_;
+  }
+
+  Technology GetTechnology() const {
+    _ASSERT_VALID(valid_);
+    return technology_;
+  }
+
+  Protocol GetProtocol() const {
+    _ASSERT_VALID(valid_);
+    return protocol_;
+  }
+
+  BitRate GetBitrate() const {
+    _ASSERT_VALID(valid_);
+    return bitrate_;
+  }
+
+  uint8_t GetPowerLevel() const {
+    _ASSERT_VALID(valid_);
+    return power_level_;
+  }
+
+  std::vector<uint8_t> GetData() const {
+    _ASSERT_VALID(valid_);
+    pdl::packet::slice span = data_;
+    std::vector<uint8_t> elements;
+    while (span.size() >= 1) {
+      elements.push_back(span.read_le<uint8_t, 1>());
+    }
+    return elements;
+  }
+
+  RfPacketType GetPacketType() const { return RfPacketType::DATA; }
+
+  std::string ToString() const { return ""; }
+
+  bool IsValid() const { return valid_; }
+
+  pdl::packet::slice bytes() const { return bytes_; }
+
+ protected:
+  explicit DataView(RfPacketView const& parent) : bytes_(parent.bytes_) {
+    valid_ = Parse(parent);
+  }
+
+  bool Parse(RfPacketView const& parent) {
+    // Check validity of parent packet.
+    if (!parent.IsValid()) {
+      return false;
     }
 
-    uint16_t GetSender() const {
-        _ASSERT_VALID(valid_);
-        return sender_;
-    }
-    
-    uint16_t GetReceiver() const {
-        _ASSERT_VALID(valid_);
-        return receiver_;
-    }
-    
-    Technology GetTechnology() const {
-        _ASSERT_VALID(valid_);
-        return technology_;
-    }
-    
-    Protocol GetProtocol() const {
-        _ASSERT_VALID(valid_);
-        return protocol_;
-    }
-    
-    BitRate GetBitrate() const {
-        _ASSERT_VALID(valid_);
-        return bitrate_;
-    }
-    
-    uint8_t GetPowerLevel() const {
-        _ASSERT_VALID(valid_);
-        return power_level_;
-    }
-    
-    std::vector<uint8_t> GetData() const {
-        _ASSERT_VALID(valid_);
-        pdl::packet::slice span = data_;
-        std::vector<uint8_t> elements;
-        while (span.size() >= 1) {
-            elements.push_back(span.read_le<uint8_t, 1>());
-        }
-        return elements;
-    }
-    
-    RfPacketType GetPacketType() const {
-        return RfPacketType::DATA;
-    }
-    
-    
-    std::string ToString() const {
-        return "";
-    }
-    
+    // Copy parent field values.
+    sender_ = parent.sender_;
+    receiver_ = parent.receiver_;
+    technology_ = parent.technology_;
+    protocol_ = parent.protocol_;
+    bitrate_ = parent.bitrate_;
+    power_level_ = parent.power_level_;
 
-    bool IsValid() const {
-        return valid_;
+    if (parent.packet_type_ != RfPacketType::DATA) {
+      return false;
     }
 
-    pdl::packet::slice bytes() const {
-        return bytes_;
-    }
+    // Parse packet field values.
+    pdl::packet::slice span = parent.payload_;
+    data_ = span;
+    span.clear();
+    return true;
+  }
 
-protected:
-    explicit DataView(RfPacketView const& parent)
-          : bytes_(parent.bytes_) {
-        valid_ = Parse(parent);
-    }
-
-    bool Parse(RfPacketView const& parent) {
-        // Check validity of parent packet.
-        if (!parent.IsValid()) {
-            return false;
-        }
-        
-        // Copy parent field values.
-        sender_ = parent.sender_;
-        receiver_ = parent.receiver_;
-        technology_ = parent.technology_;
-        protocol_ = parent.protocol_;
-        bitrate_ = parent.bitrate_;
-        power_level_ = parent.power_level_;
-        
-        if (parent.packet_type_ != RfPacketType::DATA) {
-            return false;
-        }
-        
-        // Parse packet field values.
-        pdl::packet::slice span = parent.payload_;
-        data_ = span;
-        span.clear();
-        return true;
-    }
-
-    bool valid_{false};
-    pdl::packet::slice bytes_;
-    uint16_t sender_{0};
-    uint16_t receiver_{0};
-    Technology technology_{Technology::NFC_A};
-    Protocol protocol_{Protocol::UNDETERMINED};
-    BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
-    uint8_t power_level_{0};
-    pdl::packet::slice data_;
-
-    
+  bool valid_{false};
+  pdl::packet::slice bytes_;
+  uint16_t sender_{0};
+  uint16_t receiver_{0};
+  Technology technology_{Technology::NFC_A};
+  Protocol protocol_{Protocol::UNDETERMINED};
+  BitRate bitrate_{BitRate::BIT_RATE_106_KBIT_S};
+  uint8_t power_level_{0};
+  pdl::packet::slice data_;
 };
 
 class DataBuilder : public RfPacketBuilder {
-public:
-    ~DataBuilder() override = default;
-    DataBuilder() = default;
-    DataBuilder(DataBuilder const&) = default;
-    DataBuilder(DataBuilder&&) = default;
-    DataBuilder& operator=(DataBuilder const&) = default;
-        DataBuilder(uint16_t sender, uint16_t receiver, Technology technology, Protocol protocol, BitRate bitrate, uint8_t power_level, std::vector<uint8_t> data)
-        : RfPacketBuilder(sender, receiver, technology, protocol, RfPacketType::DATA, bitrate, power_level, std::vector<uint8_t>{}), data_(std::move(data)) {
-    
-}
-    static std::unique_ptr<DataBuilder> Create(uint16_t sender, uint16_t receiver, Technology technology, Protocol protocol, BitRate bitrate, uint8_t power_level, std::vector<uint8_t> data) {
-    return std::make_unique<DataBuilder>(sender, receiver, technology, protocol, bitrate, power_level, std::move(data));
-}
+ public:
+  ~DataBuilder() override = default;
+  DataBuilder() = default;
+  DataBuilder(DataBuilder const&) = default;
+  DataBuilder(DataBuilder&&) = default;
+  DataBuilder& operator=(DataBuilder const&) = default;
+  DataBuilder(uint16_t sender, uint16_t receiver, Technology technology,
+              Protocol protocol, BitRate bitrate, uint8_t power_level,
+              std::vector<uint8_t> data)
+      : RfPacketBuilder(sender, receiver, technology, protocol,
+                        RfPacketType::DATA, bitrate, power_level,
+                        std::vector<uint8_t>{}),
+        data_(std::move(data)) {}
+  static std::unique_ptr<DataBuilder> Create(uint16_t sender, uint16_t receiver,
+                                             Technology technology,
+                                             Protocol protocol, BitRate bitrate,
+                                             uint8_t power_level,
+                                             std::vector<uint8_t> data) {
+    return std::make_unique<DataBuilder>(sender, receiver, technology, protocol,
+                                         bitrate, power_level, std::move(data));
+  }
 
-    void Serialize(std::vector<uint8_t>& output) const override {
-        pdl::packet::Builder::write_le<uint16_t, 2>(output, (static_cast<uint16_t>(sender_ & 0xffff) << 0));
-        pdl::packet::Builder::write_le<uint16_t, 2>(output, (static_cast<uint16_t>(receiver_ & 0xffff) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(technology_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(protocol_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(RfPacketType::DATA) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(bitrate_) << 0));
-        pdl::packet::Builder::write_le<uint8_t, 1>(output, (static_cast<uint8_t>(power_level_ & 0xff) << 0));
-        output.insert(output.end(), data_.begin(), data_.end());
-    }
+  void Serialize(std::vector<uint8_t>& output) const override {
+    pdl::packet::Builder::write_le<uint16_t, 2>(
+        output, (static_cast<uint16_t>(sender_ & 0xffff) << 0));
+    pdl::packet::Builder::write_le<uint16_t, 2>(
+        output, (static_cast<uint16_t>(receiver_ & 0xffff) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(technology_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(protocol_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(RfPacketType::DATA) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(bitrate_) << 0));
+    pdl::packet::Builder::write_le<uint8_t, 1>(
+        output, (static_cast<uint8_t>(power_level_ & 0xff) << 0));
+    output.insert(output.end(), data_.begin(), data_.end());
+  }
 
-    size_t GetSize() const override {
-        return GetDataSize() + 9;
-    }
+  size_t GetSize() const override { return GetDataSize() + 9; }
 
-    size_t GetDataSize() const {
-        return data_.size() * 1;
-    }
-    
-    std::vector<uint8_t> data_;
+  size_t GetDataSize() const { return data_.size() * 1; }
+
+  std::vector<uint8_t> data_;
 };
-}  // casimir::rf
+}  // namespace casimir::rf

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/BUILD.bazel
@@ -120,7 +120,6 @@ cf_cc_library(
     name = "launch_cvd_templates",
     srcs = ["launch_cvd_templates.cpp"],
     hdrs = ["launch_cvd_templates.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:json",
         "//cuttlefish/host/commands/cvd/cli/parser:cf_configs_common",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/BUILD.bazel
@@ -104,7 +104,6 @@ cf_cc_library(
 cf_cc_test(
     name = "disk_configs_test",
     srcs = ["disk_configs_test.cc"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/cvd/cli/parser:test_common",
         "@jsoncpp",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/disk_configs_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/disk_configs_test.cc
@@ -42,8 +42,7 @@ TEST(BootFlagsParserTest, ParseTwoInstancesBlankDataImageEmptyJson) {
       << "Invalid Json string";
   auto serialized_data = LaunchCvdParserTester(json_configs);
   EXPECT_TRUE(serialized_data.ok()) << serialized_data.error().Trace();
-  EXPECT_FALSE(
-      FindConfig(*serialized_data, R"(--blank_data_image_mb=)"))
+  EXPECT_FALSE(FindConfig(*serialized_data, R"(--blank_data_image_mb=)"))
       << "blank_data_image_mb flag is set";
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/launch_cvd_templates.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/launch_cvd_templates.cpp
@@ -232,7 +232,8 @@ static constexpr std::string_view kFoldableInstanceTemplate = R""""(
 }
   )"""";
 
-static Result<Json::Value> LoadTemplateByName(const std::string& template_name) {
+static Result<Json::Value> LoadTemplateByName(
+    const std::string& template_name) {
   static auto* kSupportedTemplatesKeyMap =
       new std::map<std::string_view, std::string_view>{
           {"phone", kPhoneInstanceTemplate},
@@ -269,7 +270,7 @@ Result<EnvironmentSpecification> ExtractLaunchTemplates(
       combined_json_sstream << ins_json;
       const auto& combined_json_str = combined_json_sstream.str();
 
-      //status = JsonStringToMessage(combined_json_str, &ins);
+      // status = JsonStringToMessage(combined_json_str, &ins);
       CF_EXPECTF(status.ok(), "{}", status.ToString());
     }
   }

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/BUILD.bazel
@@ -31,7 +31,6 @@ cf_cc_library(
     name = "data_viewer",
     srcs = ["data_viewer.cpp"],
     hdrs = ["data_viewer.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:signals",

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/data_viewer.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/data_viewer.h
@@ -123,4 +123,3 @@ class DataViewer {
 };
 
 }  // namespace cuttlefish
-

--- a/base/cvd/cuttlefish/host/commands/cvd/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/utils/BUILD.bazel
@@ -39,7 +39,6 @@ cf_cc_library(
     name = "interrupt_listener",
     srcs = ["interrupt_listener.cpp"],
     hdrs = ["interrupt_listener.h"],
-    clang_format_enabled = False,
     copts = COPTS + ["-Werror=sign-compare"],
     deps = [
         "//cuttlefish/common/libs/utils:signals",

--- a/base/cvd/cuttlefish/host/commands/cvd/utils/interrupt_listener.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/utils/interrupt_listener.cpp
@@ -163,7 +163,9 @@ void PopInterruptListener(size_t listener_index) {
 
 }  // namespace
 
-InterruptListenerHandle::~InterruptListenerHandle() { PopInterruptListener(listener_index_); }
+InterruptListenerHandle::~InterruptListenerHandle() {
+  PopInterruptListener(listener_index_);
+}
 
 Result<std::unique_ptr<InterruptListenerHandle>> PushInterruptListener(
     InterruptListener listener) {

--- a/base/cvd/cuttlefish/host/commands/cvd_env/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd_env/BUILD.bazel
@@ -9,7 +9,6 @@ cf_cc_binary(
     srcs = [
         "main.cc",
     ],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:tee_logging",
         "//cuttlefish/host/libs/config:cuttlefish_config",

--- a/base/cvd/cuttlefish/host/commands/cvd_env/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_env/main.cc
@@ -15,8 +15,8 @@
  */
 
 #include <iostream>
-#include <vector>
 #include <string>
+#include <vector>
 
 #include "absl/log/check.h"
 #include "absl/strings/match.h"
@@ -94,8 +94,7 @@ Result<void> CvdEnvMain(int argc, char** argv) {
     }
   }
   if (!args.empty()) {
-    CF_EXPECT(args[0] == kServiceControlEnvProxy,
-              "Prohibited service name");
+    CF_EXPECT(args[0] == kServiceControlEnvProxy, "Prohibited service name");
   }
 
   const auto* config = CuttlefishConfig::Get();

--- a/base/cvd/cuttlefish/host/commands/cvd_import_locations/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd_import_locations/BUILD.bazel
@@ -9,7 +9,6 @@ cf_cc_binary(
     srcs = [
         "main.cc",
     ],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:tee_logging",

--- a/base/cvd/cuttlefish/host/commands/cvd_import_locations/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_import_locations/main.cc
@@ -97,11 +97,9 @@ int ImportLocationsCvdMain(int argc, char** argv) {
   LOG(INFO) << "Server port: " << server_port << " socket: " << socket_name
             << std::endl;
   if (FLAGS_format == "gpx" || FLAGS_format == "GPX") {
-    isOk =
-        GpxParser::parseFile(FLAGS_file_path.c_str(), &coordinates, &error);
+    isOk = GpxParser::parseFile(FLAGS_file_path.c_str(), &coordinates, &error);
   } else if (FLAGS_format == "kml" || FLAGS_format == "KML") {
-    isOk =
-        KmlParser::parseFile(FLAGS_file_path.c_str(), &coordinates, &error);
+    isOk = KmlParser::parseFile(FLAGS_file_path.c_str(), &coordinates, &error);
   }
 
   LOG(INFO) << "Number of parsed points: " << coordinates.size() << std::endl;
@@ -112,7 +110,7 @@ int ImportLocationsCvdMain(int argc, char** argv) {
   }
 
   int delay = (int)(1000 * FLAGS_delay);
-  auto status = gpsclient.SendGpsLocations(delay,coordinates);
+  auto status = gpsclient.SendGpsLocations(delay, coordinates);
   CHECK(status.ok()) << "Failed to send gps location data \n";
   if (!status.ok()) {
     return 1;

--- a/base/cvd/cuttlefish/host/commands/cvd_send_id_disclosure/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd_send_id_disclosure/BUILD.bazel
@@ -9,7 +9,6 @@ cf_cc_binary(
     srcs = [
         "main.cc",
     ],
-    clang_format_enabled = False,
     deps = [
         ":libcvd_id_disclosure_builder",
         "//cuttlefish/common/libs/fs",
@@ -29,7 +28,6 @@ cf_cc_library(
     hdrs = [
         "cellular_identifier_disclosure_command_builder.h",
     ],
-    clang_format_enabled = False,
     deps = [
         "@fmt",
     ],

--- a/base/cvd/cuttlefish/host/commands/cvd_send_id_disclosure/cellular_identifier_disclosure_command_builder.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_send_id_disclosure/cellular_identifier_disclosure_command_builder.cc
@@ -20,10 +20,9 @@
 
 #include <fmt/format.h>
 
-
 namespace cuttlefish {
 
-std::string GetATCommand(const std::string &plmn, int32_t identifierType,
+std::string GetATCommand(const std::string& plmn, int32_t identifierType,
                          int32_t protocolMessage, bool isEmergency) {
   return fmt::format("AT+REMOTEIDDISCLOSURE:\"{}\",{},{},{:d}\r", plmn,
                      identifierType, protocolMessage, isEmergency);

--- a/base/cvd/cuttlefish/host/commands/cvd_send_id_disclosure/cellular_identifier_disclosure_command_builder.h
+++ b/base/cvd/cuttlefish/host/commands/cvd_send_id_disclosure/cellular_identifier_disclosure_command_builder.h
@@ -27,7 +27,7 @@ namespace cuttlefish {
  * unsolicited calls to
  * aidl::android::hardware::radio::network::IRadioNetworkIndication::cellularIdentifierDisclosed.
  */
-std::string GetATCommand(const std::string &plmn, int32_t identifierType,
+std::string GetATCommand(const std::string& plmn, int32_t identifierType,
                          int32_t protocolMessage, bool isEmergency);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd_send_id_disclosure/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_send_id_disclosure/main.cc
@@ -83,6 +83,6 @@ int SendIdDisclosureMain(int argc, char** argv) {
 }  // namespace
 }  // namespace cuttlefish
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   return cuttlefish::SendIdDisclosureMain(argc, argv);
 }

--- a/base/cvd/cuttlefish/host/commands/cvd_update_location/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd_update_location/BUILD.bazel
@@ -9,7 +9,6 @@ cf_cc_binary(
     srcs = [
         "main.cc",
     ],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:tee_logging",
         "//cuttlefish/host/libs/config:cuttlefish_config",

--- a/base/cvd/cuttlefish/host/commands/cvd_update_location/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_update_location/main.cc
@@ -57,11 +57,11 @@ int UpdateLocationCvdMain(int argc, char** argv) {
 
   GpsFixArray coordinates;
   GpsFix location;
-  location.longitude=FLAGS_longitude;
-  location.latitude=FLAGS_latitude;
-  location.elevation=FLAGS_elevation;
+  location.longitude = FLAGS_longitude;
+  location.latitude = FLAGS_latitude;
+  location.elevation = FLAGS_elevation;
   coordinates.push_back(location);
-  auto status = gpsclient.SendGpsLocations(1000,coordinates);
+  auto status = gpsclient.SendGpsLocations(1000, coordinates);
   CHECK(status.ok()) << "Failed to send gps location data \n";
   if (!status.ok()) {
     return 1;

--- a/base/cvd/cuttlefish/host/commands/cvd_update_security_algorithm/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd_update_security_algorithm/BUILD.bazel
@@ -9,7 +9,6 @@ cf_cc_binary(
     srcs = [
         "main.cc",
     ],
-    clang_format_enabled = False,
     deps = [
         ":libcvd_update_security_algorithm_builder",
         "//cuttlefish/common/libs/fs",

--- a/base/cvd/cuttlefish/host/commands/cvd_update_security_algorithm/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_update_security_algorithm/main.cc
@@ -85,6 +85,6 @@ int UpdateSecurityAlgorithmMain(int argc, char** argv) {
 }  // namespace
 }  // namespace cuttlefish
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   return cuttlefish::UpdateSecurityAlgorithmMain(argc, argv);
 }

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/BUILD.bazel
@@ -10,7 +10,6 @@ cf_cc_library(
         "interface.cpp",
     ],
     hdrs = ["interface.h"],
-    clang_format_enabled = False,
     deps = [
         "@abseil-cpp//absl/strings:str_format",
     ],

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/interface.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/interface.cpp
@@ -19,7 +19,7 @@
 
 namespace cuttlefish {
 
-std::string CvdallocInterfaceName(const std::string &name, int num) {
+std::string CvdallocInterfaceName(const std::string& name, int num) {
   return absl::StrFormat("%s-%s%d", kCvdallocInterfacePrefix, name, num);
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/interface.h
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/interface.h
@@ -27,7 +27,7 @@ constexpr char kCvdallocWirelessIpPrefix[] = "192.168.160";
 constexpr char kCvdallocWirelessApIpPrefix[] = "192.168.176";
 constexpr char kCvdallocEthernetIpPrefix[] = "192.168.192";
 
-std::string CvdallocInterfaceName(const std::string &name, int num);
+std::string CvdallocInterfaceName(const std::string& name, int num);
 std::string InstanceToMobileGatewayAddress(int num);
 std::string InstanceToMobileAddress(int num);
 std::string InstanceToMobileBroadcast(int num);

--- a/base/cvd/cuttlefish/host/commands/metrics/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/metrics/BUILD.bazel
@@ -31,7 +31,6 @@ cf_cc_library(
     name = "events",
     srcs = ["events.cc"],
     hdrs = ["events.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/metrics:clearcut_protos",
         "//cuttlefish/host/commands/metrics:send",

--- a/base/cvd/cuttlefish/host/commands/metrics/events.cc
+++ b/base/cvd/cuttlefish/host/commands/metrics/events.cc
@@ -17,8 +17,8 @@
 
 #include <sys/utsname.h>
 
-#include "google/protobuf/timestamp.pb.h"
 #include "absl/log/log.h"
+#include "google/protobuf/timestamp.pb.h"
 
 #include "cuttlefish/host/commands/metrics/clearcut_protos.h"
 #include "cuttlefish/host/commands/metrics/send.h"

--- a/base/cvd/cuttlefish/host/commands/metrics/events.h
+++ b/base/cvd/cuttlefish/host/commands/metrics/events.h
@@ -30,4 +30,4 @@ int SendVMStop(VmmMode);
 int SendDeviceBoot(VmmMode);
 int SendLockScreen(VmmMode);
 
-}  // namespace cuttlefish
+}  // namespace cuttlefish::metrics

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/BUILD.bazel
@@ -46,7 +46,6 @@ cf_cc_library(
 cf_cc_test(
     name = "command_parser_test",
     srcs = ["unittest/command_parser_test.cpp"],
-    clang_format_enabled = False,
     deps = ["//cuttlefish/host/commands/modem_simulator:command_parser"],
 )
 
@@ -66,7 +65,6 @@ cf_cc_library(
     name = "device_config",
     srcs = ["cf_device_config.cpp"],
     hdrs = ["device_config.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/libs/config:cuttlefish_config",
     ],
@@ -76,7 +74,6 @@ cf_cc_library(
     name = "misc_service",
     srcs = ["misc_service.cpp"],
     hdrs = ["misc_service.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/modem_simulator:device_config",
         "//cuttlefish/host/commands/modem_simulator:modem_service",
@@ -87,7 +84,6 @@ cf_cc_library(
     name = "modem_service",
     srcs = ["modem_service.cpp"],
     hdrs = ["modem_service.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/modem_simulator:channel_monitor",
         "//cuttlefish/host/commands/modem_simulator:command_parser",
@@ -102,7 +98,6 @@ cf_cc_library(
     name = "modem_simulator_class",
     srcs = ["modem_simulator.cpp"],
     hdrs = ["modem_simulator.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/modem_simulator:channel_monitor",
         "//cuttlefish/host/commands/modem_simulator:data_service",
@@ -201,7 +196,6 @@ cf_cc_library(
     name = "nvram_config",
     srcs = ["nvram_config.cpp"],
     hdrs = ["nvram_config.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/commands/modem_simulator:device_config",
@@ -222,7 +216,6 @@ cf_cc_library(
 cf_cc_test(
     name = "pdu_parser_test",
     srcs = ["unittest/pdu_parser_test.cpp"],
-    clang_format_enabled = False,
     deps = ["//cuttlefish/host/commands/modem_simulator:pdu_parser"],
 )
 
@@ -253,7 +246,6 @@ cf_cc_library(
     name = "sup_service",
     srcs = ["sup_service.cpp"],
     hdrs = ["sup_service.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/modem_simulator:modem_service",
     ],
@@ -263,7 +255,6 @@ cf_cc_library(
     name = "thread_looper",
     srcs = ["thread_looper.cpp"],
     hdrs = ["thread_looper.h"],
-    clang_format_enabled = False,
     deps = [
         "//libbase",
         "@abseil-cpp//absl/log",

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/cf_device_config.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/cf_device_config.cpp
@@ -32,7 +32,7 @@ int DeviceConfig::host_id() {
 
 std::string DeviceConfig::PerInstancePath(const char* file_name) {
   if (!cuttlefish::CuttlefishConfig::Get()) {
-      return "";
+    return "";
   }
   auto config = cuttlefish::CuttlefishConfig::Get();
   auto instance = config->ForDefaultInstance();
@@ -62,11 +62,12 @@ std::string DeviceConfig::ril_dns() {
 }
 
 std::ifstream DeviceConfig::open_ifstream_crossplat(const char* filename) {
-    return std::ifstream(filename);
+  return std::ifstream(filename);
 }
 
-std::ofstream DeviceConfig::open_ofstream_crossplat(const char* filename, std::ios_base::openmode mode) {
-    return std::ofstream(filename, mode);
+std::ofstream DeviceConfig::open_ofstream_crossplat(
+    const char* filename, std::ios_base::openmode mode) {
+  return std::ofstream(filename, mode);
 }
 
 }  // namespace modem

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/device_config.h
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/device_config.h
@@ -16,9 +16,9 @@
 
 #pragma once
 
-#include <string>
 #include <fstream>
- 
+#include <string>
+
 // this file provide a few device (cvd or emulator) specific hooks for
 // modem-simulator
 
@@ -34,7 +34,8 @@ class DeviceConfig {
   static std::string ril_gateway();
   static std::string ril_dns();
   static std::ifstream open_ifstream_crossplat(const char* filename);
-  static std::ofstream open_ofstream_crossplat(const char* filename, std::ios_base::openmode mode = std::ios_base::out);
+  static std::ofstream open_ofstream_crossplat(
+      const char* filename, std::ios_base::openmode mode = std::ios_base::out);
 };
 
 }  // namespace modem

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/misc_service.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/misc_service.cpp
@@ -32,7 +32,8 @@ MiscService::MiscService(int32_t service_id, ChannelMonitor* channel_monitor,
 void MiscService::ParseTimeZone() {
 #if defined(__linux__)
   constexpr char TIMEZONE_FILENAME[] = "/etc/timezone";
-  std::ifstream ifs = modem::DeviceConfig::open_ifstream_crossplat(TIMEZONE_FILENAME);
+  std::ifstream ifs =
+      modem::DeviceConfig::open_ifstream_crossplat(TIMEZONE_FILENAME);
   if (ifs.is_open()) {
     std::string line;
     if (std::getline(ifs, line)) {
@@ -141,19 +142,18 @@ void MiscService::HandleGetIMEI(const Client& client, std::string& command) {
 }
 
 void MiscService::HandleTimeUpdate(const Client& client, std::string& command) {
-    (void)client;
-    (void)command;
-    TimeUpdate();
+  (void)client;
+  (void)command;
+  TimeUpdate();
 }
 
-long MiscService::TimeZoneOffset(time_t* utctime)
-{
-    struct tm local = *std::localtime(utctime);
-    time_t local_time = std::mktime(&local);
-    struct tm gmt = *std::gmtime(utctime);
-    // mktime() converts struct tm according to local timezone.
-    time_t gmt_time = std::mktime(&gmt);
-    return (long)difftime(local_time, gmt_time);
+long MiscService::TimeZoneOffset(time_t* utctime) {
+  struct tm local = *std::localtime(utctime);
+  time_t local_time = std::mktime(&local);
+  struct tm gmt = *std::gmtime(utctime);
+  // mktime() converts struct tm according to local timezone.
+  time_t gmt_time = std::mktime(&gmt);
+  return (long)difftime(local_time, gmt_time);
 }
 
 void MiscService::TimeUpdate() {
@@ -166,14 +166,14 @@ void MiscService::TimeUpdate() {
   auto tzdiff = TimeZoneOffset(&now) / (15 * 60);
 
   std::stringstream ss;
-  ss << "%CTZV: " << std::setfill('0') << std::setw(2)
-     << gm_time.tm_year % 100 << "/" << std::setfill('0') << std::setw(2)
-     << gm_time.tm_mon + 1 << "/" << std::setfill('0') << std::setw(2)
-     << gm_time.tm_mday << ":" << std::setfill('0') << std::setw(2)
-     << gm_time.tm_hour << ":" << std::setfill('0') << std::setw(2)
-     << gm_time.tm_min << ":" << std::setfill('0') << std::setw(2)
-     << gm_time.tm_sec << (tzdiff >= 0 ? '+' : '-')
-     << (tzdiff >= 0 ? tzdiff : -tzdiff) << ":" << local_time.tm_isdst;
+  ss << "%CTZV: " << std::setfill('0') << std::setw(2) << gm_time.tm_year % 100
+     << "/" << std::setfill('0') << std::setw(2) << gm_time.tm_mon + 1 << "/"
+     << std::setfill('0') << std::setw(2) << gm_time.tm_mday << ":"
+     << std::setfill('0') << std::setw(2) << gm_time.tm_hour << ":"
+     << std::setfill('0') << std::setw(2) << gm_time.tm_min << ":"
+     << std::setfill('0') << std::setw(2) << gm_time.tm_sec
+     << (tzdiff >= 0 ? '+' : '-') << (tzdiff >= 0 ? tzdiff : -tzdiff) << ":"
+     << local_time.tm_isdst;
   if (!timezone_.empty()) {
     ss << ":" << timezone_;
   }

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/misc_service.h
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/misc_service.h
@@ -21,14 +21,15 @@
 
 namespace cuttlefish {
 
-class MiscService : public ModemService, public std::enable_shared_from_this<MiscService>  {
+class MiscService : public ModemService,
+                    public std::enable_shared_from_this<MiscService> {
  public:
   MiscService(int32_t service_id, ChannelMonitor* channel_monitor,
               ThreadLooper* thread_looper);
   ~MiscService() = default;
 
-  MiscService(const MiscService &) = delete;
-  MiscService &operator=(const MiscService &) = delete;
+  MiscService(const MiscService&) = delete;
+  MiscService& operator=(const MiscService&) = delete;
 
   void HandleGetIMEI(const Client& client, std::string& command);
   void HandleTimeUpdate(const Client& client, std::string& command);
@@ -39,7 +40,7 @@ class MiscService : public ModemService, public std::enable_shared_from_this<Mis
 
  private:
   void ParseTimeZone();
-  long TimeZoneOffset(time_t* utctime); // in seconds.
+  long TimeZoneOffset(time_t* utctime);  // in seconds.
   void FixTimeZone(std::string& line);
   std::string timezone_;
   std::vector<CommandHandler> InitializeCommandHandlers();

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/modem_service.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/modem_service.cpp
@@ -36,7 +36,8 @@ CommandHandler::CommandHandler(const std::string& command, p_func handler)
 int CommandHandler::Compare(const std::string& command) const {
   int result = -1;
   if (match_mode == PARTIAL_MATCH) {
-    result = command.compare(2, command_prefix.size(), command_prefix);  // skip "AT"
+    result =
+        command.compare(2, command_prefix.size(), command_prefix);  // skip "AT"
   } else {
     result = command.compare(2, command.size(), command_prefix);
   }

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/modem_service.h
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/modem_service.h
@@ -15,7 +15,6 @@
 
 #pragma once
 
-
 #include <functional>
 #include <map>
 #include <optional>
@@ -27,18 +26,19 @@
 namespace cuttlefish {
 
 enum ModemServiceType : int {
-  kSimService     = 0,
+  kSimService = 0,
   kNetworkService = 1,
-  kDataService    = 2,
-  kCallService    = 3,
-  kSmsService     = 4,
-  kSupService     = 5,
-  kStkService     = 6,
-  kMiscService    = 7,
+  kDataService = 2,
+  kCallService = 3,
+  kSmsService = 4,
+  kSupService = 5,
+  kStkService = 6,
+  kMiscService = 7,
 };
 
-using f_func = std::function<void(const Client&)>;                // Full match
-using p_func = std::function<void(const Client&, std::string&)>;  // Partial match
+using f_func = std::function<void(const Client&)>;  // Full match
+using p_func =
+    std::function<void(const Client&, std::string&)>;  // Partial match
 
 class CommandHandler {
  public:
@@ -51,7 +51,7 @@ class CommandHandler {
   void HandleCommand(const Client& client, std::string& command) const;
 
  private:
-  enum MatchMode {FULL_MATCH = 0, PARTIAL_MATCH = 1};
+  enum MatchMode { FULL_MATCH = 0, PARTIAL_MATCH = 1 };
 
   std::string command_prefix;
   MatchMode match_mode;
@@ -62,11 +62,10 @@ class CommandHandler {
 
 class ModemService {
  public:
-
   virtual ~ModemService() = default;
 
-  ModemService(const ModemService &) = delete;
-  ModemService &operator=(const ModemService &) = delete;
+  ModemService(const ModemService&) = delete;
+  ModemService& operator=(const ModemService&) = delete;
 
   bool HandleModemCommand(const Client& client, std::string command);
 

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/modem_simulator.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/modem_simulator.cpp
@@ -94,7 +94,8 @@ void ModemSimulator::RegisterModemService() {
   modem_services_[kMiscService] = std::move(miscservice);
 }
 
-void ModemSimulator::DispatchCommand(const Client& client, std::string& command) {
+void ModemSimulator::DispatchCommand(const Client& client,
+                                     std::string& command) {
   if (sms_service_) {
     if (sms_service_->IsWaitingSmsPdu()) {
       sms_service_->HandleSendSMSPDU(client, command);

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/modem_simulator.h
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/modem_simulator.h
@@ -50,6 +50,7 @@ class ModemSimulator : public VirtualModemSimulator {
 
   void SetTimeZone(std::string timezone);
   bool SetPhoneNumber(std::string_view number);
+
  private:
   int32_t modem_id_;
   std::unique_ptr<ChannelMonitor> channel_monitor_;

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/nvram_config.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/nvram_config.cpp
@@ -34,7 +34,7 @@ static constexpr char kModemTechnoloy[] = "modem_technoloy";
 static constexpr char kPreferredNetworkMode[] = "preferred_network_mode";
 static constexpr char kEmergencyMode[] = "emergency_mode";
 
-static constexpr int kDefaultNetworkSelectionMode = 0;     // AUTOMATIC
+static constexpr int kDefaultNetworkSelectionMode = 0;  // AUTOMATIC
 static constexpr int kDefaultModemTechnoloy = ModemTechnology::M_MODEM_TECH_LTE;
 static constexpr int kDefaultPreferredNetworkMode =
     ModemTechnology::M_MODEM_TECH_LTE | ModemTechnology::M_MODEM_TECH_WCDMA |
@@ -115,18 +115,19 @@ bool NvramConfig::LoadFromFile(const char* file) {
   }
 
   Json::CharReaderBuilder builder;
-  std::ifstream ifs = modem::DeviceConfig::open_ifstream_crossplat(real_file_path.c_str());
+  std::ifstream ifs =
+      modem::DeviceConfig::open_ifstream_crossplat(real_file_path.c_str());
   std::string errorMessage;
   if (!Json::parseFromStream(builder, ifs, dictionary_.get(), &errorMessage)) {
-    LOG(ERROR) << "Could not read config file " << file << ": "
-               << errorMessage;
+    LOG(ERROR) << "Could not read config file " << file << ": " << errorMessage;
     return false;
   }
   return true;
 }
 
 bool NvramConfig::SaveToFile(const std::string& file) const {
-  std::ofstream ofs = modem::DeviceConfig::open_ofstream_crossplat(file.c_str());
+  std::ofstream ofs =
+      modem::DeviceConfig::open_ofstream_crossplat(file.c_str());
   if (!ofs.is_open()) {
     LOG(ERROR) << "Unable to write to file " << file;
     return false;
@@ -165,7 +166,8 @@ std::string NvramConfig::InstanceSpecific::operator_numeric() const {
   return (*Dictionary())[kOperatorNumeric].asString();
 }
 
-void NvramConfig::InstanceSpecific::set_operator_numeric(std::string& operator_numeric) {
+void NvramConfig::InstanceSpecific::set_operator_numeric(
+    std::string& operator_numeric) {
   (*Dictionary())[kOperatorNumeric] = operator_numeric;
 }
 
@@ -193,8 +195,6 @@ void NvramConfig::InstanceSpecific::set_emergency_mode(bool mode) {
   (*Dictionary())[kEmergencyMode] = mode;
 }
 
-int NvramConfig::sim_type() const {
-  return sim_type_;
-}
+int NvramConfig::sim_type() const { return sim_type_; }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/nvram_config.h
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/nvram_config.h
@@ -21,7 +21,6 @@ namespace cuttlefish {
 
 // Holds the configuration of modem simulator.
 class NvramConfig {
-
  public:
   static void InitNvramConfigService(size_t num_instances, int sim_type);
   static const NvramConfig* Get();
@@ -46,7 +45,7 @@ class NvramConfig {
 
   // A view into an existing modem simulator object for a particular instance.
   class InstanceSpecific {
-  public:
+   public:
     int network_selection_mode() const;
     void set_network_selection_mode(int mode);
 

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/sup_service.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/sup_service.cpp
@@ -61,6 +61,7 @@ void SupService::InitializeServiceState() {
   };
 }
 
+// clang-format off
 /**
  * AT+CUSD
  *   This command allows control of the Unstructured Supplementary Service Data (USSD)
@@ -82,10 +83,12 @@ void SupService::InitializeServiceState() {
  *
  * see RIL_REQUEST_SEND_USSD or RIL_REQUEST_CANCEL_USSD in RIL
  */
+// clang-format on
 void SupService::HandleUSSD(const Client& client, std::string& /*command*/) {
   client.SendCommandResponse("OK");
 }
 
+// clang-format off
 /**
  * AT+CLIR
  *   This command refers to CLIR‑service according to 3GPP TS 22.081 that allows
@@ -109,6 +112,7 @@ void SupService::HandleUSSD(const Client& client, std::string& /*command*/) {
  *
  * see RIL_REQUEST_SET_CLIR or RIL_REQUEST_GET_CLIR in RIL
  */
+// clang-format on
 void SupService::HandleCLIR(const Client& client, std::string& command) {
   std::vector<std::string> responses;
   std::stringstream ss;
@@ -125,6 +129,7 @@ void SupService::HandleCLIR(const Client& client, std::string& command) {
   client.SendCommandResponse(responses);
 }
 
+// clang-format off
 /**
  * AT+CLIP
  *   This command refers to the supplementary service CLIP (Calling Line
@@ -146,11 +151,13 @@ void SupService::HandleCLIR(const Client& client, std::string& command) {
  *
  * see RIL_REQUEST_QUERY_CLIP in RIL
  */
+// clang-format on
 void SupService::HandleCLIP(const Client& client) {
   std::vector<std::string> responses = {"+CLIP: 0, 0", "OK"};
   client.SendCommandResponse(responses);
 }
 
+// clang-format off
 /**
  * AT+CSSN
  *   This command refers to supplementary service related network initiated
@@ -171,10 +178,12 @@ void SupService::HandleCLIP(const Client& client) {
  *
  * see RIL_REQUEST_SET_SUPP_SVC_NOTIFICATION in RIL
  */
+// clang-format on
 void SupService::HandleSuppServiceNotifications(const Client& client, std::string& /*command*/) {
   client.SendCommandResponse("OK");
 }
 
+// clang-format off
 /**
  * AT+CCFCU
  *   The command allows control of the communication forwarding supplementary service
@@ -191,6 +200,7 @@ void SupService::HandleSuppServiceNotifications(const Client& client, std::strin
  *
  * see RIL_REQUEST_SET_CALL_FORWARD or RIL_REQUEST_QUERY_CALL_FORWARD_STATUS in RIL
  */
+// clang-format on
 void SupService::HandleCallForward(const Client& client, std::string& command) {
   std::vector<std::string> responses;
   std::stringstream ss;
@@ -264,6 +274,7 @@ void SupService::HandleCallForward(const Client& client, std::string& command) {
   client.SendCommandResponse(responses);
 }
 
+// clang-format off
 /**
  * AT+CCWA
  *   This command allows control of the supplementary service Call Waiting
@@ -290,6 +301,7 @@ void SupService::HandleCallForward(const Client& client, std::string& command) {
  *
  * see RIL_REQUEST_QUERY_CALL_WAITING and RIL_REQUEST_SET_CALL_WAITING in RIL
  */
+// clang-format on
 void SupService::HandleCallWaiting(const Client& client, std::string& command) {
   std::vector<std::string> responses;
   std::stringstream ss;

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/sup_service.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/sup_service.cpp
@@ -53,12 +53,10 @@ std::vector<CommandHandler> SupService::InitializeCommandHandlers() {
 }
 
 void SupService::InitializeServiceState() {
-  call_forward_infos_ = {
-    CallForwardInfo(CallForwardInfo::Reason::CFU),
-    CallForwardInfo(CallForwardInfo::Reason::CFB),
-    CallForwardInfo(CallForwardInfo::Reason::CFNR),
-    CallForwardInfo(CallForwardInfo::Reason::CFNRC)
-  };
+  call_forward_infos_ = {CallForwardInfo(CallForwardInfo::Reason::CFU),
+                         CallForwardInfo(CallForwardInfo::Reason::CFB),
+                         CallForwardInfo(CallForwardInfo::Reason::CFNR),
+                         CallForwardInfo(CallForwardInfo::Reason::CFNRC)};
 }
 
 // clang-format off
@@ -179,7 +177,8 @@ void SupService::HandleCLIP(const Client& client) {
  * see RIL_REQUEST_SET_SUPP_SVC_NOTIFICATION in RIL
  */
 // clang-format on
-void SupService::HandleSuppServiceNotifications(const Client& client, std::string& /*command*/) {
+void SupService::HandleSuppServiceNotifications(const Client& client,
+                                                std::string& /*command*/) {
   client.SendCommandResponse("OK");
 }
 
@@ -221,8 +220,8 @@ void SupService::HandleCallForward(const Client& client, std::string& command) {
         auto iter = call_forward_infos_.begin();
         for (; iter != call_forward_infos_.end(); ++iter) {
           ss.clear();
-          ss << "+CCFCU: " << iter->status << "," << classx << "," << number_type
-                  << "," << ton << ",\"" << iter->number << "\"";
+          ss << "+CCFCU: " << iter->status << "," << classx << ","
+             << number_type << "," << ton << ",\"" << iter->number << "\"";
           if (iter->reason == CallForwardInfo::Reason::CFNR) {
             ss << ",,," << iter->timeSeconds;
           }
@@ -237,8 +236,8 @@ void SupService::HandleCallForward(const Client& client, std::string& command) {
     case CallForwardInfo::Reason::CFNR:
     case CallForwardInfo::Reason::CFNRC: {
       if (status == CallForwardInfo::CallForwardInfoStatus::INTERROGATE) {
-        ss << "+CCFCU: " << call_forward_infos_[reason].status
-           << "," << classx << "," << number_type << "," << ton << ",\""
+        ss << "+CCFCU: " << call_forward_infos_[reason].status << "," << classx
+           << "," << number_type << "," << ton << ",\""
            << call_forward_infos_[reason].number << "\"";
         if (reason == CallForwardInfo::Reason::CFNR) {
           ss << ",,," << call_forward_infos_[reason].timeSeconds;
@@ -246,11 +245,11 @@ void SupService::HandleCallForward(const Client& client, std::string& command) {
         responses.push_back(ss.str());
       } else {
         if (status == CallForwardInfo::CallForwardInfoStatus::REGISTRATION) {
-          call_forward_infos_[reason].status
-                = CallForwardInfo::CallForwardInfoStatus::ENABLE;
+          call_forward_infos_[reason].status =
+              CallForwardInfo::CallForwardInfoStatus::ENABLE;
         } else {
           call_forward_infos_[reason].status =
-                (CallForwardInfo::CallForwardInfoStatus)status;
+              (CallForwardInfo::CallForwardInfoStatus)status;
         }
         call_forward_infos_[reason].number_type = number_type;
         call_forward_infos_[reason].ton = ton;
@@ -260,7 +259,8 @@ void SupService::HandleCallForward(const Client& client, std::string& command) {
           cmd.SkipComma();
           cmd.SkipComma();
           int timeSeconds = cmd.GetNextInt();
-          call_forward_infos_[reason].timeSeconds = timeSeconds >= 0 ? timeSeconds : 0;
+          call_forward_infos_[reason].timeSeconds =
+              timeSeconds >= 0 ? timeSeconds : 0;
         }
       }
       break;

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/sup_service.h
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/sup_service.h
@@ -19,21 +19,23 @@
 
 namespace cuttlefish {
 
-class SupService : public ModemService, public std::enable_shared_from_this<SupService> {
+class SupService : public ModemService,
+                   public std::enable_shared_from_this<SupService> {
  public:
   SupService(int32_t service_id, ChannelMonitor* channel_monitor,
              ThreadLooper* thread_looper);
   ~SupService() = default;
 
-  SupService(const SupService &) = delete;
-  SupService &operator=(const SupService &) = delete;
+  SupService(const SupService&) = delete;
+  SupService& operator=(const SupService&) = delete;
 
   void HandleUSSD(const Client& client, std::string& command);
   void HandleCLIR(const Client& client, std::string& command);
   void HandleCallWaiting(const Client& client, std::string& command);
   void HandleCLIP(const Client& client);
   void HandleCallForward(const Client& client, std::string& command);
-  void HandleSuppServiceNotifications(const Client& client, std::string& command);
+  void HandleSuppServiceNotifications(const Client& client,
+                                      std::string& command);
 
  private:
   std::vector<CommandHandler> InitializeCommandHandlers();
@@ -41,17 +43,17 @@ class SupService : public ModemService, public std::enable_shared_from_this<SupS
 
   struct ClirStatusInfo {
     enum ClirType {
-      DEFAULT = 0,                  // "use subscription default value"
-      CLIR_INVOCATION        = 1,   // restrict CLI presentation
-      CLIR_SUPPRESSION       = 2,   // allow CLI presentation
+      DEFAULT = 0,           // "use subscription default value"
+      CLIR_INVOCATION = 1,   // restrict CLI presentation
+      CLIR_SUPPRESSION = 2,  // allow CLI presentation
     };
 
     enum ClirStatus {
-      CLIR_NOT_PROVISIONED         = 0,
-      CLIR_PROVISIONED             = 1,
-      UNKNOWN                       = 2,
+      CLIR_NOT_PROVISIONED = 0,
+      CLIR_PROVISIONED = 1,
+      UNKNOWN = 2,
       CLIR_PRESENTATION_RESTRICTED = 3,
-      CLIR_PRESENTATION_ALLOWED    = 4,
+      CLIR_PRESENTATION_ALLOWED = 4,
     };
 
     ClirType type;
@@ -61,46 +63,49 @@ class SupService : public ModemService, public std::enable_shared_from_this<SupS
 
   struct CallForwardInfo {
     enum CallForwardInfoStatus {
-      DISABLE       = 0,
-      ENABLE        = 1,
-      INTERROGATE   = 2,
-      REGISTRATION  = 3,
-      ERASURE       = 4,
+      DISABLE = 0,
+      ENABLE = 1,
+      INTERROGATE = 2,
+      REGISTRATION = 3,
+      ERASURE = 4,
     };
 
     enum Reason {
-      CFU         = 0,  // communication forwarding unconditional
-      CFB         = 1,  //communication forwarding on busy user
-      CFNR        = 2,  // communication forwarding on no reply
-      CFNRC       = 3,  // communication forwarding on subscriber not reachable
-      ALL_CF      = 4,  // all call forwarding
-      ALL_CONDITIONAL_CF = 5, //all conditional call forwarding
-      CD          = 6,  // communication deflection
-      CFNL        = 7,  // communication forwarding on not logged-in
+      CFU = 0,     // communication forwarding unconditional
+      CFB = 1,     // communication forwarding on busy user
+      CFNR = 2,    // communication forwarding on no reply
+      CFNRC = 3,   // communication forwarding on subscriber not reachable
+      ALL_CF = 4,  // all call forwarding
+      ALL_CONDITIONAL_CF = 5,  // all conditional call forwarding
+      CD = 6,                  // communication deflection
+      CFNL = 7,                // communication forwarding on not logged-in
     };
 
     CallForwardInfoStatus status;
     Reason reason;
-    int number_type;    // From 27.007 +CCFC/+CLCK "class"
-    int ton;            // "type" from TS 27.007 7.11
-    std::string number; // "number" from TS 27.007 7.11. May be NULL
-    int timeSeconds;    // for CF no reply only
+    int number_type;     // From 27.007 +CCFC/+CLCK "class"
+    int ton;             // "type" from TS 27.007 7.11
+    std::string number;  // "number" from TS 27.007 7.11. May be NULL
+    int timeSeconds;     // for CF no reply only
 
-    CallForwardInfo(Reason reason) :
-      status(DISABLE), reason(reason), number_type(2), ton(129), number(""),
-        timeSeconds(0){};
+    CallForwardInfo(Reason reason)
+        : status(DISABLE),
+          reason(reason),
+          number_type(2),
+          ton(129),
+          number(""),
+          timeSeconds(0) {};
   };
   std::vector<CallForwardInfo> call_forward_infos_;
 
   struct CallWaitingInfo {
-    int presentation_status;  // sets / shows the result code presentation status to the TE,
-                              // 0: disable; 1: enable
+    int presentation_status;  // sets / shows the result code presentation
+                              // status to the TE, 0: disable; 1: enable
     int mode;                 // 0: disable; 1: enable; 2: query status
-    int classx;               // a sum of integers each representing a class of information
-                              // default 7-voice, data and fax, see FacilityLock::Class
+    int classx;  // a sum of integers each representing a class of information
+                 // default 7-voice, data and fax, see FacilityLock::Class
 
-    CallWaitingInfo() :
-      presentation_status(1), mode(0), classx(7) {};
+    CallWaitingInfo() : presentation_status(1), mode(0), classx(7) {};
   };
   CallWaitingInfo call_waiting_info_;
 };

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/thread_looper.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/thread_looper.cpp
@@ -19,14 +19,13 @@
 
 namespace cuttlefish {
 
-ThreadLooper::ThreadLooper()
-  :   stopped_(false), next_serial_(1) {
+ThreadLooper::ThreadLooper() : stopped_(false), next_serial_(1) {
   looper_thread_ = std::thread([this]() { ThreadLoop(); });
 }
 
 ThreadLooper::~ThreadLooper() { Stop(); }
 
-bool ThreadLooper::Event::operator<=(const Event &other) const {
+bool ThreadLooper::Event::operator<=(const Event& other) const {
   return when <= other.when;
 }
 
@@ -37,7 +36,7 @@ ThreadLooper::Serial ThreadLooper::Post(Callback cb) {
   // If it's the time to process event with delay exactly when posting
   // a event without delay. Looper would process the event without delay firstly
   // if when set to be std::nullptr. so set when_ to be now.
-  Insert({ std::chrono::steady_clock::now(), cb, serial });
+  Insert({std::chrono::steady_clock::now(), cb, serial});
 
   return serial;
 }
@@ -47,7 +46,7 @@ ThreadLooper::Serial ThreadLooper::Post(
   CHECK(cb != nullptr);
 
   auto serial = next_serial_++;
-  Insert({ std::chrono::steady_clock::now() + delay, cb, serial });
+  Insert({std::chrono::steady_clock::now() + delay, cb, serial});
 
   return serial;
 }
@@ -69,7 +68,7 @@ bool ThreadLooper::CancelSerial(Serial serial) {
   return found;
 }
 
-void ThreadLooper::Insert(const Event &event) {
+void ThreadLooper::Insert(const Event& event) {
   std::lock_guard<std::mutex> autolock(lock_);
 
   auto iter = queue_.begin();
@@ -82,7 +81,7 @@ void ThreadLooper::Insert(const Event &event) {
 }
 
 void ThreadLooper::ThreadLoop() {
-  for(;;) {
+  for (;;) {
     Callback cb;
     {
       std::unique_lock<std::mutex> lock(lock_);
@@ -96,7 +95,8 @@ void ThreadLooper::ThreadLoop() {
         continue;
       }
 
-      auto time_to_wait = queue_.front().when - std::chrono::steady_clock::now();
+      auto time_to_wait =
+          queue_.front().when - std::chrono::steady_clock::now();
       if (time_to_wait.count() > 0) {
         // wait with timeout
         auto durationMs =
@@ -104,7 +104,7 @@ void ThreadLooper::ThreadLoop() {
         cond_.wait_for(lock, durationMs);
         continue;
       }
-      cb = queue_.front().cb; // callback at front of queue
+      cb = queue_.front().cb;  // callback at front of queue
       queue_.pop_front();
     }
     cb();

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/thread_looper.h
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/thread_looper.h
@@ -26,7 +26,7 @@
 namespace cuttlefish {
 
 template <typename T>
-std::function<void()> makeSafeCallback(T *me, std::function<void(T *)> f) {
+std::function<void()> makeSafeCallback(T* me, std::function<void(T*)> f) {
   return [f, me] {
     if (me) {
       f(me);
@@ -34,18 +34,18 @@ std::function<void()> makeSafeCallback(T *me, std::function<void(T *)> f) {
   };
 }
 
-template<typename T, typename... Params>
-std::function<void()> makeSafeCallback(
-    T *obj, void (T::*f)(const Params&...), const Params&... params) {
+template <typename T, typename... Params>
+std::function<void()> makeSafeCallback(T* obj, void (T::*f)(const Params&...),
+                                       const Params&... params) {
   return makeSafeCallback<T>(obj,
-                             [f, params...](T *me) { (me->*f)(params...); });
+                             [f, params...](T* me) { (me->*f)(params...); });
 }
 
-template<typename T, typename... Params>
-std::function<void()> makeSafeCallback(
-      T *obj, void (T::*f)(Params...), const Params&... params) {
+template <typename T, typename... Params>
+std::function<void()> makeSafeCallback(T* obj, void (T::*f)(Params...),
+                                       const Params&... params) {
   return makeSafeCallback<T>(obj,
-                             [f, params...](T *me) { (me->*f)(params...); });
+                             [f, params...](T* me) { (me->*f)(params...); });
 }
 
 class ThreadLooper {
@@ -53,8 +53,8 @@ class ThreadLooper {
   ThreadLooper();
   ~ThreadLooper();
 
-  ThreadLooper(const ThreadLooper &) = delete;
-  ThreadLooper &operator=(const ThreadLooper &) = delete;
+  ThreadLooper(const ThreadLooper&) = delete;
+  ThreadLooper& operator=(const ThreadLooper&) = delete;
 
   typedef std::function<void()> Callback;
   typedef int32_t Serial;
@@ -69,11 +69,11 @@ class ThreadLooper {
 
  private:
   struct Event {
-      std::chrono::steady_clock::time_point when;
-      Callback cb;
-      Serial serial;
+    std::chrono::steady_clock::time_point when;
+    Callback cb;
+    Serial serial;
 
-      bool operator<=(const Event &other) const;
+    bool operator<=(const Event& other) const;
   };
 
   bool stopped_;
@@ -86,7 +86,7 @@ class ThreadLooper {
 
   void ThreadLoop();
 
-  void Insert(const Event &event);
+  void Insert(const Event& event);
 };
 
 };  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/unittest/command_parser_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/unittest/command_parser_test.cpp
@@ -82,7 +82,8 @@ TEST(CommandParserUnitTest, GetNextInt) {
   ASSERT_EQ(28421, cmd.GetNextInt());
 }
 
-TEST(CommandParserUnitTest, GetNextHexInt) {  // Hexadecimal string to decimal value
+TEST(CommandParserUnitTest,
+     GetNextHexInt) {  // Hexadecimal string to decimal value
   std::string command = "C0,6F05";
 
   cuttlefish::CommandParser cmd(command);

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/unittest/pdu_parser_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/unittest/pdu_parser_test.cpp
@@ -18,7 +18,9 @@
 #include <gtest/gtest.h>
 
 TEST(PDUParserTest, IsValidPDU_true) {
-  std::string pdu = "0001000D91688118109844F0000017AFD7903AB55A9BBA69D639D4ADCBF99E3DCCAE9701";
+  std::string pdu =
+      "0001000D91688118109844F0000017AFD7903AB55A9BBA69D639D4ADCBF99E3DCCAE970"
+      "1";
   cuttlefish::PDUParser smspdu(pdu);
   EXPECT_TRUE(smspdu.IsValidPDU());
 
@@ -28,32 +30,38 @@ TEST(PDUParserTest, IsValidPDU_true) {
 }
 
 TEST(PDUParserTest, IsValidPDU_false) {
-  std::string pdu = "000100fD91688118109844F0000017AFD7903AB55A9BBA69D639D4ADCBF99E3DCCAE9701";
+  std::string pdu =
+      "000100fD91688118109844F0000017AFD7903AB55A9BBA69D639D4ADCBF99E3DCCAE970"
+      "1";
   cuttlefish::PDUParser smspdu(pdu);
   EXPECT_FALSE(smspdu.IsValidPDU());
 }
 
 TEST(PDUParserTest, CreatePDU) {
-  std::string pdu = "0001000D91688118109844F0000017AFD7903AB55A9BBA69D639D4ADCBF99E3DCCAE9701";
+  std::string pdu =
+      "0001000D91688118109844F0000017AFD7903AB55A9BBA69D639D4ADCBF99E3DCCAE970"
+      "1";
   cuttlefish::PDUParser smspdu(pdu);
   EXPECT_TRUE(smspdu.IsValidPDU());
   std::string new_pdu = smspdu.CreatePDU();
-  const char *expect = "";
+  const char* expect = "";
   ASSERT_STRNE(new_pdu.c_str(), expect);
 }
 
 TEST(PDUParserTest, GetPhoneNumberFromAddress) {
-  std::string pdu = "0001000D91688118109844F0000017AFD7903AB55A9BBA69D639D4ADCBF99E3DCCAE9701";
+  std::string pdu =
+      "0001000D91688118109844F0000017AFD7903AB55A9BBA69D639D4ADCBF99E3DCCAE970"
+      "1";
   cuttlefish::PDUParser smspdu(pdu);
   EXPECT_TRUE(smspdu.IsValidPDU());
   std::string phone_number = smspdu.GetPhoneNumberFromAddress();
-  const char *expect = "18810189440";
+  const char* expect = "18810189440";
   ASSERT_STREQ(phone_number.c_str(), expect);
 }
 
 TEST(PDUParserTest, BCDToString) {
   std::string value = "12345678";
   std::string process_value = cuttlefish::PDUParser::BCDToString(value);
-  const char *expect = "21436587";
+  const char* expect = "21436587";
   ASSERT_STREQ(process_value.c_str(), expect);
 }

--- a/base/cvd/cuttlefish/host/commands/powerwash_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/powerwash_cvd/BUILD.bazel
@@ -9,7 +9,6 @@ cf_cc_binary(
     srcs = [
         "powerwash_cvd.cc",
     ],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:tee_logging",

--- a/base/cvd/cuttlefish/host/commands/powerwash_cvd/powerwash_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/powerwash_cvd/powerwash_cvd.cc
@@ -64,8 +64,8 @@ Result<void> PowerwashCvdMain() {
   return {};
 }
 
-} // namespace
-} // namespace cuttlefish
+}  // namespace
+}  // namespace cuttlefish
 
 int main(int argc, char** argv) {
   cuttlefish::LogToStderr();

--- a/base/cvd/cuttlefish/host/commands/restart_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/restart_cvd/BUILD.bazel
@@ -9,7 +9,6 @@ cf_cc_binary(
     srcs = [
         "restart_cvd.cc",
     ],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:tee_logging",

--- a/base/cvd/cuttlefish/host/commands/restart_cvd/restart_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/restart_cvd/restart_cvd.cc
@@ -35,8 +35,9 @@ DEFINE_int32(
     "How many seconds to wait for the launcher to respond to the status "
     "command. A value of zero means wait indefinitely.");
 
-DEFINE_int32(boot_timeout, 1000, "How many seconds to wait for the device to "
-                                 "reboot.");
+DEFINE_int32(boot_timeout, 1000,
+             "How many seconds to wait for the device to "
+             "reboot.");
 
 namespace cuttlefish {
 namespace {
@@ -63,8 +64,8 @@ Result<void> RestartCvdMain() {
   return {};
 }
 
-} // namespace
-} // namespace cuttlefish
+}  // namespace
+}  // namespace cuttlefish
 
 int main(int argc, char** argv) {
   cuttlefish::LogToStderr();

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
@@ -75,7 +75,6 @@ cf_cc_library(
     name = "enable_multitouch",
     srcs = ["enable_multitouch.cpp"],
     hdrs = ["enable_multitouch.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:guest_os",

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/enable_multitouch.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/enable_multitouch.cpp
@@ -26,4 +26,3 @@ bool ShouldEnableMultitouch(
 }
 
 }  // namespace cuttlefish
-

--- a/base/cvd/cuttlefish/host/commands/secure_env/oemlock/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/secure_env/oemlock/BUILD.bazel
@@ -8,7 +8,6 @@ cf_cc_library(
     name = "oemlock",
     srcs = ["oemlock.cpp"],
     hdrs = ["oemlock.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/commands/secure_env/storage",
         "//cuttlefish/result",

--- a/base/cvd/cuttlefish/host/commands/secure_env/oemlock/oemlock.h
+++ b/base/cvd/cuttlefish/host/commands/secure_env/oemlock/oemlock.h
@@ -29,7 +29,7 @@ namespace oemlock {
  *
  * Inspired by OemLock HAL interface:
  * https://cs.android.com/android/platform/superproject/+/master:hardware/interfaces/oemlock/aidl/default/Android.bp
-*/
+ */
 class OemLock {
  public:
   OemLock(secure_env::Storage& storage);
@@ -47,5 +47,5 @@ class OemLock {
   secure_env::Storage& storage_;
 };
 
-} // namespace oemlock
-} // namespace cuttlefish
+}  // namespace oemlock
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/secure_env/storage/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/secure_env/storage/BUILD.bazel
@@ -24,7 +24,6 @@ cf_cc_library(
     name = "storage",
     srcs = ["storage.cpp"],
     hdrs = ["storage.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/result",
     ],

--- a/base/cvd/cuttlefish/host/commands/secure_env/storage/storage.cpp
+++ b/base/cvd/cuttlefish/host/commands/secure_env/storage/storage.cpp
@@ -19,15 +19,13 @@
 namespace cuttlefish {
 namespace secure_env {
 
-void StorageDataDestroyer::operator()(StorageData* ptr) {
-  std::free(ptr);
-}
+void StorageDataDestroyer::operator()(StorageData* ptr) { std::free(ptr); }
 
 Result<ManagedStorageData> CreateStorageData(size_t size) {
   const auto bytes_to_allocate = sizeof(StorageData) + size;
   auto memory = std::malloc(bytes_to_allocate);
-  CF_EXPECT(memory != nullptr,
-            "Cannot allocate " << bytes_to_allocate << " bytes for storage data");
+  CF_EXPECT(memory != nullptr, "Cannot allocate " << bytes_to_allocate
+                                                  << " bytes for storage data");
   auto data = reinterpret_cast<StorageData*>(memory);
   data->size = size;
   return ManagedStorageData(data);

--- a/base/cvd/cuttlefish/host/commands/secure_env/storage/storage.h
+++ b/base/cvd/cuttlefish/host/commands/secure_env/storage/storage.h
@@ -28,7 +28,8 @@ struct StorageData {
   uint8_t payload[0];
 
   Result<uint8_t> asUint8() {
-    CF_EXPECT(size == sizeof(uint8_t), "Size of payload is not matched with uint8 size");
+    CF_EXPECT(size == sizeof(uint8_t),
+              "Size of payload is not matched with uint8 size");
     return *reinterpret_cast<uint8_t*>(payload);
   }
 };
@@ -54,16 +55,17 @@ Result<ManagedStorageData> CreateStorageData(const void* data, size_t size);
 
 /**
  * Storage abstraction to store binary blobs associated with string key
-*/
+ */
 class Storage {
  public:
   virtual Result<bool> HasKey(const std::string& key) const = 0;
   virtual Result<ManagedStorageData> Read(const std::string& key) const = 0;
-  virtual Result<void> Write(const std::string& key, const StorageData& data) = 0;
+  virtual Result<void> Write(const std::string& key,
+                             const StorageData& data) = 0;
   virtual bool Exists() const = 0;
 
   virtual ~Storage() = default;
 };
 
-} // namespace secure_env
-} // namespace cuttlefish
+}  // namespace secure_env
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/sensors_simulator/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/sensors_simulator/BUILD.bazel
@@ -12,7 +12,6 @@ cf_cc_library(
     hdrs = [
         "sensors_simulator.h",
     ],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/sensors",
         "//libbase",
@@ -46,7 +45,6 @@ cf_cc_binary(
     srcs = [
         "main.cpp",
     ],
-    clang_format_enabled = False,
     deps = [
         ":libsensors_hal_proxy",
         ":libsensors_simulator",

--- a/base/cvd/cuttlefish/host/commands/sensors_simulator/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/sensors_simulator/main.cpp
@@ -25,10 +25,14 @@
 #include "cuttlefish/host/commands/sensors_simulator/sensors_simulator.h"
 #include "cuttlefish/host/libs/config/logging.h"
 
-DEFINE_int32(control_from_guest_fd, -1, "Sensors control virtio-console from guest to host");
-DEFINE_int32(control_to_guest_fd, -1, "Sensors control virtio-console from host to guest");
-DEFINE_int32(data_from_guest_fd, -1, "Sensors data virtio-console from guest to host");
-DEFINE_int32(data_to_guest_fd, -1, "Sensors data virtio-console from host to guest");
+DEFINE_int32(control_from_guest_fd, -1,
+             "Sensors control virtio-console from guest to host");
+DEFINE_int32(control_to_guest_fd, -1,
+             "Sensors control virtio-console from host to guest");
+DEFINE_int32(data_from_guest_fd, -1,
+             "Sensors data virtio-console from guest to host");
+DEFINE_int32(data_to_guest_fd, -1,
+             "Sensors data virtio-console from host to guest");
 DEFINE_int32(webrtc_fd, -1, "A file descriptor to communicate with webrtc");
 DEFINE_int32(kernel_events_fd, -1,
              "A pipe for monitoring events based on messages "

--- a/base/cvd/cuttlefish/host/commands/sensors_simulator/sensors_simulator.cpp
+++ b/base/cvd/cuttlefish/host/commands/sensors_simulator/sensors_simulator.cpp
@@ -28,7 +28,7 @@ constexpr float kLight = 1000.0f;       // lux
 constexpr float kPressure = 1013.25f;   // hpa
 constexpr float kHumidity = 40.0f;      // percent
 constexpr float kHingeAngle0 = 180.0f;  // degree
-constexpr double kG = 9.80665;  // meter per second^2
+constexpr double kG = 9.80665;          // meter per second^2
 const Eigen::Vector3d kMagneticField{0, 5.9, -48.4};
 inline double ToRadians(double x) { return x * M_PI / 180; }
 

--- a/base/cvd/cuttlefish/host/frontend/webrtc/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/BUILD.bazel
@@ -111,7 +111,6 @@ cf_cc_library(
     name = "libcuttlefish_webrtc_client_server",
     srcs = ["client_server.cpp"],
     hdrs = ["client_server.h"],
-    clang_format_enabled = False,
     deps = [
         "//libbase",
         "@abseil-cpp//absl/log",

--- a/base/cvd/cuttlefish/host/frontend/webrtc/client_server.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/client_server.cpp
@@ -113,4 +113,3 @@ void ClientFilesServer::Serve() {
   }
 }
 }  // namespace cuttlefish
-

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/BUILD.bazel
@@ -8,7 +8,6 @@ cf_cc_library(
     name = "audio_device",
     srcs = ["audio_device.cpp"],
     hdrs = ["audio_device.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/frontend/webrtc/libcommon:audio_source",
         "//libbase",
@@ -80,7 +79,6 @@ cf_cc_library(
     name = "vp8only_encoder_factory",
     srcs = ["vp8only_encoder_factory.cpp"],
     hdrs = ["vp8only_encoder_factory.h"],
-    clang_format_enabled = False,
     deps = [
         "@libwebrtc",
     ],

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/audio_device.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/audio_device.h
@@ -33,14 +33,16 @@ class CfAudioDeviceModule : public webrtc::AudioDeviceModule,
 
   // Returns number of frames if there is data available, 0 if the stream is not
   // playing (no clients or the streams are muted), -1 on error.
-  int GetMoreAudioData(void* data, int bytes_per_samples, int samples_per_channel,
-                       int num_channels, int sample_rate, bool& muted) override;
+  int GetMoreAudioData(void* data, int bytes_per_samples,
+                       int samples_per_channel, int num_channels,
+                       int sample_rate, bool& muted) override;
 
   // Retrieve the currently utilized audio layer
   int32_t ActiveAudioLayer(AudioLayer* audioLayer) const override;
 
   // Full-duplex transportation of PCM audio
-  int32_t RegisterAudioCallback(webrtc::AudioTransport* audio_callback) override;
+  int32_t RegisterAudioCallback(
+      webrtc::AudioTransport* audio_callback) override;
 
   // Main initialization and termination
   int32_t Init() override;

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/vp8only_encoder_factory.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/vp8only_encoder_factory.h
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <api/video_codecs/video_encoder_factory.h>
 #include <api/video_codecs/video_encoder.h>
+#include <api/video_codecs/video_encoder_factory.h>
 
 namespace cuttlefish {
 namespace webrtc_streaming {

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/BUILD.bazel
@@ -15,7 +15,6 @@ cf_cc_library(
 cf_cc_library(
     name = "audio_sink",
     hdrs = ["audio_sink.h"],
-    clang_format_enabled = False,
     deps = [
         ":audio_frame_buffer",
     ],
@@ -25,7 +24,6 @@ cf_cc_library(
     name = "audio_track_source_impl",
     srcs = ["audio_track_source_impl.cpp"],
     hdrs = ["audio_track_source_impl.h"],
-    clang_format_enabled = False,
     deps = [
         ":audio_sink",
         "//cuttlefish/host/frontend/webrtc/libcommon:audio_source",
@@ -80,7 +78,6 @@ cf_cc_library(
 cf_cc_library(
     name = "connection_observer",
     hdrs = ["connection_observer.h"],
-    clang_format_enabled = False,
     deps = [
         ":camera_controller",
         ":lights_observer",
@@ -114,7 +111,6 @@ cf_cc_library(
     name = "gamepad",
     srcs = ["gamepad.cpp"],
     hdrs = ["gamepad.h"],
-    clang_format_enabled = False,
     deps = [
         "//libbase",
     ],
@@ -145,7 +141,6 @@ cf_cc_library(
     name = "local_recorder",
     srcs = ["local_recorder.cpp"],
     hdrs = ["local_recorder.h"],
-    clang_format_enabled = False,
     linkopts = [
         "-lopus",
     ],
@@ -165,7 +160,6 @@ cf_cc_library(
     name = "recording_manager",
     srcs = ["recording_manager.cpp"],
     hdrs = ["recording_manager.h"],
-    clang_format_enabled = False,
     deps = [
         ":local_recorder",
         "//cuttlefish/host/libs/config:cuttlefish_config",
@@ -180,7 +174,6 @@ cf_cc_library(
     name = "server_connection",
     srcs = ["server_connection.cpp"],
     hdrs = ["server_connection.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:json",

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/audio_sink.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/audio_sink.h
@@ -26,8 +26,7 @@ namespace webrtc_streaming {
 class AudioSink {
  public:
   virtual ~AudioSink() = default;
-  virtual void OnFrame(const AudioFrameBuffer& frame,
-                       int64_t timestamp_us) = 0;
+  virtual void OnFrame(const AudioFrameBuffer& frame, int64_t timestamp_us) = 0;
 };
 
 }  // namespace webrtc_streaming

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/audio_track_source_impl.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/audio_track_source_impl.cpp
@@ -51,12 +51,11 @@ const cricket::AudioOptions AudioTrackSourceImpl::options() const {
 
 void AudioTrackSourceImpl::OnFrame(const AudioFrameBuffer& frame,
                                    int64_t timestamp_ms) {
-    std::lock_guard<std::mutex> lock(sinks_mutex_);
-    for (auto sink : sinks_) {
-      sink->OnData(frame.data(), frame.bits_per_sample(),
-                   frame.sample_rate(), frame.channels(), frame.frames(),
-                   timestamp_ms);
-    }
+  std::lock_guard<std::mutex> lock(sinks_mutex_);
+  for (auto sink : sinks_) {
+    sink->OnData(frame.data(), frame.bits_per_sample(), frame.sample_rate(),
+                 frame.channels(), frame.frames(), timestamp_ms);
+  }
 }
 
 AudioTrackSourceImpl::SourceState AudioTrackSourceImpl::state() const {

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/audio_track_source_impl.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/audio_track_source_impl.h
@@ -74,8 +74,7 @@ class AudioTrackSourceImplSinkWrapper : public AudioSink {
   AudioTrackSourceImplSinkWrapper(rtc::scoped_refptr<AudioTrackSourceImpl> obj)
       : track_source_impl_(obj) {}
 
-  void OnFrame(const AudioFrameBuffer& frame,
-               int64_t timestamp_ms) override {
+  void OnFrame(const AudioFrameBuffer& frame, int64_t timestamp_ms) override {
     track_source_impl_->OnFrame(frame, timestamp_ms);
   }
 

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/connection_observer.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/connection_observer.h
@@ -118,4 +118,3 @@ class ConnectionObserverFactory {
 
 }  // namespace webrtc_streaming
 }  // namespace cuttlefish
-

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/gamepad.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/gamepad.cpp
@@ -40,5 +40,4 @@ uint16_t JsIndexToLinux(const int32_t& index_code) {
   return kJsIndexToLinuxMapping[index_code];
 }
 
-}
-
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/gamepad.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/gamepad.h
@@ -24,5 +24,3 @@ namespace cuttlefish {
 uint16_t JsIndexToLinux(const int32_t& index_code);
 
 }
-
-

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/local_recorder.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/local_recorder.cpp
@@ -45,12 +45,13 @@ constexpr double kRtpTicksPerUs = kRtpTicksPerMs / 1000.;
 constexpr double kRtpTicksPerNs = kRtpTicksPerUs / 1000.;
 
 class LocalRecorder::Display
-    : public webrtc::EncodedImageCallback
-    , public rtc::VideoSinkInterface<webrtc::VideoFrame> {
-public:
+    : public webrtc::EncodedImageCallback,
+      public rtc::VideoSinkInterface<webrtc::VideoFrame> {
+ public:
   Display(LocalRecorder::Impl& impl);
   ~Display() {
-    CHECK(!encoder_running_) << "LocalRecorder::Display destroyed before calling Stop()";
+    CHECK(!encoder_running_)
+        << "LocalRecorder::Display destroyed before calling Stop()";
   }
 
   void EncoderLoop();
@@ -78,7 +79,7 @@ public:
 };
 
 class LocalRecorder::Impl {
-public:
+ public:
   mkvmuxer::MkvWriter file_writer_;
   mkvmuxer::Segment segment_;
   std::unique_ptr<webrtc::VideoEncoderFactory> encoder_factory_;
@@ -114,8 +115,7 @@ std::unique_ptr<LocalRecorder> LocalRecorder::Create(
 }
 
 LocalRecorder::LocalRecorder(std::unique_ptr<LocalRecorder::Impl> impl)
-    : impl_(std::move(impl)) {
-}
+    : impl_(std::move(impl)) {}
 
 LocalRecorder::~LocalRecorder() = default;
 
@@ -144,8 +144,8 @@ void LocalRecorder::AddDisplay(
     return;
   }
 
-  display->video_encoder_ =
-      impl_->encoder_factory_->CreateVideoEncoder(webrtc::SdpVideoFormat("VP8"));
+  display->video_encoder_ = impl_->encoder_factory_->CreateVideoEncoder(
+      webrtc::SdpVideoFormat("VP8"));
   if (!display->video_encoder_) {
     LOG(ERROR) << "Could not create vp8 video encoder";
     return;
@@ -158,17 +158,17 @@ void LocalRecorder::AddDisplay(
   }
   source->AddOrUpdateSink(display.get(), rtc::VideoSinkWants{});
 
-  webrtc::VideoCodec codec {};
+  webrtc::VideoCodec codec{};
   memset(&codec, 0, sizeof(codec));
   codec.codecType = webrtc::kVideoCodecVP8;
   codec.width = width;
   codec.height = height;
-  codec.startBitrate = 1000; // kilobits/sec
+  codec.startBitrate = 1000;  // kilobits/sec
   codec.maxBitrate = 2000;
   codec.minBitrate = 0;
   codec.maxFramerate = 60;
   codec.active = true;
-  codec.qpMax = 56; // kDefaultMaxQp from simulcast_encoder_adapter.cc
+  codec.qpMax = 56;  // kDefaultMaxQp from simulcast_encoder_adapter.cc
   codec.mode = webrtc::VideoCodecMode::kScreensharing;
   codec.expect_encode_from_texture = false;
   *codec.VP8() = webrtc::VideoEncoder::GetDefaultVp8Settings();
@@ -183,9 +183,8 @@ void LocalRecorder::AddDisplay(
   }
 
   display->encoder_running_ = true;
-  display->encoder_thread_ = std::thread([](Display* display) {
-    display->EncoderLoop();
-  }, display.get());
+  display->encoder_thread_ = std::thread(
+      [](Display* display) { display->EncoderLoop(); }, display.get());
 
   impl_->displays_[label] = std::move(display);
 }
@@ -198,8 +197,7 @@ void LocalRecorder::Stop() {
   impl_->segment_.Finalize();
 }
 
-LocalRecorder::Display::Display(LocalRecorder::Impl& impl) : impl_(impl) {
-}
+LocalRecorder::Display::Display(LocalRecorder::Impl& impl) : impl_(impl) {}
 
 void LocalRecorder::Display::OnFrame(const webrtc::VideoFrame& frame) {
   std::lock_guard queue_lock(encode_queue_mutex_);
@@ -235,9 +233,8 @@ void LocalRecorder::Display::EncoderLoop() {
     if (start_timestamp.time_since_epoch().count() == 0) {
       start_timestamp = now;
     }
-    auto timestamp_diff =
-        std::chrono::duration_cast<std::chrono::microseconds>(
-              now - start_timestamp);
+    auto timestamp_diff = std::chrono::duration_cast<std::chrono::microseconds>(
+        now - start_timestamp);
     frame->set_timestamp_us(timestamp_diff.count());
     frame->set_timestamp(timestamp_diff.count() * kRtpTicksPerUs);
 
@@ -276,17 +273,13 @@ webrtc::EncodedImageCallback::Result LocalRecorder::Display::OnEncodedImage(
 
   bool is_key =
       encoded_image._frameType == webrtc::VideoFrameType::kVideoFrameKey;
-  bool success = impl_.segment_.AddFrame(
-      encoded_image.data(),
-      encoded_image.size(),
-      video_track_number_,
-      timestamp,
-      is_key);
+  bool success =
+      impl_.segment_.AddFrame(encoded_image.data(), encoded_image.size(),
+                              video_track_number_, timestamp, is_key);
 
   webrtc::EncodedImageCallback::Result result(
-      success
-          ? webrtc::EncodedImageCallback::Result::Error::OK
-          : webrtc::EncodedImageCallback::Result::Error::ERROR_SEND_FAILED);
+      success ? webrtc::EncodedImageCallback::Result::Error::OK
+              : webrtc::EncodedImageCallback::Result::Error::ERROR_SEND_FAILED);
 
   if (success) {
     result.frame_id = encoded_image.Timestamp();
@@ -294,6 +287,5 @@ webrtc::EncodedImageCallback::Result LocalRecorder::Display::OnEncodedImage(
   return result;
 }
 
-} // namespace webrtc_streaming
-} // namespace cuttlefish
-
+}  // namespace webrtc_streaming
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/local_recorder.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/local_recorder.h
@@ -29,7 +29,7 @@ namespace webrtc_streaming {
 class VideoTrackSourceImpl;
 
 class LocalRecorder {
-public:
+ public:
   ~LocalRecorder();
 
   static std::unique_ptr<LocalRecorder> Create(const std::string& filename);
@@ -38,7 +38,7 @@ public:
                   std::shared_ptr<::webrtc::VideoTrackSourceInterface> source);
   void Stop();
 
-private:
+ private:
   class Display;
   class Impl;
 
@@ -47,5 +47,5 @@ private:
   std::unique_ptr<Impl> impl_;
 };
 
-} // namespace webrtc_streaming
-} // namespace cuttlefish
+}  // namespace webrtc_streaming
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/recording_manager.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/recording_manager.cpp
@@ -114,13 +114,15 @@ void RecordingManager::StartSingleRecorder(const std::string& label) {
   }
 
   int recording_time = rtc::TimeMillis();
-  std::string recording_path = fmt::format("{}recording_{}_{}_{}.webm", recording_directory_,
-                                           instance_name_, label, recording_time);
+  std::string recording_path =
+      fmt::format("{}recording_{}_{}_{}.webm", recording_directory_,
+                  instance_name_, label, recording_time);
   std::unique_ptr<cuttlefish::webrtc_streaming::LocalRecorder> local_recorder =
       LocalRecorder::Create(recording_path);
   CHECK(local_recorder) << "Could not create local recorder";
   local_recorder->AddDisplay(label, existing_source->second->width_,
-                             existing_source->second->height_, existing_source->second->video_);
+                             existing_source->second->height_,
+                             existing_source->second->video_);
   local_recorders_[label] = std::move(local_recorder);
 }
 

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/recording_manager.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/recording_manager.h
@@ -32,25 +32,25 @@ namespace cuttlefish {
 namespace webrtc_streaming {
 
 class Source {
-public:
+ public:
   size_t width_;
   size_t height_;
   std::shared_ptr<::webrtc::VideoTrackSourceInterface> video_;
 };
 
 class RecordingManager {
-public:
+ public:
   RecordingManager();
 
   void AddSource(size_t width, size_t height,
-           std::shared_ptr<::webrtc::VideoTrackSourceInterface> video,
-           const std::string& label);
+                 std::shared_ptr<::webrtc::VideoTrackSourceInterface> video,
+                 const std::string& label);
   void RemoveSource(const std::string& label);
   void Start();
   void Stop();
   void WaitForSources(size_t num_sources);
 
-private:
+ private:
   bool recording_;
   std::string recording_directory_;
   std::string instance_name_;
@@ -58,7 +58,8 @@ private:
   std::condition_variable video_source_ready_signal_;
   std::map<std::string, std::unique_ptr<Source>> sources_;
   std::map<std::string,
-           std::unique_ptr<cuttlefish::webrtc_streaming::LocalRecorder>> local_recorders_;
+           std::unique_ptr<cuttlefish::webrtc_streaming::LocalRecorder>>
+      local_recorders_;
 
   void StartSingleRecorder(const std::string& label);
 };

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/server_connection.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/server_connection.cpp
@@ -71,9 +71,7 @@ UnixServerConnection::UnixServerConnection(
     const std::string& addr, std::weak_ptr<ServerConnectionObserver> observer)
     : addr_(addr), observer_(observer) {}
 
-UnixServerConnection::~UnixServerConnection() {
-  StopThread();
-}
+UnixServerConnection::~UnixServerConnection() { StopThread(); }
 
 bool UnixServerConnection::Send(const Json::Value& msg) {
   Json::StreamWriterBuilder factory;
@@ -118,7 +116,7 @@ void UnixServerConnection::Connect() {
   }
   // Start the thread
   running_ = true;
-  thread_ = std::thread([this](){ReadLoop();});
+  thread_ = std::thread([this]() { ReadLoop(); });
 }
 
 void UnixServerConnection::StopThread() {

--- a/base/cvd/cuttlefish/host/graphics_detector/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/graphics_detector/BUILD.bazel
@@ -47,7 +47,6 @@ cf_cc_binary(
         "vulkan.cpp",
         "vulkan.h",
     ],
-    clang_format_enabled = False,
     clang_tidy_enabled = False,
     copts = COPTS + [
         "-DVULKAN_HPP_ASSERT_ON_RESULT=",

--- a/base/cvd/cuttlefish/host/graphics_detector/graphics_detector_vk_precision_qualifiers_on_yuv_samplers.cpp
+++ b/base/cvd/cuttlefish/host/graphics_detector/graphics_detector_vk_precision_qualifiers_on_yuv_samplers.cpp
@@ -298,7 +298,8 @@ gfxstream::expected<bool, vk::Result> CanHandlePrecisionQualifierWithYuvSampler(
       .basePipelineHandle = VK_NULL_HANDLE,
       .basePipelineIndex = 0,
   };
-  auto pipeline_rv = vk.device().createGraphicsPipelineUnique({}, pipelineCreateInfo);
+  auto pipeline_rv =
+      vk.device().createGraphicsPipelineUnique({}, pipelineCreateInfo);
   if (pipeline_rv.result != vk::Result::eSuccess) {
     return false;
   }

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -372,7 +372,6 @@ cf_cc_library(
     name = "kernel_args",
     srcs = ["kernel_args.cpp"],
     hdrs = ["kernel_args.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:host_info",
         "//cuttlefish/host/libs/config:cuttlefish_config",
@@ -406,7 +405,6 @@ cf_cc_library(
     name = "logging",
     srcs = ["logging.cpp"],
     hdrs = ["logging.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:tee_logging",
         "//cuttlefish/host/libs/config:cuttlefish_config",

--- a/base/cvd/cuttlefish/host/libs/config/adb/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/adb/BUILD.bazel
@@ -42,7 +42,6 @@ cf_cc_test(
     srcs = [
         "test.cpp",
     ],
-    clang_format_enabled = False,
     deps = [
         ":adb",
         "//cuttlefish/host/libs/config:config_flag",

--- a/base/cvd/cuttlefish/host/libs/config/adb/test.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/adb/test.cpp
@@ -21,8 +21,8 @@
 #include <vector>
 
 #include <fruit/component.h>
-#include <fruit/macro.h>
 #include <fruit/injector.h>
+#include <fruit/macro.h>
 #include <gtest/gtest.h>
 
 #include "cuttlefish/host/libs/config/config_flag.h"

--- a/base/cvd/cuttlefish/host/libs/config/kernel_args.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/kernel_args.cpp
@@ -42,20 +42,24 @@ std::vector<std::string> VmManagerKernelCmdline(
       if (instance.enable_kernel_log()) {
         vm_manager_cmdline.push_back("console=hvc0");
 
+        // clang-format off
         // To update the pl011 address:
         // $ qemu-system-aarch64 -machine virt -cpu cortex-a57 -machine dumpdtb=virt.dtb
         // $ dtc -O dts -o virt.dts -I dtb virt.dtb
         // In the virt.dts file, look for a uart node
+        // clang-format on
         vm_manager_cmdline.push_back("earlycon=pl011,mmio32,0x9000000");
       }
     } else if (target_arch == Arch::RiscV64) {
         vm_manager_cmdline.push_back("console=hvc0");
 
+        // clang-format off
         // To update the uart8250 address:
         // $ qemu-system-riscv64 -machine virt -machine dumpdtb=virt.dtb
         // $ dtc -O dts -o virt.dts -I dtb virt.dtb
         // In the virt.dts file, look for a uart node
         // Only 'mmio' mode works; mmio32 does not
+        // clang-format on
         vm_manager_cmdline.push_back("earlycon=uart8250,mmio,0x10000000");
 
         // The kernel defaults to Sv57. Disable 5-level paging to set the mode
@@ -65,9 +69,11 @@ std::vector<std::string> VmManagerKernelCmdline(
       if (instance.enable_kernel_log()) {
         vm_manager_cmdline.push_back("console=hvc0");
 
+        // clang-format off
         // To update the uart8250 address:
         // $ qemu-system-x86_64 -kernel bzImage -serial stdio | grep ttyS0
         // Only 'io' mode works; mmio and mmio32 do not
+        // clang-format on
         vm_manager_cmdline.push_back("earlycon=uart8250,io,0x3f8");
       }
 

--- a/base/cvd/cuttlefish/host/libs/config/kernel_args.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/kernel_args.cpp
@@ -25,7 +25,7 @@
 namespace cuttlefish {
 namespace {
 
-template<typename T>
+template <typename T>
 void AppendVector(std::vector<T>* destination, const std::vector<T>& source) {
   destination->insert(destination->end(), source.begin(), source.end());
 }
@@ -51,20 +51,20 @@ std::vector<std::string> VmManagerKernelCmdline(
         vm_manager_cmdline.push_back("earlycon=pl011,mmio32,0x9000000");
       }
     } else if (target_arch == Arch::RiscV64) {
-        vm_manager_cmdline.push_back("console=hvc0");
+      vm_manager_cmdline.push_back("console=hvc0");
 
-        // clang-format off
+      // clang-format off
         // To update the uart8250 address:
         // $ qemu-system-riscv64 -machine virt -machine dumpdtb=virt.dtb
         // $ dtc -O dts -o virt.dts -I dtb virt.dtb
         // In the virt.dts file, look for a uart node
         // Only 'mmio' mode works; mmio32 does not
-        // clang-format on
-        vm_manager_cmdline.push_back("earlycon=uart8250,mmio,0x10000000");
+      // clang-format on
+      vm_manager_cmdline.push_back("earlycon=uart8250,mmio,0x10000000");
 
-        // The kernel defaults to Sv57. Disable 5-level paging to set the mode
-        // to Sv48.
-        vm_manager_cmdline.push_back("no5lvl");
+      // The kernel defaults to Sv57. Disable 5-level paging to set the mode
+      // to Sv48.
+      vm_manager_cmdline.push_back("no5lvl");
     } else {
       if (instance.enable_kernel_log()) {
         vm_manager_cmdline.push_back("console=hvc0");
@@ -85,7 +85,8 @@ std::vector<std::string> VmManagerKernelCmdline(
       // crosvm sets up the ramoops.xx= flags for us, but QEMU does not.
       // See external/crosvm/x86_64/src/lib.rs
       // this feature is not supported on aarch64
-      // check guest's /proc/iomem when you need to change mem_address or mem_size
+      // check guest's /proc/iomem when you need to change mem_address or
+      // mem_size
       vm_manager_cmdline.push_back("ramoops.mem_address=0x150000000");
       vm_manager_cmdline.push_back("ramoops.mem_size=0x200000");
       vm_manager_cmdline.push_back("ramoops.console_size=0x80000");
@@ -101,7 +102,7 @@ std::vector<std::string> VmManagerKernelCmdline(
   return vm_manager_cmdline;
 }
 
-} // namespace
+}  // namespace
 
 std::vector<std::string> KernelCommandLineFromConfig(
     const CuttlefishConfig& config,
@@ -112,4 +113,4 @@ std::vector<std::string> KernelCommandLineFromConfig(
   return kernel_cmdline;
 }
 
-} // namespace cuttlefish
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/config/kernel_args.h
+++ b/base/cvd/cuttlefish/host/libs/config/kernel_args.h
@@ -27,4 +27,4 @@ std::vector<std::string> KernelCommandLineFromConfig(
     const CuttlefishConfig& config,
     const CuttlefishConfig::InstanceSpecific& instance);
 
-} // namespace cuttlefish
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/config/logging.h
+++ b/base/cvd/cuttlefish/host/libs/config/logging.h
@@ -19,7 +19,7 @@
 
 namespace cuttlefish {
 
-void DefaultSubprocessLogging(char* argv[],
-                              MetadataLevel stderr_level = MetadataLevel::ONLY_MESSAGE);
+void DefaultSubprocessLogging(
+    char* argv[], MetadataLevel stderr_level = MetadataLevel::ONLY_MESSAGE);
 
-} // namespace cuttlefish
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/image_aggregator/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/image_aggregator/BUILD.bazel
@@ -167,7 +167,6 @@ cf_cc_library(
     name = "qcow2",
     srcs = ["qcow2.cc"],
     hdrs = ["qcow2.h"],
-    clang_format_enabled = False,
     copts = COPTS + [
         "-Wno-packed-non-pod",
     ],

--- a/base/cvd/cuttlefish/host/libs/image_aggregator/qcow2.cc
+++ b/base/cvd/cuttlefish/host/libs/image_aggregator/qcow2.cc
@@ -85,9 +85,7 @@ Result<Qcow2Image> Qcow2Image::OpenExisting(std::string path) {
 
 std::string Qcow2Image::MagicString() { return "QFI\xfb"; }
 
-Qcow2Image::Qcow2Image(Qcow2Image&& other) {
-  impl_ = std::move(other.impl_);
-}
+Qcow2Image::Qcow2Image(Qcow2Image&& other) { impl_ = std::move(other.impl_); }
 Qcow2Image::~Qcow2Image() = default;
 Qcow2Image& Qcow2Image::operator=(Qcow2Image&& other) {
   impl_ = std::move(other.impl_);

--- a/base/cvd/cuttlefish/host/libs/input_connector/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/input_connector/BUILD.bazel
@@ -18,7 +18,6 @@ cf_cc_library(
         "input_connector.h",
         "input_devices.h",
     ],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:cf_endian",

--- a/base/cvd/cuttlefish/host/libs/input_connector/input_connector.cpp
+++ b/base/cvd/cuttlefish/host/libs/input_connector/input_connector.cpp
@@ -235,4 +235,3 @@ std::unique_ptr<InputConnector> InputConnectorBuilder::Build() && {
 }
 
 }  // namespace cuttlefish
-

--- a/base/cvd/cuttlefish/host/libs/input_connector/input_connector.h
+++ b/base/cvd/cuttlefish/host/libs/input_connector/input_connector.h
@@ -86,4 +86,3 @@ class InputConnectorBuilder {
 };
 
 }  // namespace cuttlefish
-

--- a/base/cvd/cuttlefish/host/libs/input_connector/input_devices.cpp
+++ b/base/cvd/cuttlefish/host/libs/input_connector/input_devices.cpp
@@ -200,4 +200,3 @@ Result<void> SwitchesDevice::SendEvent(uint16_t code, bool state) {
 }
 
 }  // namespace cuttlefish
-

--- a/base/cvd/cuttlefish/host/libs/input_connector/input_devices.h
+++ b/base/cvd/cuttlefish/host/libs/input_connector/input_devices.h
@@ -45,8 +45,7 @@ class InputDevice {
 
 class TouchDevice : public InputDevice {
  public:
-  TouchDevice(InputConnection conn)
-      : InputDevice(conn) {}
+  TouchDevice(InputConnection conn) : InputDevice(conn) {}
 
   Result<void> SendTouchEvent(int x, int y, bool down);
 
@@ -85,8 +84,7 @@ class TouchDevice : public InputDevice {
 
 class MouseDevice : public InputDevice {
  public:
-  MouseDevice(InputConnection conn)
-      : InputDevice(conn) {}
+  MouseDevice(InputConnection conn) : InputDevice(conn) {}
 
   Result<void> SendMoveEvent(int x, int y);
   Result<void> SendButtonEvent(int button, bool down);
@@ -103,27 +101,23 @@ class GamepadDevice : public InputDevice {
 
 class KeyboardDevice : public InputDevice {
  public:
-  KeyboardDevice(InputConnection conn)
-      : InputDevice(conn) {}
+  KeyboardDevice(InputConnection conn) : InputDevice(conn) {}
 
   Result<void> SendEvent(uint16_t code, bool down);
 };
 
 class RotaryDevice : public InputDevice {
  public:
-  RotaryDevice(InputConnection conn)
-      : InputDevice(conn) {}
+  RotaryDevice(InputConnection conn) : InputDevice(conn) {}
 
   Result<void> SendEvent(int pixels);
 };
 
 class SwitchesDevice : public InputDevice {
  public:
-  SwitchesDevice(InputConnection conn)
-      : InputDevice(conn) {}
+  SwitchesDevice(InputConnection conn) : InputDevice(conn) {}
 
   Result<void> SendEvent(uint16_t code, bool state);
 };
 
 }  // namespace cuttlefish
-

--- a/base/cvd/cuttlefish/host/libs/metrics/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/metrics/BUILD.bazel
@@ -265,7 +265,6 @@ cf_cc_library(
         "metrics_configs.h",
         "metrics_defs.h",
     ],
-    clang_format_enabled = False,
 )
 
 cf_cc_library(

--- a/base/cvd/cuttlefish/host/libs/metrics/metrics_defs.h
+++ b/base/cvd/cuttlefish/host/libs/metrics/metrics_defs.h
@@ -18,9 +18,9 @@
 namespace cuttlefish {
 
 enum MetricsExitCodes : int {
-  kSuccess=0,
-  kMetricsError=1,
-  kInvalidHostConfiguration=2,
+  kSuccess = 0,
+  kMetricsError = 1,
+  kInvalidHostConfiguration = 2,
 };
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/screen_recording_controls/BUILD
+++ b/base/cvd/cuttlefish/host/libs/screen_recording_controls/BUILD
@@ -12,7 +12,6 @@ cf_cc_library(
     hdrs = [
         "screen_recording_controls.h",
     ],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/host/libs/command_util",

--- a/base/cvd/cuttlefish/host/libs/screen_recording_controls/screen_recording_controls.cc
+++ b/base/cvd/cuttlefish/host/libs/screen_recording_controls/screen_recording_controls.cc
@@ -51,4 +51,3 @@ Result<void> StopScreenRecording(
 }
 
 }  // namespace cuttlefish
-

--- a/base/cvd/cuttlefish/host/libs/web/http_client/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/BUILD.bazel
@@ -54,7 +54,6 @@ cf_cc_library(
     name = "http_client",
     srcs = ["http_client.cc"],
     hdrs = ["http_client.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/result",
         "@fmt",

--- a/base/cvd/cuttlefish/host/libs/web/http_client/http_client.h
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/http_client.h
@@ -45,17 +45,28 @@ struct HttpResponse {
 
   std::string StatusDescription() const {
     switch (http_code) {
-        case 200: return "OK";
-        case 201: return "Created";
-        case 204: return "No Content";
-        case 400: return "Bad Request";
-        case 401: return "Unauthorized";
-        case 403: return "Forbidden";
-        case 404: return "File Not Found";
-        case 500: return "Internal Server Error";
-        case 502: return "Bad Gateway";
-        case 503: return "Service Unavailable";
-        default: return fmt::format("Status Code: {}", http_code);
+      case 200:
+        return "OK";
+      case 201:
+        return "Created";
+      case 204:
+        return "No Content";
+      case 400:
+        return "Bad Request";
+      case 401:
+        return "Unauthorized";
+      case 403:
+        return "Forbidden";
+      case 404:
+        return "File Not Found";
+      case 500:
+        return "Internal Server Error";
+      case 502:
+        return "Bad Gateway";
+      case 503:
+        return "Service Unavailable";
+      default:
+        return fmt::format("Status Code: {}", http_code);
     }
   }
 

--- a/base/cvd/cuttlefish/host/libs/zip/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/zip/BUILD.bazel
@@ -66,7 +66,6 @@ cf_cc_library(
     name = "remote_zip",
     srcs = ["remote_zip.cc"],
     hdrs = ["remote_zip.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/host/libs/web/http_client",
         "//cuttlefish/host/libs/zip/libzip_cc:seekable_source",

--- a/base/cvd/cuttlefish/host/libs/zip/remote_zip.h
+++ b/base/cvd/cuttlefish/host/libs/zip/remote_zip.h
@@ -30,4 +30,4 @@ namespace cuttlefish {
  * `HttpClient`. */
 Result<SeekableZipSource> ZipSourceFromUrl(HttpClient&, const std::string& url,
                                            std::vector<std::string> headers);
-}
+}  // namespace cuttlefish


### PR DESCRIPTION
Format source files and enable clang-format enforcement across all build targets where none of the files have been modified since the start of 2026.

Using a reduced set of targets makes it less likely to introduce merge conflicts. Some comments are manually preserved with formatting exclusions (see the first commit).

Out of 768 total targets under //cuttlefish/... (243 unformatted), 55 targets were formatted and enabled in this commit, and 188 targets remain unformatted.

Bug: b/512215781
Assisted-by: gemini-next:current