### PR TITLE
Prettier printing of flag description in cvd help commands

### DIFF
--- a/base/cvd/cuttlefish/flag_parser/BUILD.bazel
+++ b/base/cvd/cuttlefish/flag_parser/BUILD.bazel
@@ -27,17 +27,25 @@ cf_cc_library(
 )
 
 cf_cc_test(
-    name = "flag_parser_test",
-    srcs = ["flag_parser_test.cpp"],
+    name = "flag_test",
+    srcs = ["flag_test.cpp"],
+    deps = [
+        ":flag_parser",
+        "//cuttlefish/result",
+        "//cuttlefish/result:result_matchers",
+    ],
+)
+
+cf_cc_test(
+    name = "gflags_compat_test",
+    srcs = ["gflags_compat_test.cpp"],
     # `layering_check` conflicts with the combination of the clang prebuilt and
     # the cmake build rules used for @libxml2.
     features = ["-layering_check"],
     deps = [
         ":flag_parser",
-        "//cuttlefish/common/libs/fs",
         "//cuttlefish/result",
         "//cuttlefish/result:result_matchers",
-        "//libbase",
         "@libxml2",
     ],
 )

--- a/base/cvd/cuttlefish/flag_parser/BUILD.bazel
+++ b/base/cvd/cuttlefish/flag_parser/BUILD.bazel
@@ -14,10 +14,11 @@ cf_cc_library(
         "flag.h",
         "gflags_compat.h",
     ],
