### PR TITLE
set data_policy to always_create when blank_data_image_mb is set

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/BUILD.bazel
@@ -43,6 +43,7 @@ cf_cc_library(
     deps = [
         "//cuttlefish/host/commands/cvd/cli/parser:cf_configs_common",
         "//cuttlefish/host/commands/cvd/cli/parser:load_config_cc_proto",
+        "//cuttlefish/host/libs/config:data_image_policy",
     ],
 )
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_disk_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_disk_configs.cpp
@@ -21,6 +21,7 @@
 
 #include "cuttlefish/host/commands/cvd/cli/parser/cf_configs_common.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/load_config.pb.h"
+#include "cuttlefish/host/libs/config/data_image_policy.h"
 
 #define DEFAULT_BLANK_DATA_IMAGE_SIZE "unset"
 
@@ -32,6 +33,7 @@ using cvd::config::Instance;
 std::vector<std::string> GenerateDiskFlags(
     const EnvironmentSpecification& config) {
   std::vector<std::string> data_image_mbs;
+  std::vector<std::string> data_policies;
   if (std::none_of(config.instances().cbegin(), config.instances().cend(),
                    [](const auto& instance) {
                      return instance.disk().has_blank_data_image_mb();
@@ -42,12 +44,17 @@ std::vector<std::string> GenerateDiskFlags(
     const auto& disk = instance.disk();
     if (disk.has_blank_data_image_mb()) {
       data_image_mbs.emplace_back(std::to_string(disk.blank_data_image_mb()));
+      data_policies.emplace_back(
+          DataImagePolicyString(DataImagePolicy::AlwaysCreate));
     } else {
       data_image_mbs.emplace_back(DEFAULT_BLANK_DATA_IMAGE_SIZE);
+      data_policies.emplace_back(
+          DataImagePolicyString(DataImagePolicy::UseExisting));
     }
   }
   return std::vector<std::string>{
       GenerateVecFlag("blank_data_image_mb", data_image_mbs),
+      GenerateVecFlag("data_policy", data_policies),
   };
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/disk_configs_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/disk_configs_test.cc
@@ -44,6 +44,8 @@ TEST(BootFlagsParserTest, ParseTwoInstancesBlankDataImageEmptyJson) {
   EXPECT_TRUE(serialized_data.ok()) << serialized_data.error().Trace();
   EXPECT_FALSE(FindConfig(*serialized_data, R"(--blank_data_image_mb=)"))
       << "blank_data_image_mb flag is set";
+  EXPECT_FALSE(FindConfig(*serialized_data, R"(--data_policy=)"))
+      << "data_policy flag is set";
 }
 
 TEST(BootFlagsParserTest, ParseTwoInstancesBlankDataImagePartialJson) {
@@ -74,6 +76,9 @@ TEST(BootFlagsParserTest, ParseTwoInstancesBlankDataImagePartialJson) {
   EXPECT_TRUE(
       FindConfig(*serialized_data, R"(--blank_data_image_mb=unset,2048)"))
       << "blank_data_image_mb flag is missing or wrongly formatted";
+  EXPECT_TRUE(FindConfig(*serialized_data,
+                         R"(--data_policy=use_existing,always_create)"))
+      << "data_policy flag is missing or wrongly formatted";
 }
 
 TEST(BootFlagsParserTest, ParseTwoInstancesBlankDataImageFullJson) {
@@ -105,6 +110,9 @@ TEST(BootFlagsParserTest, ParseTwoInstancesBlankDataImageFullJson) {
   EXPECT_TRUE(
       FindConfig(*serialized_data, R"(--blank_data_image_mb=2048,4096)"))
       << "blank_data_image_mb flag is missing or wrongly formatted";
+  EXPECT_TRUE(FindConfig(*serialized_data,
+                         R"(--data_policy=always_create,always_create)"))
+      << "data_policy flag is missing or wrongly formatted";
 }
 
 }  // namespace cuttlefish


### PR DESCRIPTION
If blank_data_image_mb is configured in the load config proto, automatically set the data_policy flag to always_create for assemble_cvd.

All infra configurations that set blank_data_image_mb also set the data_policy flag .... which we would like to deprecate in the leadup to userdata creation occuring by default by the platform itself.

To that end, default inject the policy setting as always_create in the launcher if the userdata size field is specified.

We can't universally set the setting to always_create yet. There's a bug I can't yet explain in the snapshot case when data_policy is set to always_create, the device times out on startup frome the snapshot.

Bug: b/475474657
Bug: b/260651960
Test: bazel test //cuttlefish/host/commands/cvd/cli/parser/...