### PR TITLE
Gather fetch.log from the top-level location

### DIFF
--- a/e2etests/cvd/common/common.go
+++ b/e2etests/cvd/common/common.go
@@ -440,6 +440,7 @@ func (tc *TestContext) TearDown() {
 				"cuttlefish_runtime/cuttlefish_config.json",
 				"cuttlefish_runtime/logcat",
 				"cuttlefish_runtime/*.log",
+				"fetch.log",
 			}
 			for _, pattern := range patterns {
 				matches, err := filepath.Glob(path.Join(tc.tempdir, pattern))


### PR DESCRIPTION
It does get copied into the instance directories, but I forget that half the time and wonder where it is in the Kokoro tests.