-    clang_format_enabled = False,
     deps = [
+        "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/result",
         "//libbase",
+        "@abseil-cpp//absl/cleanup",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/log:check",
         "@abseil-cpp//absl/strings",
@@ -28,7 +29,6 @@ cf_cc_library(
 cf_cc_test(
     name = "flag_parser_test",
     srcs = ["flag_parser_test.cpp"],
-    clang_format_enabled = False,
     # `layering_check` conflicts with the combination of the clang prebuilt and
     # the cmake build rules used for @libxml2.
     features = ["-layering_check"],
@@ -49,6 +49,7 @@ cf_cc_library(
     deps = [
         ":flag_parser",
         "//cuttlefish/common/libs/fs",
+        "//cuttlefish/result",
         "//libbase",
         "@abseil-cpp//absl/strings",
     ],

--- a/base/cvd/cuttlefish/flag_parser/flag.cpp
+++ b/base/cvd/cuttlefish/flag_parser/flag.cpp
@@ -121,22 +121,6 @@ const std::string& Flag::Description() const { return help_; }
 
 std::string Flag::CurrentValue() const { return getter_(); }
 
-Result<void> Flag::Parse(std::vector<std::string>& arguments) const {
-  for (auto it = arguments.begin(); it != arguments.end();) {
-    size_t consumed = CF_EXPECT(Match(*it, std::span(it + 1, arguments.end())));
-    if (consumed == 0) {
-      ++it;
-    } else {
-      it = arguments.erase(it, it + consumed);
-    }
-  }
-  return {};
-}
-Result<void> Flag::Parse(std::vector<std::string>&& arguments) const {
-  CF_EXPECT(Parse(arguments));
-  return {};
-}
-
 Flag::Flag(std::string name, Flag::Style style) : style_(style) {
   ValidateAlias(name);
   aliases_.emplace_back(std::move(name));

--- a/base/cvd/cuttlefish/flag_parser/flag.cpp
+++ b/base/cvd/cuttlefish/flag_parser/flag.cpp
@@ -19,142 +19,77 @@
 #include <algorithm>
 #include <functional>
 #include <iostream>
-#include <iterator>
-#include <optional>
 #include <ostream>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
+#include "absl/cleanup/cleanup.h"
 #include "absl/log/check.h"
-#include "absl/log/log.h"
-#include "absl/strings/match.h"
+#include "absl/strings/str_join.h"
 #include "absl/strings/str_replace.h"
+#include "absl/strings/strip.h"
 
+#include "cuttlefish/common/libs/utils/contains.h"
 #include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
 
 namespace {
 
-struct Separated {
-  std::vector<std::string> args_before_mark;
-  std::vector<std::string> args_after_mark;
-};
-Separated SeparateByEndOfOptionMark(std::vector<std::string> args) {
-  std::vector<std::string> args_before_mark;
-  std::vector<std::string> args_after_mark;
-
-  auto itr = std::find(args.begin(), args.end(), "--");
-  bool has_mark = (itr != args.end());
-  if (!has_mark) {
-    args_before_mark = std::move(args);
-  } else {
-    args_before_mark.insert(args_before_mark.end(), args.begin(), itr);
-    args_after_mark.insert(args_after_mark.end(), itr + 1, args.end());
+// Removes "--" or "-" from the beginning. Returns true if it removed something.
+bool ConsumeDashes(std::string_view& flag_arg) {
+  if (!absl::ConsumePrefix(&flag_arg, "-")) {
+    return false;
   }
-
-  return Separated{
-      .args_before_mark = std::move(args_before_mark),
-      .args_after_mark = std::move(args_after_mark),
-  };
+  absl::ConsumePrefix(&flag_arg, "-");
+  return true;
 }
 
-Result<void> ConsumeFlagsImpl(const std::vector<Flag>& flags,
-                                     std::vector<std::string>& args) {
-  for (const auto& flag : flags) {
-    CF_EXPECT(flag.Parse(args));
-  }
-  return {};
-}
-
-Result<void> ConsumeFlagsImpl(const std::vector<Flag>& flags,
-                                     std::vector<std::string>&& args) {
-  for (const auto& flag : flags) {
-    CF_EXPECT(flag.Parse(args));
-  }
-  return {};
+bool MatchNormalized(std::string_view str1, std::string_view str2) {
+  const std::string n1 = absl::StrReplaceAll(str1, {{"-", "_"}});
+  const std::string n2 = absl::StrReplaceAll(str2, {{"-", "_"}});
+  return n1 == n2;
 }
 
 }  // namespace
 
-std::ostream& operator<<(std::ostream& out, const FlagAlias& alias) {
-  switch (alias.mode) {
-    case FlagAliasMode::kFlagExact:
-      return out << alias.name;
-    case FlagAliasMode::kFlagPrefix:
-      return out << alias.name << "*";
-    case FlagAliasMode::kFlagConsumesFollowing:
-      return out << alias.name << " *";
-    default:
-      LOG(FATAL) << "Unexpected flag alias mode " << (int)alias.mode;
-  }
-  return out;
+Flag Flag::StringFlag(std::string name) {
+  return Flag(std::move(name), Style::String);
 }
 
-Flag& Flag::UnvalidatedAlias(const FlagAlias& alias) & {
-  aliases_.push_back(alias);
-  return *this;
-}
-Flag Flag::UnvalidatedAlias(const FlagAlias& alias) && {
-  aliases_.push_back(alias);
-  return *this;
+Flag Flag::BoolFlag(std::string name) {
+  return Flag(std::move(name), Style::Bool);
 }
 
-void Flag::ValidateAlias(const FlagAlias& alias) {
-  using absl::StartsWith;
-
-  CHECK(StartsWith(alias.name, "-")) << "Flags should start with \"-\"";
-  if (alias.mode == FlagAliasMode::kFlagPrefix) {
-    CHECK(absl::EndsWith(alias.name, "=")) << "Prefix flags must end with '='";
-  }
-
-  CHECK(!HasAlias(alias)) << "Duplicate flag alias: " << alias.name;
-  if (alias.mode == FlagAliasMode::kFlagConsumesFollowing) {
-    CHECK(!HasAlias({FlagAliasMode::kFlagExact, alias.name}))
-        << "Overlapping flag aliases for " << alias.name;
-  } else if (alias.mode == FlagAliasMode::kFlagExact) {
-    CHECK(!HasAlias({FlagAliasMode::kFlagConsumesFollowing, alias.name}))
-        << "Overlapping flag aliases for " << alias.name;
-  }
-}
-
-Flag& Flag::Alias(const FlagAlias& alias) & {
+Flag& Flag::Alias(std::string alias) & {
   ValidateAlias(alias);
-  aliases_.push_back(alias);
+  aliases_.emplace_back(std::move(alias));
   return *this;
 }
-Flag Flag::Alias(const FlagAlias& alias) && {
-  ValidateAlias(alias);
-  aliases_.push_back(alias);
+Flag Flag::Alias(std::string alias) && { return std::move(Alias(alias)); }
+
+Flag& Flag::Help(std::string help) & {
+  help_ = std::move(help);
   return *this;
+}
+Flag Flag::Help(std::string help) && { return std::move(Help(help)); }
+
+Flag& Flag::Getter(std::function<std::string()> getter) & {
+  getter_ = std::move(getter);
+  return *this;
+}
+Flag Flag::Getter(std::function<std::string()> getter) && {
+  return std::move(Getter(getter));
 }
 
-Flag& Flag::Help(const std::string& help) & {
-  help_ = help;
-  return *this;
-}
-Flag Flag::Help(const std::string& help) && {
-  help_ = help;
-  return *this;
-}
-
-Flag& Flag::Getter(std::function<std::string()> fn) & {
-  getter_ = std::move(fn);
-  return *this;
-}
-Flag Flag::Getter(std::function<std::string()> fn) && {
-  getter_ = std::move(fn);
-  return *this;
-}
-
-Flag& Flag::Setter(std::function<Result<void>(const FlagMatch&)> setter) & {
+Flag& Flag::Setter(std::function<Result<void>(std::string_view)> setter) & {
   setter_ = std::move(setter);
   return *this;
 }
-Flag Flag::Setter(std::function<Result<void>(const FlagMatch&)> setter) && {
-  setter_ = std::move(setter);
-  return *this;
+Flag Flag::Setter(std::function<Result<void>(std::string_view)> setter) && {
+  return std::move(Setter(setter));
 }
 
 Flag& Flag::AddValidator(std::function<Result<void>()> validator) & {
@@ -162,198 +97,191 @@ Flag& Flag::AddValidator(std::function<Result<void>()> validator) & {
   return *this;
 }
 Flag Flag::AddValidator(std::function<Result<void>()> validator) && {
-  validators_.emplace_back(std::move(validator));
-  return *this;
+  return std::move(AddValidator(validator));
 }
 
-Result<Flag::FlagProcessResult> Flag::Process(
-    const std::string& arg, const std::optional<std::string>& next_arg) const {
-  auto normalized_arg = absl::StrReplaceAll(arg, {{"-", "_"}});
-  if (!setter_ && !aliases_.empty()) {
-    return CF_ERRF("No setter for flag with alias {}", aliases_[0].name);
-  }
-  for (auto& alias : aliases_) {
-    auto normalized_alias = absl::StrReplaceAll(alias.name, {{"-", "_"}});
-    switch (alias.mode) {
-      case FlagAliasMode::kFlagConsumesFollowing:
-        if (normalized_arg != normalized_alias) {
-          continue;
-        }
-        CF_EXPECTF(next_arg.has_value(), "Expected an argument after \"{}\"",
-                   arg);
-        CF_EXPECTF(SetAndValidate({arg, *next_arg}),
-                   "Processing \"{}\" \"{}\" failed", arg, *next_arg);
-        return FlagProcessResult::kFlagConsumedWithFollowing;
-      case FlagAliasMode::kFlagExact:
-        if (normalized_arg != normalized_alias) {
-          continue;
-        }
-        CF_EXPECTF(SetAndValidate({arg, arg}), "Processing \"{}\" failed", arg);
-        return FlagProcessResult::kFlagConsumed;
-      case FlagAliasMode::kFlagPrefix:
-        if (!absl::StartsWith(normalized_arg, normalized_alias)) {
-          continue;
-        }
-        CF_EXPECTF(SetAndValidate({alias.name, arg.substr(alias.name.size())}),
-                   "Processing \"{}\" failed", arg);
-        return FlagProcessResult::kFlagConsumed;
-      default:
-        return CF_ERRF("Unknown flag alias mode: {}", (int)alias.mode);
-    }
-  }
-  return FlagProcessResult::kFlagSkip;
-}
-
-Result<void> Flag::SetAndValidate(const FlagMatch& match) const {
-  CF_EXPECT((*setter_)(match));
-  for (auto& validator: validators_) {
-    CF_EXPECT(validator());
-  }
-  return {};
-}
+std::string Flag::Name() const { return aliases_.front(); }
 
 Result<void> Flag::Parse(std::vector<std::string>& arguments) const {
-  for (int i = 0; i < arguments.size();) {
-    std::string arg = arguments[i];
-    std::optional<std::string> next_arg;
-    if (i < arguments.size() - 1) {
-      next_arg = arguments[i + 1];
-    }
-    switch (CF_EXPECT(Process(arg, next_arg))) {
-      case FlagProcessResult::kFlagConsumed:
-        arguments.erase(arguments.begin() + i);
-        break;
-      case FlagProcessResult::kFlagConsumedWithFollowing:
-        arguments.erase(arguments.begin() + i, arguments.begin() + i + 2);
-        break;
-      case FlagProcessResult::kFlagSkip:
-        i++;
-        break;
+  for (auto it = arguments.begin(); it != arguments.end();) {
+    size_t consumed = CF_EXPECT(Match(*it, std::span(it + 1, arguments.end())));
+    if (consumed == 0) {
+      ++it;
+    } else {
+      it = arguments.erase(it, it + consumed);
     }
   }
   return {};
 }
 Result<void> Flag::Parse(std::vector<std::string>&& arguments) const {
-  CF_EXPECT(Parse(static_cast<std::vector<std::string>&>(arguments)));
+  CF_EXPECT(Parse(arguments));
   return {};
 }
 
-bool Flag::HasAlias(const FlagAlias& test) const {
-  for (const auto& alias : aliases_) {
-    if (alias.mode == test.mode && alias.name == test.name) {
-      return true;
+Flag::Flag(std::string name, Flag::Style style) : style_(style) {
+  ValidateAlias(name);
+  aliases_.emplace_back(std::move(name));
+}
+
+void Flag::ValidateAlias(const std::string& alias) {
+  CHECK(!alias.starts_with("-")) << "Flag aliases should not start with \"-\"";
+  CHECK(!Contains(aliases_, alias)) << "Duplicate flag alias: " << alias;
+}
+
+Result<size_t> Flag::Match(std::string_view current_arg,
+                           std::span<const std::string> following_args) const {
+  switch (style_) {
+    case Style::String:
+      return CF_EXPECT(MatchStringStyleFlag(current_arg, following_args));
+    case Style::Bool:
+      return CF_EXPECT(MatchBoolStyleFlag(current_arg));
+  }
+}
+
+Result<size_t> Flag::MatchStringStyleFlag(
+    std::string_view current_arg,
+    std::span<const std::string> following_args) const {
+  if (!ConsumeDashes(current_arg)) {
+    // Doesn't begin with "-"
+    return 0;
+  }
+  for (const std::string& alias : aliases_) {
+    if (MatchNormalized(current_arg.substr(0, alias.size() + 1), alias + "=")) {
+      CF_EXPECT(SetAndValidate(current_arg.substr(alias.size() + 1)));
+      return 1;
     }
   }
-  return false;
+  std::vector<std::string> keys;
+  for (const std::string& alias : aliases_) {
+    if (!MatchNormalized(current_arg, alias)) {
+      continue;
+    }
+    CF_EXPECTF(!following_args.empty(), "No argument provided for flag '{}'",
+               current_arg);
+    CF_EXPECT(SetAndValidate(following_args[0]));
+    return 2;
+  }
+  return 0;
+}
+
+Result<size_t> Flag::MatchBoolStyleFlag(std::string_view current_arg) const {
+  if (!ConsumeDashes(current_arg)) {
+    // Doesn't begin with "-"
+    return 0;
+  }
+  for (const std::string& alias : aliases_) {
+    if (MatchNormalized(current_arg.substr(0, alias.size() + 1), alias + "=")) {
+      CF_EXPECT(SetAndValidate(current_arg.substr(alias.size() + 1)));
+      return 1;
+    }
+    if (MatchNormalized(current_arg, alias)) {
+      CF_EXPECT(SetAndValidate("yes"));
+      return 1;
+    }
+    if (MatchNormalized(current_arg, "no" + alias)) {
+      CF_EXPECT(SetAndValidate("no"));
+      return 1;
+    }
+  }
+  return 0;
+}
+
+Result<void> Flag::SetAndValidate(std::string_view value) const {
+  CF_EXPECT(setter_(value));
+  for (auto& validator : validators_) {
+    CF_EXPECT(validator());
+  }
+  return {};
 }
 
 std::ostream& operator<<(std::ostream& out, const Flag& flag) {
-  for (auto it = flag.aliases_.begin(); it != flag.aliases_.end(); it++) {
-    if (it != flag.aliases_.begin()) {
-      out << ", ";
+  std::vector<std::string> options;
+  for (const std::string& alias : flag.aliases_) {
+    switch (flag.style_) {
+      case Flag::Style::String:
+        options.emplace_back("--" + alias + "=VAL");
+        break;
+      case Flag::Style::Bool:
+        options.emplace_back("--[no]" + alias);
+        break;
     }
-    out << *it;
   }
-  out << "\n";
-  if (flag.help_) {
-    out <<  *flag.help_ << "\n";
+  out << absl::StrJoin(options, ", ") << "\n";
+
+  if (!flag.help_.empty()) {
+    out << flag.help_ << "\n";
   }
-  if (flag.getter_) {
-    out << "Current value: \"" << (*flag.getter_)() << "\"\n";
-  }
+  out << "Current value: \"" << flag.getter_() << "\"\n";
   return out;
 }
 
 Result<void> ConsumeFlags(const std::vector<Flag>& flags,
                           std::vector<std::string>& args,
-                          const bool recognize_end_of_option_mark) {
-  if (!recognize_end_of_option_mark) {
-    CF_EXPECT(ConsumeFlagsImpl(flags, args));
-    return {};
+                          ConsumeFlagsOpts opts) {
+  std::unordered_set<std::string_view> aliases;
+  for (const Flag& flag : flags) {
+    for (std::string_view alias : flag.aliases_) {
+      const auto [_, inserted] = aliases.insert(alias);
+      CF_EXPECTF(!!inserted,
+                 "Ambiguous argument parsing possible: '--{}' could be matched "
+                 "by multiple flags",
+                 alias);
+    }
   }
-  auto separated = SeparateByEndOfOptionMark(std::move(args));
-  args.clear();
-  auto result = ConsumeFlagsImpl(flags, separated.args_before_mark);
-  args = std::move(separated.args_before_mark);
-  args.insert(args.end(),
-              std::make_move_iterator(separated.args_after_mark.begin()),
-              std::make_move_iterator(separated.args_after_mark.end()));
-  CF_EXPECT(std::move(result));
+
+  auto end = args.end();
+  if (opts.stop_at_double_dashes) {
+    end = std::find(args.begin(), args.end(), "--");
+  }
+
+  auto available_slot_it = args.begin();
+  auto match_it = args.begin();
+  absl::Cleanup delete_args = [&args, &available_slot_it, &match_it, opts]() {
+    auto after_erase_it = args.erase(available_slot_it, match_it);
+    // TODO(jemoreira): Removing the "--" separator from the arguments list
+    // prevents distinguishing between unconsumed arguments before and after the
+    // separator, but existing usage expects it to be removed. The separator
+    // should be left in place and its index returned so the callers have as
+    // much flexibility as possible.
+    if (opts.stop_at_double_dashes && after_erase_it != args.end() &&
+        *after_erase_it == "--") {
+      args.erase(after_erase_it);
+    }
+  };
+  while (match_it != end) {
+    size_t consumed = 0;
+    for (const Flag& flag : flags) {
+      consumed = CF_EXPECT(flag.Match(*match_it, std::span(match_it + 1, end)));
+      if (consumed) {
+        break;
+      }
+    }
+    if (consumed) {
+      match_it += consumed;
+      continue;
+    }
+    CF_EXPECTF(!opts.fail_on_unexpected_argument, "Unexpected argument \"{}\"",
+               *match_it);
+    // This argument was not consumed, keep it at the first available consumed
+    // slot
+    if (available_slot_it != match_it) {
+      *available_slot_it = std::move(*match_it);
+    }
+    ++available_slot_it;
+    ++match_it;
+    if (opts.constrained_matching) {
+      // Stop parsing at first unrecognized argument.
+      break;
+    }
+  }
   return {};
 }
 
 Result<void> ConsumeFlags(const std::vector<Flag>& flags,
                           std::vector<std::string>&& args,
-                          const bool recognize_end_of_option_mark) {
-  if (!recognize_end_of_option_mark) {
-    CF_EXPECT(ConsumeFlagsImpl(flags, std::move(args)));
-    return {};
-  }
-  auto separated = SeparateByEndOfOptionMark(std::move(args));
-  CF_EXPECT(ConsumeFlagsImpl(flags, std::move(separated.args_before_mark)));
+                          ConsumeFlagsOpts opts) {
+  CF_EXPECT(ConsumeFlags(flags, args, opts));
   return {};
-}
-
-Result<void> ConsumeFlagsConstrained(const std::vector<Flag>& flags,
-                                     std::vector<std::string>& args) {
-  while (!args.empty()) {
-    const std::string& first_arg = args[0];
-    std::optional<std::string> next_arg;
-    if (args.size() > 1) {
-      next_arg = args[1];
-    }
-    Flag::FlagProcessResult outcome = Flag::FlagProcessResult::kFlagSkip;
-    for (const Flag& flag : flags) {
-      Flag::FlagProcessResult flag_outcome = 
-          CF_EXPECT(flag.Process(first_arg, next_arg));
-      if (flag_outcome == Flag::FlagProcessResult::kFlagSkip) {
-        continue;
-      }
-      CF_EXPECTF(outcome == Flag::FlagProcessResult::kFlagSkip,
-                 "Multiple '{}' handlers", first_arg);
-      outcome = flag_outcome;
-    }
-    switch (outcome) {
-      case Flag::FlagProcessResult::kFlagSkip:
-        return {};
-      case Flag::FlagProcessResult::kFlagConsumed:
-        args.erase(args.begin());
-        break;
-      case Flag::FlagProcessResult::kFlagConsumedWithFollowing:
-        args.erase(args.begin(), args.begin() + 2);
-        break;
-    }
-  }
-  return {};
-}
-
-Result<void> ConsumeFlagsConstrained(const std::vector<Flag>& flags,
-                                     std::vector<std::string>&& args) {
-  std::vector<std::string>& args_ref = args;
-  CF_EXPECT(ConsumeFlagsConstrained(flags, args_ref));
-  return {};
-}
-
-Flag InvalidFlagGuard() {
-  return Flag("_invalid_flag_guard_")
-      .UnvalidatedAlias({FlagAliasMode::kFlagPrefix, "-"})
-      .Help(
-          "This executable only supports the flags in `-help`. Positional "
-          "arguments may be supported.")
-      .Setter([](const FlagMatch& match) -> Result<void> {
-        return CF_ERRF("Unknown flag \"{}\"", match.value);
-      });
-}
-
-Flag UnexpectedArgumentGuard() {
-  return Flag("_unexpected_argument_guard_")
-      .UnvalidatedAlias({FlagAliasMode::kFlagPrefix, ""})
-      .Help(
-          "This executable only supports the flags in `-help`. Positional "
-          "arguments are not supported.")
-      .Setter([](const FlagMatch& match) -> Result<void> {
-        return CF_ERRF("Unexpected argument \"{}\"", match.value);
-      });
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/flag_parser/flag.cpp
+++ b/base/cvd/cuttlefish/flag_parser/flag.cpp
@@ -262,10 +262,6 @@ Result<void> ConsumeFlags(const std::vector<Flag>& flags,
     }
     ++available_slot_it;
     ++match_it;
-    if (opts.constrained_matching) {
-      // Stop parsing at first unrecognized argument.
-      break;
-    }
   }
   return {};
 }

--- a/base/cvd/cuttlefish/flag_parser/flag.cpp
+++ b/base/cvd/cuttlefish/flag_parser/flag.cpp
@@ -102,6 +102,25 @@ Flag Flag::AddValidator(std::function<Result<void>()> validator) && {
 
 std::string Flag::Name() const { return aliases_.front(); }
 
+std::string Flag::Synopsis() const {
+  std::vector<std::string> options;
+  for (const std::string& alias : aliases_) {
+    switch (style_) {
+      case Flag::Style::String:
+        options.emplace_back(absl::StrCat("--", alias, "=VAL"));
+        break;
+      case Flag::Style::Bool:
+        options.emplace_back("--[no]" + alias);
+        break;
+    }
+  }
+  return absl::StrJoin(options, ", ");
+}
+
+const std::string& Flag::Description() const { return help_; }
+
+std::string Flag::CurrentValue() const { return getter_(); }
+
 Result<void> Flag::Parse(std::vector<std::string>& arguments) const {
   for (auto it = arguments.begin(); it != arguments.end();) {
     size_t consumed = CF_EXPECT(Match(*it, std::span(it + 1, arguments.end())));
@@ -195,23 +214,13 @@ Result<void> Flag::SetAndValidate(std::string_view value) const {
 }
 
 std::ostream& operator<<(std::ostream& out, const Flag& flag) {
-  std::vector<std::string> options;
-  for (const std::string& alias : flag.aliases_) {
-    switch (flag.style_) {
-      case Flag::Style::String:
-        options.emplace_back("--" + alias + "=VAL");
-        break;
-      case Flag::Style::Bool:
-        options.emplace_back("--[no]" + alias);
-        break;
-    }
-  }
-  out << absl::StrJoin(options, ", ") << "\n";
+  out << flag.Synopsis() << "\n";
 
-  if (!flag.help_.empty()) {
-    out << flag.help_ << "\n";
+  std::string help = flag.Description();
+  if (!help.empty()) {
+    out << help << "\n";
   }
-  out << "Current value: \"" << flag.getter_() << "\"\n";
+  out << "Current value: \"" << flag.CurrentValue() << "\"\n";
   return out;
 }
 

--- a/base/cvd/cuttlefish/flag_parser/flag.h
+++ b/base/cvd/cuttlefish/flag_parser/flag.h
@@ -99,9 +99,6 @@ struct ConsumeFlagsOpts {
   bool stop_at_double_dashes = false;
   /* Fail if there are unconsumed arguments left. */
   bool fail_on_unexpected_argument = false;
-  /* Stops matching if an unrecognized argument is encountered; although it
-   * still succeeds unless configured to fail by one of the previous options. */
-  bool constrained_matching = false;
 };
 /* Matches flags against a list of arguments, removing all matches and leaving
  * only unmatched arguments.

--- a/base/cvd/cuttlefish/flag_parser/flag.h
+++ b/base/cvd/cuttlefish/flag_parser/flag.h
@@ -56,6 +56,9 @@ class Flag {
 
   std::string Name() const;
   bool operator<(const Flag& other) const { return Name() < other.Name(); }
+  std::string Synopsis() const;
+  const std::string& Description() const;
+  std::string CurrentValue() const;
 
   /* Examines a list of arguments, removing any matches from the list and
    * invoking the `Setter` for every match. Returns error if the setter or any
@@ -83,7 +86,6 @@ class Flag {
   Result<void> SetAndValidate(std::string_view) const;
 
   friend void WriteGflagsCompatXml(const Flag&, std::ostream&);
-  friend std::ostream& operator<<(std::ostream&, const Flag&);
   friend Result<void> ConsumeFlags(const std::vector<Flag>&,
                                    std::vector<std::string>&, ConsumeFlagsOpts);
 

--- a/base/cvd/cuttlefish/flag_parser/flag.h
+++ b/base/cvd/cuttlefish/flag_parser/flag.h
@@ -17,144 +17,104 @@
 #pragma once
 
 #include <functional>
-#include <optional>
 #include <ostream>
+#include <span>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
 
-/* The matching behavior used with the name in `FlagAlias::name`. */
-enum class FlagAliasMode {
-  /* Match arguments of the form `<name><value>`. In practice, <name> usually
-   * looks like "-flag=" or "--flag=", where the "-" and "=" are included in
-   * parsing. */
-  kFlagPrefix,
-  /* Match arguments of the form `<name>`. In practice, <name> will look like
-   * "-flag" or "--flag". */
-  kFlagExact,
-  /* Match a pair of arguments of the form `<name>` `<value>`. In practice,
-   * <name> will look like "-flag" or "--flag". */
-  kFlagConsumesFollowing,
-};
-
-/* A single matching rule for a `Flag`. One `Flag` can have multiple rules. */
-struct FlagAlias {
-  FlagAliasMode mode;
-  std::string name;
-};
-
-std::ostream& operator<<(std::ostream&, const FlagAlias&);
-
-/* A successful match in an argument list from a `FlagAlias` inside a `Flag`.
- * The `key` value corresponds to `FlagAlias::name`. For a match of
- * `FlagAliasMode::kFlagExact`, `key` and `value` will both be the `name`. */
-struct FlagMatch {
-  std::string key;
-  std::string value;
-};
+struct ConsumeFlagsOpts;
 
 class Flag {
  public:
-  explicit Flag(std::string name) : name_(std::move(name)) {}
+  static Flag StringFlag(std::string name);
+  static Flag BoolFlag(std::string name);
 
   /* Add an alias that triggers matches and calls to the `Setter` function. */
-  Flag& Alias(const FlagAlias& alias) &;
-  Flag Alias(const FlagAlias& alias) &&;
+  Flag& Alias(std::string alias) &;
+  Flag Alias(std::string alias) &&;
   /* Set help text, visible in the class ostream writer method. Optional. */
-  Flag& Help(const std::string&) &;
-  Flag Help(const std::string&) &&;
+  Flag& Help(std::string) &;
+  Flag Help(std::string) &&;
   /* Set a loader that displays the current value in help text. Optional. */
   Flag& Getter(std::function<std::string()>) &;
   Flag Getter(std::function<std::string()>) &&;
   /* Set the callback for matches. The callback may be invoked multiple times.
    */
-  Flag& Setter(std::function<Result<void>(const FlagMatch&)>) &;
-  Flag Setter(std::function<Result<void>(const FlagMatch&)>) &&;
+  Flag& Setter(std::function<Result<void>(std::string_view)>) &;
+  Flag Setter(std::function<Result<void>(std::string_view)>) &&;
   /* Add a callback to validate the parsed flag value. These callbacks are
    * guaranteed to be called after Setter succeeds in the same order they are
    * added. Validation stops when one validator callback fails, remaining
-   * callbacks are not executed.
-   */
+   * callbacks are not executed. */
   Flag& AddValidator(std::function<Result<void>()>) &;
   Flag AddValidator(std::function<Result<void>()>) &&;
 
-  const std::string& Name() const { return name_; }
+  std::string Name() const;
   bool operator<(const Flag& other) const { return Name() < other.Name(); }
 
   /* Examines a list of arguments, removing any matches from the list and
-   * invoking the `Setter` for every match. Returns `false` if the callback ever
-   * returns `false`. Non-matches are left in place. */
+   * invoking the `Setter` for every match. Returns error if the setter or any
+   * validator ever return error. Non-matches are left in place. */
   Result<void> Parse(std::vector<std::string>& arguments) const;
   Result<void> Parse(std::vector<std::string>&& arguments) const;
 
  private:
-  /* Write gflags `--helpxml` style output for a string-type flag. */
-  friend bool WriteGflagsCompatXml(const Flag&, std::ostream&);
-
-  /* Reports whether `Process` wants to consume zero, one, or two arguments. */
-  enum class FlagProcessResult {
-    /* Error in handling a flag, exit flag handling with an error result. */
-    kFlagSkip,                  /* Flag skipped; consume no arguments. */
-    kFlagConsumed,              /* Flag processed; consume one argument. */
-    kFlagConsumedWithFollowing, /* Flag processed; consume 2 arguments. */
+  enum class Style {
+    String,
+    Bool,
   };
+  Flag(std::string name, Style style);
 
-  void ValidateAlias(const FlagAlias& alias);
-  Flag& UnvalidatedAlias(const FlagAlias& alias) &;
-  Flag UnvalidatedAlias(const FlagAlias& alias) &&;
+  void ValidateAlias(const std::string&);
 
-  /* Attempt to match a single argument. */
-  Result<FlagProcessResult> Process(
-      const std::string& argument,
-      const std::optional<std::string>& next_arg) const;
-  Result<void> SetAndValidate(const FlagMatch&) const;
+  /* Calls the flag's setter with the appropriate value if it matches the
+   * current argument. Returns the number of arguments consumed by the flag
+   * (typically between 0 and 2), with 0 indicating the flag doesn't match. */
+  Result<size_t> Match(std::string_view current_arg,
+                       std::span<const std::string> following_args) const;
+  Result<size_t> MatchStringStyleFlag(std::string_view,
+                                      std::span<const std::string>) const;
+  Result<size_t> MatchBoolStyleFlag(std::string_view) const;
+  Result<void> SetAndValidate(std::string_view) const;
 
-  bool HasAlias(const FlagAlias&) const;
-
+  friend void WriteGflagsCompatXml(const Flag&, std::ostream&);
   friend std::ostream& operator<<(std::ostream&, const Flag&);
-  friend Flag InvalidFlagGuard();
-  friend Flag UnexpectedArgumentGuard();
+  friend Result<void> ConsumeFlags(const std::vector<Flag>&,
+                                   std::vector<std::string>&, ConsumeFlagsOpts);
 
-  friend Result<void> ConsumeFlagsConstrained(const std::vector<Flag>& flags,
-                                              std::vector<std::string>&);
-
-  std::string name_;
-  std::vector<FlagAlias> aliases_;
-  std::optional<std::string> help_;
-  std::optional<std::function<std::string()>> getter_;
-  std::optional<std::function<Result<void>(const FlagMatch&)>> setter_;
+  std::vector<std::string> aliases_;
+  Style style_;
+  std::string help_;
+  std::function<std::string()> getter_ = []() { return ""; };
+  std::function<Result<void>(std::string_view value)> setter_;
   std::vector<std::function<Result<void>()>> validators_;
 };
 
 std::ostream& operator<<(std::ostream&, const Flag&);
 
-/* Catches any argument that begin with `-` and errors out. When used after all
- * valid flags it effectively fails on unrecognized flags.
+struct ConsumeFlagsOpts {
+  /* Stop matching flags when the "--" separator is found. The other options
+   * only apply to the arguments up to but exluding the "--", if present. */
+  bool stop_at_double_dashes = false;
+  /* Fail if there are unconsumed arguments left. */
+  bool fail_on_unexpected_argument = false;
+  /* Stops matching if an unrecognized argument is encountered; although it
+   * still succeeds unless configured to fail by one of the previous options. */
+  bool constrained_matching = false;
+};
+/* Matches flags against a list of arguments, removing all matches and leaving
+ * only unmatched arguments.
  */
-Flag InvalidFlagGuard();
-/* Catches any arguments not extracted by other Flag matchers and errors out.
- * This effectively denies unknown flags and any positional arguments. */
-Flag UnexpectedArgumentGuard();
-
-/* Handles a list of flags. Flags are matched in the order given in case two
- * flags match the same argument. Matched flags are removed, leaving only
- * unmatched arguments. */
 Result<void> ConsumeFlags(const std::vector<Flag>& flags,
                           std::vector<std::string>& args,
-                          bool recognize_end_of_option_mark = false);
+                          ConsumeFlagsOpts opts = {});
 Result<void> ConsumeFlags(const std::vector<Flag>& flags,
-                          std::vector<std::string>&&,
-                          bool recognize_end_of_option_mark = false);
-
-/* Handles a list of flags. Arguments are handled from the beginning. When an
- * unrecognized argument is encountered, parsing stops. At most one flag matcher
- * can handle a particular argument. */
-Result<void> ConsumeFlagsConstrained(const std::vector<Flag>& flags,
-                                     std::vector<std::string>&);
-Result<void> ConsumeFlagsConstrained(const std::vector<Flag>& flags,
-                                     std::vector<std::string>&&);
+                          std::vector<std::string>&& args,
+                          ConsumeFlagsOpts opts = {});
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/flag_parser/flag.h
+++ b/base/cvd/cuttlefish/flag_parser/flag.h
@@ -60,12 +60,6 @@ class Flag {
   const std::string& Description() const;
   std::string CurrentValue() const;
 
-  /* Examines a list of arguments, removing any matches from the list and
-   * invoking the `Setter` for every match. Returns error if the setter or any
-   * validator ever return error. Non-matches are left in place. */
-  Result<void> Parse(std::vector<std::string>& arguments) const;
-  Result<void> Parse(std::vector<std::string>&& arguments) const;
-
  private:
   enum class Style {
     String,

--- a/base/cvd/cuttlefish/flag_parser/flag_parser_test.cpp
+++ b/base/cvd/cuttlefish/flag_parser/flag_parser_test.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include <libxml/parser.h>
 #include <stdint.h>
 
 #include <map>
@@ -26,6 +25,7 @@
 
 #include "gmock/gmock-matchers.h"
 #include "gtest/gtest.h"
+#include "libxml/parser.h"
 
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/flag_parser/gflags_compat.h"

--- a/base/cvd/cuttlefish/flag_parser/flag_parser_test.cpp
+++ b/base/cvd/cuttlefish/flag_parser/flag_parser_test.cpp
@@ -351,36 +351,6 @@ TEST(FlagParser, EndOfOptionMark) {
   ASSERT_TRUE(flag);
 }
 
-TEST(FlagParser, ConsumesConstrainedEquals) {
-  std::vector<std::string> args{"--name=abc", "status", "--name=def"};
-
-  std::string name;
-  Flag name_flag = GflagsCompatFlag("name", name);
-
-  std::vector<Flag> flags = {name_flag};
-  EXPECT_THAT(ConsumeFlags(flags, args, {.constrained_matching = true}),
-              IsOk());
-
-  std::vector<std::string> expected_args = {"status", "--name=def"};
-  EXPECT_EQ(args, expected_args);
-  EXPECT_EQ(name, "abc");
-}
-
-TEST(FlagParser, ConsumesConstrainedSeparated) {
-  std::vector<std::string> args{"--name", "abc", "status", "--name", "def"};
-
-  std::string name;
-  Flag name_flag = GflagsCompatFlag("name", name);
-
-  std::vector<Flag> flags = {name_flag};
-  EXPECT_THAT(ConsumeFlags(flags, args, {.constrained_matching = true}),
-              IsOk());
-
-  std::vector<std::string> expected_args = {"status", "--name", "def"};
-  EXPECT_EQ(args, expected_args);
-  EXPECT_EQ(name, "abc");
-}
-
 TEST(FlagParser, OptionalStringFlag_DefaultOptNotPresent) {
   std::optional<std::string> value;
 

--- a/base/cvd/cuttlefish/flag_parser/flag_parser_test.cpp
+++ b/base/cvd/cuttlefish/flag_parser/flag_parser_test.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <libxml/parser.h>
 #include <stdint.h>
 
 #include <map>
@@ -23,7 +24,6 @@
 #include <string_view>
 #include <vector>
 
-#include <libxml/parser.h>
 #include "gmock/gmock-matchers.h"
 #include "gtest/gtest.h"
 
@@ -45,30 +45,30 @@ TEST(FlagParser, DuplicateAlias) {
 TEST(FlagParser, StringFlag) {
   std::string value;
   auto flag = GflagsCompatFlag("myflag", value);
-  ASSERT_THAT(flag.Parse({"-myflag=a"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"-myflag=a"}), IsOk());
   ASSERT_EQ(value, "a");
-  ASSERT_THAT(flag.Parse({"--myflag=b"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=b"}), IsOk());
   ASSERT_EQ(value, "b");
-  ASSERT_THAT(flag.Parse({"-myflag", "c"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"-myflag", "c"}), IsOk());
   ASSERT_EQ(value, "c");
-  ASSERT_THAT(flag.Parse({"--myflag", "d"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag", "d"}), IsOk());
   ASSERT_EQ(value, "d");
-  ASSERT_THAT(flag.Parse({"--myflag="}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag="}), IsOk());
   ASSERT_EQ(value, "");
 }
 
 TEST(FlagParser, NormalizedStringFlag) {
   std::string value;
   auto flag = GflagsCompatFlag("my_flag", value);
-  ASSERT_THAT(flag.Parse({"-my-flag=a"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"-my-flag=a"}), IsOk());
   ASSERT_EQ(value, "a");
-  ASSERT_THAT(flag.Parse({"--my-flag=b"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--my-flag=b"}), IsOk());
   ASSERT_EQ(value, "b");
-  ASSERT_THAT(flag.Parse({"-my-flag", "c"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"-my-flag", "c"}), IsOk());
   ASSERT_EQ(value, "c");
-  ASSERT_THAT(flag.Parse({"--my-flag", "d"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--my-flag", "d"}), IsOk());
   ASSERT_EQ(value, "d");
-  ASSERT_THAT(flag.Parse({"--my-flag="}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--my-flag="}), IsOk());
   ASSERT_EQ(value, "");
 }
 
@@ -116,7 +116,7 @@ TEST(FlagParser, StringFlagXml) {
 TEST(FlagParser, RepeatedStringFlag) {
   std::string value;
   auto flag = GflagsCompatFlag("myflag", value);
-  ASSERT_THAT(flag.Parse({"-myflag=a", "--myflag", "b"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"-myflag=a", "--myflag", "b"}), IsOk());
   ASSERT_EQ(value, "b");
 }
 
@@ -127,7 +127,7 @@ TEST(FlagParser, RepeatedListFlag) {
     elems.emplace_back(arg);
     return {};
   });
-  ASSERT_THAT(flag.Parse({"-myflag=a", "--myflag", "b"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"-myflag=a", "--myflag", "b"}), IsOk());
   ASSERT_EQ(elems, (std::vector<std::string>{"a", "b"}));
 }
 
@@ -135,11 +135,11 @@ TEST(FlagParser, FlagRemoval) {
   std::string value;
   auto flag = GflagsCompatFlag("myflag", value);
   std::vector<std::string> flags = {"-myflag=a", "-otherflag=c"};
-  ASSERT_THAT(flag.Parse(flags), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, flags), IsOk());
   ASSERT_EQ(value, "a");
   ASSERT_EQ(flags, std::vector<std::string>{"-otherflag=c"});
   flags = {"-otherflag=a", "-myflag=c"};
-  ASSERT_THAT(flag.Parse(flags), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, flags), IsOk());
   ASSERT_EQ(value, "c");
   ASSERT_EQ(flags, std::vector<std::string>{"-otherflag=a"});
 }
@@ -147,13 +147,13 @@ TEST(FlagParser, FlagRemoval) {
 TEST(FlagParser, IntFlag) {
   int32_t value = 0;
   auto flag = GflagsCompatFlag("myflag", value);
-  ASSERT_THAT(flag.Parse({"-myflag=5"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"-myflag=5"}), IsOk());
   ASSERT_EQ(value, 5);
-  ASSERT_THAT(flag.Parse({"--myflag=6"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=6"}), IsOk());
   ASSERT_EQ(value, 6);
-  ASSERT_THAT(flag.Parse({"-myflag", "7"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"-myflag", "7"}), IsOk());
   ASSERT_EQ(value, 7);
-  ASSERT_THAT(flag.Parse({"--myflag", "8"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag", "8"}), IsOk());
   ASSERT_EQ(value, 8);
 }
 
@@ -173,38 +173,38 @@ TEST(FlagParser, IntFlagXml) {
 TEST(FlagParser, BoolFlag) {
   bool value = false;
   auto flag = GflagsCompatFlag("myflag", value);
-  ASSERT_THAT(flag.Parse({"-myflag"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"-myflag"}), IsOk());
   ASSERT_TRUE(value);
 
   value = false;
-  ASSERT_THAT(flag.Parse({"--myflag"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag"}), IsOk());
   ASSERT_TRUE(value);
 
   value = false;
-  ASSERT_THAT(flag.Parse({"-myflag=true"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"-myflag=true"}), IsOk());
   ASSERT_TRUE(value);
 
   value = false;
-  ASSERT_THAT(flag.Parse({"--myflag=true"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=true"}), IsOk());
   ASSERT_TRUE(value);
 
   value = true;
-  ASSERT_THAT(flag.Parse({"-nomyflag"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"-nomyflag"}), IsOk());
   ASSERT_FALSE(value);
 
   value = true;
-  ASSERT_THAT(flag.Parse({"--nomyflag"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--nomyflag"}), IsOk());
   ASSERT_FALSE(value);
 
   value = true;
-  ASSERT_THAT(flag.Parse({"-myflag=false"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"-myflag=false"}), IsOk());
   ASSERT_FALSE(value);
 
   value = true;
-  ASSERT_THAT(flag.Parse({"--myflag=false"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=false"}), IsOk());
   ASSERT_FALSE(value);
 
-  ASSERT_THAT(flag.Parse({"--myflag=nonsense"}), IsError());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=nonsense"}), IsError());
 }
 
 TEST(FlagParser, BoolFlagXml) {
@@ -244,22 +244,22 @@ TEST(FlagParser, StringVectorFlag) {
   std::vector<std::string> value;
   auto flag = GflagsCompatFlag("myflag", value);
 
-  ASSERT_THAT(flag.Parse({"--myflag="}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag="}), IsOk());
   ASSERT_TRUE(value.empty());
 
-  ASSERT_THAT(flag.Parse({"--myflag=foo"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=foo"}), IsOk());
   ASSERT_EQ(value, std::vector<std::string>({"foo"}));
 
-  ASSERT_THAT(flag.Parse({"--myflag=foo,bar"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=foo,bar"}), IsOk());
   ASSERT_EQ(value, std::vector<std::string>({"foo", "bar"}));
 
-  ASSERT_THAT(flag.Parse({"--myflag=,bar"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=,bar"}), IsOk());
   ASSERT_EQ(value, std::vector<std::string>({"", "bar"}));
 
-  ASSERT_THAT(flag.Parse({"--myflag=foo,"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=foo,"}), IsOk());
   ASSERT_EQ(value, std::vector<std::string>({"foo", ""}));
 
-  ASSERT_THAT(flag.Parse({"--myflag=,"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=,"}), IsOk());
   ASSERT_EQ(value, std::vector<std::string>({"", ""}));
 }
 
@@ -267,34 +267,34 @@ TEST(FlagParser, BoolVectorFlag) {
   std::vector<bool> value;
   bool default_value = true;
   auto flag = GflagsCompatFlag("myflag", value, default_value);
-  ASSERT_THAT(flag.Parse({"--myflag="}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag="}), IsOk());
   ASSERT_TRUE(value.empty());
-  ASSERT_THAT(flag.Parse({"--myflag=foo"}), IsError());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=foo"}), IsError());
   ASSERT_TRUE(value.empty());
-  ASSERT_THAT(flag.Parse({"--myflag=true,bar"}), IsError());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=true,bar"}), IsError());
   ASSERT_TRUE(value.empty());
 
-  ASSERT_THAT(flag.Parse({"--myflag=true"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=true"}), IsOk());
   ASSERT_EQ(value, std::vector<bool>({true}));
   ASSERT_TRUE(flagXml(flag));
   ASSERT_EQ((*flagXml(flag))["default"], "true");
 
-  ASSERT_THAT(flag.Parse({"--myflag=true,false"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=true,false"}), IsOk());
   ASSERT_EQ(value, std::vector<bool>({true, false}));
   ASSERT_TRUE(flagXml(flag));
   ASSERT_EQ((*flagXml(flag))["default"], "true,false");
 
-  ASSERT_THAT(flag.Parse({"--myflag=,false"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=,false"}), IsOk());
   ASSERT_EQ(value, std::vector<bool>({true, false}));
   ASSERT_TRUE(flagXml(flag));
   ASSERT_EQ((*flagXml(flag))["default"], "true,false");
 
-  ASSERT_THAT(flag.Parse({"--myflag=true,"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=true,"}), IsOk());
   ASSERT_EQ(value, std::vector<bool>({true, true}));
   ASSERT_TRUE(flagXml(flag));
   ASSERT_EQ((*flagXml(flag))["default"], "true,true");
 
-  ASSERT_THAT(flag.Parse({"--myflag=,"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=,"}), IsOk());
   ASSERT_EQ(value, std::vector<bool>({true, true}));
   ASSERT_TRUE(flagXml(flag));
   ASSERT_EQ((*flagXml(flag))["default"], "true,true");
@@ -303,19 +303,19 @@ TEST(FlagParser, BoolVectorFlag) {
 TEST(FlagParser, InvalidStringFlag) {
   std::string value;
   auto flag = GflagsCompatFlag("myflag", value);
-  ASSERT_THAT(flag.Parse({"-myflag"}), IsError());
-  ASSERT_THAT(flag.Parse({"--myflag"}), IsError());
+  ASSERT_THAT(ConsumeFlags({flag}, {"-myflag"}), IsError());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag"}), IsError());
 }
 
 TEST(FlagParser, InvalidIntFlag) {
   int value;
   auto flag = GflagsCompatFlag("myflag", value);
-  ASSERT_THAT(flag.Parse({"-myflag"}), IsError());
-  ASSERT_THAT(flag.Parse({"--myflag"}), IsError());
-  ASSERT_THAT(flag.Parse({"-myflag=abc"}), IsError());
-  ASSERT_THAT(flag.Parse({"--myflag=def"}), IsError());
-  ASSERT_THAT(flag.Parse({"-myflag", "abc"}), IsError());
-  ASSERT_THAT(flag.Parse({"--myflag", "def"}), IsError());
+  ASSERT_THAT(ConsumeFlags({flag}, {"-myflag"}), IsError());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag"}), IsError());
+  ASSERT_THAT(ConsumeFlags({flag}, {"-myflag=abc"}), IsError());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=def"}), IsError());
+  ASSERT_THAT(ConsumeFlags({flag}, {"-myflag", "abc"}), IsError());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag", "def"}), IsError());
 }
 
 TEST(FlagParser, UnexpectedArgumentGuard) {
@@ -389,7 +389,7 @@ TEST(FlagParser, OptionalStringFlag_DefaultOptNotPresent) {
 
   // Not present, should remain default (nullopt)
   value = std::nullopt;
-  ASSERT_THAT(flag_default.Parse({}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag_default}, {}), IsOk());
   ASSERT_FALSE(value.has_value());
 }
 
@@ -401,7 +401,7 @@ TEST(FlagParser, OptionalStringFlag_DefaultOptPresent) {
 
   // Present with value
   value = std::nullopt;
-  ASSERT_THAT(flag_default.Parse({"--myflag=foo"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag_default}, {"--myflag=foo"}), IsOk());
   ASSERT_TRUE(value.has_value());
   ASSERT_EQ(*value, "foo");
 }
@@ -414,7 +414,7 @@ TEST(FlagParser, OptionalStringFlag_DefaultOptEmtpyFlag) {
 
   // Present with empty value
   value = std::nullopt;
-  ASSERT_THAT(flag_default.Parse({"--myflag="}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag_default}, {"--myflag="}), IsOk());
   ASSERT_TRUE(value.has_value());
   ASSERT_EQ(*value, "");
 }
@@ -428,7 +428,7 @@ TEST(FlagParser, OptionalStringFlag_EmptyOptEmtpyFlag) {
 
   // Present with empty value -> should be nullopt
   value = "before";
-  ASSERT_THAT(flag_empty_string.Parse({"--myflag="}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag_empty_string}, {"--myflag="}), IsOk());
   ASSERT_FALSE(value.has_value());
 }
 
@@ -441,7 +441,7 @@ TEST(FlagParser, OptionalStringFlag_EmptyOptPresent) {
 
   // Present with value -> should be value
   value = std::nullopt;
-  ASSERT_THAT(flag_empty_string.Parse({"--myflag=bar"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag_empty_string}, {"--myflag=bar"}), IsOk());
   ASSERT_TRUE(value.has_value());
   ASSERT_EQ(*value, "bar");
 }
@@ -455,7 +455,7 @@ TEST(FlagParser, OptionalStringFlag_UnsetOptUnsetValue) {
 
   // Present with "unset" -> should be nullopt
   value = "before";
-  ASSERT_THAT(flag_unset.Parse({"--myflag=unset"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag_unset}, {"--myflag=unset"}), IsOk());
   ASSERT_FALSE(value.has_value());
 }
 
@@ -468,7 +468,7 @@ TEST(FlagParser, OptionalStringFlag_UnsetOptOtherValue) {
 
   // Present with other value -> should be value
   value = std::nullopt;
-  ASSERT_THAT(flag_unset.Parse({"--myflag=baz"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag_unset}, {"--myflag=baz"}), IsOk());
   ASSERT_TRUE(value.has_value());
   ASSERT_EQ(*value, "baz");
 }
@@ -481,7 +481,7 @@ TEST(FlagParser, OptionalStringVectorFlag_DefaultOptNotPresent) {
 
   // Not present, should remain default (nullopt)
   value = std::nullopt;
-  ASSERT_THAT(flag_default.Parse({}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag_default}, {}), IsOk());
   ASSERT_FALSE(value.has_value());
 }
 
@@ -493,7 +493,7 @@ TEST(FlagParser, OptionalStringVectorFlag_DefaultOptPresent) {
 
   // Present with value
   value = std::nullopt;
-  ASSERT_THAT(flag_default.Parse({"--myflag=foo,bar"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag_default}, {"--myflag=foo,bar"}), IsOk());
   ASSERT_TRUE(value.has_value());
   ASSERT_EQ(*value, std::vector<std::string>({"foo", "bar"}));
 }
@@ -507,7 +507,7 @@ TEST(FlagParser, OptionalStringVectorFlag_DefaultOptEmptyValue) {
   // Present with empty value (should be empty vector, not nullopt, because opt
   // is None)
   value = std::nullopt;
-  ASSERT_THAT(flag_default.Parse({"--myflag="}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag_default}, {"--myflag="}), IsOk());
   ASSERT_TRUE(value.has_value());
   ASSERT_TRUE(value->empty());
 }
@@ -521,7 +521,7 @@ TEST(FlagParser, OptionalStringVectorFlag_EmptyOptEmptyValue) {
 
   // Present with empty value -> should be nullopt
   value = std::vector<std::string>{"before"};
-  ASSERT_THAT(flag_empty_string.Parse({"--myflag="}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag_empty_string}, {"--myflag="}), IsOk());
   ASSERT_FALSE(value.has_value());
 }
 
@@ -534,7 +534,7 @@ TEST(FlagParser, OptionalStringVectorFlag_EmptyOptPresent) {
 
   // Present with value -> should be value
   value = std::nullopt;
-  ASSERT_THAT(flag_empty_string.Parse({"--myflag=bar,baz"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag_empty_string}, {"--myflag=bar,baz"}), IsOk());
   ASSERT_TRUE(value.has_value());
   ASSERT_EQ(*value, std::vector<std::string>({"bar", "baz"}));
 }
@@ -548,7 +548,7 @@ TEST(FlagParser, OptionalStringVectorFlag_UnsetOptUnsetValue) {
 
   // Present with "unset" -> should be nullopt
   value = std::vector<std::string>{"before"};
-  ASSERT_THAT(flag_unset.Parse({"--myflag=unset"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag_unset}, {"--myflag=unset"}), IsOk());
   ASSERT_FALSE(value.has_value());
 }
 
@@ -561,7 +561,7 @@ TEST(FlagParser, OptionalStringVectorFlag_UnsetOptPresent) {
 
   // Present with other value -> should be value
   value = std::nullopt;
-  ASSERT_THAT(flag_unset.Parse({"--myflag=baz"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag_unset}, {"--myflag=baz"}), IsOk());
   ASSERT_TRUE(value.has_value());
   ASSERT_EQ(*value, std::vector<std::string>({"baz"}));
 }
@@ -570,7 +570,7 @@ TEST(FlagParser, OptionalBoolFlag_DefaultOptNotPresent) {
   std::optional<bool> value;
   auto flag = GflagsCompatFlag("myflag", value);
   value = std::nullopt;
-  ASSERT_THAT(flag.Parse({}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {}), IsOk());
   ASSERT_FALSE(value.has_value());
 }
 
@@ -578,7 +578,7 @@ TEST(FlagParser, OptionalBoolFlag_DefaultOptPresent_FlagOnly) {
   std::optional<bool> value;
   auto flag = GflagsCompatFlag("myflag", value);
   value = std::nullopt;
-  ASSERT_THAT(flag.Parse({"--myflag"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag"}), IsOk());
   ASSERT_TRUE(value.has_value());
   ASSERT_TRUE(*value);
 }
@@ -587,7 +587,7 @@ TEST(FlagParser, OptionalBoolFlag_DefaultOptPresent_TrueValue) {
   std::optional<bool> value;
   auto flag = GflagsCompatFlag("myflag", value);
   value = std::nullopt;
-  ASSERT_THAT(flag.Parse({"--myflag=true"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=true"}), IsOk());
   ASSERT_TRUE(value.has_value());
   ASSERT_TRUE(*value);
 }
@@ -596,7 +596,7 @@ TEST(FlagParser, OptionalBoolFlag_DefaultOptPresent_FalseValue) {
   std::optional<bool> value;
   auto flag = GflagsCompatFlag("myflag", value);
   value = std::nullopt;
-  ASSERT_THAT(flag.Parse({"--myflag=false"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=false"}), IsOk());
   ASSERT_TRUE(value.has_value());
   ASSERT_FALSE(*value);
 }
@@ -605,7 +605,7 @@ TEST(FlagParser, OptionalBoolFlag_NoFlag) {
   std::optional<bool> value;
   auto flag = GflagsCompatFlag("myflag", value);
   value = std::nullopt;
-  ASSERT_THAT(flag.Parse({"--nomyflag"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--nomyflag"}), IsOk());
   ASSERT_TRUE(value.has_value());
   ASSERT_FALSE(*value);
 }
@@ -614,7 +614,7 @@ TEST(FlagParser, OptionalBoolFlag_EmptyOptEmptyFlag) {
   std::optional<bool> value;
   auto flag = GflagsCompatFlag("myflag", value, CoerceToNullopt::EmptyString);
   value = true;
-  ASSERT_THAT(flag.Parse({"--myflag="}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag="}), IsOk());
   ASSERT_FALSE(value.has_value());
 }
 
@@ -622,7 +622,7 @@ TEST(FlagParser, OptionalBoolFlag_UnsetOptUnsetValue) {
   std::optional<bool> value;
   auto flag = GflagsCompatFlag("myflag", value, CoerceToNullopt::UnsetKeyword);
   value = true;
-  ASSERT_THAT(flag.Parse({"--myflag=unset"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=unset"}), IsOk());
   ASSERT_FALSE(value.has_value());
 }
 
@@ -630,7 +630,7 @@ TEST(FlagParser, OptionalInt64Flag_Present) {
   std::optional<int64_t> value;
   auto flag = GflagsCompatFlag("myflag", value);
   value = std::nullopt;
-  ASSERT_THAT(flag.Parse({"--myflag=123456789012345"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=123456789012345"}), IsOk());
   ASSERT_TRUE(value.has_value());
   ASSERT_EQ(*value, 123456789012345LL);
 }
@@ -639,7 +639,7 @@ TEST(FlagParser, OptionalInt64Flag_NotPresent) {
   std::optional<int64_t> value;
   auto flag = GflagsCompatFlag("myflag", value);
   value = std::nullopt;
-  ASSERT_THAT(flag.Parse({}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {}), IsOk());
   ASSERT_FALSE(value.has_value());
 }
 

--- a/base/cvd/cuttlefish/flag_parser/flag_parser_test.cpp
+++ b/base/cvd/cuttlefish/flag_parser/flag_parser_test.cpp
@@ -14,35 +14,32 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/flag_parser/flag.h"
-#include "cuttlefish/flag_parser/gflags_compat.h"
-
 #include <stdint.h>
 
 #include <map>
 #include <optional>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <vector>
 
-#include <gmock/gmock-matchers.h>
-#include <gtest/gtest.h>
 #include <libxml/parser.h>
+#include "gmock/gmock-matchers.h"
+#include "gtest/gtest.h"
 
+#include "cuttlefish/flag_parser/flag.h"
+#include "cuttlefish/flag_parser/gflags_compat.h"
 #include "cuttlefish/result/result_matchers.h"
 
 namespace cuttlefish {
 
 TEST(FlagParser, DuplicateAlias) {
-  FlagAlias alias = {FlagAliasMode::kFlagExact, "--flag"};
-  ASSERT_DEATH({ Flag("flag").Alias(alias).Alias(alias); }, "Duplicate flag alias");
-}
-
-TEST(FlagParser, ConflictingAlias) {
-  FlagAlias exact_alias = {FlagAliasMode::kFlagExact, "--flag"};
-  FlagAlias following_alias = {FlagAliasMode::kFlagConsumesFollowing, "--flag"};
-  ASSERT_DEATH({ Flag("flag").Alias(exact_alias).Alias(following_alias); },
-               "Overlapping flag aliases");
+  ASSERT_DEATH(
+      { Flag::StringFlag("flag").Alias("flag"); },
+      "Duplicate flag alias: flag");
+  ASSERT_DEATH(
+      { Flag::StringFlag("flag").Alias("foo").Alias("foo"); },
+      "Duplicate flag alias: foo");
 }
 
 TEST(FlagParser, StringFlag) {
@@ -77,12 +74,10 @@ TEST(FlagParser, NormalizedStringFlag) {
 
 std::optional<std::map<std::string, std::string>> flagXml(const Flag& f) {
   std::stringstream xml_stream;
-  if (!WriteGflagsCompatXml(f, xml_stream)) {
-    return {};
-  }
+  WriteGflagsCompatXml(f, xml_stream);
   auto xml = xml_stream.str();
   // Holds all memory for the parsed structure.
-  std::unique_ptr<xmlDoc, void(*)(xmlDocPtr)> doc(
+  std::unique_ptr<xmlDoc, void (*)(xmlDocPtr)> doc(
       xmlReadMemory(xml.c_str(), xml.size(), nullptr, nullptr, 0), xmlFreeDoc);
   if (!doc) {
     return {};
@@ -103,11 +98,6 @@ std::optional<std::map<std::string, std::string>> flagXml(const Flag& f) {
     elements_map[(char*)elem->name] = (char*)elem->children->content;
   }
   return elements_map;
-}
-
-TEST(FlagParser, GflagsIncompatibleFlag) {
-  auto flag = Flag("flag").Alias({FlagAliasMode::kFlagExact, "--flag"});
-  ASSERT_FALSE(flagXml(flag));
 }
 
 TEST(FlagParser, StringFlagXml) {
@@ -132,9 +122,9 @@ TEST(FlagParser, RepeatedStringFlag) {
 
 TEST(FlagParser, RepeatedListFlag) {
   std::vector<std::string> elems;
-  auto flag = GflagsCompatFlag("myflag");
-  flag.Setter([&elems](const FlagMatch& match) -> Result<void> {
-    elems.push_back(match.value);
+  auto flag = Flag::StringFlag("myflag");
+  flag.Setter([&elems](std::string_view arg) -> Result<void> {
+    elems.emplace_back(arg);
     return {};
   });
   ASSERT_THAT(flag.Parse({"-myflag=a", "--myflag", "b"}), IsOk());
@@ -328,32 +318,35 @@ TEST(FlagParser, InvalidIntFlag) {
   ASSERT_THAT(flag.Parse({"--myflag", "def"}), IsError());
 }
 
-TEST(FlagParser, InvalidFlagGuard) {
-  auto flag = InvalidFlagGuard();
-  ASSERT_THAT(flag.Parse({}), IsOk());
-  ASSERT_THAT(flag.Parse({"positional"}), IsOk());
-  ASSERT_THAT(flag.Parse({"positional", "positional2"}), IsOk());
-  ASSERT_THAT(flag.Parse({"-flag"}), IsError());
-  ASSERT_THAT(flag.Parse({"-"}), IsError());
-}
-
 TEST(FlagParser, UnexpectedArgumentGuard) {
-  auto flag = UnexpectedArgumentGuard();
-  ASSERT_THAT(flag.Parse({}), IsOk());
-  ASSERT_THAT(flag.Parse({"positional"}), IsError());
-  ASSERT_THAT(flag.Parse({"positional", "positional2"}), IsError());
-  ASSERT_THAT(flag.Parse({"-flag"}), IsError());
-  ASSERT_THAT(flag.Parse({"-"}), IsError());
+  auto consume_check_unexpected = [](std::vector<std::string> args) {
+    return ConsumeFlags({}, std::move(args),
+                        {.fail_on_unexpected_argument = true});
+  };
+  ASSERT_THAT(consume_check_unexpected({}), IsOk());
+  ASSERT_THAT(consume_check_unexpected({"positional"}), IsError());
+  ASSERT_THAT(consume_check_unexpected({"positional", "positional2"}),
+              IsError());
+  ASSERT_THAT(consume_check_unexpected({"-flag"}), IsError());
+  ASSERT_THAT(consume_check_unexpected({"-"}), IsError());
 }
 
 TEST(FlagParser, EndOfOptionMark) {
   std::vector<std::string> args{"-flag", "--", "-invalid_flag"};
   bool flag = false;
-  std::vector<Flag> flags{GflagsCompatFlag("flag", flag), InvalidFlagGuard()};
+  std::vector<Flag> flags{GflagsCompatFlag("flag", flag)};
 
-  EXPECT_THAT(ConsumeFlags(flags, args), IsError());
   EXPECT_THAT(ConsumeFlags(flags, args,
-                           /* recognize_end_of_option_mark */ true),
+                           {
+                               .fail_on_unexpected_argument = true,
+                           }),
+              IsError());
+  EXPECT_EQ(args, std::vector<std::string>({"--", "-invalid_flag"}));
+  EXPECT_THAT(ConsumeFlags(flags, args,
+                           {
+                               .stop_at_double_dashes = true,
+                               .fail_on_unexpected_argument = true,
+                           }),
               IsOk());
   ASSERT_TRUE(flag);
 }
@@ -365,7 +358,8 @@ TEST(FlagParser, ConsumesConstrainedEquals) {
   Flag name_flag = GflagsCompatFlag("name", name);
 
   std::vector<Flag> flags = {name_flag};
-  EXPECT_THAT(ConsumeFlagsConstrained(flags, args), IsOk());
+  EXPECT_THAT(ConsumeFlags(flags, args, {.constrained_matching = true}),
+              IsOk());
 
   std::vector<std::string> expected_args = {"status", "--name=def"};
   EXPECT_EQ(args, expected_args);
@@ -379,7 +373,8 @@ TEST(FlagParser, ConsumesConstrainedSeparated) {
   Flag name_flag = GflagsCompatFlag("name", name);
 
   std::vector<Flag> flags = {name_flag};
-  EXPECT_THAT(ConsumeFlagsConstrained(flags, args), IsOk());
+  EXPECT_THAT(ConsumeFlags(flags, args, {.constrained_matching = true}),
+              IsOk());
 
   std::vector<std::string> expected_args = {"status", "--name", "def"};
   EXPECT_EQ(args, expected_args);
@@ -428,7 +423,8 @@ TEST(FlagParser, OptionalStringFlag_EmptyOptEmtpyFlag) {
   std::optional<std::string> value;
 
   // With EmptyString option
-  auto flag_empty_string = GflagsCompatFlag("myflag", value, CoerceToNullopt::EmptyString);
+  auto flag_empty_string =
+      GflagsCompatFlag("myflag", value, CoerceToNullopt::EmptyString);
 
   // Present with empty value -> should be nullopt
   value = "before";
@@ -440,7 +436,8 @@ TEST(FlagParser, OptionalStringFlag_EmptyOptPresent) {
   std::optional<std::string> value;
 
   // With EmptyString option
-  auto flag_empty_string = GflagsCompatFlag("myflag", value, CoerceToNullopt::EmptyString);
+  auto flag_empty_string =
+      GflagsCompatFlag("myflag", value, CoerceToNullopt::EmptyString);
 
   // Present with value -> should be value
   value = std::nullopt;
@@ -453,7 +450,8 @@ TEST(FlagParser, OptionalStringFlag_UnsetOptUnsetValue) {
   std::optional<std::string> value;
 
   // With UnsetKeyword option
-  auto flag_unset = GflagsCompatFlag("myflag", value, CoerceToNullopt::UnsetKeyword);
+  auto flag_unset =
+      GflagsCompatFlag("myflag", value, CoerceToNullopt::UnsetKeyword);
 
   // Present with "unset" -> should be nullopt
   value = "before";
@@ -465,7 +463,8 @@ TEST(FlagParser, OptionalStringFlag_UnsetOptOtherValue) {
   std::optional<std::string> value;
 
   // With UnsetKeyword option
-  auto flag_unset = GflagsCompatFlag("myflag", value, CoerceToNullopt::UnsetKeyword);
+  auto flag_unset =
+      GflagsCompatFlag("myflag", value, CoerceToNullopt::UnsetKeyword);
 
   // Present with other value -> should be value
   value = std::nullopt;
@@ -505,7 +504,8 @@ TEST(FlagParser, OptionalStringVectorFlag_DefaultOptEmptyValue) {
   // Default options: None
   auto flag_default = GflagsCompatFlag("myflag", value);
 
-  // Present with empty value (should be empty vector, not nullopt, because opt is None)
+  // Present with empty value (should be empty vector, not nullopt, because opt
+  // is None)
   value = std::nullopt;
   ASSERT_THAT(flag_default.Parse({"--myflag="}), IsOk());
   ASSERT_TRUE(value.has_value());
@@ -516,7 +516,8 @@ TEST(FlagParser, OptionalStringVectorFlag_EmptyOptEmptyValue) {
   std::optional<std::vector<std::string>> value;
 
   // With EmptyString option
-  auto flag_empty_string = GflagsCompatFlag("myflag", value, CoerceToNullopt::EmptyString);
+  auto flag_empty_string =
+      GflagsCompatFlag("myflag", value, CoerceToNullopt::EmptyString);
 
   // Present with empty value -> should be nullopt
   value = std::vector<std::string>{"before"};
@@ -528,7 +529,8 @@ TEST(FlagParser, OptionalStringVectorFlag_EmptyOptPresent) {
   std::optional<std::vector<std::string>> value;
 
   // With EmptyString option
-  auto flag_empty_string = GflagsCompatFlag("myflag", value, CoerceToNullopt::EmptyString);
+  auto flag_empty_string =
+      GflagsCompatFlag("myflag", value, CoerceToNullopt::EmptyString);
 
   // Present with value -> should be value
   value = std::nullopt;
@@ -541,7 +543,8 @@ TEST(FlagParser, OptionalStringVectorFlag_UnsetOptUnsetValue) {
   std::optional<std::vector<std::string>> value;
 
   // With UnsetKeyword option
-  auto flag_unset = GflagsCompatFlag("myflag", value, CoerceToNullopt::UnsetKeyword);
+  auto flag_unset =
+      GflagsCompatFlag("myflag", value, CoerceToNullopt::UnsetKeyword);
 
   // Present with "unset" -> should be nullopt
   value = std::vector<std::string>{"before"};
@@ -553,7 +556,8 @@ TEST(FlagParser, OptionalStringVectorFlag_UnsetOptPresent) {
   std::optional<std::vector<std::string>> value;
 
   // With UnsetKeyword option
-  auto flag_unset = GflagsCompatFlag("myflag", value, CoerceToNullopt::UnsetKeyword);
+  auto flag_unset =
+      GflagsCompatFlag("myflag", value, CoerceToNullopt::UnsetKeyword);
 
   // Present with other value -> should be value
   value = std::nullopt;

--- a/base/cvd/cuttlefish/flag_parser/flag_test.cpp
+++ b/base/cvd/cuttlefish/flag_parser/flag_test.cpp
@@ -1,0 +1,87 @@
+
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/flag_parser/flag.h"
+
+#include <stdint.h>
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "gmock/gmock-matchers.h"
+#include "gtest/gtest.h"
+
+#include "cuttlefish/flag_parser/gflags_compat.h"
+#include "cuttlefish/result/result_matchers.h"
+
+namespace cuttlefish {
+
+TEST(FlagParser, DuplicateAlias) {
+  ASSERT_DEATH(
+      { Flag::StringFlag("flag").Alias("flag"); },
+      "Duplicate flag alias: flag");
+  ASSERT_DEATH(
+      { Flag::StringFlag("flag").Alias("foo").Alias("foo"); },
+      "Duplicate flag alias: foo");
+}
+
+TEST(FlagParser, RepeatedListFlag) {
+  std::vector<std::string> elems;
+  auto flag = Flag::StringFlag("myflag");
+  flag.Setter([&elems](std::string_view arg) -> Result<void> {
+    elems.emplace_back(arg);
+    return {};
+  });
+  ASSERT_THAT(ConsumeFlags({flag}, {"-myflag=a", "--myflag", "b"}), IsOk());
+  ASSERT_EQ(elems, (std::vector<std::string>{"a", "b"}));
+}
+
+TEST(FlagParser, UnexpectedArgumentGuard) {
+  auto consume_check_unexpected = [](std::vector<std::string> args) {
+    return ConsumeFlags({}, std::move(args),
+                        {.fail_on_unexpected_argument = true});
+  };
+  ASSERT_THAT(consume_check_unexpected({}), IsOk());
+  EXPECT_THAT(consume_check_unexpected({"positional"}), IsError());
+  EXPECT_THAT(consume_check_unexpected({"positional", "positional2"}),
+              IsError());
+  EXPECT_THAT(consume_check_unexpected({"-flag"}), IsError());
+  EXPECT_THAT(consume_check_unexpected({"-"}), IsError());
+}
+
+TEST(FlagParser, EndOfOptionMark) {
+  std::vector<std::string> args{"-flag", "--", "-invalid_flag"};
+  bool flag = false;
+  std::vector<Flag> flags{GflagsCompatFlag("flag", flag)};
+
+  EXPECT_THAT(ConsumeFlags(flags, args,
+                           {
+                               .fail_on_unexpected_argument = true,
+                           }),
+              IsError());
+  EXPECT_EQ(args, std::vector<std::string>({"--", "-invalid_flag"}));
+  EXPECT_THAT(ConsumeFlags(flags, args,
+                           {
+                               .stop_at_double_dashes = true,
+                               .fail_on_unexpected_argument = true,
+                           }),
+              IsOk());
+  ASSERT_TRUE(flag);
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/flag_parser/gflags_compat.cpp
+++ b/base/cvd/cuttlefish/flag_parser/gflags_compat.cpp
@@ -378,8 +378,10 @@ Flag HelpXmlFlag(const std::vector<Flag>& flags, std::ostream& out, bool& value,
     value = print_xml;
     out << "<?xml version=\"1.0\"?>" << std::endl << "<AllFlags>" << std::endl;
     WriteGflagsCompatXml(flags, out);
-    out << "</AllFlags>" << std::flush;
-    return CF_ERR("Requested early exit");
+    out << "</AllFlags>\n" << std::flush;
+    // return value of 1 matches gflags --help flag behavior
+    std::exit(1);
+    return {};
   };
   return GflagsCompatBoolFlag(name).Setter(setter);
 }

--- a/base/cvd/cuttlefish/flag_parser/gflags_compat.cpp
+++ b/base/cvd/cuttlefish/flag_parser/gflags_compat.cpp
@@ -17,14 +17,12 @@
 #include "cuttlefish/flag_parser/gflags_compat.h"
 
 #include <concepts>
-#include <functional>
 #include <iostream>
 #include <optional>
 #include <ostream>
 #include <string>
 #include <string_view>
 #include <type_traits>
-#include <unordered_set>
 #include <vector>
 
 #include "absl/log/log.h"
@@ -32,8 +30,7 @@
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_replace.h"
 #include "absl/strings/str_split.h"
-#include <fmt/format.h>
-#include <fmt/ranges.h>  // NOLINT(misc-include-cleaner): version difference
+#include "fmt/format.h"
 
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/result/result.h"
@@ -91,7 +88,7 @@ Result<T> ParseFlagValue(std::string_view str) {
 }
 
 // Setter for bool, default getter is fine
-template<>
+template <>
 Result<bool> ParseFlagValue<bool>(std::string_view str) {
   bool result;
   CF_EXPECT(absl::SimpleAtob(str, &result));
@@ -113,7 +110,8 @@ std::string FlagValueToString(const std::vector<T>& values) {
 // ParseFlagValue too and just be an overload but using a different name makes
 // it clear which implementation the compiler is choosing.
 template <typename T>
-Result<std::vector<T>> ParseFlagVectorValue(std::string_view str, T default_value) {
+Result<std::vector<T>> ParseFlagVectorValue(std::string_view str,
+                                            T default_value) {
   if (str.empty()) {
     return {};
   }
@@ -160,16 +158,15 @@ Result<std::optional<T>> ParseFlagOptionalValue(std::string_view str,
 // Template versions of the GflagsCompatFlag functions to reduce duplication
 template <std::integral T>
 Flag GflagsCompatFlagImpl(const std::string& name, T& value) {
-  return GflagsCompatFlag(name)
+  return Flag::StringFlag(name)
       .Getter([&value]() { return std::to_string(value); })
-      .Setter([&value](const FlagMatch& match) -> Result<void> {
+      .Setter([&value](std::string_view arg) -> Result<void> {
         if constexpr (std::is_unsigned_v<T>) {
-          CF_EXPECTF(absl::SimpleAtoi<T>(match.value, &value),
-                     "Failed to parse \"{}\" as an unsigned integer",
-                     match.value);
+          CF_EXPECTF(absl::SimpleAtoi<T>(arg, &value),
+                     "Failed to parse \"{}\" as an unsigned integer", arg);
         } else {
-          CF_EXPECTF(absl::SimpleAtoi<T>(match.value, &value),
-                     "Failed to parse \"{}\" as an integer", match.value);
+          CF_EXPECTF(absl::SimpleAtoi<T>(arg, &value),
+                     "Failed to parse \"{}\" as an integer", arg);
         }
         return {};
       });
@@ -178,22 +175,22 @@ Flag GflagsCompatFlagImpl(const std::string& name, T& value) {
 template <typename T>
 Flag GflagsCompatFlagImpl(const std::string& name, std::vector<T>& value,
                           const T default_value) {
-  return GflagsCompatFlag(name)
+  return Flag::StringFlag(name)
       .Getter([&value]() { return FlagValueToString(value); })
-      .Setter([name, &value,
-               default_value](const FlagMatch& match) -> Result<void> {
-        value = CF_EXPECT(ParseFlagVectorValue(match.value, default_value));
-        return {};
-      });
+      .Setter(
+          [name, &value, default_value](std::string_view arg) -> Result<void> {
+            value = CF_EXPECT(ParseFlagVectorValue(arg, default_value));
+            return {};
+          });
 }
 
 template <typename T>
 Flag GflagsCompatFlagImpl(const std::string& name, std::optional<T>& value,
                           CoerceToNullopt opt) {
-  return GflagsCompatFlag(name)
+  return Flag::StringFlag(name)
       .Getter([&value, opt]() { return FlagValueToString(value, opt); })
-      .Setter([&value, opt](const FlagMatch& match) -> Result<void> {
-        value = CF_EXPECT(ParseFlagOptionalValue<T>(match.value, opt));
+      .Setter([&value, opt](std::string_view arg) -> Result<void> {
+        value = CF_EXPECT(ParseFlagOptionalValue<T>(arg, opt));
         return {};
       });
 }
@@ -202,140 +199,38 @@ std::string XmlEscape(const std::string& s) {
   return absl::StrReplaceAll(s, {{"<", "&lt;"}, {">", "&gt;"}});
 }
 
-Result<void> GflagsCompatBoolFlagSetter(const std::string& name, bool& value,
-                                        const FlagMatch& match) {
-  const auto& key = match.key;
-  if (key == "-" + name || key == "--" + name) {
-    value = true;
-    return {};
-  } else if (key == "-no" + name || key == "--no" + name) {
-    value = false;
-    return {};
-  } else if (key == "-" + name + "=" || key == "--" + name + "=") {
-    if (match.value == "true") {
-      value = true;
-      return {};
-    } else if (match.value == "false") {
-      value = false;
-      return {};
-    } else {
-      return CF_ERRF("Unexpected boolean value \"{}\" for \"{}\"", match.value,
-                     name);
-    }
-  }
-  return CF_ERRF("Unexpected key \"{}\" for \"{}\"", match.key, name);
-}
-
-Result<void> GflagsCompatBoolFlagSetter(const std::string& name,
-                                        std::optional<bool>& value,
-                                        const FlagMatch& match,
-                                        CoerceToNullopt opt) {
-  const auto& key = match.key;
-  if (key == "-" + name || key == "--" + name) {
-    value = true;
-    return {};
-  } else if (key == "-no" + name || key == "--no" + name) {
-    value = false;
-    return {};
-  } else if (key == "-" + name + "=" || key == "--" + name + "=") {
-    if (ShouldBeNullOpt(match.value, opt)) {
-      value = std::nullopt;
-      return {};
-    }
-    if (match.value == "true") {
-      value = true;
-      return {};
-    } else if (match.value == "false") {
-      value = false;
-      return {};
-    } else {
-      return CF_ERRF("Unexpected boolean value \"{}\" for \"{}\"", match.value,
-                     name);
-    }
-  }
-  return CF_ERRF("Unexpected key \"{}\" for \"{}\"", match.key, name);
-}
-
 }  // namespace
 
-bool WriteGflagsCompatXml(const Flag& flag, std::ostream& out) {
-  std::unordered_set<std::string> name_guesses;
-  for (const auto& alias : flag.aliases_) {
-    std::string_view name = alias.name;
-    if (!absl::ConsumePrefix(&name, "-")) {
-      continue;
-    }
-    absl::ConsumePrefix(&name, "-");
-    if (alias.mode == FlagAliasMode::kFlagExact) {
-      absl::ConsumePrefix(&name, "no");
-      name_guesses.insert(std::string{name});
-    } else if (alias.mode == FlagAliasMode::kFlagConsumesFollowing) {
-      name_guesses.insert(std::string{name});
-    } else if (alias.mode == FlagAliasMode::kFlagPrefix) {
-      if (!absl::ConsumeSuffix(&name, "=")) {
-        continue;
-      }
-      name_guesses.insert(std::string{name});
-    }
+void WriteGflagsCompatXml(const Flag& flag, std::ostream& out) {
+  std::string type_str;
+  switch (flag.style_) {
+    case Flag::Style::String:
+      type_str = "string";
+      break;
+    case Flag::Style::Bool:
+      type_str = "bool";
+      break;
   }
-  bool found_alias = false;
-  for (const auto& name : name_guesses) {
-    bool has_bool_aliases =
-        flag.HasAlias({FlagAliasMode::kFlagPrefix, "-" + name + "="}) &&
-        flag.HasAlias({FlagAliasMode::kFlagPrefix, "--" + name + "="}) &&
-        flag.HasAlias({FlagAliasMode::kFlagExact, "-" + name}) &&
-        flag.HasAlias({FlagAliasMode::kFlagExact, "--" + name}) &&
-        flag.HasAlias({FlagAliasMode::kFlagExact, "-no" + name}) &&
-        flag.HasAlias({FlagAliasMode::kFlagExact, "--no" + name});
-    bool has_other_aliases =
-        flag.HasAlias({FlagAliasMode::kFlagPrefix, "-" + name + "="}) &&
-        flag.HasAlias({FlagAliasMode::kFlagPrefix, "--" + name + "="}) &&
-        flag.HasAlias({FlagAliasMode::kFlagConsumesFollowing, "-" + name}) &&
-        flag.HasAlias({FlagAliasMode::kFlagConsumesFollowing, "--" + name});
-    bool has_help_aliases = flag.HasAlias({FlagAliasMode::kFlagExact, "-help"}) &&
-                            flag.HasAlias({FlagAliasMode::kFlagExact, "--help"});
-    std::vector<bool> has_aliases = {has_bool_aliases, has_other_aliases,
-                                     has_help_aliases};
-    const auto true_count =
-        std::count(has_aliases.cbegin(), has_aliases.cend(), true);
-    if (true_count > 1) {
-      LOG(ERROR) << "Expected exactly one of has_bool_aliases, "
-                 << "has_other_aliases, and has_help_aliases, got "
-                 << true_count << " for \"" << name << "\".";
-      return false;
-    }
-    if (true_count == 0) {
-      continue;
-    }
-    found_alias = true;
-    std::string type_str =
-        (has_bool_aliases || has_help_aliases) ? "bool" : "string";
-    // Lifted from external/gflags/src/gflags_reporting.cc:DescribeOneFlagInXML
-    out << "<flag>\n";
-    out << "  <file>file.cc</file>\n";
-    out << "  <name>" << XmlEscape(name) << "</name>\n";
-    auto help = flag.help_ ? XmlEscape(*flag.help_) : std::string{""};
-    out << "  <meaning>" << help << "</meaning>\n";
-    auto value = flag.getter_ ? XmlEscape((*flag.getter_)()) : std::string{""};
-    out << "  <default>" << value << "</default>\n";
-    out << "  <current>" << value << "</current>\n";
-    out << "  <type>" << type_str << "</type>\n";
-    out << "</flag>\n";
-  }
-  return found_alias;
+  // Lifted from external/gflags/src/gflags_reporting.cc:DescribeOneFlagInXML
+  out << "<flag>\n";
+  out << "  <file>file.cc</file>\n";
+  out << "  <name>" << flag.Name() << "</name>\n";
+  out << "  <meaning>" << XmlEscape(flag.help_) << "</meaning>\n";
+  auto value = XmlEscape(flag.getter_());
+  out << "  <default>" << value << "</default>\n";
+  out << "  <current>" << value << "</current>\n";
+  out << "  <type>" << type_str << "</type>\n";
+  out << "</flag>\n";
 }
 
-bool WriteGflagsCompatXml(const std::vector<Flag>& flags, std::ostream& out) {
+void WriteGflagsCompatXml(const std::vector<Flag>& flags, std::ostream& out) {
   for (const auto& flag : flags) {
-    if (!WriteGflagsCompatXml(flag, out)) {
-      return false;
-    }
+    WriteGflagsCompatXml(flag, out);
   }
-  return true;
 }
 
 Flag HelpFlag(const std::vector<Flag>& flags, std::string text) {
-  auto setter = [&flags, text](FlagMatch) -> Result<void> {
+  auto setter = [&flags, text](std::string_view) -> Result<void> {
     if (!text.empty()) {
       LOG(INFO) << text;
     }
@@ -346,36 +241,22 @@ Flag HelpFlag(const std::vector<Flag>& flags, std::string text) {
     std::exit(1);
     return {};
   };
-  return Flag("help")
-      .Alias({FlagAliasMode::kFlagExact, "-help"})
-      .Alias({FlagAliasMode::kFlagExact, "--help"})
-      .Setter(setter);
+  return Flag::BoolFlag("help").Setter(setter);
 }
 
-Flag GflagsCompatBoolFlag(const std::string& name) {
-  return Flag(name)
-      .Alias({FlagAliasMode::kFlagPrefix, "-" + name + "="})
-      .Alias({FlagAliasMode::kFlagPrefix, "--" + name + "="})
-      .Alias({FlagAliasMode::kFlagExact, "-" + name})
-      .Alias({FlagAliasMode::kFlagExact, "--" + name})
-      .Alias({FlagAliasMode::kFlagExact, "-no" + name})
-      .Alias({FlagAliasMode::kFlagExact, "--no" + name});
-}
-
-Flag HelpXmlFlag(const std::vector<Flag>& flags, std::ostream& out, bool& value,
-                 std::string text) {
+Flag HelpXmlFlag(const std::vector<Flag>& flags, std::ostream& out,
+                 bool& print_xml, std::string text) {
   const std::string name = "helpxml";
-  auto setter = [name, &out, &value, text,
-                 &flags](const FlagMatch& match) -> Result<void> {
-    bool print_xml = false;
-    CF_EXPECT(GflagsCompatBoolFlagSetter(name, print_xml, match));
+  auto setter = [name, &out, &print_xml, text,
+                 &flags](std::string_view arg) -> Result<void> {
+    print_xml = CF_EXPECTF(ParseFlagValue<bool>(arg),
+                           "Unexpected value for '--helpxml': '{}'", arg);
     if (!print_xml) {
       return {};
     }
     if (!text.empty()) {
       out << text << std::endl;
     }
-    value = print_xml;
     out << "<?xml version=\"1.0\"?>" << std::endl << "<AllFlags>" << std::endl;
     WriteGflagsCompatXml(flags, out);
     out << "</AllFlags>\n" << std::flush;
@@ -383,22 +264,14 @@ Flag HelpXmlFlag(const std::vector<Flag>& flags, std::ostream& out, bool& value,
     std::exit(1);
     return {};
   };
-  return GflagsCompatBoolFlag(name).Setter(setter);
-}
-
-Flag GflagsCompatFlag(const std::string& name) {
-  return Flag(name)
-      .Alias({FlagAliasMode::kFlagPrefix, "-" + name + "="})
-      .Alias({FlagAliasMode::kFlagPrefix, "--" + name + "="})
-      .Alias({FlagAliasMode::kFlagConsumesFollowing, "-" + name})
-      .Alias({FlagAliasMode::kFlagConsumesFollowing, "--" + name});
+  return Flag::BoolFlag(name).Setter(setter);
 }
 
 Flag GflagsCompatFlag(const std::string& name, std::string& value) {
-  return GflagsCompatFlag(name)
+  return Flag::StringFlag(name)
       .Getter([&value]() { return value; })
-      .Setter([&value](const FlagMatch& match) -> Result<void> {
-        value = match.value;
+      .Setter([&value](std::string_view arg) -> Result<void> {
+        value = arg;
         return {};
       });
 }
@@ -412,10 +285,12 @@ Flag GflagsCompatFlag(const std::string& name, size_t& value) {
 }
 
 Flag GflagsCompatFlag(const std::string& name, bool& value) {
-  return GflagsCompatBoolFlag(name)
+  return Flag::BoolFlag(name)
       .Getter([&value]() { return fmt::format("{}", value); })
-      .Setter([name, &value](const FlagMatch& match) {
-        return GflagsCompatBoolFlagSetter(name, value, match);
+      .Setter([name, &value](std::string_view arg) -> Result<void> {
+        value = CF_EXPECTF(ParseFlagValue<bool>(arg),
+                           "Unexpected value for \"--{}\": \"{}\"", arg, name);
+        return {};
       });
 }
 
@@ -424,8 +299,7 @@ Flag GflagsCompatFlag(const std::string& name,
   return GflagsCompatFlagImpl<std::string>(name, value, "");
 }
 
-Flag GflagsCompatFlag(const std::string& name,
-                      std::vector<unsigned>& value) {
+Flag GflagsCompatFlag(const std::string& name, std::vector<unsigned>& value) {
   return GflagsCompatFlagImpl<unsigned>(name, value, 0);
 }
 
@@ -435,8 +309,7 @@ Flag GflagsCompatFlag(const std::string& name, std::vector<bool>& value,
 }
 
 Flag GflagsCompatFlag(const std::string& name,
-                      std::optional<std::string>& value,
-                      CoerceToNullopt opt) {
+                      std::optional<std::string>& value, CoerceToNullopt opt) {
   return GflagsCompatFlagImpl(name, value, opt);
 }
 
@@ -462,10 +335,13 @@ Flag GflagsCompatFlag(const std::string& name, std::optional<int64_t>& value,
 
 Flag GflagsCompatFlag(const std::string& name, std::optional<bool>& value,
                       CoerceToNullopt opt) {
-  return GflagsCompatBoolFlag(name)
-      .Getter([&value, opt]() { return FlagValueToString(value, opt); })
-      .Setter([name, &value, opt](const FlagMatch& match) {
-        return GflagsCompatBoolFlagSetter(name, value, match, opt);
+  return Flag::BoolFlag(name)
+      .Getter([&value]() -> std::string {
+        return value ? fmt::format("{}", *value) : "";
+      })
+      .Setter([name, &value, opt](std::string_view arg) -> Result<void> {
+        value = CF_EXPECT(ParseFlagOptionalValue<bool>(arg, opt));
+        return {};
       });
 }
 

--- a/base/cvd/cuttlefish/flag_parser/gflags_compat.h
+++ b/base/cvd/cuttlefish/flag_parser/gflags_compat.h
@@ -26,15 +26,13 @@
 namespace cuttlefish {
 
 /* Write gflags `--helpxml` style output for a string-type flag. */
-bool WriteGflagsCompatXml(const Flag&, std::ostream&);
-bool WriteGflagsCompatXml(const std::vector<Flag>&, std::ostream&);
+void WriteGflagsCompatXml(const Flag&, std::ostream&);
+void WriteGflagsCompatXml(const std::vector<Flag>&, std::ostream&);
 
 // Create a flag resembling a gflags argument of the given type. This includes
 // "-[-]flag=*",support for all types, "-[-]noflag" support for booleans, and
 // "-flag *", "--flag *", support for other types. The value passed in the flag
 // is saved to the defined reference.
-Flag GflagsCompatFlag(const std::string& name);
-Flag GflagsCompatBoolFlag(const std::string& name);
 Flag GflagsCompatFlag(const std::string& name, std::string& value);
 Flag GflagsCompatFlag(const std::string& name, int32_t& value);
 Flag GflagsCompatFlag(const std::string& name, size_t& value);
@@ -45,41 +43,36 @@ Flag GflagsCompatFlag(const std::string& name, std::vector<bool>& value,
                       bool default_value);
 // Indicates when to assign std::nullopt to the std::optional backing the flag.
 enum class CoerceToNullopt {
-  None, // When the flag is not present in the arguments
-  UnsetKeyword, // When the flag has the "unset" special value.
-  EmptyString, // When the flag has an empty value (`--flag "" or `--flag=`)
+  None,          // When the flag is not present in the arguments
+  UnsetKeyword,  // When the flag has the "unset" special value.
+  EmptyString,   // When the flag has an empty value (`--flag "" or `--flag=`)
 };
-Flag GflagsCompatFlag(
-    const std::string& name, std::optional<std::string>& value,
-    CoerceToNullopt opt = CoerceToNullopt::None);
-Flag GflagsCompatFlag(
-    const std::string& name, std::optional<int>& value,
-    CoerceToNullopt opt = CoerceToNullopt::None);
-Flag GflagsCompatFlag(
-    const std::string& name, std::optional<size_t>& value,
-    CoerceToNullopt opt = CoerceToNullopt::None);
-Flag GflagsCompatFlag(
-    const std::string& name, std::optional<unsigned>& value,
-    CoerceToNullopt opt = CoerceToNullopt::None);
-Flag GflagsCompatFlag(
-    const std::string& name, std::optional<int64_t>& value,
-    CoerceToNullopt opt = CoerceToNullopt::None);
-Flag GflagsCompatFlag(
-    const std::string& name, std::optional<bool>& value,
-    CoerceToNullopt opt = CoerceToNullopt::None);
+Flag GflagsCompatFlag(const std::string& name,
+                      std::optional<std::string>& value,
+                      CoerceToNullopt opt = CoerceToNullopt::None);
+Flag GflagsCompatFlag(const std::string& name, std::optional<int>& value,
+                      CoerceToNullopt opt = CoerceToNullopt::None);
+Flag GflagsCompatFlag(const std::string& name, std::optional<size_t>& value,
+                      CoerceToNullopt opt = CoerceToNullopt::None);
+Flag GflagsCompatFlag(const std::string& name, std::optional<unsigned>& value,
+                      CoerceToNullopt opt = CoerceToNullopt::None);
+Flag GflagsCompatFlag(const std::string& name, std::optional<int64_t>& value,
+                      CoerceToNullopt opt = CoerceToNullopt::None);
+Flag GflagsCompatFlag(const std::string& name, std::optional<bool>& value,
+                      CoerceToNullopt opt = CoerceToNullopt::None);
 
-Flag GflagsCompatFlag(
-    const std::string& name, std::optional<std::vector<std::string>>& value,
-    CoerceToNullopt opt = CoerceToNullopt::None);
-Flag GflagsCompatFlag(
-    const std::string& name, std::optional<std::vector<unsigned>>& value,
-    CoerceToNullopt opt = CoerceToNullopt::None);
+Flag GflagsCompatFlag(const std::string& name,
+                      std::optional<std::vector<std::string>>& value,
+                      CoerceToNullopt opt = CoerceToNullopt::None);
+Flag GflagsCompatFlag(const std::string& name,
+                      std::optional<std::vector<unsigned>>& value,
+                      CoerceToNullopt opt = CoerceToNullopt::None);
 
 /* If a "-help" or "--help" flag is present, prints all the flags and fails. */
 Flag HelpFlag(const std::vector<Flag>& flags, std::string text = "");
 
 /* If a "-helpxml" is present, prints all the flags in XML and fails. */
-Flag HelpXmlFlag(const std::vector<Flag>& flags, std::ostream&, bool& value,
+Flag HelpXmlFlag(const std::vector<Flag>& flags, std::ostream&, bool& print_xml,
                  std::string text = "");
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/flag_parser/gflags_compat_test.cpp
+++ b/base/cvd/cuttlefish/flag_parser/gflags_compat_test.cpp
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
+#include "cuttlefish/flag_parser/gflags_compat.h"
+
 #include <stdint.h>
 
 #include <map>
 #include <optional>
 #include <sstream>
 #include <string>
-#include <string_view>
 #include <vector>
 
 #include "gmock/gmock-matchers.h"
@@ -28,19 +29,9 @@
 #include "libxml/parser.h"
 
 #include "cuttlefish/flag_parser/flag.h"
-#include "cuttlefish/flag_parser/gflags_compat.h"
 #include "cuttlefish/result/result_matchers.h"
 
 namespace cuttlefish {
-
-TEST(FlagParser, DuplicateAlias) {
-  ASSERT_DEATH(
-      { Flag::StringFlag("flag").Alias("flag"); },
-      "Duplicate flag alias: flag");
-  ASSERT_DEATH(
-      { Flag::StringFlag("flag").Alias("foo").Alias("foo"); },
-      "Duplicate flag alias: foo");
-}
 
 TEST(FlagParser, StringFlag) {
   std::string value;
@@ -118,17 +109,6 @@ TEST(FlagParser, RepeatedStringFlag) {
   auto flag = GflagsCompatFlag("myflag", value);
   ASSERT_THAT(ConsumeFlags({flag}, {"-myflag=a", "--myflag", "b"}), IsOk());
   ASSERT_EQ(value, "b");
-}
-
-TEST(FlagParser, RepeatedListFlag) {
-  std::vector<std::string> elems;
-  auto flag = Flag::StringFlag("myflag");
-  flag.Setter([&elems](std::string_view arg) -> Result<void> {
-    elems.emplace_back(arg);
-    return {};
-  });
-  ASSERT_THAT(ConsumeFlags({flag}, {"-myflag=a", "--myflag", "b"}), IsOk());
-  ASSERT_EQ(elems, (std::vector<std::string>{"a", "b"}));
 }
 
 TEST(FlagParser, FlagRemoval) {
@@ -316,39 +296,6 @@ TEST(FlagParser, InvalidIntFlag) {
   ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=def"}), IsError());
   ASSERT_THAT(ConsumeFlags({flag}, {"-myflag", "abc"}), IsError());
   ASSERT_THAT(ConsumeFlags({flag}, {"--myflag", "def"}), IsError());
-}
-
-TEST(FlagParser, UnexpectedArgumentGuard) {
-  auto consume_check_unexpected = [](std::vector<std::string> args) {
-    return ConsumeFlags({}, std::move(args),
-                        {.fail_on_unexpected_argument = true});
-  };
-  ASSERT_THAT(consume_check_unexpected({}), IsOk());
-  ASSERT_THAT(consume_check_unexpected({"positional"}), IsError());
-  ASSERT_THAT(consume_check_unexpected({"positional", "positional2"}),
-              IsError());
-  ASSERT_THAT(consume_check_unexpected({"-flag"}), IsError());
-  ASSERT_THAT(consume_check_unexpected({"-"}), IsError());
-}
-
-TEST(FlagParser, EndOfOptionMark) {
-  std::vector<std::string> args{"-flag", "--", "-invalid_flag"};
-  bool flag = false;
-  std::vector<Flag> flags{GflagsCompatFlag("flag", flag)};
-
-  EXPECT_THAT(ConsumeFlags(flags, args,
-                           {
-                               .fail_on_unexpected_argument = true,
-                           }),
-              IsError());
-  EXPECT_EQ(args, std::vector<std::string>({"--", "-invalid_flag"}));
-  EXPECT_THAT(ConsumeFlags(flags, args,
-                           {
-                               .stop_at_double_dashes = true,
-                               .fail_on_unexpected_argument = true,
-                           }),
-              IsOk());
-  ASSERT_TRUE(flag);
 }
 
 TEST(FlagParser, OptionalStringFlag_DefaultOptNotPresent) {

--- a/base/cvd/cuttlefish/flag_parser/shared_fd_flag.cpp
+++ b/base/cvd/cuttlefish/flag_parser/shared_fd_flag.cpp
@@ -17,31 +17,28 @@
 
 #include <unistd.h>
 
-#include <functional>
 #include <string>
 
 #include "absl/strings/numbers.h"
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
-#include "cuttlefish/flag_parser/gflags_compat.h"
+#include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
 
-static Result<void> Set(const FlagMatch& match, SharedFD& out) {
-  int raw_fd;
-  CF_EXPECTF(absl::SimpleAtoi(match.value, &raw_fd),
-             "Failed to parse value \"{}\" for fd flag \"{}\"", match.value,
-             match.key);
-  out = SharedFD::Dup(raw_fd);
-  if (out->IsOpen()) {
-    close(raw_fd);
-  }
-  return {};
-}
-
 Flag SharedFDFlag(const std::string& name, SharedFD& out) {
-  return GflagsCompatFlag(name).Setter(
-      [&out](const FlagMatch& mat) { return Set(mat, out); });
+  return Flag::StringFlag(name).Setter(
+      [&out, name](std::string_view arg) -> Result<void> {
+        int raw_fd;
+        CF_EXPECTF(absl::SimpleAtoi(arg, &raw_fd),
+                   "Failed to parse value \"{}\" for fd flag \"--{}\"", arg,
+                   name);
+        out = SharedFD::Dup(raw_fd);
+        CF_EXPECTF(out->IsOpen(), "Unable to dup file descriptor '{}': {}",
+                   raw_fd, out->StrError());
+        close(raw_fd);
+        return {};
+      });
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd.cc
@@ -598,9 +598,7 @@ Result<int> AssembleCvdMain(int argc, char** argv) {
       GflagsCompatFlag("helppackage", help_str),
       GflagsCompatFlag("helpxml", helpxml),
   };
-  for (const auto& help_flag : help_flags) {
-    CF_EXPECT(help_flag.Parse(args), "Failed to process help flag");
-  }
+  CF_EXPECT(ConsumeFlags(help_flags, args), "Failed to process help flags");
 
   {
     std::string process_name = "assemble_cvd";

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/display.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/display.cpp
@@ -77,8 +77,9 @@ class DisplaysConfigsFlagImpl : public DisplaysConfigsFlag {
   }
 
   bool WriteGflagsCompatHelpXml(std::ostream& out) const override {
-    Flag display_flag = GflagsCompatFlag(kDisplayFlag).Help(kDisplayHelp);
-    return WriteGflagsCompatXml({display_flag}, out);
+    Flag display_flag = Flag::StringFlag(kDisplayFlag).Help(kDisplayHelp);
+    WriteGflagsCompatXml({display_flag}, out);
+    return true;
   }
 
  private:

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/media.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/media.cpp
@@ -72,8 +72,9 @@ class MediaConfigsFlagImpl : public MediaConfigsFlag {
   }
 
   bool WriteGflagsCompatHelpXml(std::ostream& out) const override {
-    Flag media_flag = GflagsCompatFlag(kMediaFlag).Help(kMediaHelp);
-    return WriteGflagsCompatXml({media_flag}, out);
+    Flag media_flag = Flag::StringFlag(kMediaFlag).Help(kMediaHelp);
+    WriteGflagsCompatXml({media_flag}, out);
+    return true;
   }
 
  private:

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/touchpad.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/touchpad.cpp
@@ -72,8 +72,9 @@ class TouchpadsConfigsFlagImpl : public TouchpadsConfigsFlag {
   }
 
   bool WriteGflagsCompatHelpXml(std::ostream& out) const override {
-    Flag touchpad_flag = GflagsCompatFlag(kTouchpadFlag).Help(kTouchpadHelp);
-    return WriteGflagsCompatXml({touchpad_flag}, out);
+    Flag touchpad_flag = Flag::StringFlag(kTouchpadFlag).Help(kTouchpadHelp);
+    WriteGflagsCompatXml({touchpad_flag}, out);
+    return true;
   }
 
  private:

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
@@ -49,7 +49,6 @@ cf_cc_library(
     deps = [
         "//cuttlefish/flag_parser",
         "@abseil-cpp//absl/log",
-        "@abseil-cpp//absl/log:check",
         "@abseil-cpp//absl/strings",
     ],
 )

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/cache.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/cache.cpp
@@ -88,8 +88,8 @@ Result<CacheArguments> ProcessArguments(
                                "operation, in gigabytes."));
   flags.emplace_back(GflagsCompatFlag("json", result.json_formatted)
                          .Help("Output `info` command in JSON format."));
-  flags.emplace_back(UnexpectedArgumentGuard());
-  CF_EXPECTF(ConsumeFlags(flags, cache_arguments),
+  CF_EXPECTF(ConsumeFlags(flags, cache_arguments,
+                          {.fail_on_unexpected_argument = true}),
              "Failure processing arguments and flags: cvd cache {} {}", action,
              fmt::join(cache_arguments, " "));
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/clear.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/clear.cpp
@@ -42,7 +42,7 @@ CvdClearCommandHandler::CvdClearCommandHandler(
 
 Result<void> CvdClearCommandHandler::Handle(const CommandRequest& request) {
   std::vector<std::string> args = request.SubcommandArguments();
-  CF_EXPECT(ConsumeFlags({UnexpectedArgumentGuard()}, args));
+  CF_EXPECT(ConsumeFlags({}, args, {.fail_on_unexpected_argument = true}));
   CF_EXPECT(instance_manager_.Clear());
   return {};
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
@@ -214,13 +214,13 @@ Result<void> CreateSymlinks(const LocalInstanceGroup& group) {
 std::vector<Flag> BuildSelectorFlagsForCreateHelp(
     const selector::SelectorOptions& selectors) {
   return {
-      GflagsCompatFlag(selector::SelectorFlags::kGroupName)
+      Flag::StringFlag(selector::SelectorFlags::kGroupName)
           .Getter([selectors]() { return selectors.group_name.value_or(""); })
           .Help("Name of the group to be created. The command will fail if a "
                 "group with that name already exists. A new name of the form "
                 "'cvd-<n>' guaranteed to not exist yet will be generated if "
                 "not provided."),
-      GflagsCompatFlag(selector::SelectorFlags::kInstanceName)
+      Flag::StringFlag(selector::SelectorFlags::kInstanceName)
           .Getter([selectors]() -> std::string {
             return absl::StrJoin(
                 selectors.instance_names.value_or(std::vector<std::string>()),

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fleet.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fleet.cpp
@@ -62,7 +62,7 @@ Result<std::string> CvdFleetCommandHandler::DetailedHelp(
 
 Result<void> CvdFleetCommandHandler::Handle(const CommandRequest& request) {
   std::vector<std::string> args = request.SubcommandArguments();
-  CF_EXPECT(ConsumeFlags({UnexpectedArgumentGuard()}, args));
+  CF_EXPECT(ConsumeFlags({}, args, {.fail_on_unexpected_argument = true}));
 
   auto all_groups = CF_EXPECT(instance_manager_.FindGroups({}));
   Json::Value groups_json(Json::arrayValue);

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/logs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/logs.cpp
@@ -36,9 +36,7 @@ struct LogsCmdOptions {
 
   std::vector<Flag> Flags() {
     return {
-        GflagsCompatFlag("print", print_target)
-            .Alias({FlagAliasMode::kFlagConsumesFollowing, "-p"}),
-        UnexpectedArgumentGuard(),
+        GflagsCompatFlag("print", print_target).Alias("p"),
     };
   }
 };
@@ -90,7 +88,8 @@ Result<void> CvdLogsHandler::Handle(const CommandRequest& request) {
 
   LogsCmdOptions opts;
   std::vector<std::string> args = request.SubcommandArguments();
-  CF_EXPECT(ConsumeFlags(opts.Flags(), args));
+  CF_EXPECT(
+      ConsumeFlags(opts.Flags(), args, {.fail_on_unexpected_argument = true}));
 
   std::vector<std::string> logs_filenames;
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/command_handler.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/command_handler.cc
@@ -80,7 +80,7 @@ Result<void> CvdMonitorCommandHandler::Handle(const CommandRequest& request) {
   CF_EXPECT(isatty(0), "The monitor command requires an interactive terminal.");
 
   std::vector<std::string> args = request.SubcommandArguments();
-  CF_EXPECT(ConsumeFlags({UnexpectedArgumentGuard()}, args));
+  CF_EXPECT(ConsumeFlags({}, args, {.fail_on_unexpected_argument = true}));
 
   auto [instance, unused] =
       CF_EXPECT(selector::SelectInstance(instance_manager_, request),

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/power_btn.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/power_btn.cpp
@@ -44,7 +44,7 @@ CvdDevicePowerBtnCommandHandler::CvdDevicePowerBtnCommandHandler(
 Result<void> CvdDevicePowerBtnCommandHandler::Handle(
     const CommandRequest& request) {
   std::vector<std::string> args = request.SubcommandArguments();
-  CF_EXPECT(ConsumeFlags({UnexpectedArgumentGuard()}, args));
+  CF_EXPECT(ConsumeFlags({}, args, {.fail_on_unexpected_argument = true}));
   auto [instance, _] =
       CF_EXPECT(selector::SelectInstance(instance_manager_, request),
                 "Unable to select an instance");

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/powerwash.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/powerwash.cpp
@@ -56,7 +56,6 @@ struct PowerwashOptions {
     return {
         GflagsCompatFlag("wait_for_launcher", wait_for_launcher_seconds),
         GflagsCompatFlag("boot_timeout", boot_timeout_seconds),
-        UnexpectedArgumentGuard(),
     };
   }
 };
@@ -70,7 +69,8 @@ Result<void> CvdDevicePowerwashCommandHandler::Handle(
     const CommandRequest& request) {
   PowerwashOptions options;
   std::vector<std::string> subcmd_args = request.SubcommandArguments();
-  CF_EXPECT(ConsumeFlags(options.Flags(), subcmd_args));
+  CF_EXPECT(ConsumeFlags(options.Flags(), subcmd_args,
+                         {.fail_on_unexpected_argument = true}));
 
   auto [instance, unused] =
       CF_EXPECT(selector::SelectInstance(instance_manager_, request),

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/remove.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/remove.cpp
@@ -58,7 +58,8 @@ bool RemoveCvdCommandHandler::RequiresDeviceExists() const { return true; }
 
 Result<void> RemoveCvdCommandHandler::Handle(const CommandRequest& request) {
   std::vector<std::string> subcmd_args = request.SubcommandArguments();
-  CF_EXPECT(ConsumeFlags({UnexpectedArgumentGuard()}, subcmd_args));
+  CF_EXPECT(
+      ConsumeFlags({}, subcmd_args, {.fail_on_unexpected_argument = true}));
 
   if (!CF_EXPECT(instance_manager_.HasInstanceGroups())) {
     return CF_ERR(NoGroupMessage(request));

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/reset.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/reset.cpp
@@ -79,24 +79,20 @@ struct ParsedFlags {
 
 static Result<ParsedFlags> ParseResetFlags(cvd_common::Args subcmd_args) {
   if (subcmd_args.size() > 2 && subcmd_args.at(2) == "help") {
-    // unfortunately, {FlagAliasMode::kFlagExact, "help"} is not allowed
+    // Turn `cvd reset help` into `cvd reset --help`
     subcmd_args[2] = "--help";
   }
 
   ParsedFlags parsed_flags;
 
-  Flag y_flag = Flag("yes")
-                    .Alias({FlagAliasMode::kFlagExact, "-y"})
-                    .Alias({FlagAliasMode::kFlagExact, "--yes"})
-                    .Setter([&parsed_flags](const FlagMatch&) -> Result<void> {
-                      parsed_flags.is_confirmed_by_flag = true;
-                      return {};
-                    });
+  Flag y_flag =
+      GflagsCompatFlag("yes", parsed_flags.is_confirmed_by_flag).Alias("y");
   std::vector<Flag> flags{
       y_flag,
       GflagsCompatFlag("clean-runtime-dir", parsed_flags.clean_runtime_dir),
-      UnexpectedArgumentGuard()};
-  CF_EXPECT(ConsumeFlags(flags, subcmd_args));
+  };
+  CF_EXPECT(
+      ConsumeFlags(flags, subcmd_args, {.fail_on_unexpected_argument = true}));
 
   return parsed_flags;
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/restart.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/restart.cpp
@@ -55,7 +55,6 @@ struct RestartOptions {
     return {
         GflagsCompatFlag("wait_for_launcher", wait_for_launcher_seconds),
         GflagsCompatFlag("boot_timeout", boot_timeout_seconds),
-        UnexpectedArgumentGuard(),
     };
   }
 };
@@ -70,7 +69,8 @@ Result<void> CvdDeviceRestartCommandHandler::Handle(
     const CommandRequest& request) {
   RestartOptions options;
   std::vector<std::string> subcmd_args = request.SubcommandArguments();
-  CF_EXPECT(ConsumeFlags(options.Flags(), subcmd_args));
+  CF_EXPECT(ConsumeFlags(options.Flags(), subcmd_args,
+                         {.fail_on_unexpected_argument = true}));
 
   auto [instance, group] =
       CF_EXPECT(selector::SelectInstance(instance_manager_, request),

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/status.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/status.cpp
@@ -105,10 +105,9 @@ Result<StatusCommandOptions> ParseFlags(cvd_common::Args& args) {
       GflagsCompatFlag("wait_for_launcher", ret.wait_for_launcher_seconds),
       GflagsCompatFlag("instance_name", ret.instance_name),
       GflagsCompatFlag("print", ret.print),
-      UnexpectedArgumentGuard(),
   };
 
-  CF_EXPECT(ConsumeFlags(flags, args));
+  CF_EXPECT(ConsumeFlags(flags, args, {.fail_on_unexpected_argument = true}));
 
   return ret;
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/stop.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/stop.cpp
@@ -69,9 +69,8 @@ Result<StopFlags> ParseCommandFlags(cvd_common::Args& args) {
   std::vector<Flag> flags = {
       GflagsCompatFlag("wait_for_launcher", flag_values.wait_for_launcher_secs),
       GflagsCompatFlag("clear_instance_dirs", flag_values.clear_instance_dirs),
-      UnexpectedArgumentGuard(),
   };
-  CF_EXPECT(ConsumeFlags(flags, args));
+  CF_EXPECT(ConsumeFlags(flags, args, {.fail_on_unexpected_argument = true}));
   return flag_values;
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/version.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/version.cpp
@@ -46,9 +46,9 @@ Result<bool> ProcessArguments(
   std::vector<Flag> flags;
   flags.emplace_back(GflagsCompatFlag("json", json_formatted)
                          .Help("Output version information in JSON format."));
-  flags.emplace_back(UnexpectedArgumentGuard());
 
-  CF_EXPECTF(ConsumeFlags(flags, version_arguments),
+  CF_EXPECTF(ConsumeFlags(flags, version_arguments,
+                          {.fail_on_unexpected_argument = true}),
              "Failure processing arguments/flags: cvd version {}",
              fmt::join(subcommand_arguments, " "));
   return json_formatted;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.cpp
@@ -19,8 +19,6 @@
 #include <string>
 #include <vector>
 
-#include "android-base/file.h"
-
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector_common_parser.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
@@ -38,7 +36,7 @@ Result<selector::SelectorOptions> ExtractCvdArgs(cvd_common::Args& args) {
   selector::SelectorOptions selector_options;
   std::vector<Flag> selector_flags =
       selector::BuildCommonSelectorFlags(selector_options);
-  CF_EXPECT(ConsumeFlags(selector_flags, args, {.constrained_matching = true}));
+  CF_EXPECT(ConsumeFlags(selector_flags, args));
 
   // Re-insert program into arguments
   args.insert(args.begin(), program);

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.cpp
@@ -38,7 +38,7 @@ Result<selector::SelectorOptions> ExtractCvdArgs(cvd_common::Args& args) {
   selector::SelectorOptions selector_options;
   std::vector<Flag> selector_flags =
       selector::BuildCommonSelectorFlags(selector_options);
-  CF_EXPECT(ConsumeFlagsConstrained(selector_flags, args));
+  CF_EXPECT(ConsumeFlags(selector_flags, args, {.constrained_matching = true}));
 
   // Re-insert program into arguments
   args.insert(args.begin(), program);

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/help_format.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/help_format.cpp
@@ -20,7 +20,6 @@
 #include <string>
 #include <vector>
 
-#include "absl/log/check.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
 
@@ -54,14 +53,6 @@ std::vector<std::string> WrapAroundLine(std::string_view str,
     ret.push_back(absl::StrJoin(line, " "));
   }
   return ret;
-}
-
-std::vector<std::string> GetFlagHelpMessage(const Flag& flag) {
-  std::stringstream ss;
-  ss << flag;
-  std::vector<std::string> flag_help_lines =
-      absl::StrSplit(ss.str(), '\n', absl::SkipWhitespace());
-  return flag_help_lines;
 }
 
 }  // namespace
@@ -98,15 +89,12 @@ std::string FormatFlagsHelp(const std::vector<Flag>& flags,
                             size_t max_line_width) {
   std::stringstream ss;
   for (const Flag& flag : flags) {
-    std::vector<std::string> help_lines = GetFlagHelpMessage(flag);
-    CHECK(!help_lines.empty())
-        << "Flag produced empty help message: " << flag.Name();
-    for (std::string_view line : help_lines) {
-      for (std::string_view wrapped_line :
-           WrapAroundLine(line, max_line_width - 4)) {
-        ss << "    " << wrapped_line << "\n";
-      }
+    ss << " " << flag.Synopsis() << "\n";
+    for (std::string_view wrapped_line :
+         WrapAroundLine(flag.Description(), max_line_width - 4)) {
+      ss << "    " << wrapped_line << "\n";
     }
+    ss << "    Current value: \"" << flag.CurrentValue() << "\"\n";
     ss << "\n";
   }
   return ss.str();

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/graphics_configs_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/graphics_configs_test.cc
@@ -57,11 +57,7 @@ InstanceDisplays DefaultDisplays() {
 
 Result<std::optional<InstancesDisplays>> DisplaysFlag(std::vector<std::string> args) {
   std::optional<std::string> flag_str_opt;
-  auto flag = GflagsCompatFlag("displays_binproto")
-                  .Setter([&flag_str_opt](const FlagMatch& m) -> Result<void> {
-                    flag_str_opt = m.value;
-                    return {};
-                  });
+  auto flag = GflagsCompatFlag("displays_binproto", flag_str_opt);
   CF_EXPECT(ConsumeFlags({flag}, args));
   if (!flag_str_opt.has_value()) {
     return {};

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.cpp
@@ -74,7 +74,7 @@ bool IsLocalBuild(std::string path) {
 Flag GflagsCompatFlagOverride(
     const std::string& name,
     std::map<std::string, std::string, std::less<void>>& overrides) {
-  return GflagsCompatFlag(name)
+  return Flag::StringFlag(name)
       .Getter([&overrides]() {
         std::vector<std::string> formatted;
         for (const auto& [k, v] : overrides) {
@@ -82,30 +82,30 @@ Flag GflagsCompatFlagOverride(
         }
         return absl::StrJoin(formatted, ",");
       })
-      .Setter([&overrides](const FlagMatch& match) -> Result<void> {
-        size_t separator_index = match.value.find(kOverrideSeparator);
+      .Setter([&overrides](std::string_view arg) -> Result<void> {
+        size_t separator_index = arg.find(kOverrideSeparator);
         CF_EXPECTF(separator_index != std::string::npos,
                    "Unable to find separator \"{}\" in input \"{}\"",
-                   kOverrideSeparator, match.value);
-        auto property_path = match.value.substr(0, separator_index);
-        auto new_value = match.value.substr(separator_index + 1);
+                   kOverrideSeparator, arg);
+        auto property_path = arg.substr(0, separator_index);
+        auto new_value = arg.substr(separator_index + 1);
         CF_EXPECTF(overrides.count(property_path) == 0,
                    "Property \"{}\" is already overridden", property_path);
         CF_EXPECTF(!property_path.empty(),
                    "Config path before the separator \"{}\" cannot be empty in "
                    "input \"{}\"",
-                   kOverrideSeparator, match.value);
+                   kOverrideSeparator, arg);
         CF_EXPECTF(!new_value.empty(),
                    "New value after the separator \"{}\" cannot be empty in "
                    "input \"{}\"",
-                   kOverrideSeparator, match.value);
+                   kOverrideSeparator, arg);
         CF_EXPECTF(property_path.front() != '.' && property_path.back() != '.',
                    "Config path \"{}\" must not start or end with dot",
                    property_path);
         CF_EXPECTF(property_path.find("..") == std::string::npos,
                    "Config path \"{}\" cannot contain two consecutive dots",
                    property_path);
-        overrides[property_path] = new_value;
+        overrides[std::string(property_path)] = new_value;
         return {};
       });
 }
@@ -256,18 +256,17 @@ std::vector<Flag> BuildCvdLoadFlags(LoadFlags& load_flags) {
               "The format is `--override=<path.to.property>:<value>`. "
               "For example: `--override=instance.0.vm.cpus=16`."));
   flags.emplace_back(
-      GflagsCompatFlag("credential_source")
+      Flag::StringFlag("credential_source")
           .Help("Source of credentials to access the Android Build Server API. "
                 "Can be left empty in most cases, see the help for `login` and "
                 "`fetch` for details.")
-          .Setter([&load_flags](const FlagMatch& match) -> Result<void> {
+          .Setter([&load_flags](std::string_view arg) -> Result<void> {
             CF_EXPECTF(
                 load_flags.overrides.count(kCredentialSourceOverride) == 0,
                 "Specifying both --override={} and the "
                 "--credential_source flag is not allowed.",
                 kCredentialSourceOverride);
-            load_flags.overrides.emplace(kCredentialSourceOverride,
-                                         match.value);
+            load_flags.overrides.emplace(kCredentialSourceOverride, arg);
             return {};
           })
           .Getter([&load_flags]() -> std::string {
@@ -278,15 +277,15 @@ std::vector<Flag> BuildCvdLoadFlags(LoadFlags& load_flags) {
             return "";
           }));
   flags.emplace_back(
-      GflagsCompatFlag("project_id")
+      Flag::StringFlag("project_id")
           .Help("Google Cloud Project ID for Android Build "
                 "Server API access and quotas.")
-          .Setter([&load_flags](const FlagMatch& match) -> Result<void> {
+          .Setter([&load_flags](std::string_view arg) -> Result<void> {
             CF_EXPECTF(load_flags.overrides.count(kProjectIDOverride) == 0,
                        "Specifying both --override={} and the --project_id "
                        "flag is not allowed.",
                        kProjectIDOverride);
-            load_flags.overrides.emplace(kProjectIDOverride, match.value);
+            load_flags.overrides.emplace(kProjectIDOverride, arg);
             return {};
           })
           .Getter([&load_flags]() -> std::string {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
@@ -233,10 +233,10 @@ Result<std::vector<Flag>> GetSiblingCommandFlags(const std::string& bin_name,
     }
     flags
         .emplace_back(desc.type.starts_with("bool")
-                          ? GflagsCompatBoolFlag(desc.name)
-                          : GflagsCompatFlag(desc.name))
+                          ? Flag::BoolFlag(desc.name)
+                          : Flag::StringFlag(desc.name))
         // Add setter and getter that won't crash
-        .Setter([](const FlagMatch& match) -> Result<void> { return {}; })
+        .Setter([](std::string_view) -> Result<void> { return {}; })
         // The getter always returns the current value reported by the internal
         // binary so the help message is accurate.
         .Getter([value = desc.current_value]() { return value; })

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/build_api_flags.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/build_api_flags.cc
@@ -31,12 +31,12 @@ namespace {
 
 Flag GflagsCompatFlagSeconds(const std::string& name,
                              std::chrono::seconds& value) {
-  return GflagsCompatFlag(name)
+  return Flag::StringFlag(name)
       .Getter([&value]() { return std::to_string(value.count()); })
-      .Setter([&value](const FlagMatch& match) -> Result<void> {
+      .Setter([&value](std::string_view arg) -> Result<void> {
         int parsed_int;
-        CF_EXPECTF(absl::SimpleAtoi(match.value, &parsed_int),
-                   "Failed to parse \"{}\" as an integer", match.value);
+        CF_EXPECTF(absl::SimpleAtoi(arg, &parsed_int),
+                   "Failed to parse \"{}\" as an integer", arg);
         value = std::chrono::seconds(parsed_int);
         return {};
       });

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd_parser.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd_parser.cc
@@ -77,7 +77,6 @@ std::vector<Flag> GetFlagsVector(FetchFlags& fetch_flags,
   flags.emplace_back(
       HelpXmlFlag(flags, std::cout, fetch_flags.helpxml, help_message.str()));
 
-  flags.emplace_back(UnexpectedArgumentGuard());
   return flags;
 }
 
@@ -87,7 +86,8 @@ Result<FetchFlags> FetchFlags::Parse(std::vector<std::string>& args) {
   FetchFlags fetch_flags;
   std::string directory;
   std::vector<Flag> flags = GetFlagsVector(fetch_flags, directory);
-  CF_EXPECT(ConsumeFlags(flags, args), "Could not process command line flags.");
+  CF_EXPECT(ConsumeFlags(flags, args, {.fail_on_unexpected_argument = true}),
+            "Could not process command line flags.");
 
   if (!directory.empty()) {
     LOG(WARNING) << "Please use --target_directory instead of --directory";

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/BUILD.bazel
@@ -104,6 +104,7 @@ cf_cc_library(
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:files",
+        "//cuttlefish/common/libs/utils:gflags_xml_parser",
         "//cuttlefish/common/libs/utils:json",
         "//cuttlefish/common/libs/utils:proc_file_utils",
         "//cuttlefish/common/libs/utils:signals",

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/status_fetcher.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/status_fetcher.cpp
@@ -16,6 +16,7 @@
 
 #include "cuttlefish/host/commands/cvd/instances/status_fetcher.h"
 
+#include <algorithm>
 #include <cctype>
 #include <string>
 #include <string_view>
@@ -31,6 +32,7 @@
 #include "cuttlefish/common/libs/utils/json.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"
 #include "cuttlefish/common/libs/utils/subprocess_managed_stdio.h"
+#include "cuttlefish/common/libs/utils/gflags_xml_parser.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/host_tool_target.h"
 #include "cuttlefish/host/commands/cvd/cli/utils.h"
 #include "cuttlefish/host/commands/cvd/instances/cvd_persistent_data.pb.h"
@@ -130,7 +132,7 @@ Result<Json::Value> FetchInstanceStatus(LocalInstance& instance,
   ConstructCommandParam help_cmd_param{
       .bin_path = bin_path,
       .home = home,
-      .args = {"--help"},
+      .args = {"--helpxml"},
       .envs = envs,
       .working_dir = working_dir,
       .command_name = bin,
@@ -140,8 +142,11 @@ Result<Json::Value> FetchInstanceStatus(LocalInstance& instance,
   std::string stdout_str, stderr_str;
   RunWithManagedStdio(std::move(help_cmd), nullptr, &stdout_str, &stderr_str);
 
-  bool has_print = stdout_str.find("--print") != std::string::npos ||
-                   stderr_str.find("--print") != std::string::npos;
+  std::vector<GflagDescription> internal_flags =
+      CF_EXPECT(ParseGflagsXmlHelp(stdout_str));
+  bool has_print = std::any_of(
+      internal_flags.begin(), internal_flags.end(),
+      [](const GflagDescription& desc) { return desc.name == "print"; });
 
   std::vector<std::string> args{"--wait_for_launcher",
                                 std::to_string(timeout.count())};

--- a/base/cvd/cuttlefish/host/commands/display/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/display/main.cpp
@@ -155,10 +155,10 @@ Result<int> DoRemove(std::vector<std::string>& args) {
 
   std::vector<std::string> displays;
   const std::vector<Flag> remove_displays_flags = {
-      GflagsCompatFlag(kDisplayFlag)
+    Flag::StringFlag(kDisplayFlag)
           .Help("Display id of a display to remove.")
-          .Setter([&](const FlagMatch& match) -> Result<void> {
-            displays.push_back(match.value);
+          .Setter([&](std::string_view arg) -> Result<void> {
+            displays.emplace_back(arg);
             return {};
           }),
   };

--- a/base/cvd/cuttlefish/host/commands/metrics/metrics_flags.cc
+++ b/base/cvd/cuttlefish/host/commands/metrics/metrics_flags.cc
@@ -18,6 +18,7 @@
 
 #include <cstdint>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "cuttlefish/common/libs/utils/base64.h"
@@ -31,29 +32,29 @@ namespace {
 
 Flag EnvironmentGflagsCompatFlag(const std::string& name,
                                  ClearcutEnvironment& value) {
-  return GflagsCompatFlag(name)
+  return Flag::StringFlag(name)
       .Getter([&value]() { return EnvironmentToString(value); })
-      .Setter([name, &value](const FlagMatch& match) -> Result<void> {
-        if (match.value == kClearcutLocal) {
+      .Setter([name, &value](std::string_view arg) -> Result<void> {
+        if (arg == kClearcutLocal) {
           value = ClearcutEnvironment::Local;
-        } else if (match.value == kClearcutStaging) {
+        } else if (arg == kClearcutStaging) {
           value = ClearcutEnvironment::Staging;
-        } else if (match.value == kClearcutProduction) {
+        } else if (arg == kClearcutProduction) {
           value = ClearcutEnvironment::Production;
         } else {
-          return CF_ERRF("Unexpected environment value: \"{}\"", match.value);
+          return CF_ERRF("Unexpected environment value: \"{}\"", arg);
         }
         return {};
       });
 }
 
 Flag Base64GflagsCompatFlag(const std::string& name, std::string& value) {
-  return GflagsCompatFlag(name)
+  return Flag::StringFlag(name)
       .Getter([&value]() { return value; })
-      .Setter([name, &value](const FlagMatch& match) -> Result<void> {
+      .Setter([name, &value](std::string_view arg) -> Result<void> {
         std::vector<uint8_t> decoded_out =
-            CF_EXPECTF(DecodeBase64(match.value),
-                       "Unable to base64 decode string: '{}'", match.value);
+            CF_EXPECTF(DecodeBase64(std::string(arg)),
+                       "Unable to base64 decode string: '{}'", arg);
         value = std::string(decoded_out.begin(), decoded_out.end());
         return {};
       });
@@ -77,9 +78,8 @@ Result<MetricsFlags> ProcessFlags(int argc, char** argv) {
           .Help("The base64 encoded, serialized proto string data to decode "
                 "and transmit."));
   flags.emplace_back(HelpFlag(flags));
-  flags.emplace_back(UnexpectedArgumentGuard());
   std::vector<std::string> args(argv + 1, argv + argc);  // Skip argv[0]
-  CF_EXPECT(ConsumeFlags(flags, args));
+  CF_EXPECT(ConsumeFlags(flags, args, {.fail_on_unexpected_argument = true}));
 
   CF_EXPECT(result.serialized_proto.empty() != result.event_filepath.empty(),
             "Must specify one and only one of the two input flags.  The event "

--- a/base/cvd/cuttlefish/host/commands/process_restarter/parser.cc
+++ b/base/cvd/cuttlefish/host/commands/process_restarter/parser.cc
@@ -64,9 +64,9 @@ Result<Parser> Parser::ConsumeAndParse(std::vector<std::string>& args) {
   flags.push_back(HelpFlag(flags, kHelp));
   bool matched_help_xml = false;
   flags.push_back(HelpXmlFlag(flags, std::cout, matched_help_xml, ""));
-  flags.push_back(UnexpectedArgumentGuard());
-  constexpr const bool recognize_end_of_option_mark = true;
-  CF_EXPECT(ConsumeFlags(flags, args, recognize_end_of_option_mark));
+  CF_EXPECT(ConsumeFlags(
+      flags, args,
+      {.stop_at_double_dashes = true, .fail_on_unexpected_argument = true}));
   return parser;
 }
 

--- a/base/cvd/cuttlefish/host/commands/snapshot_util_cvd/parse.cc
+++ b/base/cvd/cuttlefish/host/commands/snapshot_util_cvd/parse.cc
@@ -126,8 +126,8 @@ Result<Parsed> Parse(std::vector<std::string>& args) {
                       .Help("Suspend/resume before/after taking the snapshot"));
   flags.push_back(HelpFlag(flags));
   flags.push_back(HelpXmlFlag(flags, std::cout, help_xml));
-  flags.push_back(UnexpectedArgumentGuard());
-  auto parse_res = ConsumeFlags(flags, args);
+  Result<void> parse_res =
+      ConsumeFlags(flags, args, {.fail_on_unexpected_argument = true});
   if (!help_xml && !parse_res.ok()) {
     // Parse fails if helpxml is passed
     CF_EXPECT(std::move(parse_res), "Flag parsing failed");

--- a/base/cvd/cuttlefish/host/commands/status/main.cc
+++ b/base/cvd/cuttlefish/host/commands/status/main.cc
@@ -65,10 +65,10 @@ Result<StatusFlags> GetFlagValues(int argc, char** argv) {
           .Help("List all instances status and instance config information."));
   flags.emplace_back(HelpFlag(flags));
   flags.emplace_back(HelpXmlFlag(flags, std::cout, flag_values.help_xml));
-  flags.emplace_back(UnexpectedArgumentGuard());
 
   std::vector<std::string> args(argv + 1, argv + argc);  // Skip argv[0]
-  CF_EXPECT(ConsumeFlags(flags, args), "Could not process command line flags.");
+  CF_EXPECT(ConsumeFlags(flags, args, {.fail_on_unexpected_argument = true}),
+            "Could not process command line flags.");
   return flag_values;
 }
 

--- a/base/cvd/cuttlefish/host/commands/stop/main.cc
+++ b/base/cvd/cuttlefish/host/commands/stop/main.cc
@@ -182,9 +182,9 @@ FlagVaules GetFlagValues(int argc, char** argv) {
   flags.emplace_back(HelpFlag(flags));
   bool helpxml = false;
   flags.emplace_back(HelpXmlFlag(flags, std::cout, helpxml));
-  flags.emplace_back(UnexpectedArgumentGuard());
   std::vector<std::string> args(argv + 1, argv + argc);  // Skip argv[0]
-  auto parse_res = ConsumeFlags(flags, args);
+  Result<void> parse_res =
+      ConsumeFlags(flags, args, {.fail_on_unexpected_argument = true});
   CHECK(parse_res.ok() || helpxml) << "Could not process command line flags.";
 
   return {wait_for_launcher, clear_instance_dirs, instance_nums, helpxml};

--- a/base/cvd/cuttlefish/host/commands/tombstone_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/tombstone_receiver/main.cpp
@@ -69,10 +69,10 @@ int TombstoneReceiverMain(int argc, char** argv) {
           .Help("File descriptor to an already created vsock server"));
 
   flags.emplace_back(HelpFlag(flags));
-  flags.emplace_back(UnexpectedArgumentGuard());
 
   std::vector<std::string> args(argv + 1, argv + argc);  // Skip argv[0]
-  auto parse_res = ConsumeFlags(flags, args);
+  Result<void> parse_res =
+      ConsumeFlags(flags, args, {.fail_on_unexpected_argument = true});
   CHECK(parse_res.ok()) << "Could not process command line flags. "
                         << parse_res.error();
 

--- a/base/cvd/cuttlefish/host/libs/config/adb/flags.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/adb/flags.cpp
@@ -43,7 +43,7 @@ class AdbConfigFlagImpl : public AdbConfigFlag {
   INJECT(AdbConfigFlagImpl(AdbConfig& config, ConfigFlag& config_flag))
       : config_(config),
         config_flag_(config_flag),
-        mode_flag_(GflagsCompatFlag("adb_mode").Help(mode_help)) {
+        mode_flag_(Flag::StringFlag("adb_mode").Help(mode_help)) {
     mode_flag_.Getter([this]() {
       std::stringstream modes;
       for (const auto& mode : config_.Modes()) {
@@ -51,10 +51,10 @@ class AdbConfigFlagImpl : public AdbConfigFlag {
       }
       return modes.str().substr(1);  // First comma
     });
-    mode_flag_.Setter([this](const FlagMatch& match) -> Result<void> {
+    mode_flag_.Setter([this](std::string_view arg) -> Result<void> {
       // TODO(schuffelen): Error on unknown types?
       std::set<AdbMode> modes;
-      for (std::string_view mode : absl::StrSplit(match.value, ',')) {
+      for (std::string_view mode : absl::StrSplit(arg, ',')) {
         modes.insert(StringToAdbMode(mode));
       }
       CF_EXPECT(config_.SetModes(modes));
@@ -88,7 +88,8 @@ class AdbConfigFlagImpl : public AdbConfigFlag {
   bool WriteGflagsCompatHelpXml(std::ostream& out) const override {
     bool run = config_.RunConnector();
     Flag run_flag = GflagsCompatFlag("run_adb_connector", run).Help(run_help);
-    return WriteGflagsCompatXml({run_flag, mode_flag_}, out);
+    WriteGflagsCompatXml({run_flag, mode_flag_}, out);
+    return true;
   }
 
  private:

--- a/base/cvd/cuttlefish/host/libs/config/config_flag.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/config_flag.cpp
@@ -134,7 +134,7 @@ class ConfigFlagImpl : public ConfigFlag {
     };
   }
   Result<void> Process(std::vector<std::string>& args) override {
-    CF_EXPECT(flag_.Parse(args), "Failed to parse `--config` flag");
+    CF_EXPECT(ConsumeFlags({flag_}, args), "Failed to parse `--config` flag");
 
     if (is_default_) {
       configs_.resize(system_image_dir_flag_.Size());

--- a/base/cvd/cuttlefish/host/libs/config/config_flag.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/config_flag.cpp
@@ -116,14 +116,14 @@ class ConfigFlagImpl : public ConfigFlag {
         configs_(s.Size(), kDefaultConfig),
         is_default_(true),
         flag_(
-            GflagsCompatFlag("config")
+            Flag::StringFlag("config")
                 .Help("Config preset name. Will automatically set flag fields "
                       "using the values from this file of presets. See "
                       "device/google/cuttlefish/shared/config/config_*.json "
                       "for possible values.")
                 .Getter([this]() { return VectorizedFlagValue(configs_); })
-                .Setter([this](const FlagMatch& m) -> Result<void> {
-                  CF_EXPECT(ChooseConfigs(m.value));
+                .Setter([this](std::string_view arg) -> Result<void> {
+                  CF_EXPECT(ChooseConfigs(arg));
                   return {};
                 })) {}
 
@@ -178,11 +178,12 @@ class ConfigFlagImpl : public ConfigFlag {
     return {};
   }
   bool WriteGflagsCompatHelpXml(std::ostream& out) const override {
-    return WriteGflagsCompatXml(flag_, out);
+    WriteGflagsCompatXml(flag_, out);
+    return true;
   }
 
  private:
-  Result<void> ChooseConfigs(const std::string& value) {
+  Result<void> ChooseConfigs(std::string_view value) {
     std::vector<std::string> configs = absl::StrSplit(value, ",");
     for (const auto& name : configs) {
       CF_EXPECTF(config_reader_.HasConfig(name),

--- a/base/cvd/cuttlefish/host/libs/config/custom_actions.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/custom_actions.cpp
@@ -18,6 +18,7 @@
 #include <optional>
 #include <ostream>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -216,44 +217,44 @@ class CustomActionConfigImpl : public CustomActionConfigProvider {
   INJECT(CustomActionConfigImpl(ConfigFlag& config))
       : config_(config),
         custom_action_config_flag_(
-            GflagsCompatFlag("custom_action_config")
+            Flag::StringFlag("custom_action_config")
                 .Help(
                     "Path to a custom action config JSON. Defaults to the file "
                     "provided by build variable CVD_CUSTOM_ACTION_CONFIG. If "
                     "this build variable is empty then the custom action "
                     "config will be empty as well.")
                 .Getter([this]() { return custom_action_config_[0]; })
-                .Setter([this](const FlagMatch& match) -> Result<void> {
-                  if (!match.value.empty() &&
-                      (match.value == "unset" || match.value == "\"unset\"")) {
+                .Setter([this](std::string_view arg) -> Result<void> {
+                  if (!arg.empty() &&
+                      (arg == "unset" || arg == "\"unset\"")) {
                     custom_action_config_.push_back(
                         DefaultCustomActionConfig());
-                  } else if (!match.value.empty() && !FileExists(match.value)) {
+                  } else if (!arg.empty() && !FileExists(std::string(arg))) {
                     return CF_ERRF(
                         "custom_action_config file \"{}\" does not exist.",
-                        match.value);
+                        arg);
                   } else {
-                    custom_action_config_.push_back(match.value);
+                    custom_action_config_.emplace_back(arg);
                   }
                   return {};
                 })),
         // TODO(schuffelen): Access ConfigFlag directly for these values.
         custom_actions_flag_(
-            GflagsCompatFlag("custom_actions")
+            Flag::StringFlag("custom_actions")
                 .Help("Serialized JSON of an array of custom action objects "
                       "(in the same format as custom action config JSON "
                       "files). For use within --config preset config files; "
                       "prefer --custom_action_config to specify a custom "
                       "config file on the command line. Actions in this flag "
                       "are combined with actions in --custom_action_config.")
-                .Setter([this](const FlagMatch& match) -> Result<void> {
+                .Setter([this](std::string_view arg) -> Result<void> {
                   // Load the custom action from the --config preset file.
-                  if (match.value == "unset" || match.value == "\"unset\"") {
+                  if (arg == "unset" || arg == "\"unset\"") {
                     AddEmptyJsonCustomActionConfigs();
                     return {};
                   }
                   auto custom_action_array =
-                      CF_EXPECT(ParseJson(match.value),
+                      CF_EXPECT(ParseJson(arg),
                                 "Could not read custom actions config flag");
                   CF_EXPECT(AddJsonCustomActionConfigs(custom_action_array));
                   return {};
@@ -358,7 +359,8 @@ class CustomActionConfigImpl : public CustomActionConfigProvider {
     return {};
   }
   bool WriteGflagsCompatHelpXml(std::ostream& out) const override {
-    return WriteGflagsCompatXml(Flags(), out);
+    WriteGflagsCompatXml(Flags(), out);
+    return true;
   }
 
  private:

--- a/base/cvd/cuttlefish/host/libs/config/display.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/display.cpp
@@ -120,10 +120,10 @@ ParseDisplayConfigsFromArgs(std::vector<std::string>& args) {
           .Help(kDisplayHelp),
       GflagsCompatFlag(kDisplay3FlagName, display3_flag_value)
           .Help(kDisplayHelp),
-      GflagsCompatFlag(kDisplayFlag)
+      Flag::StringFlag(kDisplayFlag)
           .Help(kDisplayHelp)
-          .Setter([&](const FlagMatch& match) -> Result<void> {
-            repeated_display_flag_values.push_back(match.value);
+          .Setter([&](std::string_view arg) -> Result<void> {
+            repeated_display_flag_values.emplace_back(arg);
             return {};
           }),
   };

--- a/base/cvd/cuttlefish/host/libs/config/fastboot/flags.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/fastboot/flags.cpp
@@ -55,8 +55,10 @@ class FastbootConfigFlagImpl : public FastbootConfigFlag {
 
   bool WriteGflagsCompatHelpXml(std::ostream& out) const override {
     bool proxy_fastboot = config_.ProxyFastboot();
-    Flag proxy_fastboot_flag = GflagsCompatFlag(kName, proxy_fastboot).Help(kHelp);
-    return WriteGflagsCompatXml({proxy_fastboot_flag}, out);
+    Flag proxy_fastboot_flag =
+        GflagsCompatFlag(kName, proxy_fastboot).Help(kHelp);
+    WriteGflagsCompatXml({proxy_fastboot_flag}, out);
+    return true;
   }
 
  private:

--- a/base/cvd/cuttlefish/host/libs/config/instance_nums.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/instance_nums.cpp
@@ -43,7 +43,7 @@ static Result<std::optional<int32_t>> ParseBaseInstanceFlag(
     std::vector<std::string>& flags) {
   int value = -1;
   auto flag = GflagsCompatFlag("base_instance_num", value);
-  CF_EXPECT(flag.Parse(flags), "Flag parsing error");
+  CF_EXPECT(ConsumeFlags({flag}, flags), "Flag parsing error");
   return value > 0 ? value : std::optional<int32_t>();
 }
 
@@ -54,7 +54,7 @@ static Result<std::optional<int32_t>> ParseNumInstancesFlag(
     std::vector<std::string>& flags) {
   int value = -1;
   auto flag = GflagsCompatFlag("num_instances", value);
-  CF_EXPECT(flag.Parse(flags), "Flag parsing error");
+  CF_EXPECT(ConsumeFlags({flag}, flags), "Flag parsing error");
   return value > 0 ? value : std::optional<int32_t>();
 }
 
@@ -91,7 +91,7 @@ static Result<std::vector<int32_t>> ParseInstanceNumsFlag(
     std::vector<std::string>& flags) {
   std::string value;
   auto flag = GflagsCompatFlag("instance_nums", value);
-  CF_EXPECT(flag.Parse(flags), "Flag parsing error");
+  CF_EXPECT(ConsumeFlags({flag}, flags), "Flag parsing error");
   if (!value.empty()) {
     return CF_EXPECT(ParseInstanceNums(value));
   } else {

--- a/base/cvd/cuttlefish/host/libs/config/media.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/media.cpp
@@ -18,20 +18,22 @@
 
 #include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
 #include "absl/strings/str_split.h"
 
 #include "cuttlefish/flag_parser/flag.h"
-#include "cuttlefish/flag_parser/gflags_compat.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 #include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
 
-static constexpr char kMediaTypeV4l2EmulatedCameraSPlane[] = "v4l2_emulated_camera_splane";
-static constexpr char kMediaTypeV4l2EmulatedCameraMPlane[] = "v4l2_emulated_camera_mplane";
+static constexpr char kMediaTypeV4l2EmulatedCameraSPlane[] =
+    "v4l2_emulated_camera_splane";
+static constexpr char kMediaTypeV4l2EmulatedCameraMPlane[] =
+    "v4l2_emulated_camera_mplane";
 static constexpr char kMediaTypeV4l2Proxy[] = "v4l2_proxy";
 
 Result<std::optional<CuttlefishConfig::MediaConfig>> ParseMediaConfig(
@@ -51,7 +53,7 @@ Result<std::optional<CuttlefishConfig::MediaConfig>> ParseMediaConfig(
 
   auto type_it = props.find("type");
   CF_EXPECT(type_it != props.end(), "Missing media type");
-  CuttlefishConfig::MediaType type { CuttlefishConfig::MediaType::kUnknown };
+  CuttlefishConfig::MediaType type{CuttlefishConfig::MediaType::kUnknown};
   if (type_it->second == kMediaTypeV4l2EmulatedCameraSPlane) {
     type = CuttlefishConfig::MediaType::kV4l2EmulatedCameraSPlane;
   } else if (type_it->second == kMediaTypeV4l2EmulatedCameraMPlane) {
@@ -71,10 +73,10 @@ Result<std::vector<CuttlefishConfig::MediaConfig>> ParseMediaConfigsFromArgs(
     std::vector<std::string>& args) {
   std::vector<std::string> repeated_media_flag_values;
   const std::vector<Flag> media_flags = {
-      GflagsCompatFlag(kMediaFlag)
+      Flag::StringFlag(kMediaFlag)
           .Help(kMediaHelp)
-          .Setter([&](const FlagMatch& match) -> Result<void> {
-            repeated_media_flag_values.push_back(match.value);
+          .Setter([&](std::string_view arg) -> Result<void> {
+            repeated_media_flag_values.emplace_back(arg);
             return {};
           }),
   };

--- a/base/cvd/cuttlefish/host/libs/config/touchpad.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/touchpad.cpp
@@ -26,7 +26,6 @@
 
 #include "cuttlefish/common/libs/utils/contains.h"
 #include "cuttlefish/flag_parser/flag.h"
-#include "cuttlefish/flag_parser/gflags_compat.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 #include "cuttlefish/result/result.h"
 
@@ -68,10 +67,10 @@ ParseTouchpadConfigsFromArgs(std::vector<std::string>& args) {
   std::vector<std::string> repeated_touchpad_flag_values;
 
   const std::vector<Flag> touchpad_flags = {
-      GflagsCompatFlag(kTouchpadFlag)
+    Flag::StringFlag(kTouchpadFlag)
           .Help(kTouchpadHelp)
-          .Setter([&](const FlagMatch& match) -> Result<void> {
-            repeated_touchpad_flag_values.push_back(match.value);
+          .Setter([&](std::string_view arg) -> Result<void> {
+            repeated_touchpad_flag_values.emplace_back(arg);
             return {};
           }),
   };

--- a/base/cvd/cuttlefish/host/libs/web/android_build_string.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_string.cpp
@@ -21,6 +21,7 @@
 #include <ostream>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -31,7 +32,6 @@
 #include <fmt/ranges.h>
 
 #include "cuttlefish/flag_parser/flag.h"
-#include "cuttlefish/flag_parser/gflags_compat.h"
 #include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
@@ -39,8 +39,8 @@ namespace cuttlefish {
 namespace {
 
 Result<std::pair<std::string, std::optional<std::string>>> ParseFilepath(
-    const std::string& build_string) {
-  std::string remaining_build_string = build_string;
+    std::string_view build_string) {
+  std::string_view remaining_build_string = build_string;
   std::optional<std::string> filepath;
   size_t open_bracket = build_string.find('{');
   size_t close_bracket = build_string.find('}');
@@ -52,13 +52,13 @@ Result<std::pair<std::string, std::optional<std::string>>> ParseFilepath(
       "Open or close curly bracket exists without its complement in \"{}\"",
       build_string);
   if (has_open && has_close) {
-    std::string remaining_substring = build_string.substr(0, open_bracket);
+    std::string_view remaining_substring = build_string.substr(0, open_bracket);
     CF_EXPECTF(
         !remaining_substring.empty(),
         "The build string excluding filepath cannot be empty.  Input: {}",
         build_string);
     size_t filepath_start = open_bracket + 1;
-    std::string filepath_substring =
+    std::string_view filepath_substring =
         build_string.substr(filepath_start, close_bracket - filepath_start);
     CF_EXPECTF(
         !filepath_substring.empty(),
@@ -67,7 +67,7 @@ Result<std::pair<std::string, std::optional<std::string>>> ParseFilepath(
     remaining_build_string = remaining_substring;
     filepath = filepath_substring;
   }
-  return {{remaining_build_string, filepath}};
+  return {{std::string(remaining_build_string), filepath}};
 }
 
 Result<BuildString> ParseDeviceBuildString(
@@ -140,7 +140,7 @@ void SetFilepath(BuildString& build_string, const std::string& value) {
   std::visit([&value](auto&& arg) { arg.filepath = value; }, build_string);
 }
 
-Result<BuildString> ParseBuildString(const std::string& build_string) {
+Result<BuildString> ParseBuildString(std::string_view build_string) {
   CF_EXPECT(!build_string.empty(), "The given build string cannot be empty");
   auto [remaining_build_string, filepath] =
       CF_EXPECT(ParseFilepath(build_string));
@@ -154,16 +154,16 @@ Result<BuildString> ParseBuildString(const std::string& build_string) {
 
 Flag GflagsCompatFlag(const std::string& name,
                       std::optional<BuildString>& value) {
-  return GflagsCompatFlag(name)
+  return Flag::StringFlag(name)
       .Getter([&value]() {
         std::stringstream result;
         result << value;
         return result.str();
       })
-      .Setter([&value](const FlagMatch& match) -> Result<void> {
+      .Setter([&value](std::string_view arg) -> Result<void> {
         value = std::nullopt;
-        if (!match.value.empty()) {
-          value = CF_EXPECT(ParseBuildString(match.value));
+        if (!arg.empty()) {
+          value = CF_EXPECT(ParseBuildString(arg));
         }
         return {};
       });
@@ -171,17 +171,16 @@ Flag GflagsCompatFlag(const std::string& name,
 
 Flag GflagsCompatFlag(const std::string& name,
                       std::vector<std::optional<BuildString>>& value) {
-  return GflagsCompatFlag(name)
+  return Flag::StringFlag(name)
       .Getter([&value]() {
         return absl::StrJoin(value, ",", absl::StreamFormatter());
       })
-      .Setter([&value](const FlagMatch& match) -> Result<void> {
-        if (match.value.empty()) {
+      .Setter([&value](std::string_view arg) -> Result<void> {
+        if (arg.empty()) {
           value.clear();
           return {};
         }
-        std::vector<std::string> str_vals =
-            absl::StrSplit(match.value, ',');
+        std::vector<std::string> str_vals = absl::StrSplit(arg, ',');
         value.clear();
         for (const auto& str_val : str_vals) {
           if (str_val.empty()) {

--- a/base/cvd/cuttlefish/host/libs/web/android_build_string.h
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_string.h
@@ -18,11 +18,11 @@
 #include <compare>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <variant>
 #include <vector>
 
 #include "cuttlefish/flag_parser/flag.h"
-#include "cuttlefish/flag_parser/gflags_compat.h"
 #include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
@@ -60,7 +60,7 @@ std::optional<std::string> GetFilepath(const BuildString& build_string);
 
 void SetFilepath(BuildString& build_string, const std::string& value);
 
-Result<BuildString> ParseBuildString(const std::string& build_string);
+Result<BuildString> ParseBuildString(std::string_view build_string);
 
 Flag GflagsCompatFlag(const std::string& name,
                       std::optional<BuildString>& value);

--- a/base/cvd/cuttlefish/host/libs/web/android_build_string_tests.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_string_tests.cpp
@@ -20,6 +20,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/host/libs/web/android_build_string.h"
 #include "cuttlefish/result/result_matchers.h"
 
@@ -127,7 +128,7 @@ TEST(SingleBuildStringGflagsCompatFlagTests, EmptyInputEmptyResultSuccess) {
   std::optional<BuildString> value;
   auto flag = GflagsCompatFlag("myflag", value);
 
-  ASSERT_THAT(flag.Parse({"--myflag="}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag="}), IsOk());
   ASSERT_THAT(value, Eq(std::nullopt));
 }
 
@@ -135,9 +136,9 @@ TEST(SingleBuildStringGflagsCompatFlagTests, HasValueSuccess) {
   std::optional<BuildString> value;
   auto flag = GflagsCompatFlag("myflag", value);
 
-  ASSERT_THAT(flag.Parse({"--myflag=12345"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=12345"}), IsOk());
   ASSERT_THAT(value, Optional(DeviceBuildString{.branch_or_id = "12345"}));
-  ASSERT_THAT(flag.Parse({"--myflag=abcde/test_target"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=abcde/test_target"}), IsOk());
   ASSERT_THAT(value, Optional(DeviceBuildString{.branch_or_id = "abcde",
                                                 .target = "test_target"}));
 }
@@ -146,7 +147,7 @@ TEST(BuildStringGflagsCompatFlagTests, EmptyInputEmptyResultSuccess) {
   std::vector<std::optional<BuildString>> value;
   auto flag = GflagsCompatFlag("myflag", value);
 
-  ASSERT_THAT(flag.Parse({"--myflag="}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag="}), IsOk());
   ASSERT_THAT(value, IsEmpty());
 }
 
@@ -154,13 +155,14 @@ TEST(BuildStringGflagsCompatFlagTests, MultiValueSuccess) {
   std::vector<std::optional<BuildString>> value;
   auto flag = GflagsCompatFlag("myflag", value);
 
-  ASSERT_THAT(flag.Parse({"--myflag=12345,abcde"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=12345,abcde"}), IsOk());
   ASSERT_THAT(value, SizeIs(2));
   ASSERT_THAT(value, ElementsAre(DeviceBuildString{.branch_or_id = "12345"},
                                  DeviceBuildString{.branch_or_id = "abcde"}));
 
-  ASSERT_THAT(flag.Parse({"--myflag=12345/test_target,abcde/test_target"}),
-              IsOk());
+  ASSERT_THAT(
+      ConsumeFlags({flag}, {"--myflag=12345/test_target,abcde/test_target"}),
+      IsOk());
   ASSERT_THAT(value, SizeIs(2));
   ASSERT_THAT(
       value,
@@ -173,7 +175,7 @@ TEST(BuildStringGflagsCompatFlagTests, MultiEmptyValueSuccess) {
   std::vector<std::optional<BuildString>> value;
   auto flag = GflagsCompatFlag("myflag", value);
 
-  ASSERT_THAT(flag.Parse({"--myflag=,"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=,"}), IsOk());
   ASSERT_THAT(value, SizeIs(2));
   ASSERT_THAT(value, ElementsAre(std::nullopt, std::nullopt));
 }
@@ -182,14 +184,15 @@ TEST(BuildStringGflagsCompatFlagTests, MultiValueMixedWithEmptySuccess) {
   std::vector<std::optional<BuildString>> value;
   auto flag = GflagsCompatFlag("myflag", value);
 
-  ASSERT_THAT(flag.Parse({"--myflag=12345,,abcde"}), IsOk());
+  ASSERT_THAT(ConsumeFlags({flag}, {"--myflag=12345,,abcde"}), IsOk());
   ASSERT_THAT(value, SizeIs(3));
   ASSERT_THAT(value, ElementsAre(DeviceBuildString{.branch_or_id = "12345"},
                                  std::nullopt,
                                  DeviceBuildString{.branch_or_id = "abcde"}));
 
-  ASSERT_THAT(flag.Parse({"--myflag=12345/test_target,,abcde/test_target"}),
-              IsOk());
+  ASSERT_THAT(
+      ConsumeFlags({flag}, {"--myflag=12345/test_target,,abcde/test_target"}),
+      IsOk());
   ASSERT_THAT(value, SizeIs(3));
   ASSERT_THAT(
       value,

--- a/base/cvd/cuttlefish/host/libs/web/chrome_os_build_string.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/chrome_os_build_string.cpp
@@ -18,6 +18,7 @@
 #include <optional>
 #include <ostream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "absl/strings/str_split.h"
@@ -27,7 +28,6 @@
 #include <fmt/ranges.h>  // NOLINT(misc-include-cleaner): version difference
 
 #include "cuttlefish/flag_parser/flag.h"
-#include "cuttlefish/flag_parser/gflags_compat.h"
 #include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
@@ -66,14 +66,14 @@ std::ostream& operator<<(std::ostream& stream,
 
 Flag GflagsCompatFlag(const std::string& name,
                       std::vector<std::optional<ChromeOsBuildString>>& value) {
-  return GflagsCompatFlag(name)
-      .Setter([&value](const FlagMatch& match) -> Result<void> {
-        if (match.value.empty()) {
+  return Flag::StringFlag(name)
+      .Setter([&value](std::string_view arg) -> Result<void> {
+        if (arg.empty()) {
           value.clear();
           return {};
         }
         std::vector<std::string> str_vals =
-            absl::StrSplit(match.value, ',');
+            absl::StrSplit(arg, ',');
         value.clear();
         for (const auto& str_val : str_vals) {
           if (str_val.empty()) {


### PR DESCRIPTION
Removes the aliases and alias modes so that the  Flag class knows more about the details of how the command line arguments are matched and can produce a more concise help output.

Bug: b/515490829