### PR TITLE
Ensure vhost_net and vhost_vsock exists before triggering udev action

### DIFF
--- a/container/debian/podcvd-setup
+++ b/container/debian/podcvd-setup
@@ -110,6 +110,11 @@ KERNEL=="kvm", RUN+="/usr/bin/setfacl -m u:$username:rw /dev/%k"
 KERNEL=="vhost-net", RUN+="/usr/bin/setfacl -m u:$username:rw /dev/%k"
 KERNEL=="vhost-vsock", RUN+="/usr/bin/setfacl -m u:$username:rw /dev/%k"
 EOF
+
+    # Ensure vhost_net and vhost_vsock exists
+    modprobe vhost_net
+    modprobe vhost_vsock
+
     udevadm control --reload-rules
     udevadm trigger --action=change /dev/kvm
     udevadm trigger --action=change /dev/vhost-net


### PR DESCRIPTION
Current device permission setup is relying on udev action trigger with executing `setfacl`, and setting ACL on given device is available when corresponding kernel module is enabled. This is only required when `podcvd-setup` is even executed before than init script of `cuttlefish-podcvd`.

Context: b/514860208