### PR TITLE
Modernize erase-remove idiom to C++20 std::erase/std::erase_if

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/test_common.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/test_common.cc
@@ -37,15 +37,13 @@ bool FindConfig(const std::vector<std::string>& vec,
 bool FindConfigIgnoreSpaces(const std::vector<std::string>& vec,
                             const std::string& str) {
   std::string target = str;
-  target.erase(std::remove(target.begin(), target.end(), ' '), target.end());
-  target.erase(std::remove(target.begin(), target.end(), '\t'), target.end());
+  std::erase(target, ' ');
+  std::erase(target, '\t');
 
   for (const auto& s : vec) {
     std::string current = s;
-    current.erase(std::remove(current.begin(), current.end(), ' '),
-                  current.end());
-    current.erase(std::remove(current.begin(), current.end(), '\t'),
-                  current.end());
+    std::erase(current, ' ');
+    std::erase(current, '\t');
     if (current == target) {
       return true;
     }

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/sandbox_manager.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/sandbox_manager.cpp
@@ -305,10 +305,8 @@ class SandboxManager::SocketClient {
     if (!env.ok()) {
       return env.status();
     }
-    fds->erase(
-        std::remove_if(fds->begin(), fds->end(),
-                       [this](auto& arg) { return arg.second == ignored_fd_; }),
-        fds->end());
+    std::erase_if(*fds,
+                  [this](auto& arg) { return arg.second == ignored_fd_; });
     return manager_.RunProcess(client_fd_.get(), std::move(*argv),
                                std::move(*fds), *env);
   }


### PR DESCRIPTION
Replace traditional erase-remove idiom usage on standard containers with C++20 std::erase and std::erase_if across the cuttlefish package.

Assisted-by: Jetski:Gemini Next