### PR TITLE
Set up `AndroidBuildApi` for testing

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/downloaders.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/downloaders.cc
@@ -89,8 +89,8 @@ Result<Downloaders> Downloaders::Create(const BuildApiFlags& flags,
   }
 
   impl->android_build_api_ = std::make_unique<AndroidBuildApi>(
-      *impl->retrying_http_client_, impl->android_creds_.get(),
-      impl->android_build_url_.get(), flags.wait_retry_period,
+      *impl->retrying_http_client_, *impl->android_build_url_,
+      impl->android_creds_.get(), flags.wait_retry_period,
       impl->cas_downloader_.get());
 
   if (flags.enable_caching && CanCache(target_directory, cache_base_path)) {

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/downloaders.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/downloaders.cc
@@ -25,7 +25,6 @@
 #include "cuttlefish/host/commands/cvd/fetch/build_api_flags.h"
 #include "cuttlefish/host/commands/cvd/fetch/fetch_cvd_parser.h"
 #include "cuttlefish/host/libs/web/android_build_api.h"
-#include "cuttlefish/host/libs/web/android_build_api_key.h"
 #include "cuttlefish/host/libs/web/android_build_url.h"
 #include "cuttlefish/host/libs/web/build_api.h"
 #include "cuttlefish/host/libs/web/caching_build_api.h"
@@ -91,8 +90,8 @@ Result<Downloaders> Downloaders::Create(const BuildApiFlags& flags,
 
   impl->android_build_api_ = std::make_unique<AndroidBuildApi>(
       *impl->retrying_http_client_, impl->android_creds_.get(),
-      GetCatchallApiKey(), impl->android_build_url_.get(),
-      flags.wait_retry_period, impl->cas_downloader_.get());
+      impl->android_build_url_.get(), flags.wait_retry_period,
+      impl->cas_downloader_.get());
 
   if (flags.enable_caching && CanCache(target_directory, cache_base_path)) {
     impl->caching_build_api_ = std::make_unique<CachingBuildApi>(

--- a/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
@@ -28,6 +28,7 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:json",
         "//cuttlefish/host/libs/web:android_build",
+        "//cuttlefish/host/libs/web:android_build_api_key",
         "//cuttlefish/host/libs/web:android_build_string",
         "//cuttlefish/host/libs/web:android_build_url",
         "//cuttlefish/host/libs/web:build_api",

--- a/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
@@ -83,6 +83,21 @@ cf_cc_test(
     ],
 )
 
+cf_cc_test(
+    name = "android_build_api_test",
+    srcs = ["android_build_api_test.cpp"],
+    deps = [
+        "//cuttlefish/host/libs/web:android_build",
+        "//cuttlefish/host/libs/web:android_build_api",
+        "//cuttlefish/host/libs/web:android_build_url",
+        "//cuttlefish/host/libs/web/http_client",
+        "//cuttlefish/host/libs/web/http_client:fake_http_client",
+        "//cuttlefish/host/libs/zip/libzip_cc:seekable_source",
+        "//cuttlefish/result",
+        "//cuttlefish/result:result_matchers",
+    ],
+)
+
 cf_cc_library(
     name = "android_build_url",
     srcs = ["android_build_url.cpp"],

--- a/base/cvd/cuttlefish/host/libs/web/android_build_api.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_api.cpp
@@ -87,13 +87,13 @@ Result<Json::Value> GetResponseJson(const HttpResponse<Json::Value>& response,
 }  // namespace
 
 AndroidBuildApi::AndroidBuildApi(HttpClient& http_client,
+                                 AndroidBuildUrl& android_build_url,
                                  CredentialSource* credential_source,
-                                 AndroidBuildUrl* android_build_url,
                                  const std::chrono::seconds retry_period,
                                  CasDownloader* cas_downloader)
     : http_client_(http_client),
-      credential_source_(credential_source),
       android_build_url_(android_build_url),
+      credential_source_(credential_source),
       retry_period_(retry_period),
       cas_downloader_(cas_downloader) {}
 
@@ -189,7 +189,7 @@ Result<SeekableZipSource> AndroidBuildApi::FileReader(
 
 Result<AndroidBuildApi::BuildInfo> AndroidBuildApi::GetBuildInfo(
     std::string_view build_id, std::string_view target) {
-  const std::string url = android_build_url_->GetBuildUrl(build_id, target);
+  const std::string url = android_build_url_.GetBuildUrl(build_id, target);
   auto response =
       CF_EXPECT(HttpGetToJson(http_client_, url, CF_EXPECT(Headers())));
 
@@ -233,7 +233,7 @@ Result<AndroidBuildApi::BuildInfo> AndroidBuildApi::GetBuildInfo(
 Result<bool> AndroidBuildApi::BlockUntilTerminalStatus(
     std::string_view initial_status, std::string_view build_id,
     std::string_view target) {
-  const std::string url = android_build_url_->GetBuildUrl(build_id, target);
+  const std::string url = android_build_url_.GetBuildUrl(build_id, target);
   CF_EXPECTF(!initial_status.empty(),
              "\"{}\" is not a valid branch or build id.", build_id);
 
@@ -276,7 +276,7 @@ Result<std::vector<std::string>> AndroidBuildApi::Headers() {
 Result<std::optional<std::string>> AndroidBuildApi::LatestBuildId(
     const std::string& branch, const std::string& target) {
   const std::string url =
-      android_build_url_->GetLatestBuildIdUrl(branch, target);
+      android_build_url_.GetLatestBuildIdUrl(branch, target);
   auto response =
       CF_EXPECT(HttpGetToJson(http_client_, url, CF_EXPECT(Headers())));
 
@@ -303,7 +303,7 @@ Result<std::unordered_set<std::string>> AndroidBuildApi::Artifacts(
   std::unordered_set<std::string> artifacts;
 
   do {
-    const std::string url = android_build_url_->GetArtifactUrl(
+    const std::string url = android_build_url_.GetArtifactUrl(
         build.id, build.target, artifact_filenames, page_token);
     auto response =
         CF_EXPECT(HttpGetToJson(http_client_, url, CF_EXPECT(Headers())));
@@ -352,7 +352,7 @@ Result<std::unordered_set<std::string>> AndroidBuildApi::Artifacts(
 Result<std::string> AndroidBuildApi::GetArtifactDownloadUrl(
     const DeviceBuild& build, const std::string& artifact) {
   const std::string download_url_endpoint =
-      android_build_url_->GetArtifactDownloadUrl(build.id, build.target,
+      android_build_url_.GetArtifactDownloadUrl(build.id, build.target,
                                                  artifact);
   auto response = CF_EXPECT(
       HttpGetToJson(http_client_, download_url_endpoint, CF_EXPECT(Headers())));

--- a/base/cvd/cuttlefish/host/libs/web/android_build_api.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_api.cpp
@@ -39,6 +39,7 @@
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/json.h"
 #include "cuttlefish/host/libs/web/android_build.h"
+#include "cuttlefish/host/libs/web/android_build_api_key.h"
 #include "cuttlefish/host/libs/web/android_build_string.h"
 #include "cuttlefish/host/libs/web/android_build_url.h"
 #include "cuttlefish/host/libs/web/cas/cas_downloader.h"
@@ -87,13 +88,11 @@ Result<Json::Value> GetResponseJson(const HttpResponse<Json::Value>& response,
 
 AndroidBuildApi::AndroidBuildApi(HttpClient& http_client,
                                  CredentialSource* credential_source,
-                                 std::string catchall_api_key,
                                  AndroidBuildUrl* android_build_url,
                                  const std::chrono::seconds retry_period,
                                  CasDownloader* cas_downloader)
     : http_client_(http_client),
       credential_source_(credential_source),
-      catchall_api_key_(catchall_api_key),
       android_build_url_(android_build_url),
       retry_period_(retry_period),
       cas_downloader_(cas_downloader) {}
@@ -268,8 +267,8 @@ Result<std::vector<std::string>> AndroidBuildApi::Headers() {
   if (credential_source_) {
     headers.push_back("Authorization: Bearer " +
                       CF_EXPECT(credential_source_->Credential()));
-  } else if (!catchall_api_key_.empty()) {
-    headers.push_back("X-goog-api-key: " + catchall_api_key_);
+  } else if (std::string key = GetCatchallApiKey(); !key.empty()) {
+    headers.push_back("X-goog-api-key: " + key);
   }
   return headers;
 }

--- a/base/cvd/cuttlefish/host/libs/web/android_build_api.h
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_api.h
@@ -41,7 +41,6 @@ class AndroidBuildApi : public BuildApi {
   AndroidBuildApi(AndroidBuildApi&&) = delete;
   virtual ~AndroidBuildApi() = default;
   AndroidBuildApi(HttpClient& http_client, CredentialSource* credential_source,
-                  std::string catchall_api_key,
                   AndroidBuildUrl* android_build_url,
                   std::chrono::seconds retry_period,
                   CasDownloader* cas_downloader = nullptr);
@@ -119,7 +118,6 @@ class AndroidBuildApi : public BuildApi {
 
   HttpClient& http_client_;
   CredentialSource* credential_source_;
-  std::string catchall_api_key_;
   AndroidBuildUrl* android_build_url_;
   std::chrono::seconds retry_period_;
   CasDownloader* cas_downloader_;

--- a/base/cvd/cuttlefish/host/libs/web/android_build_api.h
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_api.h
@@ -40,10 +40,11 @@ class AndroidBuildApi : public BuildApi {
   AndroidBuildApi() = delete;
   AndroidBuildApi(AndroidBuildApi&&) = delete;
   virtual ~AndroidBuildApi() = default;
-  AndroidBuildApi(HttpClient& http_client, CredentialSource* credential_source,
-                  AndroidBuildUrl* android_build_url,
-                  std::chrono::seconds retry_period,
-                  CasDownloader* cas_downloader = nullptr);
+  AndroidBuildApi(
+      HttpClient& http_client, AndroidBuildUrl& android_build_url,
+      CredentialSource* credential_source = nullptr,
+      std::chrono::seconds retry_period = std::chrono::seconds::zero(),
+      CasDownloader* cas_downloader = nullptr);
 
   Result<Build> GetBuild(const BuildString& build_string) override;
 
@@ -117,8 +118,8 @@ class AndroidBuildApi : public BuildApi {
                                        const std::string& artifact_name);
 
   HttpClient& http_client_;
+  AndroidBuildUrl& android_build_url_;
   CredentialSource* credential_source_;
-  AndroidBuildUrl* android_build_url_;
   std::chrono::seconds retry_period_;
   CasDownloader* cas_downloader_;
 };

--- a/base/cvd/cuttlefish/host/libs/web/android_build_api_test.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_api_test.cpp
@@ -1,0 +1,70 @@
+//
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cuttlefish/host/libs/web/android_build_api.h"
+
+#include <string>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "cuttlefish/host/libs/web/android_build.h"
+#include "cuttlefish/host/libs/web/android_build_url.h"
+#include "cuttlefish/host/libs/web/http_client/fake_http_client.h"
+#include "cuttlefish/host/libs/web/http_client/http_client.h"
+#include "cuttlefish/host/libs/zip/libzip_cc/seekable_source.h"
+#include "cuttlefish/result/result.h"
+#include "cuttlefish/result/result_matchers.h"
+
+namespace cuttlefish {
+namespace {
+
+TEST(AndroidBuildApiTest, FileReader) {
+  FakeHttpClient http_client;
+  AndroidBuildUrl build_url("https://androidbuild-pa.googleapis.com/v4", "",
+                            "");
+  AndroidBuildApi api(http_client, build_url);
+
+  http_client.SetResponse("{\"signedUrl\": \"http://zip-url\"}", "/url");
+
+  HttpResponse<std::string> res = {
+      .data = "abc",
+      .http_code = 200,
+      .headers =
+          {
+              {"accept-ranges", "bytes"},
+              {"content-length", "3"},
+          },
+  };
+  http_client.SetResponse(res, "http://zip-url");
+
+  Build build = DeviceBuild{.id = "123", .target = "test"};
+  Result<SeekableZipSource> source = api.FileReader(build, "a.zip");
+  ASSERT_THAT(source, IsOk());
+
+  Result<SeekingZipSourceReader> reader = source->Reader();
+  ASSERT_THAT(reader, IsOk());
+
+  char buf[4] = {};
+  ASSERT_THAT(reader->Read(buf, 3), IsOkAndValue(3));
+  EXPECT_STREQ(buf, "abc");
+
+  EXPECT_TRUE(http_client.RequestMade(
+      "https://androidbuild-pa.googleapis.com/v4/builds/123/test/attempts/"
+      "latest/artifacts/a.zip/url"));
+}
+
+}  // namespace
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/web/http_client/fake_http_client.cc
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/fake_http_client.cc
@@ -31,8 +31,25 @@ void FakeHttpClient::SetResponse(std::string data, std::string url) {
       .http_code = 200,
       .headers = {},
   };
-  auto handler = [res = std::move(res)](const HttpRequest&) { return res; };
+  SetResponse(std::move(res), std::move(url));
+}
+
+void FakeHttpClient::SetResponse(HttpResponse<std::string> response,
+                                 std::string url) {
+  auto handler = [res = std::move(response)](const HttpRequest&) {
+    return res;
+  };
   SetResponse(std::move(handler), std::move(url));
+}
+
+bool FakeHttpClient::RequestMade(std::string_view url) const {
+  std::lock_guard lock(mutex_);
+  for (const auto& requested : requested_urls_) {
+    if (requested.find(url) != std::string_view::npos) {
+      return true;
+    }
+  }
+  return false;
 }
 
 void FakeHttpClient::SetResponse(FakeHttpClient::Handler handler,
@@ -60,6 +77,7 @@ const FakeHttpClient::Handler* FakeHttpClient::FindHandler(
 Result<HttpResponse<void>> FakeHttpClient::DownloadToCallback(
     HttpRequest request, HttpClient::DataCallback callback) {
   std::lock_guard lock(mutex_);
+  requested_urls_.push_back(request.url);
   CF_EXPECT(callback(nullptr, 0));
   const Handler* handler = FindHandler(request.url);
   HttpResponse<void> response;

--- a/base/cvd/cuttlefish/host/libs/web/http_client/fake_http_client.h
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/fake_http_client.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <vector>
 
 #include "cuttlefish/host/libs/web/http_client/http_client.h"
 #include "cuttlefish/result/result.h"
@@ -33,7 +34,9 @@ class FakeHttpClient : public HttpClient {
   // The longest string that is a complete substring of `url` is used to match
   // requests.
   void SetResponse(std::string data, std::string url = "");
+  void SetResponse(HttpResponse<std::string> response, std::string url = "");
   void SetResponse(Handler handler, std::string url = "");
+  bool RequestMade(std::string_view url) const;
   // Returns response's status code.
   Result<HttpResponse<void>> DownloadToCallback(
       HttpRequest request, HttpClient::DataCallback callback) override;
@@ -41,8 +44,9 @@ class FakeHttpClient : public HttpClient {
  private:
   const Handler* FindHandler(std::string_view url) const;
 
-  std::mutex mutex_;
+  mutable std::mutex mutex_;
   std::unordered_map<std::string, Handler> responses_;
+  std::vector<std::string> requested_urls_;
 };
 
 }  // namespace cuttlefish


### PR DESCRIPTION
This PR attempts to move `AndroidBuildApi` in the direction of "can be tested by mocking its dependencies."

- `catchall_api_key` is removed as a constructor argument, since it is only ever given one value.
- `AndroidBuildApi::AndroidBuildApi` accepts `AndroidBuildUrl` by reference, since it is mandatory
- Non-reference `AndroidBuildApi::AndroidBuildApi` arguments are given sensible defaults
- `FakeHttpClient` gets some more utilities
- `AndroidBuildApi::FileReader` gets a test

Outstanding issues that are inconvenient for tests:

- `DownloadFile*` interacts with the filesystem
- `GetBuild` is kind of complicated with multiple API roundtrips