### PR TITLE
Enforce project style include grouping with clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -25,7 +25,7 @@ IncludeCategories:
     Priority:        4
   - Regex:           '^<(zip|zlib|png|lz4|archive|tinyxml2|pcre2)\.h>'
     Priority:        3
-  - Regex:           '^<([^/]*|(sys|linux|netinet|arpa|asm|net|gnu)/.*)\.h>'
+  - Regex:           '^<.*\.h>'
     Priority:        1
   - Regex:           '^<[a-z_]*>'
     Priority:        2

--- a/.clang-format
+++ b/.clang-format
@@ -19,4 +19,15 @@
 # of the below options.
 
 BasedOnStyle: Google
-IncludeBlocks: Preserve
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex:           '^[<"](cuttlefish|allocd|external_proto)/'
+    Priority:        4
+  - Regex:           '^<(zip|zlib|png|lz4|archive|tinyxml2|pcre2)\.h>'
+    Priority:        3
+  - Regex:           '^<([^/]*|(sys|linux|netinet|arpa|asm|net|gnu)/.*)\.h>'
+    Priority:        1
+  - Regex:           '^<[a-z_]*>'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3

--- a/.clang-format
+++ b/.clang-format
@@ -19,15 +19,22 @@
 # of the below options.
 
 BasedOnStyle: Google
+# Enforce grouping and sorting of #include directives into distinct blocks
+# separated by a blank line, evaluated in the order listed below:
 IncludeBlocks: Regroup
 IncludeCategories:
+  # 1. Project headers (cuttlefish/, allocd/, and external_proto/)
   - Regex:           '^[<"](cuttlefish|allocd|external_proto)/'
     Priority:        4
+  # 2. Plain C external third-party library headers inside angle brackets
   - Regex:           '^<(zip|zlib|png|lz4|archive|tinyxml2|pcre2)\.h>'
     Priority:        3
+  # 3. C/POSIX system headers (any other angle-bracket header ending in .h)
   - Regex:           '^<.*\.h>'
     Priority:        1
+  # 4. C++ standard library headers (extensionless angle-bracket headers)
   - Regex:           '^<[a-z_]*>'
     Priority:        2
+  # 5. External third-party library headers inside double quotes
   - Regex:           '.*'
     Priority:        3

--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd_test.cpp
@@ -16,8 +16,9 @@
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 
-#include <gtest/gtest.h>
 #include <unistd.h>
+
+#include <gtest/gtest.h>
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd_test.cpp
@@ -18,7 +18,7 @@
 
 #include <unistd.h>
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/common/libs/utils/base64.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/base64.cpp
@@ -23,7 +23,7 @@
 #include <string_view>
 #include <vector>
 
-#include <openssl/base64.h>
+#include "openssl/base64.h"
 
 #include "cuttlefish/result/expect.h"
 #include "cuttlefish/result/result_type.h"

--- a/base/cvd/cuttlefish/common/libs/utils/cf_endian.h
+++ b/base/cvd/cuttlefish/common/libs/utils/cf_endian.h
@@ -17,7 +17,7 @@
 
 #include <inttypes.h>
 
-#include <android-base/endian.h>
+#include "android-base/endian.h"
 
 // The utilities in android-base/endian.h still require the use of regular int
 // types to store values with any endianness, which requires the user to

--- a/base/cvd/cuttlefish/common/libs/utils/environment_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/environment_test.cpp
@@ -21,7 +21,7 @@
 #include <string_view>
 
 #include "absl/cleanup/cleanup.h"
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/common/libs/utils/environment_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/environment_test.cpp
@@ -20,8 +20,8 @@
 #include <string>
 #include <string_view>
 
-#include <gtest/gtest.h>
 #include "absl/cleanup/cleanup.h"
+#include <gtest/gtest.h>
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/common/libs/utils/files_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/files_test.cpp
@@ -18,11 +18,11 @@
 #include <fstream>
 #include <string>
 
+#include "absl/cleanup/cleanup.h"
+#include "absl/strings/str_cat.h"
 #include <android-base/file.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include "absl/cleanup/cleanup.h"
-#include "absl/strings/str_cat.h"
 
 #include "cuttlefish/result/result.h"
 #include "cuttlefish/result/result_matchers.h"

--- a/base/cvd/cuttlefish/common/libs/utils/files_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/files_test.cpp
@@ -20,9 +20,9 @@
 
 #include "absl/cleanup/cleanup.h"
 #include "absl/strings/str_cat.h"
-#include <android-base/file.h>
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+#include "android-base/file.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 #include "cuttlefish/result/result.h"
 #include "cuttlefish/result/result_matchers.h"

--- a/base/cvd/cuttlefish/common/libs/utils/flags_validator.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/flags_validator.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <string>
-
 #include "cuttlefish/common/libs/utils/flags_validator.h"
+
+#include <string>
 
 namespace cuttlefish {
 Result<void> ValidateSetupWizardMode(const std::string& setupwizard_mode) {

--- a/base/cvd/cuttlefish/common/libs/utils/gflags_xml_parser.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/gflags_xml_parser.cpp
@@ -20,7 +20,7 @@
 #include <string_view>
 #include <vector>
 
-#include <libxml/parser.h>
+#include "libxml/parser.h"
 
 #include "cuttlefish/result/result.h"
 

--- a/base/cvd/cuttlefish/common/libs/utils/gflags_xml_parser_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/gflags_xml_parser_test.cpp
@@ -18,8 +18,8 @@
 #include <string>
 #include <vector>
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 #include "cuttlefish/result/result_matchers.h"
 

--- a/base/cvd/cuttlefish/common/libs/utils/inotify.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/inotify.cpp
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 
+#include "inotify.h"
+
 #include <limits.h>
 #include <string.h>
 #include <sys/inotify.h>
 #include <unistd.h>
+
 #include <string>
 #include <vector>
 
 #include "absl/log/log.h"
-
-#include "inotify.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/common/libs/utils/json.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/json.cpp
@@ -13,13 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "cuttlefish/common/libs/utils/json.h"
+
 #include <memory>
 #include <string>
 #include <string_view>
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"
-#include "cuttlefish/common/libs/utils/json.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/common/libs/utils/json.h
+++ b/base/cvd/cuttlefish/common/libs/utils/json.h
@@ -19,7 +19,7 @@
 #include <string_view>
 #include <vector>
 
-#include <json/json.h>
+#include "json/json.h"
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/result/result.h"

--- a/base/cvd/cuttlefish/common/libs/utils/known_paths.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/known_paths.cpp
@@ -16,9 +16,9 @@
 
 #include "cuttlefish/common/libs/utils/known_paths.h"
 
-#include "cuttlefish/common/libs/utils/environment.h"
-
 #include <string>
+
+#include "cuttlefish/common/libs/utils/environment.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/common/libs/utils/network_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/network_test.cpp
@@ -15,7 +15,7 @@
 
 #include "cuttlefish/common/libs/utils/network.h"
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/common/libs/utils/network_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/network_test.cpp
@@ -13,9 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gtest/gtest.h>
-
 #include "cuttlefish/common/libs/utils/network.h"
+
+#include <gtest/gtest.h>
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/common/libs/utils/proc_file_utils.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/proc_file_utils.cpp
@@ -25,14 +25,14 @@
 #include <unordered_map>
 #include <vector>
 
-#include <android-base/file.h>
-#include <fmt/core.h>
 #include "absl/log/log.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/match.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/strip.h"
+#include <android-base/file.h>
+#include <fmt/core.h>
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"

--- a/base/cvd/cuttlefish/common/libs/utils/proc_file_utils.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/proc_file_utils.cpp
@@ -31,8 +31,8 @@
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/strip.h"
-#include <android-base/file.h>
-#include <fmt/core.h>
+#include "android-base/file.h"
+#include "fmt/core.h"
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"

--- a/base/cvd/cuttlefish/common/libs/utils/proc_file_utils_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/proc_file_utils_test.cpp
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "cuttlefish/common/libs/utils/proc_file_utils.h"
+
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -22,7 +24,6 @@
 #include <gtest/gtest.h>
 
 #include "cuttlefish/common/libs/utils/contains.h"
-#include "cuttlefish/common/libs/utils/proc_file_utils.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/common/libs/utils/proc_file_utils_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/proc_file_utils_test.cpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <vector>
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 #include "cuttlefish/common/libs/utils/contains.h"
 

--- a/base/cvd/cuttlefish/common/libs/utils/proto.h
+++ b/base/cvd/cuttlefish/common/libs/utils/proto.h
@@ -16,10 +16,10 @@
 #include <type_traits>
 #include <vector>
 
-#include <fmt/core.h>
-#include <google/protobuf/message.h>
-#include <google/protobuf/text_format.h>
-#include <google/protobuf/util/json_util.h>
+#include "fmt/core.h"
+#include "google/protobuf/message.h"
+#include "google/protobuf/text_format.h"
+#include "google/protobuf/util/json_util.h"
 
 /* Format proto messages as textproto with {} or {:t} and json with {:j}. */
 template <typename T>

--- a/base/cvd/cuttlefish/common/libs/utils/semver_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/semver_test.cpp
@@ -18,7 +18,7 @@
 
 #include <string>
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/common/libs/utils/semver_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/semver_test.cpp
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+#include "cuttlefish/common/libs/utils/semver.h"
+
 #include <string>
 
 #include <gtest/gtest.h>
-
-#include "cuttlefish/common/libs/utils/semver.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/common/libs/utils/subprocess.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/subprocess.cpp
@@ -49,6 +49,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
+
 #include "cuttlefish/common/libs/utils/contains.h"
 #include "cuttlefish/common/libs/utils/files.h"
 

--- a/base/cvd/cuttlefish/common/libs/utils/unix_sockets_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/unix_sockets_test.cpp
@@ -20,8 +20,8 @@
 #include <utility>
 
 #include "absl/log/check.h"
-#include <android-base/result.h>
-#include <gtest/gtest.h>
+#include "android-base/result.h"
+#include "gtest/gtest.h"
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"

--- a/base/cvd/cuttlefish/common/libs/utils/unix_sockets_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/unix_sockets_test.cpp
@@ -19,9 +19,9 @@
 #include <string>
 #include <utility>
 
+#include "absl/log/check.h"
 #include <android-base/result.h>
 #include <gtest/gtest.h>
-#include "absl/log/check.h"
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"

--- a/base/cvd/cuttlefish/common/libs/utils/uuid.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/uuid.cpp
@@ -16,9 +16,9 @@
 
 #include "cuttlefish/common/libs/utils/uuid.h"
 
-#include <uuid/uuid.h>
-
 #include <string>
+
+#include <uuid/uuid.h>
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/common/libs/utils/uuid.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/uuid.cpp
@@ -18,7 +18,7 @@
 
 #include <string>
 
-#include <uuid/uuid.h>
+#include "uuid/uuid.h"
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/common/libs/utils/vsock_connection.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/vsock_connection.cpp
@@ -32,7 +32,7 @@
 #include <vector>
 
 #include "absl/log/log.h"
-#include <json/json.h>
+#include "json/json.h"
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_select.h"

--- a/base/cvd/cuttlefish/common/libs/utils/vsock_connection.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/vsock_connection.cpp
@@ -31,8 +31,8 @@
 #include <utility>
 #include <vector>
 
-#include <json/json.h>
 #include "absl/log/log.h"
+#include <json/json.h>
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_select.h"

--- a/base/cvd/cuttlefish/common/libs/utils/vsock_connection.h
+++ b/base/cvd/cuttlefish/common/libs/utils/vsock_connection.h
@@ -23,7 +23,7 @@
 #include <string>
 #include <vector>
 
-#include <json/json.h>
+#include "json/json.h"
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 

--- a/base/cvd/cuttlefish/common/libs/utils/wait_for_file.cc
+++ b/base/cvd/cuttlefish/common/libs/utils/wait_for_file.cc
@@ -25,8 +25,8 @@
 #include <string>
 #include <vector>
 
-#include <android-base/file.h>
-#include <android-base/unique_fd.h>
+#include "android-base/file.h"
+#include "android-base/unique_fd.h"
 
 #include "cuttlefish/common/libs/utils/contains.h"
 #include "cuttlefish/common/libs/utils/files.h"

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/android_build/target_files.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/android_build/target_files.cc
@@ -28,10 +28,10 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/strip.h"
-#include "cuttlefish/host/commands/assemble_cvd/android_build/combined_android_build.h"
 
 #include "cuttlefish/common/libs/key_equals_value/key_equals_value.h"
 #include "cuttlefish/host/commands/assemble_cvd/android_build/android_build.h"
+#include "cuttlefish/host/commands/assemble_cvd/android_build/combined_android_build.h"
 #include "cuttlefish/host/commands/assemble_cvd/android_build/find_build_archive.h"
 #include "cuttlefish/host/commands/assemble_cvd/android_build/misc_info_metadata.h"
 #include "cuttlefish/host/libs/config/build_archive.h"

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/create_dynamic_disk_files.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/create_dynamic_disk_files.cc
@@ -21,9 +21,9 @@
 #include <memory>
 #include <string>
 
-#include <gflags/gflags.h>
 #include "absl/log/log.h"
 #include "absl/strings/match.h"
+#include <gflags/gflags.h>
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/commands/assemble_cvd/android_build/android_builds.h"

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/create_dynamic_disk_files.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/create_dynamic_disk_files.cc
@@ -23,7 +23,7 @@
 
 #include "absl/log/log.h"
 #include "absl/strings/match.h"
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/commands/assemble_cvd/android_build/android_builds.h"

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/gem5_image_unpacker.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/gem5_image_unpacker.cpp
@@ -17,7 +17,7 @@
 #include "cuttlefish/host/commands/assemble_cvd/disk/gem5_image_unpacker.h"
 
 #include "absl/log/log.h"
-#include <android-base/file.h>
+#include "android-base/file.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/commands/assemble_cvd/boot_image_utils.h"

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/gem5_image_unpacker.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/gem5_image_unpacker.cpp
@@ -16,8 +16,8 @@
 
 #include "cuttlefish/host/commands/assemble_cvd/disk/gem5_image_unpacker.h"
 
-#include <android-base/file.h>
 #include "absl/log/log.h"
+#include <android-base/file.h>
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/commands/assemble_cvd/boot_image_utils.h"

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk_builder.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk_builder.cpp
@@ -19,8 +19,8 @@
 #include <string>
 #include <vector>
 
-#include <android-base/file.h>
 #include "absl/log/log.h"
+#include <android-base/file.h>
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/libs/config/vmm_mode.h"

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk_builder.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk_builder.cpp
@@ -20,7 +20,7 @@
 #include <vector>
 
 #include "absl/log/log.h"
-#include <android-base/file.h>
+#include "android-base/file.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/libs/config/vmm_mode.h"

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/blank_data_image_mb.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/blank_data_image_mb.cc
@@ -19,7 +19,7 @@
 #include <utility>
 #include <vector>
 
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/host/commands/assemble_cvd/flags/flag_base.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags/from_gflags.h"

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/build_super_image.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/build_super_image.cc
@@ -19,7 +19,7 @@
 #include <utility>
 #include <vector>
 
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/host/commands/assemble_cvd/flags/flag_base.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags/from_gflags.h"

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/cpus.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/cpus.cc
@@ -19,7 +19,7 @@
 #include <utility>
 #include <vector>
 
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/host/commands/assemble_cvd/flags/flag_base.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags/from_gflags.h"

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/daemon.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/daemon.cc
@@ -19,7 +19,7 @@
 #include <utility>
 #include <vector>
 
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/host/commands/assemble_cvd/flags/flag_base.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags/from_gflags.h"

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/data_policy.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/data_policy.cc
@@ -21,7 +21,7 @@
 #include <utility>
 #include <vector>
 
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/host/commands/assemble_cvd/flags/flag_base.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags/from_gflags.h"

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/display_proto.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/display_proto.cc
@@ -19,9 +19,9 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/format.h>
-#include <gflags/gflags.h>
-#include <google/protobuf/text_format.h>
+#include "fmt/format.h"
+#include "gflags/gflags.h"
+#include "google/protobuf/text_format.h"
 
 #include "cuttlefish/common/libs/utils/base64.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags_defaults.h"

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/extra_kernel_cmdline.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/extra_kernel_cmdline.cc
@@ -20,7 +20,7 @@
 #include <utility>
 #include <vector>
 
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/host/commands/assemble_cvd/flags/flag_base.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags_defaults.h"

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/gpu_mode.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/gpu_mode.cc
@@ -20,7 +20,7 @@
 #include <utility>
 #include <vector>
 
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/host/commands/assemble_cvd/flags/flag_base.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags/from_gflags.h"

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/guest_enforce_security.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/guest_enforce_security.cc
@@ -19,8 +19,8 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/format.h>
-#include <gflags/gflags.h>
+#include "fmt/format.h"
+#include "gflags/gflags.h"
 
 #include "cuttlefish/host/commands/assemble_cvd/flags/flag_base.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags/from_gflags.h"

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/memory_mb.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/memory_mb.cc
@@ -20,7 +20,7 @@
 #include <utility>
 #include <vector>
 
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/host/commands/assemble_cvd/flags/flag_base.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags/from_gflags.h"

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/required_directories.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/required_directories.cc
@@ -16,6 +16,7 @@
 #include "cuttlefish/host/commands/assemble_cvd/required_directories.h"
 
 #include <unistd.h>
+
 #include <string>
 #include <vector>
 

--- a/base/cvd/cuttlefish/host/commands/casimir_control_server/casimir_controller.cpp
+++ b/base/cvd/cuttlefish/host/commands/casimir_control_server/casimir_controller.cpp
@@ -17,12 +17,12 @@
 #include "cuttlefish/host/commands/casimir_control_server/casimir_controller.h"
 
 #include <fcntl.h>
+
 #include <chrono>
 #include <cstdint>
 
-#include "cuttlefish/host/commands/casimir_control_server/crc.h"
-
 #include "cuttlefish/host/commands/casimir_control_server/casimir_control.grpc.pb.h"
+#include "cuttlefish/host/commands/casimir_control_server/crc.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/commands/casimir_control_server/casimir_controller.h
+++ b/base/cvd/cuttlefish/host/commands/casimir_control_server/casimir_controller.h
@@ -20,9 +20,8 @@
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"
-#include "cuttlefish/result/result.h"
-
 #include "cuttlefish/host/commands/casimir_control_server/rf_packets.h"
+#include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/commands/control_env_proxy_server/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/control_env_proxy_server/main.cpp
@@ -20,11 +20,11 @@
 #include <memory>
 #include <string>
 
-#include <gflags/gflags.h>
-#include <grpcpp/ext/proto_server_reflection_plugin.h>
-#include <grpcpp/grpcpp.h>
-#include <grpcpp/health_check_service_interface.h>
-#include <json/json.h>
+#include "gflags/gflags.h"
+#include "grpcpp/ext/proto_server_reflection_plugin.h"
+#include "grpcpp/grpcpp.h"
+#include "grpcpp/health_check_service_interface.h"
+#include "json/json.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/commands/control_env_proxy_server/control_env_proxy.grpc.pb.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/cache.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/cache.cpp
@@ -23,11 +23,11 @@
 #include <string_view>
 #include <vector>
 
-#include <fmt/base.h>
-#include <fmt/core.h>
-#include <fmt/format.h>
-#include <fmt/ranges.h>
-#include <json/value.h>
+#include "fmt/base.h"
+#include "fmt/core.h"
+#include "fmt/format.h"
+#include "fmt/ranges.h"
+#include "json/value.h"
 
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/flag_parser/gflags_compat.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.cpp
@@ -21,9 +21,9 @@
 #include <utility>
 #include <vector>
 
+#include "absl/log/log.h"
 #include <fmt/core.h>
 #include <fmt/format.h>
-#include "absl/log/log.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/tee_logging.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.cpp
@@ -22,8 +22,8 @@
 #include <vector>
 
 #include "absl/log/log.h"
-#include <fmt/core.h>
-#include <fmt/format.h>
+#include "fmt/core.h"
+#include "fmt/format.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/tee_logging.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fleet.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fleet.cpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <vector>
 
-#include <json/value.h>
+#include "json/value.h"
 
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/logs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/logs.cpp
@@ -1,6 +1,5 @@
 #include "cuttlefish/host/commands/cvd/cli/commands/logs.h"
 
-#include <android-base/file.h>
 #include <unistd.h>
 
 #include <algorithm>
@@ -12,6 +11,8 @@
 #include <vector>
 
 #include "absl/log/log.h"
+#include <android-base/file.h>
+
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/flag_parser/gflags_compat.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/logs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/logs.cpp
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include "absl/log/log.h"
-#include <android-base/file.h>
+#include "android-base/file.h"
 
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/flag_parser/gflags_compat.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/snapshot.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/snapshot.cpp
@@ -19,14 +19,14 @@
 #include <signal.h>  // IWYU pragma: keep
 #include <stdlib.h>
 
-#include <android-base/file.h>
-#include "absl/log/log.h"
-
 #include <iostream>
 #include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
+
+#include "absl/log/log.h"
+#include <android-base/file.h>
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/snapshot.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/snapshot.cpp
@@ -26,7 +26,7 @@
 #include <vector>
 
 #include "absl/log/log.h"
-#include <android-base/file.h>
+#include "android-base/file.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/status.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/status.cpp
@@ -24,9 +24,9 @@
 #include <utility>
 #include <vector>
 
-#include <json/value.h>
 #include "absl/strings/numbers.h"
 #include "absl/strings/strip.h"
+#include <json/value.h>
 
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/flag_parser/gflags_compat.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/status.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/status.cpp
@@ -26,7 +26,7 @@
 
 #include "absl/strings/numbers.h"
 #include "absl/strings/strip.h"
-#include <json/value.h>
+#include "json/value.h"
 
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/flag_parser/gflags_compat.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser.cpp
@@ -19,7 +19,7 @@
 #include <string>
 #include <vector>
 
-#include <android-base/file.h>
+#include "android-base/file.h"
 
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector_common_parser.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser_test.cpp
@@ -18,7 +18,7 @@
 #include <string>
 #include <vector>
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 #include "cuttlefish/host/commands/cvd/cli/selector/selector_common_parser.h"
 #include "cuttlefish/result/result_matchers.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/frontline_parser_test.cpp
@@ -13,12 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "cuttlefish/host/commands/cvd/cli/frontline_parser.h"
+
 #include <string>
 #include <vector>
 
 #include <gtest/gtest.h>
 
-#include "cuttlefish/host/commands/cvd/cli/frontline_parser.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector_common_parser.h"
 #include "cuttlefish/result/result_matchers.h"
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/cf_configs_common.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/cf_configs_common.cpp
@@ -18,8 +18,8 @@
 #include <string>
 #include <vector>
 
-#include <fmt/format.h>
-#include <json/json.h>
+#include "fmt/format.h"
+#include "json/json.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/cf_configs_common.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/cf_configs_common.h
@@ -20,10 +20,10 @@
 #include <type_traits>
 #include <vector>
 
-#include <fmt/format.h>
-#include <fmt/ranges.h>  // NOLINT(misc-include-cleaner): version difference
-#include <google/protobuf/message.h>
-#include <json/json.h>
+#include "fmt/format.h"
+#include "fmt/ranges.h"  // NOLINT(misc-include-cleaner): version difference
+#include "google/protobuf/message.h"
+#include "json/json.h"
 
 #include "cuttlefish/host/commands/cvd/cli/parser/load_config.pb.h"
 #include "cuttlefish/result/result.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/cf_flags_validator.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/cf_flags_validator.cpp
@@ -18,8 +18,8 @@
 
 #include <sstream>
 
-#include <google/protobuf/util/json_util.h>
-#include <json/value.h>
+#include "google/protobuf/util/json_util.h"
+#include "json/value.h"
 
 #include "cuttlefish/host/commands/cvd/cli/parser/load_config.pb.h"
 #include "cuttlefish/result/result.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/configs_inheritance_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/configs_inheritance_test.cc
@@ -16,8 +16,8 @@
 
 #include <string>
 
-#include <android-base/file.h>
-#include <gtest/gtest.h>
+#include "android-base/file.h"
+#include "gtest/gtest.h"
 
 #include "cuttlefish/host/commands/cvd/cli/parser/cf_configs_common.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/test_common.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/boot_configs_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/boot_configs_test.cc
@@ -16,7 +16,7 @@
 
 #include <string>
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 #include "cuttlefish/host/commands/cvd/cli/parser/test_common.h"
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_security_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_security_configs.cpp
@@ -18,7 +18,7 @@
 #include <string>
 #include <vector>
 
-#include <fmt/format.h>
+#include "fmt/format.h"
 
 #include "cuttlefish/host/commands/assemble_cvd/flags_defaults.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/cf_configs_common.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_vm_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_vm_configs.cpp
@@ -22,7 +22,7 @@
 #include <utility>
 #include <vector>
 
-#include <google/protobuf/util/json_util.h>
+#include "google/protobuf/util/json_util.h"
 
 #include "cuttlefish/common/libs/utils/flags_validator.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags_defaults.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_vm_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_vm_configs.cpp
@@ -15,13 +15,14 @@
  */
 #include "cuttlefish/host/commands/cvd/cli/parser/instance/cf_vm_configs.h"
 
-#include <google/protobuf/util/json_util.h>
 #include <stdint.h>
 
 #include <optional>
 #include <string>
 #include <utility>
 #include <vector>
+
+#include <google/protobuf/util/json_util.h>
 
 #include "cuttlefish/common/libs/utils/flags_validator.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags_defaults.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/disk_configs_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/disk_configs_test.cc
@@ -16,7 +16,7 @@
 
 #include <string>
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 #include "cuttlefish/host/commands/cvd/cli/parser/test_common.h"
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/launch_cvd_templates.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/launch_cvd_templates.cpp
@@ -20,8 +20,8 @@
 #include <string>
 #include <string_view>
 
-#include <google/protobuf/util/json_util.h>
-#include <json/value.h>
+#include "google/protobuf/util/json_util.h"
+#include "json/value.h"
 
 #include "cuttlefish/common/libs/utils/json.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/cf_configs_common.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/metrics_configs_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/metrics_configs_test.cc
@@ -16,9 +16,9 @@
 
 #include <string>
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-#include <json/value.h>
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "json/value.h"
 
 #include "cuttlefish/host/commands/cvd/cli/parser/test_common.h"
 #include "cuttlefish/result/result.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/test_common.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/test_common.cc
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
+#include "cuttlefish/host/commands/cvd/cli/parser/test_common.h"
+
 #include <algorithm>
 #include <string>
 #include <vector>
 
 #include "cuttlefish/host/commands/cvd/cli/parser/cf_flags_validator.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/launch_cvd_parser.h"
-#include "cuttlefish/host/commands/cvd/cli/parser/test_common.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/test_common.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/test_common.h
@@ -17,7 +17,7 @@
 #include <string>
 #include <vector>
 
-#include <json/value.h>
+#include "json/value.h"
 
 #include "cuttlefish/result/result.h"
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/host_tool_target_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/host_tool_target_test.cpp
@@ -13,12 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "cuttlefish/host/commands/cvd/cli/commands/host_tool_target.h"
+
 #include <string>
 
 #include <gtest/gtest.h>
 
 #include "cuttlefish/common/libs/utils/environment.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/host_tool_target.h"
 #include "cuttlefish/result/result_matchers.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/host_tool_target_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/host_tool_target_test.cpp
@@ -17,7 +17,7 @@
 
 #include <string>
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 #include "cuttlefish/common/libs/utils/environment.h"
 #include "cuttlefish/result/result_matchers.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/num_instances_parser_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/num_instances_parser_test.cpp
@@ -16,7 +16,7 @@
 
 #include "cuttlefish/host/commands/cvd/cli/selector/num_instances_parser.h"
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector_common_parser.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/num_instances_parser_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/num_instances_parser_test.cpp
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
+#include "cuttlefish/host/commands/cvd/cli/selector/num_instances_parser.h"
+
 #include <gtest/gtest.h>
 
 #include "cuttlefish/flag_parser/flag.h"
-#include "cuttlefish/host/commands/cvd/cli/selector/num_instances_parser.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector_common_parser.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/result/result_matchers.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/downloaders_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/downloaders_test.cpp
@@ -18,10 +18,10 @@
 #include <fstream>
 #include <string>
 
+#include "android-base/file.h"
 #include "fmt/core.h"
-#include <android-base/file.h>
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/commands/cvd/fetch/fetch_cvd_parser.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/downloaders_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/downloaders_test.cpp
@@ -13,16 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "cuttlefish/host/commands/cvd/fetch/downloaders.h"
+
 #include <fstream>
 #include <string>
 
+#include "fmt/core.h"
 #include <android-base/file.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include "fmt/core.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
-#include "cuttlefish/host/commands/cvd/fetch/downloaders.h"
 #include "cuttlefish/host/commands/cvd/fetch/fetch_cvd_parser.h"
 #include "cuttlefish/result/result.h"
 #include "cuttlefish/result/result_matchers.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_context.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_context.cc
@@ -26,9 +26,9 @@
 
 #include "absl/strings/match.h"
 #include "absl/strings/strip.h"
-#include <android-base/file.h>
-#include <fmt/format.h>
-#include <fmt/ranges.h>
+#include "android-base/file.h"
+#include "fmt/format.h"
+#include "fmt/ranges.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/commands/cvd/fetch/builds.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_context.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_context.cc
@@ -24,11 +24,11 @@
 #include <variant>
 #include <vector>
 
+#include "absl/strings/match.h"
+#include "absl/strings/strip.h"
 #include <android-base/file.h>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
-#include "absl/strings/match.h"
-#include "absl/strings/strip.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/commands/cvd/fetch/builds.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd_parser_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd_parser_test.cpp
@@ -18,8 +18,8 @@
 #include <string>
 #include <vector>
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 #include "cuttlefish/result/result.h"
 #include "cuttlefish/result/result_matchers.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_tracer.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_tracer.cpp
@@ -26,7 +26,7 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/format.h>
+#include "fmt/format.h"
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/host_package.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/host_package.cc
@@ -22,7 +22,7 @@
 #include <vector>
 
 #include "absl/log/log.h"
-#include <android-base/file.h>
+#include "android-base/file.h"
 
 #include "cuttlefish/common/libs/utils/archive.h"
 #include "cuttlefish/common/libs/utils/files.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/host_package.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/host_package.cc
@@ -15,7 +15,6 @@
 
 #include "cuttlefish/host/commands/cvd/fetch/host_package.h"
 
-#include <android-base/file.h>
 #include <sys/stat.h>
 
 #include <optional>
@@ -23,6 +22,7 @@
 #include <vector>
 
 #include "absl/log/log.h"
+#include <android-base/file.h>
 
 #include "cuttlefish/common/libs/utils/archive.h"
 #include "cuttlefish/common/libs/utils/files.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/config_path.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/config_path.cpp
@@ -16,7 +16,7 @@
 
 #include "cuttlefish/host/commands/cvd/instances/config_path.h"
 
-#include <android-base/file.h>
+#include "android-base/file.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_database_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_database_test.cpp
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "cuttlefish/host/commands/cvd/instances/instance_database.h"
+
 #include <iostream>
 #include <optional>
 #include <string>
@@ -23,7 +25,6 @@
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/json.h"
-#include "cuttlefish/host/commands/cvd/instances/instance_database.h"
 #include "cuttlefish/host/commands/cvd/instances/instance_database_helper.h"
 #include "cuttlefish/host/commands/cvd/instances/local_instance_group.h"
 #include "cuttlefish/result/result_matchers.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/instance_database_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/instance_database_test.cpp
@@ -21,7 +21,7 @@
 #include <utility>
 #include <vector>
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/json.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/local_instance_group_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/local_instance_group_test.cpp
@@ -18,7 +18,7 @@
 #include <string>
 #include <vector>
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 #include "cuttlefish/host/commands/cvd/instances/cvd_persistent_data.pb.h"
 #include "cuttlefish/result/result_matchers.h"

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/local_instance_group_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/local_instance_group_test.cpp
@@ -13,13 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "cuttlefish/host/commands/cvd/instances/local_instance_group.h"
+
 #include <string>
 #include <vector>
 
 #include <gtest/gtest.h>
 
 #include "cuttlefish/host/commands/cvd/instances/cvd_persistent_data.pb.h"
-#include "cuttlefish/host/commands/cvd/instances/local_instance_group.h"
 #include "cuttlefish/result/result_matchers.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/local_instance_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/local_instance_test.cpp
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 #include "cuttlefish/host/commands/cvd/instances/local_instance_group.h"
 

--- a/base/cvd/cuttlefish/host/commands/cvd/version/version.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/version/version.cpp
@@ -18,7 +18,7 @@
 
 #include <string>
 
-#include <fmt/format.h>
+#include "fmt/format.h"
 
 #include "cuttlefish/host/libs/version/version.h"
 

--- a/base/cvd/cuttlefish/host/commands/cvd_import_locations/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_import_locations/main.cc
@@ -16,9 +16,9 @@
 
 #include <thread>
 
-#include <gflags/gflags.h>
 #include "absl/log/check.h"
 #include "absl/log/log.h"
+#include <gflags/gflags.h>
 
 #include "cuttlefish/common/libs/utils/tee_logging.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"

--- a/base/cvd/cuttlefish/host/commands/cvd_import_locations/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_import_locations/main.cc
@@ -18,7 +18,7 @@
 
 #include "absl/log/check.h"
 #include "absl/log/log.h"
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/common/libs/utils/tee_logging.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"

--- a/base/cvd/cuttlefish/host/commands/cvd_import_locations/unittest/gpx_parser_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_import_locations/unittest/gpx_parser_test.cc
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+#include <fstream>
+
 #include <android-base/file.h>
 #include <gtest/gtest.h>
-#include <fstream>
+
 #include "cuttlefish/host/libs/location/GpsFix.h"
 #include "cuttlefish/host/libs/location/GpxParser.h"
 #include "cuttlefish/host/libs/location/StringParse.h"

--- a/base/cvd/cuttlefish/host/commands/cvd_import_locations/unittest/gpx_parser_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_import_locations/unittest/gpx_parser_test.cc
@@ -16,8 +16,8 @@
 
 #include <fstream>
 
-#include <android-base/file.h>
-#include <gtest/gtest.h>
+#include "android-base/file.h"
+#include "gtest/gtest.h"
 
 #include "cuttlefish/host/libs/location/GpsFix.h"
 #include "cuttlefish/host/libs/location/GpxParser.h"

--- a/base/cvd/cuttlefish/host/commands/cvd_import_locations/unittest/kml_parser_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_import_locations/unittest/kml_parser_test.cc
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+#include <fstream>
+
 #include <android-base/file.h>
 #include <gtest/gtest.h>
-#include <fstream>
+
 #include "cuttlefish/host/libs/location/GpsFix.h"
 #include "cuttlefish/host/libs/location/KmlParser.h"
 #include "cuttlefish/host/libs/location/StringParse.h"

--- a/base/cvd/cuttlefish/host/commands/cvd_import_locations/unittest/kml_parser_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_import_locations/unittest/kml_parser_test.cc
@@ -16,8 +16,8 @@
 
 #include <fstream>
 
-#include <android-base/file.h>
-#include <gtest/gtest.h>
+#include "android-base/file.h"
+#include "gtest/gtest.h"
 
 #include "cuttlefish/host/libs/location/GpsFix.h"
 #include "cuttlefish/host/libs/location/KmlParser.h"

--- a/base/cvd/cuttlefish/host/commands/cvd_send_id_disclosure/cellular_identifier_disclosure_command_builder.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_send_id_disclosure/cellular_identifier_disclosure_command_builder.cc
@@ -18,7 +18,7 @@
 
 #include <string>
 
-#include <fmt/format.h>
+#include "fmt/format.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/commands/cvd_send_id_disclosure/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_send_id_disclosure/main.cc
@@ -16,8 +16,8 @@
 
 #include <string>
 
-#include <gflags/gflags.h>
 #include "absl/log/log.h"
+#include <gflags/gflags.h>
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"

--- a/base/cvd/cuttlefish/host/commands/cvd_send_id_disclosure/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_send_id_disclosure/main.cc
@@ -17,7 +17,7 @@
 #include <string>
 
 #include "absl/log/log.h"
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"

--- a/base/cvd/cuttlefish/host/commands/cvd_send_id_disclosure/unittest/cellular_identifier_disclosure_command_builder_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_send_id_disclosure/unittest/cellular_identifier_disclosure_command_builder_test.cc
@@ -15,7 +15,7 @@
 
 #include "cuttlefish/host/commands/cvd_send_id_disclosure/cellular_identifier_disclosure_command_builder.h"
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 TEST(CommandBuilderTest, GetATCommand) {
   std::string serialized = cuttlefish::GetATCommand("001001", 2, 3, false);

--- a/base/cvd/cuttlefish/host/commands/cvd_send_sms/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_send_sms/main.cc
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <gflags/gflags.h>
 #include "absl/log/log.h"
+#include <gflags/gflags.h>
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/host/commands/cvd_send_sms/sms_sender.h"

--- a/base/cvd/cuttlefish/host/commands/cvd_send_sms/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_send_sms/main.cc
@@ -15,7 +15,7 @@
  */
 
 #include "absl/log/log.h"
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/host/commands/cvd_send_sms/sms_sender.h"

--- a/base/cvd/cuttlefish/host/commands/cvd_send_sms/sms_sender.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_send_sms/sms_sender.cc
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "absl/log/log.h"
+
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/host/commands/cvd_send_sms/pdu_format_builder.h"
 

--- a/base/cvd/cuttlefish/host/commands/cvd_send_sms/unittest/pdu_format_builder_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_send_sms/unittest/pdu_format_builder_test.cc
@@ -15,7 +15,7 @@
 
 #include "cuttlefish/host/commands/cvd_send_sms/pdu_format_builder.h"
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/host/commands/cvd_send_sms/unittest/sms_sender_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_send_sms/unittest/sms_sender_test.cc
@@ -18,8 +18,8 @@
 #include <sstream>
 
 #include "absl/log/check.h"
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 

--- a/base/cvd/cuttlefish/host/commands/cvd_send_sms/unittest/sms_sender_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_send_sms/unittest/sms_sender_test.cc
@@ -17,9 +17,9 @@
 
 #include <sstream>
 
+#include "absl/log/check.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include "absl/log/check.h"
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 

--- a/base/cvd/cuttlefish/host/commands/cvd_update_location/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_update_location/main.cc
@@ -19,9 +19,9 @@
 
 #include "absl/log/check.h"
 #include "absl/log/log.h"
-#include <gflags/gflags.h>
-#include <grpc/grpc.h>
-#include <grpcpp/create_channel.h>
+#include "gflags/gflags.h"
+#include "grpc/grpc.h"
+#include "grpcpp/create_channel.h"
 
 #include "cuttlefish/common/libs/utils/tee_logging.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"

--- a/base/cvd/cuttlefish/host/commands/cvd_update_location/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_update_location/main.cc
@@ -17,11 +17,11 @@
 #include <ostream>
 #include <string>
 
+#include "absl/log/check.h"
+#include "absl/log/log.h"
 #include <gflags/gflags.h>
 #include <grpc/grpc.h>
 #include <grpcpp/create_channel.h>
-#include "absl/log/check.h"
-#include "absl/log/log.h"
 
 #include "cuttlefish/common/libs/utils/tee_logging.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"

--- a/base/cvd/cuttlefish/host/commands/cvd_update_security_algorithm/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_update_security_algorithm/main.cc
@@ -16,8 +16,8 @@
 
 #include <string>
 
-#include <gflags/gflags.h>
 #include "absl/log/log.h"
+#include <gflags/gflags.h>
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"

--- a/base/cvd/cuttlefish/host/commands/cvd_update_security_algorithm/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_update_security_algorithm/main.cc
@@ -17,7 +17,7 @@
 #include <string>
 
 #include "absl/log/log.h"
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"

--- a/base/cvd/cuttlefish/host/commands/cvd_update_security_algorithm/unittest/update_security_algorithm_command_builder_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_update_security_algorithm/unittest/update_security_algorithm_command_builder_test.cc
@@ -15,7 +15,7 @@
 
 #include "cuttlefish/host/commands/cvd_update_security_algorithm/update_security_algorithm_command_builder.h"
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 TEST(CommandBuilderTest, GetATCommand) {
   std::string serialized = cuttlefish::GetATCommand(1, 2, 3, false);

--- a/base/cvd/cuttlefish/host/commands/cvd_update_security_algorithm/update_security_algorithm_command_builder.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd_update_security_algorithm/update_security_algorithm_command_builder.cc
@@ -18,7 +18,7 @@
 
 #include <string>
 
-#include <fmt/format.h>
+#include "fmt/format.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/commands/echo_server/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/echo_server/main.cpp
@@ -21,10 +21,10 @@
 #include <memory>
 #include <string>
 
-#include <gflags/gflags.h>
-#include <grpcpp/ext/proto_server_reflection_plugin.h>
-#include <grpcpp/grpcpp.h>
-#include <grpcpp/health_check_service_interface.h>
+#include "gflags/gflags.h"
+#include "grpcpp/ext/proto_server_reflection_plugin.h"
+#include "grpcpp/grpcpp.h"
+#include "grpcpp/health_check_service_interface.h"
 
 #include "cuttlefish/host/commands/echo_server/echo.grpc.pb.h"
 

--- a/base/cvd/cuttlefish/host/commands/health/health.cpp
+++ b/base/cvd/cuttlefish/host/commands/health/health.cpp
@@ -15,10 +15,11 @@
  */
 
 #include <stdlib.h>
+
 #include <iostream>
 
-#include <gflags/gflags.h>
 #include "absl/log/log.h"
+#include <gflags/gflags.h>
 
 #include "cuttlefish/common/libs/utils/subprocess.h"
 #include "cuttlefish/common/libs/utils/subprocess_managed_stdio.h"

--- a/base/cvd/cuttlefish/host/commands/health/health.cpp
+++ b/base/cvd/cuttlefish/host/commands/health/health.cpp
@@ -19,7 +19,7 @@
 #include <iostream>
 
 #include "absl/log/log.h"
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/common/libs/utils/subprocess.h"
 #include "cuttlefish/common/libs/utils/subprocess_managed_stdio.h"

--- a/base/cvd/cuttlefish/host/commands/metrics/debug_reader.cc
+++ b/base/cvd/cuttlefish/host/commands/metrics/debug_reader.cc
@@ -18,7 +18,7 @@
 
 #include <string>
 
-#include <google/protobuf/text_format.h>
+#include "google/protobuf/text_format.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/result/result.h"

--- a/base/cvd/cuttlefish/host/commands/metrics/metrics.cc
+++ b/base/cvd/cuttlefish/host/commands/metrics/metrics.cc
@@ -13,10 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gflags/gflags.h>
-
 #include "absl/log/check.h"
 #include "absl/log/log.h"
+#include <gflags/gflags.h>
 
 #include "cuttlefish/common/libs/utils/tee_logging.h"
 #include "cuttlefish/host/commands/metrics/host_receiver.h"

--- a/base/cvd/cuttlefish/host/commands/metrics/metrics.cc
+++ b/base/cvd/cuttlefish/host/commands/metrics/metrics.cc
@@ -15,7 +15,7 @@
 
 #include "absl/log/check.h"
 #include "absl/log/log.h"
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/common/libs/utils/tee_logging.h"
 #include "cuttlefish/host/commands/metrics/host_receiver.h"

--- a/base/cvd/cuttlefish/host/commands/metrics/utils_tests.cpp
+++ b/base/cvd/cuttlefish/host/commands/metrics/utils_tests.cpp
@@ -16,7 +16,7 @@
 
 #include <string>
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 #include "cuttlefish/host/commands/metrics/utils.h"
 

--- a/base/cvd/cuttlefish/host/commands/metrics_launcher/metrics_launcher.cpp
+++ b/base/cvd/cuttlefish/host/commands/metrics_launcher/metrics_launcher.cpp
@@ -18,8 +18,8 @@
 #include <iostream>
 #include <string>
 
-#include <gflags/gflags.h>
 #include "absl/log/log.h"
+#include <gflags/gflags.h>
 
 #include "cuttlefish/common/libs/utils/tee_logging.h"
 #include "cuttlefish/host/libs/metrics/metrics_receiver.h"

--- a/base/cvd/cuttlefish/host/commands/metrics_launcher/metrics_launcher.cpp
+++ b/base/cvd/cuttlefish/host/commands/metrics_launcher/metrics_launcher.cpp
@@ -19,7 +19,7 @@
 #include <string>
 
 #include "absl/log/log.h"
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/common/libs/utils/tee_logging.h"
 #include "cuttlefish/host/libs/metrics/metrics_receiver.h"

--- a/base/cvd/cuttlefish/host/commands/mkenvimage_slim/mkenvimage_slim.cc
+++ b/base/cvd/cuttlefish/host/commands/mkenvimage_slim/mkenvimage_slim.cc
@@ -17,13 +17,14 @@
 // https://github.com/u-boot/u-boot/blob/master/tools/mkenvimage.c The bare
 // minimum amount of functionality for our application is replicated.
 
+#include "cuttlefish/host/libs/config/mkenvimage_slim.h"
+
 #include <stdlib.h>
 
 #include "absl/log/log.h"
 #include "gflags/gflags.h"
 
 #include "cuttlefish/common/libs/utils/tee_logging.h"
-#include "cuttlefish/host/libs/config/mkenvimage_slim.h"
 #include "cuttlefish/result/result.h"
 
 DEFINE_int32(env_size, 4096, "file size of resulting env");

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/misc_service.h
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/misc_service.h
@@ -15,9 +15,9 @@
 
 #pragma once
 
-#include "cuttlefish/host/commands/modem_simulator/modem_service.h"
-
 #include <ctime>
+
+#include "cuttlefish/host/commands/modem_simulator/modem_service.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/nvram_config.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/nvram_config.cpp
@@ -15,11 +15,11 @@
 
 #include "cuttlefish/host/commands/modem_simulator/nvram_config.h"
 
-#include <json/json.h>
-#include "absl/log/log.h"
-
 #include <fstream>
 #include <mutex>
+
+#include "absl/log/log.h"
+#include <json/json.h>
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/commands/modem_simulator/device_config.h"

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/nvram_config.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/nvram_config.cpp
@@ -19,7 +19,7 @@
 #include <mutex>
 
 #include "absl/log/log.h"
-#include <json/json.h>
+#include "json/json.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/commands/modem_simulator/device_config.h"

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/nvram_config.h
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/nvram_config.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <json/json.h>
+#include "json/json.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/unittest/command_parser_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/unittest/command_parser_test.cpp
@@ -15,7 +15,7 @@
 
 #include "cuttlefish/host/commands/modem_simulator/command_parser.h"
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 TEST(CommandParserUnitTest, SkipPrefix) {
   std::string command = "AT+SPUSATENVECMD=\"D3078202018190014E\"";

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/unittest/pdu_parser_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/unittest/pdu_parser_test.cpp
@@ -15,7 +15,7 @@
 
 #include "cuttlefish/host/commands/modem_simulator/pdu_parser.h"
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 TEST(PDUParserTest, IsValidPDU_true) {
   std::string pdu =

--- a/base/cvd/cuttlefish/host/commands/openwrt_control_server/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/openwrt_control_server/main.cpp
@@ -22,13 +22,13 @@
 #include <regex>
 #include <string>
 
+#include "absl/strings/match.h"
 #include <fmt/format.h>
 #include <gflags/gflags.h>
 #include <google/protobuf/empty.pb.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
-#include "absl/strings/match.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/commands/openwrt_control_server/openwrt_control.grpc.pb.h"

--- a/base/cvd/cuttlefish/host/commands/openwrt_control_server/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/openwrt_control_server/main.cpp
@@ -23,12 +23,12 @@
 #include <string>
 
 #include "absl/strings/match.h"
-#include <fmt/format.h>
-#include <gflags/gflags.h>
-#include <google/protobuf/empty.pb.h>
-#include <grpcpp/ext/proto_server_reflection_plugin.h>
-#include <grpcpp/grpcpp.h>
-#include <grpcpp/health_check_service_interface.h>
+#include "fmt/format.h"
+#include "gflags/gflags.h"
+#include "google/protobuf/empty.pb.h"
+#include "grpcpp/ext/proto_server_reflection_plugin.h"
+#include "grpcpp/grpcpp.h"
+#include "grpcpp/health_check_service_interface.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/commands/openwrt_control_server/openwrt_control.grpc.pb.h"

--- a/base/cvd/cuttlefish/host/commands/powerbtn_cvd/powerbtn_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/powerbtn_cvd/powerbtn_cvd.cc
@@ -17,7 +17,7 @@
 #include <cstdlib>
 
 #include "absl/log/log.h"
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/common/libs/utils/subprocess.h"
 #include "cuttlefish/common/libs/utils/subprocess_managed_stdio.h"

--- a/base/cvd/cuttlefish/host/commands/powerbtn_cvd/powerbtn_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/powerbtn_cvd/powerbtn_cvd.cc
@@ -16,8 +16,8 @@
 
 #include <cstdlib>
 
-#include <gflags/gflags.h>
 #include "absl/log/log.h"
+#include <gflags/gflags.h>
 
 #include "cuttlefish/common/libs/utils/subprocess.h"
 #include "cuttlefish/common/libs/utils/subprocess_managed_stdio.h"

--- a/base/cvd/cuttlefish/host/commands/powerwash_cvd/powerwash_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/powerwash_cvd/powerwash_cvd.cc
@@ -18,7 +18,7 @@
 #include <cstdlib>
 
 #include "absl/log/log.h"
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/tee_logging.h"

--- a/base/cvd/cuttlefish/host/commands/powerwash_cvd/powerwash_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/powerwash_cvd/powerwash_cvd.cc
@@ -17,8 +17,8 @@
 #include <cstdint>
 #include <cstdlib>
 
-#include <gflags/gflags.h>
 #include "absl/log/log.h"
+#include <gflags/gflags.h>
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/tee_logging.h"

--- a/base/cvd/cuttlefish/host/commands/process_restarter/main.cc
+++ b/base/cvd/cuttlefish/host/commands/process_restarter/main.cc
@@ -23,7 +23,7 @@
 #include <vector>
 
 #include "absl/log/log.h"
-#include <fmt/ranges.h>  // NOLINT(misc-include-cleaner): version difference
+#include "fmt/ranges.h"  // NOLINT(misc-include-cleaner): version difference
 
 #include "cuttlefish/common/libs/utils/contains.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"

--- a/base/cvd/cuttlefish/host/commands/process_restarter/main.cc
+++ b/base/cvd/cuttlefish/host/commands/process_restarter/main.cc
@@ -22,8 +22,8 @@
 #include <string_view>
 #include <vector>
 
-#include <fmt/ranges.h>  // NOLINT(misc-include-cleaner): version difference
 #include "absl/log/log.h"
+#include <fmt/ranges.h>  // NOLINT(misc-include-cleaner): version difference
 
 #include "cuttlefish/common/libs/utils/contains.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/adb_connector.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/adb_connector.cpp
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <sys/socket.h>
 #include <syscall.h>
 
 #include "sandboxed_api/sandbox2/allowlists/unrestricted_networking.h"
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/assemble_cvd.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/assemble_cvd.cpp
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <linux/prctl.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
@@ -26,6 +24,8 @@
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
 #include "sandboxed_api/util/path.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/avbtool.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/avbtool.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <stdlib.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
@@ -25,10 +23,11 @@
 #include <string>
 
 #include "absl/log/check.h"
-
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
 #include "sandboxed_api/util/path.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/baseline.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/baseline.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <linux/filter.h>
 #include <sys/mman.h>
 
@@ -26,6 +24,8 @@
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
 #include "sandboxed_api/util/path.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/casimir.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/casimir.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <linux/filter.h>
 #include <netinet/ip_icmp.h>
 #include <sys/ioctl.h>
@@ -27,6 +25,8 @@
 
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/casimir_control_server.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/casimir_control_server.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <linux/filter.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
@@ -25,6 +23,8 @@
 
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/cf_vhost_user_input.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/cf_vhost_user_input.cpp
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <sys/mman.h>
 #include <syscall.h>
 
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
 #include "sandboxed_api/util/path.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/control_env_proxy_server.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/control_env_proxy_server.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <linux/filter.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
@@ -26,6 +24,8 @@
 
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/cvd_internal_start.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/cvd_internal_start.cpp
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <linux/prctl.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
@@ -24,6 +22,8 @@
 
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/echo_server.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/echo_server.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <sys/mman.h>
 #include <sys/socket.h>
 #include <syscall.h>
@@ -24,6 +22,8 @@
 
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/gnss_grpc_proxy.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/gnss_grpc_proxy.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <errno.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
@@ -23,6 +21,8 @@
 
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/kernel_log_monitor.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/kernel_log_monitor.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include "sandboxed_api/sandbox2/policybuilder.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/log_tee.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/log_tee.cpp
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <syscall.h>
 
 #include "sandboxed_api/sandbox2/policybuilder.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/logcat_receiver.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/logcat_receiver.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include "sandboxed_api/sandbox2/policybuilder.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/metrics.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/metrics.cpp
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <syscall.h>
 
 #include "sandboxed_api/sandbox2/allowlists/unrestricted_networking.h"
 #include "sandboxed_api/sandbox2/policybuilder.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/mkenvimage_slim.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/mkenvimage_slim.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include "sandboxed_api/sandbox2/policybuilder.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/modem_simulator.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/modem_simulator.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <linux/filter.h>
 #include <sys/socket.h>
 #include <syscall.h>
@@ -25,6 +23,8 @@
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
 #include "sandboxed_api/util/path.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/netsimd.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/netsimd.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <linux/filter.h>
 #include <linux/prctl.h>
 #include <netinet/in.h>
@@ -30,6 +28,8 @@
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
 #include "sandboxed_api/util/path.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/newfs_msdos.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/newfs_msdos.cpp
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <sys/syscall.h>
 
 #include "sandboxed_api/sandbox2/policybuilder.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/no_policy.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/no_policy.cpp
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <set>
 #include <string>
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/openwrt_control_server.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/openwrt_control_server.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <linux/filter.h>
 #include <netinet/tcp.h>
 #include <sys/mman.h>
@@ -27,6 +25,8 @@
 #include "sandboxed_api/sandbox2/allowlists/unrestricted_networking.h"
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/operator_proxy.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/operator_proxy.cpp
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <syscall.h>
 
 #include "sandboxed_api/sandbox2/allowlists/unrestricted_networking.h"
 #include "sandboxed_api/sandbox2/policybuilder.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/process_restarter.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/process_restarter.cpp
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <linux/prctl.h>
 #include <sys/socket.h>
 #include <syscall.h>
@@ -23,6 +21,8 @@
 
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/run_cvd.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/run_cvd.cpp
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <linux/bpf_common.h>
 #include <linux/filter.h>
 #include <linux/prctl.h>
@@ -33,6 +31,8 @@
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
 #include "sandboxed_api/util/path.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/screen_recording_server.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/screen_recording_server.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <errno.h>
 #include <linux/filter.h>
 #include <sys/mman.h>
@@ -26,6 +24,8 @@
 
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/secure_env.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/secure_env.cpp
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <syscall.h>
 
 #include <string>
 
 #include "sandboxed_api/sandbox2/policybuilder.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/simg2img.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/simg2img.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <linux/filter.h>
 #include <sys/mman.h>
 #include <syscall.h>
@@ -24,6 +22,8 @@
 
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/socket_vsock_proxy.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/socket_vsock_proxy.cpp
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <sys/socket.h>
 #include <syscall.h>
 
 #include "sandboxed_api/sandbox2/allowlists/unrestricted_networking.h"
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/tcp_connector.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/tcp_connector.cpp
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <sys/socket.h>
 #include <sys/syscall.h>
 
 #include "sandboxed_api/sandbox2/allowlists/unrestricted_networking.h"
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/tombstone_receiver.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/tombstone_receiver.cpp
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <sys/syscall.h>
 
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/util/path.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/vhost_device_vsock.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/vhost_device_vsock.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <linux/filter.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
@@ -26,6 +24,8 @@
 
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/webrtc.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/webrtc.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <linux/filter.h>
 #include <linux/prctl.h>
 #include <linux/sockios.h>
@@ -32,6 +30,8 @@
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
 #include "sandboxed_api/util/path.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/webrtc_operator.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/webrtc_operator.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <linux/filter.h>
 #include <linux/prctl.h>
 #include <netinet/ip_icmp.h>
@@ -30,6 +28,8 @@
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
 #include "sandboxed_api/util/path.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/wmediumd.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/wmediumd.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include <linux/filter.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
@@ -27,6 +25,8 @@
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/sandbox2/util/bpf_helper.h"
 #include "sandboxed_api/util/path.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/wmediumd_gen_config.cpp
+++ b/base/cvd/cuttlefish/host/commands/process_sandboxer/policies/wmediumd_gen_config.cpp
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/commands/process_sandboxer/policies.h"
-
 #include "sandboxed_api/sandbox2/policybuilder.h"
 #include "sandboxed_api/util/path.h"
+
+#include "cuttlefish/host/commands/process_sandboxer/policies.h"
 
 namespace cuttlefish::process_sandboxer {
 

--- a/base/cvd/cuttlefish/host/commands/record_cvd/record_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/record_cvd/record_cvd.cc
@@ -18,7 +18,7 @@
 #include <string>
 
 #include "absl/log/log.h"
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/common/libs/utils/tee_logging.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"

--- a/base/cvd/cuttlefish/host/commands/record_cvd/record_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/record_cvd/record_cvd.cc
@@ -17,8 +17,8 @@
 #include <cstdlib>
 #include <string>
 
-#include <gflags/gflags.h>
 #include "absl/log/log.h"
+#include <gflags/gflags.h>
 
 #include "cuttlefish/common/libs/utils/tee_logging.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"

--- a/base/cvd/cuttlefish/host/commands/restart_cvd/restart_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/restart_cvd/restart_cvd.cc
@@ -18,7 +18,7 @@
 #include <cstdlib>
 
 #include "absl/log/log.h"
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/tee_logging.h"

--- a/base/cvd/cuttlefish/host/commands/restart_cvd/restart_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/restart_cvd/restart_cvd.cc
@@ -17,8 +17,8 @@
 #include <cstdint>
 #include <cstdlib>
 
-#include <gflags/gflags.h>
 #include "absl/log/log.h"
+#include <gflags/gflags.h>
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/tee_logging.h"

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/auto_cmd.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/auto_cmd.h
@@ -22,7 +22,7 @@
 #include <utility>
 #include <vector>
 
-#include <fruit/fruit.h>
+#include "fruit/fruit.h"
 
 #include "cuttlefish/common/libs/utils/type_name.h"
 #include "cuttlefish/host/libs/feature/command_source.h"

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/control_env_proxy_server.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/control_env_proxy_server.cpp
@@ -20,9 +20,9 @@
 #include <utility>
 #include <vector>
 
-#include <fruit/component.h>
-#include <fruit/fruit_forward_decls.h>
-#include <fruit/macro.h>
+#include "fruit/component.h"
+#include "fruit/fruit_forward_decls.h"
+#include "fruit/macro.h"
 
 #include "cuttlefish/common/libs/utils/subprocess.h"
 #include "cuttlefish/host/commands/run_cvd/launch/grpc_socket_creator.h"

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/control_env_proxy_server.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/control_env_proxy_server.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <fruit/fruit.h>
+#include "fruit/fruit.h"
 
 #include "cuttlefish/host/commands/run_cvd/launch/grpc_socket_creator.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/grpc_socket_creator.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/grpc_socket_creator.h
@@ -15,9 +15,9 @@
 
 #pragma once
 
-#include <fruit/fruit.h>
-
 #include <string>
+
+#include <fruit/fruit.h>
 
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/grpc_socket_creator.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/grpc_socket_creator.h
@@ -17,7 +17,7 @@
 
 #include <string>
 
-#include <fruit/fruit.h>
+#include "fruit/fruit.h"
 
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/log_tee_creator.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/log_tee_creator.h
@@ -17,7 +17,7 @@
 
 #include <string>
 
-#include <fruit/fruit.h>
+#include "fruit/fruit.h"
 
 #include "cuttlefish/common/libs/utils/subprocess.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/netsim_server.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/netsim_server.cpp
@@ -20,9 +20,9 @@
 #include <utility>
 #include <vector>
 
-#include <fruit/component.h>
-#include <fruit/fruit_forward_decls.h>
-#include <fruit/macro.h>
+#include "fruit/component.h"
+#include "fruit/fruit_forward_decls.h"
+#include "fruit/macro.h"
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/files.h"

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/netsim_server.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/netsim_server.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <fruit/fruit.h>
+#include "fruit/fruit.h"
 
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/openwrt_control_server.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/openwrt_control_server.cpp
@@ -20,9 +20,9 @@
 #include <utility>
 #include <vector>
 
-#include <fruit/component.h>
-#include <fruit/fruit_forward_decls.h>
-#include <fruit/macro.h>
+#include "fruit/component.h"
+#include "fruit/fruit_forward_decls.h"
+#include "fruit/macro.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/openwrt_control_server.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/openwrt_control_server.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <fruit/fruit.h>
+#include "fruit/fruit.h"
 
 #include "cuttlefish/host/commands/run_cvd/launch/grpc_socket_creator.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/root_canal.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/root_canal.cpp
@@ -20,9 +20,9 @@
 #include <utility>
 #include <vector>
 
-#include <fruit/component.h>
-#include <fruit/fruit_forward_decls.h>
-#include <fruit/macro.h>
+#include "fruit/component.h"
+#include "fruit/fruit_forward_decls.h"
+#include "fruit/macro.h"
 
 #include "cuttlefish/common/libs/utils/subprocess.h"
 #include "cuttlefish/host/commands/run_cvd/launch/log_tee_creator.h"

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/root_canal.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/root_canal.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <fruit/fruit.h>
+#include "fruit/fruit.h"
 
 #include "cuttlefish/host/commands/run_cvd/launch/log_tee_creator.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/snapshot_control_files.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/snapshot_control_files.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <fruit/fruit.h>
+#include "fruit/fruit.h"
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/ti50_emulator.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/ti50_emulator.cpp
@@ -28,9 +28,9 @@
 #include <vector>
 
 #include "absl/log/log.h"
-#include <fruit/component.h>
-#include <fruit/fruit_forward_decls.h>
-#include <fruit/macro.h>
+#include "fruit/component.h"
+#include "fruit/fruit_forward_decls.h"
+#include "fruit/macro.h"
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/ti50_emulator.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/ti50_emulator.cpp
@@ -27,10 +27,10 @@
 #include <utility>
 #include <vector>
 
+#include "absl/log/log.h"
 #include <fruit/component.h>
 #include <fruit/fruit_forward_decls.h>
 #include <fruit/macro.h>
-#include "absl/log/log.h"
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/ti50_emulator.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/ti50_emulator.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <fruit/fruit.h>
+#include "fruit/fruit.h"
 
 #include "cuttlefish/host/commands/run_cvd/launch/log_tee_creator.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/vhal_proxy_server.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/vhal_proxy_server.cpp
@@ -19,8 +19,8 @@
 
 #include <optional>
 
-#include <fmt/core.h>
-#include <fmt/format.h>
+#include "fmt/core.h"
+#include "fmt/format.h"
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/vhost_device_vsock.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/vhost_device_vsock.cpp
@@ -23,11 +23,11 @@
 #include <vector>
 
 #include "absl/log/log.h"
-#include <fmt/core.h>
-#include <fmt/format.h>
-#include <fruit/component.h>
-#include <fruit/fruit_forward_decls.h>
-#include <fruit/macro.h>
+#include "fmt/core.h"
+#include "fmt/format.h"
+#include "fruit/component.h"
+#include "fruit/fruit_forward_decls.h"
+#include "fruit/macro.h"
 
 #include "cuttlefish/common/libs/utils/known_paths.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/vhost_device_vsock.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/vhost_device_vsock.cpp
@@ -22,12 +22,12 @@
 #include <utility>
 #include <vector>
 
+#include "absl/log/log.h"
 #include <fmt/core.h>
 #include <fmt/format.h>
 #include <fruit/component.h>
 #include <fruit/fruit_forward_decls.h>
 #include <fruit/macro.h>
-#include "absl/log/log.h"
 
 #include "cuttlefish/common/libs/utils/known_paths.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/vhost_device_vsock.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/vhost_device_vsock.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <fruit/fruit.h>
+#include "fruit/fruit.h"
 
 #include "cuttlefish/host/commands/run_cvd/launch/log_tee_creator.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/webrtc_controller.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/webrtc_controller.cpp
@@ -19,10 +19,10 @@
 
 #include <string>
 
-#include <fruit/component.h>
 #include "absl/log/log.h"
 #include "google/rpc/code.pb.h"
 #include "google/rpc/status.pb.h"
+#include <fruit/component.h>
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/host/frontend/webrtc/webrtc_commands.pb.h"

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/webrtc_controller.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/webrtc_controller.cpp
@@ -20,9 +20,9 @@
 #include <string>
 
 #include "absl/log/log.h"
+#include "fruit/component.h"
 #include "google/rpc/code.pb.h"
 #include "google/rpc/status.pb.h"
-#include <fruit/component.h>
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/host/frontend/webrtc/webrtc_commands.pb.h"

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/webrtc_controller.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/webrtc_controller.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <fruit/fruit.h>
+#include "fruit/fruit.h"
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/host/frontend/webrtc/webrtc_command_channel.h"

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/wmediumd_server.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/wmediumd_server.cpp
@@ -20,9 +20,9 @@
 #include <utility>
 #include <vector>
 
-#include <fruit/component.h>
-#include <fruit/fruit_forward_decls.h>
-#include <fruit/macro.h>
+#include "fruit/component.h"
+#include "fruit/fruit_forward_decls.h"
+#include "fruit/macro.h"
 
 #include "cuttlefish/common/libs/utils/subprocess.h"
 #include "cuttlefish/common/libs/utils/wait_for_unix_socket.h"

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/wmediumd_server.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/wmediumd_server.h
@@ -19,7 +19,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include <fruit/fruit.h>
+#include "fruit/fruit.h"
 
 #include "cuttlefish/host/commands/run_cvd/launch/grpc_socket_creator.h"
 #include "cuttlefish/host/commands/run_cvd/launch/log_tee_creator.h"

--- a/base/cvd/cuttlefish/host/commands/run_cvd/reporting.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/reporting.h
@@ -20,7 +20,7 @@
 #include <tuple>
 #include <vector>
 
-#include <fruit/fruit.h>
+#include "fruit/fruit.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/commands/screen_recording_server/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/screen_recording_server/main.cpp
@@ -19,11 +19,11 @@
 #include <string>
 
 #include "absl/log/log.h"
-#include <gflags/gflags.h>
-#include <google/protobuf/empty.pb.h>
-#include <grpcpp/ext/proto_server_reflection_plugin.h>
-#include <grpcpp/grpcpp.h>
-#include <grpcpp/health_check_service_interface.h>
+#include "gflags/gflags.h"
+#include "google/protobuf/empty.pb.h"
+#include "grpcpp/ext/proto_server_reflection_plugin.h"
+#include "grpcpp/grpcpp.h"
+#include "grpcpp/health_check_service_interface.h"
 
 #include "cuttlefish/host/commands/screen_recording_server/screen_recording.grpc.pb.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"

--- a/base/cvd/cuttlefish/host/commands/screen_recording_server/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/screen_recording_server/main.cpp
@@ -18,12 +18,12 @@
 #include <memory>
 #include <string>
 
+#include "absl/log/log.h"
 #include <gflags/gflags.h>
 #include <google/protobuf/empty.pb.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
-#include "absl/log/log.h"
 
 #include "cuttlefish/host/commands/screen_recording_server/screen_recording.grpc.pb.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"

--- a/base/cvd/cuttlefish/host/commands/secure_env/oemlock/oemlock.h
+++ b/base/cvd/cuttlefish/host/commands/secure_env/oemlock/oemlock.h
@@ -17,9 +17,8 @@
 
 #pragma once
 
-#include "cuttlefish/result/result.h"
-
 #include "cuttlefish/host/commands/secure_env/storage/storage.h"
+#include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
 namespace oemlock {

--- a/base/cvd/cuttlefish/host/commands/sensors_simulator/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/sensors_simulator/main.cpp
@@ -17,7 +17,7 @@
 #include <string>
 
 #include "absl/log/log.h"
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/common/libs/transport/channel_sharedfd.h"
 #include "cuttlefish/common/libs/utils/device_type.h"

--- a/base/cvd/cuttlefish/host/commands/sensors_simulator/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/sensors_simulator/main.cpp
@@ -16,8 +16,8 @@
 
 #include <string>
 
-#include <gflags/gflags.h>
 #include "absl/log/log.h"
+#include <gflags/gflags.h>
 
 #include "cuttlefish/common/libs/transport/channel_sharedfd.h"
 #include "cuttlefish/common/libs/utils/device_type.h"

--- a/base/cvd/cuttlefish/host/commands/sensors_simulator/sensors_simulator.h
+++ b/base/cvd/cuttlefish/host/commands/sensors_simulator/sensors_simulator.h
@@ -21,7 +21,7 @@
 #include <mutex>
 #include <string>
 
-#include <Eigen/Dense>
+#include "Eigen/Dense"
 
 #include "cuttlefish/common/libs/sensors/sensors.h"
 

--- a/base/cvd/cuttlefish/host/commands/start/start_flags.cpp
+++ b/base/cvd/cuttlefish/host/commands/start/start_flags.cpp
@@ -16,7 +16,7 @@
 
 #include "cuttlefish/host/commands/start/start_flags.h"
 
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/host/commands/assemble_cvd/flags_defaults.h"
 

--- a/base/cvd/cuttlefish/host/commands/start/start_flags.h
+++ b/base/cvd/cuttlefish/host/commands/start/start_flags.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 DECLARE_int32(num_instances);
 DECLARE_string(report_anonymous_usage_stats);

--- a/base/cvd/cuttlefish/host/commands/tcp_connector/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/tcp_connector/main.cpp
@@ -20,8 +20,8 @@
 #include <mutex>
 #include <thread>
 
-#include <gflags/gflags.h>
 #include "absl/log/log.h"
+#include <gflags/gflags.h>
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"

--- a/base/cvd/cuttlefish/host/commands/tcp_connector/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/tcp_connector/main.cpp
@@ -21,7 +21,7 @@
 #include <thread>
 
 #include "absl/log/log.h"
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"

--- a/base/cvd/cuttlefish/host/frontend/operator_proxy/main.cpp
+++ b/base/cvd/cuttlefish/host/frontend/operator_proxy/main.cpp
@@ -18,7 +18,7 @@
 
 #include "absl/log/check.h"
 #include "absl/log/log.h"
-#include <gflags/gflags.h>
+#include "gflags/gflags.h"
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/socket2socket_proxy.h"

--- a/base/cvd/cuttlefish/host/frontend/operator_proxy/main.cpp
+++ b/base/cvd/cuttlefish/host/frontend/operator_proxy/main.cpp
@@ -16,9 +16,9 @@
 
 #include <signal.h>
 
-#include <gflags/gflags.h>
 #include "absl/log/check.h"
 #include "absl/log/log.h"
+#include <gflags/gflags.h>
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/socket2socket_proxy.h"

--- a/base/cvd/cuttlefish/host/frontend/webrtc/client_server.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/client_server.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include "cuttlefish/host/frontend/webrtc/client_server.h"
+
 #include "absl/log/log.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/host/frontend/webrtc/client_server.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/client_server.h
@@ -15,12 +15,12 @@
 
 #pragma once
 
+#include <libwebsockets.h>
+
 #include <atomic>
 #include <memory>
 #include <string>
 #include <thread>
-
-#include <libwebsockets.h>
 
 namespace cuttlefish {
 // Utility class to serve the client files in a thread

--- a/base/cvd/cuttlefish/host/frontend/webrtc/display_handler.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/display_handler.cpp
@@ -25,7 +25,7 @@
 #include <string>
 
 #include "absl/log/log.h"
-#include <drm/drm_fourcc.h>
+#include "drm/drm_fourcc.h"
 
 #include "cuttlefish/host/frontend/webrtc/libdevice/streamer.h"
 #include "cuttlefish/host/libs/screen_connector/composition_manager.h"

--- a/base/cvd/cuttlefish/host/frontend/webrtc/display_handler.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/display_handler.cpp
@@ -16,6 +16,7 @@
 
 #include "cuttlefish/host/frontend/webrtc/display_handler.h"
 
+#include <libyuv.h>
 #include <stdint.h>
 
 #include <chrono>
@@ -23,9 +24,8 @@
 #include <optional>
 #include <string>
 
-#include <drm/drm_fourcc.h>
-#include <libyuv.h>
 #include "absl/log/log.h"
+#include <drm/drm_fourcc.h>
 
 #include "cuttlefish/host/frontend/webrtc/libdevice/streamer.h"
 #include "cuttlefish/host/libs/screen_connector/composition_manager.h"

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/audio_device.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/audio_device.h
@@ -16,9 +16,9 @@
 
 #pragma once
 
-#include <modules/audio_device/include/audio_device.h>
-
 #include <atomic>
+
+#include <modules/audio_device/include/audio_device.h>
 
 #include "cuttlefish/host/frontend/webrtc/libcommon/audio_source.h"
 

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/audio_device.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/audio_device.h
@@ -18,7 +18,7 @@
 
 #include <atomic>
 
-#include <modules/audio_device/include/audio_device.h>
+#include "modules/audio_device/include/audio_device.h"
 
 #include "cuttlefish/host/frontend/webrtc/libcommon/audio_source.h"
 

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/connection_controller.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/connection_controller.cpp
@@ -20,7 +20,7 @@
 
 #include "absl/log/check.h"
 #include "absl/log/log.h"
-#include <fmt/format.h>
+#include "fmt/format.h"
 
 #include "cuttlefish/common/libs/utils/json.h"
 #include "cuttlefish/host/frontend/webrtc/libcommon/utils.h"

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/connection_controller.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/connection_controller.cpp
@@ -18,9 +18,9 @@
 
 #include <vector>
 
-#include <fmt/format.h>
 #include "absl/log/check.h"
 #include "absl/log/log.h"
+#include <fmt/format.h>
 
 #include "cuttlefish/common/libs/utils/json.h"
 #include "cuttlefish/host/frontend/webrtc/libcommon/utils.h"

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/connection_controller.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/connection_controller.h
@@ -19,8 +19,8 @@
 #include <memory>
 #include <mutex>
 
-#include <api/peer_connection_interface.h>
-#include <json/json.h>
+#include "api/peer_connection_interface.h"
+#include "json/json.h"
 
 #include "cuttlefish/host/frontend/webrtc/libcommon/peer_signaling_handler.h"
 #include "cuttlefish/result/result.h"

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/peer_signaling_handler.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/peer_signaling_handler.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <json/json.h>
+#include "json/json.h"
 
 #include "cuttlefish/result/result.h"
 

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/utils.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/utils.cpp
@@ -18,8 +18,8 @@
 
 #include <functional>
 
-#include <json/json.h>
 #include "absl/log/log.h"
+#include <json/json.h>
 
 #include "cuttlefish/common/libs/utils/json.h"
 

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/utils.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/utils.cpp
@@ -19,7 +19,7 @@
 #include <functional>
 
 #include "absl/log/log.h"
-#include <json/json.h>
+#include "json/json.h"
 
 #include "cuttlefish/common/libs/utils/json.h"
 

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/utils.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/utils.h
@@ -19,9 +19,8 @@
 #include <memory>
 #include <vector>
 
-#include <json/json.h>
-
 #include <api/peer_connection_interface.h>
+#include <json/json.h>
 
 #include "cuttlefish/result/result.h"
 

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/utils.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/utils.h
@@ -19,8 +19,8 @@
 #include <memory>
 #include <vector>
 
-#include <api/peer_connection_interface.h>
-#include <json/json.h>
+#include "api/peer_connection_interface.h"
+#include "json/json.h"
 
 #include "cuttlefish/result/result.h"
 

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/vp8only_encoder_factory.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/vp8only_encoder_factory.cpp
@@ -16,7 +16,7 @@
 
 #include "cuttlefish/host/frontend/webrtc/libcommon/vp8only_encoder_factory.h"
 
-#include <api/video_codecs/video_encoder.h>
+#include "api/video_codecs/video_encoder.h"
 
 namespace cuttlefish {
 namespace webrtc_streaming {

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/vp8only_encoder_factory.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libcommon/vp8only_encoder_factory.h
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <api/video_codecs/video_encoder.h>
-#include <api/video_codecs/video_encoder_factory.h>
+#include "api/video_codecs/video_encoder.h"
+#include "api/video_codecs/video_encoder_factory.h"
 
 namespace cuttlefish {
 namespace webrtc_streaming {

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/audio_track_source_impl.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/audio_track_source_impl.h
@@ -19,7 +19,7 @@
 #include <mutex>
 #include <set>
 
-#include <api/media_stream_interface.h>
+#include "api/media_stream_interface.h"
 
 #include "cuttlefish/host/frontend/webrtc/libdevice/audio_sink.h"
 

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/camera_controller.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/camera_controller.h
@@ -17,7 +17,7 @@
 
 #include <functional>
 
-#include <json/json.h>
+#include "json/json.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/camera_streamer.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/camera_streamer.cpp
@@ -16,7 +16,9 @@
 #include "camera_streamer.h"
 
 #include <chrono>
+
 #include "absl/log/log.h"
+
 #include "cuttlefish/common/libs/utils/vsock_connection.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/camera_streamer.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/camera_streamer.h
@@ -20,10 +20,10 @@
 #include <thread>
 #include <vector>
 
-#include <api/video/i420_buffer.h>
-#include <api/video/video_frame.h>
-#include <api/video/video_sink_interface.h>
-#include <json/json.h>
+#include "api/video/i420_buffer.h"
+#include "api/video/video_frame.h"
+#include "api/video/video_sink_interface.h"
+#include "json/json.h"
 
 #include "cuttlefish/common/libs/utils/vsock_connection.h"
 #include "cuttlefish/host/frontend/webrtc/libdevice/camera_controller.h"

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/camera_streamer.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/camera_streamer.h
@@ -15,6 +15,11 @@
  */
 
 #pragma once
+#include <atomic>
+#include <mutex>
+#include <thread>
+#include <vector>
+
 #include <api/video/i420_buffer.h>
 #include <api/video/video_frame.h>
 #include <api/video/video_sink_interface.h>
@@ -22,11 +27,6 @@
 
 #include "cuttlefish/common/libs/utils/vsock_connection.h"
 #include "cuttlefish/host/frontend/webrtc/libdevice/camera_controller.h"
-
-#include <atomic>
-#include <mutex>
-#include <thread>
-#include <vector>
 
 namespace cuttlefish {
 namespace webrtc_streaming {

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/connection_observer.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/connection_observer.h
@@ -18,7 +18,7 @@
 
 #include <functional>
 
-#include <json/json.h>
+#include "json/json.h"
 
 #include "cuttlefish/result/result.h"
 

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/lights_observer.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/lights_observer.cpp
@@ -18,7 +18,7 @@
 #include <chrono>
 
 #include "absl/log/log.h"
-#include <json/json.h>
+#include "json/json.h"
 
 #include "cuttlefish/common/libs/utils/vsock_connection.h"
 

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/lights_observer.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/lights_observer.cpp
@@ -16,10 +16,11 @@
 #include "lights_observer.h"
 
 #include <chrono>
-#include "absl/log/log.h"
-#include "cuttlefish/common/libs/utils/vsock_connection.h"
 
+#include "absl/log/log.h"
 #include <json/json.h>
+
+#include "cuttlefish/common/libs/utils/vsock_connection.h"
 
 namespace cuttlefish {
 namespace webrtc_streaming {

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/lights_observer.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/lights_observer.h
@@ -15,14 +15,14 @@
  */
 
 #pragma once
-#include "cuttlefish/common/libs/utils/vsock_connection.h"
-
 #include <atomic>
 #include <mutex>
 #include <thread>
 #include <unordered_map>
 
 #include <json/json.h>
+
+#include "cuttlefish/common/libs/utils/vsock_connection.h"
 
 namespace cuttlefish {
 namespace webrtc_streaming {

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/lights_observer.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/lights_observer.h
@@ -20,7 +20,7 @@
 #include <thread>
 #include <unordered_map>
 
-#include <json/json.h>
+#include "json/json.h"
 
 #include "cuttlefish/common/libs/utils/vsock_connection.h"
 

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/local_recorder.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/local_recorder.cpp
@@ -25,15 +25,15 @@
 
 #include "absl/log/check.h"
 #include "absl/log/log.h"
-#include <api/media_stream_interface.h>
-#include <api/rtp_parameters.h>
-#include <api/task_queue/default_task_queue_factory.h>
-#include <api/video/builtin_video_bitrate_allocator_factory.h>
-#include <api/video_codecs/builtin_video_encoder_factory.h>
-#include <api/video_codecs/video_encoder.h>
-#include <mkvmuxer/mkvmuxer.h>
-#include <mkvmuxer/mkvwriter.h>
-#include <system_wrappers/include/clock.h>
+#include "api/media_stream_interface.h"
+#include "api/rtp_parameters.h"
+#include "api/task_queue/default_task_queue_factory.h"
+#include "api/video/builtin_video_bitrate_allocator_factory.h"
+#include "api/video_codecs/builtin_video_encoder_factory.h"
+#include "api/video_codecs/video_encoder.h"
+#include "mkvmuxer/mkvmuxer.h"
+#include "mkvmuxer/mkvwriter.h"
+#include "system_wrappers/include/clock.h"
 
 namespace cuttlefish {
 namespace webrtc_streaming {

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/local_recorder.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/local_recorder.cpp
@@ -25,7 +25,6 @@
 
 #include "absl/log/check.h"
 #include "absl/log/log.h"
-
 #include <api/media_stream_interface.h>
 #include <api/rtp_parameters.h>
 #include <api/task_queue/default_task_queue_factory.h>

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/recording_manager.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/recording_manager.cpp
@@ -19,7 +19,7 @@
 
 #include "absl/log/check.h"
 #include "absl/log/log.h"
-#include <rtc_base/time_utils.h>
+#include "rtc_base/time_utils.h"
 
 #include "cuttlefish/host/frontend/webrtc/libdevice/local_recorder.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/recording_manager.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/recording_manager.cpp
@@ -17,9 +17,9 @@
 
 #include <mutex>
 
-#include <rtc_base/time_utils.h>
 #include "absl/log/check.h"
 #include "absl/log/log.h"
+#include <rtc_base/time_utils.h>
 
 #include "cuttlefish/host/frontend/webrtc/libdevice/local_recorder.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/recording_manager.h
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/recording_manager.h
@@ -16,13 +16,13 @@
 
 #pragma once
 
-#include "cuttlefish/host/frontend/webrtc/libdevice/local_recorder.h"
-
 #include <condition_variable>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <string>
+
+#include "cuttlefish/host/frontend/webrtc/libdevice/local_recorder.h"
 
 namespace webrtc {
 class VideoTrackSourceInterface;

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/server_connection.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/server_connection.cpp
@@ -21,7 +21,7 @@
 #include <thread>
 
 #include "absl/log/log.h"
-#include <json/json.h>
+#include "json/json.h"
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/fs/shared_select.h"

--- a/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/server_connection.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/libdevice/server_connection.cpp
@@ -20,8 +20,8 @@
 #include <string>
 #include <thread>
 
-#include <json/json.h>
 #include "absl/log/log.h"
+#include <json/json.h>
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/fs/shared_select.h"

--- a/base/cvd/cuttlefish/host/frontend/webrtc/main.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/main.cpp
@@ -14,19 +14,24 @@
  * limitations under the License.
  */
 
+#include <libyuv.h>
+
 #include <memory>
 #include <string_view>
 
-#include <fruit/fruit.h>
-#include <gflags/gflags.h>
-#include <libyuv.h>
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_split.h"
+#include "google/protobuf/text_format.h"
+#include "google/rpc/code.pb.h"
+#include "google/rpc/status.pb.h"
+#include <fruit/fruit.h>
+#include <gflags/gflags.h>
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/host/commands/assemble_cvd/proto/guest_config.pb.h"
 #include "cuttlefish/host/frontend/webrtc/audio_handler.h"
 #include "cuttlefish/host/frontend/webrtc/client_server.h"
 #include "cuttlefish/host/frontend/webrtc/connection_observer.h"
@@ -49,11 +54,6 @@
 #include "cuttlefish/host/libs/input_connector/input_connector.h"
 #include "cuttlefish/host/libs/screen_connector/composition_manager.h"
 #include "cuttlefish/host/libs/screen_connector/screen_connector.h"
-#include "google/protobuf/text_format.h"
-#include "google/rpc/code.pb.h"
-#include "google/rpc/status.pb.h"
-
-#include "cuttlefish/host/commands/assemble_cvd/proto/guest_config.pb.h"
 
 DEFINE_bool(multitouch, true,
             "Whether to send multi-touch or single-touch events");

--- a/base/cvd/cuttlefish/host/frontend/webrtc/main.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/main.cpp
@@ -23,11 +23,11 @@
 #include "absl/log/log.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_split.h"
+#include "fruit/fruit.h"
+#include "gflags/gflags.h"
 #include "google/protobuf/text_format.h"
 #include "google/rpc/code.pb.h"
 #include "google/rpc/status.pb.h"
-#include <fruit/fruit.h>
-#include <gflags/gflags.h>
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/files.h"

--- a/base/cvd/cuttlefish/host/graphics_detector/lib.cpp
+++ b/base/cvd/cuttlefish/host/graphics_detector/lib.cpp
@@ -16,9 +16,9 @@
 
 #include "cuttlefish/host/graphics_detector/lib.h"
 
-#include <string>
-
 #include <dlfcn.h>
+
+#include <string>
 
 namespace gfxstream {
 

--- a/base/cvd/cuttlefish/host/graphics_detector/main.cpp
+++ b/base/cvd/cuttlefish/host/graphics_detector/main.cpp
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include <google/protobuf/text_format.h>
-
 #include <fstream>
 #include <string>
+
+#include <google/protobuf/text_format.h>
 
 #include "cuttlefish/host/graphics_detector/graphics_detector.h"
 #include "cuttlefish/host/graphics_detector/graphics_detector.pb.h"

--- a/base/cvd/cuttlefish/host/graphics_detector/main.cpp
+++ b/base/cvd/cuttlefish/host/graphics_detector/main.cpp
@@ -17,7 +17,7 @@
 #include <fstream>
 #include <string>
 
-#include <google/protobuf/text_format.h>
+#include "google/protobuf/text_format.h"
 
 #include "cuttlefish/host/graphics_detector/graphics_detector.h"
 #include "cuttlefish/host/graphics_detector/graphics_detector.pb.h"

--- a/base/cvd/cuttlefish/host/graphics_detector/vulkan.h
+++ b/base/cvd/cuttlefish/host/graphics_detector/vulkan.h
@@ -21,10 +21,10 @@
 #include <string>
 #include <vector>
 
-#include "cuttlefish/host/graphics_detector/expected.h"
-
 #include "vulkan/vulkan_raii.hpp"
 #include "vulkan/vulkan_to_string.hpp"
+
+#include "cuttlefish/host/graphics_detector/expected.h"
 
 namespace gfxstream {
 

--- a/base/cvd/cuttlefish/host/libs/config/adb/test.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/adb/test.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/libs/config/adb/adb.h"
-
 #include <set>
 #include <string>
 #include <vector>
@@ -25,6 +23,7 @@
 #include <fruit/macro.h>
 #include <gtest/gtest.h>
 
+#include "cuttlefish/host/libs/config/adb/adb.h"
 #include "cuttlefish/host/libs/config/config_flag.h"
 #include "cuttlefish/host/libs/feature/feature.h"
 

--- a/base/cvd/cuttlefish/host/libs/config/adb/test.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/adb/test.cpp
@@ -18,10 +18,10 @@
 #include <string>
 #include <vector>
 
-#include <fruit/component.h>
-#include <fruit/injector.h>
-#include <fruit/macro.h>
-#include <gtest/gtest.h>
+#include "fruit/component.h"
+#include "fruit/injector.h"
+#include "fruit/macro.h"
+#include "gtest/gtest.h"
 
 #include "cuttlefish/host/libs/config/adb/adb.h"
 #include "cuttlefish/host/libs/config/config_flag.h"

--- a/base/cvd/cuttlefish/host/libs/config/config_fragment.h
+++ b/base/cvd/cuttlefish/host/libs/config/config_fragment.h
@@ -17,7 +17,7 @@
 
 #include <string>
 
-#include <json/json.h>
+#include "json/json.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/config/esp/make_fat_image.cc
+++ b/base/cvd/cuttlefish/host/libs/config/esp/make_fat_image.cc
@@ -15,9 +15,8 @@
 
 #include "cuttlefish/host/libs/config/esp/make_fat_image.h"
 
-#include <sys/types.h>
-
 #include <fcntl.h>
+#include <sys/types.h>
 
 #include <string>
 #include <vector>

--- a/base/cvd/cuttlefish/host/libs/directories/xdg.cpp
+++ b/base/cvd/cuttlefish/host/libs/directories/xdg.cpp
@@ -22,7 +22,7 @@
 #include <string>
 
 #include "absl/strings/str_split.h"
-#include <android-base/file.h>
+#include "android-base/file.h"
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"

--- a/base/cvd/cuttlefish/host/libs/directories/xdg.cpp
+++ b/base/cvd/cuttlefish/host/libs/directories/xdg.cpp
@@ -21,8 +21,8 @@
 
 #include <string>
 
-#include <android-base/file.h>
 #include "absl/strings/str_split.h"
+#include <android-base/file.h>
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"

--- a/base/cvd/cuttlefish/host/libs/feature/inject.h
+++ b/base/cvd/cuttlefish/host/libs/feature/inject.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <fruit/fruit.h>
+#include "fruit/fruit.h"
 
 #include "cuttlefish/result/result.h"
 

--- a/base/cvd/cuttlefish/host/libs/image_aggregator/image_aggregator.cc
+++ b/base/cvd/cuttlefish/host/libs/image_aggregator/image_aggregator.cc
@@ -32,10 +32,10 @@
 #include <string>
 #include <vector>
 
-#include <android-base/file.h>
-#include <google/protobuf/text_format.h>
-#include <google/protobuf/util/message_differencer.h>
-#include <sparse/sparse.h>
+#include "android-base/file.h"
+#include "google/protobuf/text_format.h"
+#include "google/protobuf/util/message_differencer.h"
+#include "sparse/sparse.h"
 #include <zlib.h>
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"

--- a/base/cvd/cuttlefish/host/libs/image_aggregator/super_builder.cc
+++ b/base/cvd/cuttlefish/host/libs/image_aggregator/super_builder.cc
@@ -24,7 +24,7 @@
 #include "liblp/builder.h"
 #include "liblp/metadata_format.h"
 #include "liblp/partition_opener.h"
-#include <openssl/sha.h>
+#include "openssl/sha.h"
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"

--- a/base/cvd/cuttlefish/host/libs/image_aggregator/super_builder.cc
+++ b/base/cvd/cuttlefish/host/libs/image_aggregator/super_builder.cc
@@ -17,8 +17,6 @@
 
 #include <stdint.h>
 
-#include <openssl/sha.h>
-
 #include <map>
 #include <string_view>
 
@@ -26,18 +24,18 @@
 #include "liblp/builder.h"
 #include "liblp/metadata_format.h"
 #include "liblp/partition_opener.h"
+#include <openssl/sha.h>
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/host/libs/config/log_string_to_dir.h"
 #include "cuttlefish/host/libs/image_aggregator/cdisk_spec.pb.h"
 #include "cuttlefish/host/libs/image_aggregator/composite_disk.h"
 #include "cuttlefish/host/libs/image_aggregator/disk_image.h"
 #include "cuttlefish/host/libs/image_aggregator/image_from_file.h"
-#include "cuttlefish/result/result.h"
-
-#include "cuttlefish/host/libs/config/log_string_to_dir.h"
 #include "cuttlefish/pretty/liblp/liblp.h"  // IWYU pragma: keep: overloads
 #include "cuttlefish/pretty/unique_ptr.h"
+#include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/host/libs/input_connector/event_buffer.cpp
+++ b/base/cvd/cuttlefish/host/libs/input_connector/event_buffer.cpp
@@ -16,11 +16,11 @@
 
 #include "cuttlefish/host/libs/input_connector/event_buffer.h"
 
+#include <linux/input.h>
+
 #include <cstdint>
 #include <cstdlib>
 #include <vector>
-
-#include <linux/input.h>
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/input_connector/event_buffer.h
+++ b/base/cvd/cuttlefish/host/libs/input_connector/event_buffer.h
@@ -18,7 +18,6 @@
 
 #include <cstdint>
 #include <cstdlib>
-
 #include <vector>
 
 #include "cuttlefish/common/libs/utils/cf_endian.h"

--- a/base/cvd/cuttlefish/host/libs/metrics/device_metrics_orchestration.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/device_metrics_orchestration.cc
@@ -20,9 +20,9 @@
 #include <string_view>
 #include <vector>
 
-#include <fmt/format.h>
 #include "absl/log/log.h"
 #include "absl/strings/str_split.h"
+#include <fmt/format.h>
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/tee_logging.h"

--- a/base/cvd/cuttlefish/host/libs/metrics/device_metrics_orchestration.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/device_metrics_orchestration.cc
@@ -22,7 +22,7 @@
 
 #include "absl/log/log.h"
 #include "absl/strings/str_split.h"
-#include <fmt/format.h>
+#include "fmt/format.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/tee_logging.h"

--- a/base/cvd/cuttlefish/host/libs/metrics/fetch_metrics_orchestration.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/fetch_metrics_orchestration.cc
@@ -21,9 +21,9 @@
 #include <string_view>
 #include <vector>
 
-#include <fmt/format.h>
 #include "absl/log/log.h"
 #include "absl/strings/str_split.h"
+#include <fmt/format.h>
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/tee_logging.h"

--- a/base/cvd/cuttlefish/host/libs/metrics/fetch_metrics_orchestration.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/fetch_metrics_orchestration.cc
@@ -23,7 +23,7 @@
 
 #include "absl/log/log.h"
 #include "absl/strings/str_split.h"
-#include <fmt/format.h>
+#include "fmt/format.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/tee_logging.h"

--- a/base/cvd/cuttlefish/host/libs/metrics/gce_environment.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/gce_environment.cc
@@ -23,7 +23,7 @@
 #include <vector>
 
 #include "absl/strings/str_split.h"
-#include <fmt/format.h>
+#include "fmt/format.h"
 
 #include "cuttlefish/host/libs/web/http_client/curl_global_init.h"
 #include "cuttlefish/host/libs/web/http_client/curl_http_client.h"

--- a/base/cvd/cuttlefish/host/libs/metrics/gce_environment.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/gce_environment.cc
@@ -22,8 +22,8 @@
 #include <string_view>
 #include <vector>
 
-#include <fmt/format.h>
 #include "absl/strings/str_split.h"
+#include <fmt/format.h>
 
 #include "cuttlefish/host/libs/web/http_client/curl_global_init.h"
 #include "cuttlefish/host/libs/web/http_client/curl_http_client.h"

--- a/base/cvd/cuttlefish/host/libs/metrics/guest_metrics.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/guest_metrics.cc
@@ -19,7 +19,7 @@
 #include <string>
 #include <vector>
 
-#include <fmt/format.h>
+#include "fmt/format.h"
 
 #include "cuttlefish/host/commands/assemble_cvd/boot_image_utils.h"
 #include "cuttlefish/result/result.h"

--- a/base/cvd/cuttlefish/host/libs/metrics/metrics_conversion.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/metrics_conversion.cc
@@ -20,8 +20,8 @@
 #include <string_view>
 #include <variant>
 
-#include <fmt/format.h>
 #include "google/protobuf/timestamp.pb.h"
+#include <fmt/format.h>
 
 #include "cuttlefish/common/libs/utils/host_info.h"
 #include "cuttlefish/host/commands/cvd/fetch/builds.h"

--- a/base/cvd/cuttlefish/host/libs/metrics/metrics_conversion.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/metrics_conversion.cc
@@ -20,8 +20,8 @@
 #include <string_view>
 #include <variant>
 
+#include "fmt/format.h"
 #include "google/protobuf/timestamp.pb.h"
-#include <fmt/format.h>
 
 #include "cuttlefish/common/libs/utils/host_info.h"
 #include "cuttlefish/host/commands/cvd/fetch/builds.h"

--- a/base/cvd/cuttlefish/host/libs/metrics/metrics_orchestration.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/metrics_orchestration.cc
@@ -24,7 +24,7 @@
 #include <vector>
 
 #include "absl/log/log.h"
-#include <fmt/format.h>
+#include "fmt/format.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/tee_logging.h"

--- a/base/cvd/cuttlefish/host/libs/metrics/metrics_orchestration.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/metrics_orchestration.cc
@@ -23,8 +23,8 @@
 #include <string_view>
 #include <vector>
 
-#include <fmt/format.h>
 #include "absl/log/log.h"
+#include <fmt/format.h>
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/tee_logging.h"

--- a/base/cvd/cuttlefish/host/libs/metrics/metrics_writer.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/metrics_writer.cc
@@ -20,8 +20,8 @@
 #include <string>
 #include <string_view>
 
-#include <fmt/format.h>
-#include <google/protobuf/text_format.h>
+#include "fmt/format.h"
+#include "google/protobuf/text_format.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/random.h"

--- a/base/cvd/cuttlefish/host/libs/metrics/session_id.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/session_id.cc
@@ -18,7 +18,7 @@
 
 #include <string>
 
-#include <fmt/format.h>
+#include "fmt/format.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/uuid.h"

--- a/base/cvd/cuttlefish/host/libs/process_monitor/process_monitor.cc
+++ b/base/cvd/cuttlefish/host/libs/process_monitor/process_monitor.cc
@@ -33,9 +33,9 @@
 #include <string>
 #include <vector>
 
-#include <android-base/file.h>
 #include "absl/log/log.h"
 #include "absl/strings/match.h"
+#include <android-base/file.h>
 
 #include "cuttlefish/common/libs/transport/channel.h"
 #include "cuttlefish/common/libs/transport/channel_sharedfd.h"

--- a/base/cvd/cuttlefish/host/libs/process_monitor/process_monitor.cc
+++ b/base/cvd/cuttlefish/host/libs/process_monitor/process_monitor.cc
@@ -35,7 +35,7 @@
 
 #include "absl/log/log.h"
 #include "absl/strings/match.h"
-#include <android-base/file.h>
+#include "android-base/file.h"
 
 #include "cuttlefish/common/libs/transport/channel.h"
 #include "cuttlefish/common/libs/transport/channel_sharedfd.h"

--- a/base/cvd/cuttlefish/host/libs/web/android_build_string_tests.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_string_tests.cpp
@@ -17,8 +17,8 @@
 #include <string>
 #include <vector>
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 #include "cuttlefish/host/libs/web/android_build_string.h"
 #include "cuttlefish/result/result_matchers.h"

--- a/base/cvd/cuttlefish/host/libs/web/android_build_string_tests.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_string_tests.cpp
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "cuttlefish/host/libs/web/android_build_string.h"
-
 #include <optional>
 #include <string>
 #include <vector>
@@ -22,6 +20,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "cuttlefish/host/libs/web/android_build_string.h"
 #include "cuttlefish/result/result_matchers.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/host/libs/web/cas/cas_downloader_test.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/cas/cas_downloader_test.cpp
@@ -25,12 +25,12 @@
 #include <utility>
 #include <vector>
 
-#include <android-base/file.h>
-#include <fmt/base.h>
-#include <fmt/core.h>
-#include <fmt/format.h>
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+#include "android-base/file.h"
+#include "fmt/base.h"
+#include "fmt/core.h"
+#include "fmt/format.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/libs/web/android_build.h"

--- a/base/cvd/cuttlefish/host/libs/web/cas/cas_flags_test.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/cas/cas_flags_test.cpp
@@ -20,8 +20,8 @@
 #include <cstddef>
 #include <string>
 
-#include <android-base/file.h>
-#include <gtest/gtest.h>
+#include "android-base/file.h"
+#include "gtest/gtest.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/web/http_client/curl_global_init.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/curl_global_init.cpp
@@ -13,9 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <curl/curl.h>
-
 #include "cuttlefish/host/libs/web/http_client/curl_global_init.h"
+
+#include <curl/curl.h>
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/web/http_client/curl_global_init.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/curl_global_init.cpp
@@ -15,7 +15,7 @@
 
 #include "cuttlefish/host/libs/web/http_client/curl_global_init.h"
 
-#include <curl/curl.h>
+#include "curl/curl.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/web/http_client/fake_http_client_test.cc
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/fake_http_client_test.cc
@@ -15,8 +15,8 @@
 
 #include "cuttlefish/host/libs/web/http_client/fake_http_client.h"
 
-#include <gmock/gmock-matchers.h>
-#include <gtest/gtest.h>
+#include "gmock/gmock-matchers.h"
+#include "gtest/gtest.h"
 
 #include "cuttlefish/host/libs/web/http_client/http_client.h"
 #include "cuttlefish/host/libs/web/http_client/http_string.h"

--- a/base/cvd/cuttlefish/host/libs/web/http_client/http_client.h
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/http_client.h
@@ -22,7 +22,7 @@
 #include <type_traits>
 #include <vector>
 
-#include <fmt/format.h>
+#include "fmt/format.h"
 
 #include "cuttlefish/result/result.h"
 

--- a/base/cvd/cuttlefish/host/libs/web/http_client/http_json.cc
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/http_json.cc
@@ -21,7 +21,7 @@
 #include <vector>
 
 #include "absl/log/log.h"
-#include <json/value.h>
+#include "json/value.h"
 
 #include "cuttlefish/common/libs/utils/json.h"
 #include "cuttlefish/host/libs/web/http_client/http_client.h"

--- a/base/cvd/cuttlefish/host/libs/web/http_client/http_json.cc
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/http_json.cc
@@ -20,8 +20,8 @@
 #include <utility>
 #include <vector>
 
-#include <json/value.h>
 #include "absl/log/log.h"
+#include <json/value.h>
 
 #include "cuttlefish/common/libs/utils/json.h"
 #include "cuttlefish/host/libs/web/http_client/http_client.h"

--- a/base/cvd/cuttlefish/host/libs/web/http_client/http_json.h
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/http_json.h
@@ -18,7 +18,7 @@
 #include <string>
 #include <vector>
 
-#include <json/json.h>
+#include "json/json.h"
 
 #include "cuttlefish/host/libs/web/http_client/http_client.h"
 #include "cuttlefish/result/result.h"

--- a/base/cvd/cuttlefish/host/libs/web/http_client/scrub_secrets_test.cc
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/scrub_secrets_test.cc
@@ -15,7 +15,7 @@
 
 #include "cuttlefish/host/libs/web/http_client/scrub_secrets.h"
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 namespace cuttlefish {
 namespace http_client {

--- a/base/cvd/cuttlefish/host/libs/web/http_client/url_escape.cc
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/url_escape.cc
@@ -15,10 +15,10 @@
 
 #include "cuttlefish/host/libs/web/http_client/url_escape.h"
 
-#include <curl/curl.h>
-
 #include <string>
 #include <string_view>
+
+#include <curl/curl.h>
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/libs/web/http_client/url_escape.cc
+++ b/base/cvd/cuttlefish/host/libs/web/http_client/url_escape.cc
@@ -18,7 +18,7 @@
 #include <string>
 #include <string_view>
 
-#include <curl/curl.h>
+#include "curl/curl.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/io/cpio_test.cc
+++ b/base/cvd/cuttlefish/io/cpio_test.cc
@@ -22,8 +22,8 @@
 #include <utility>
 #include <vector>
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 #include "cuttlefish/io/in_memory.h"
 #include "cuttlefish/io/io.h"

--- a/base/cvd/cuttlefish/io/lz4_legacy_test.cc
+++ b/base/cvd/cuttlefish/io/lz4_legacy_test.cc
@@ -22,8 +22,8 @@
 #include <string_view>
 #include <utility>
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 #include "cuttlefish/io/filesystem.h"
 #include "cuttlefish/io/in_memory.h"

--- a/base/cvd/cuttlefish/pretty/string.cc
+++ b/base/cvd/cuttlefish/pretty/string.cc
@@ -19,6 +19,7 @@
 #include <string_view>
 
 #include "absl/strings/str_cat.h"
+
 #include "cuttlefish/pretty/pretty.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/pretty/struct_test.cc
+++ b/base/cvd/cuttlefish/pretty/struct_test.cc
@@ -17,6 +17,7 @@
 #include "cuttlefish/pretty/struct.h"
 
 #include <string_view>
+
 #include "absl/strings/ascii.h"
 #include "fmt/format.h"
 #include "gtest/gtest.h"

--- a/base/cvd/cuttlefish/result/error_type.cc
+++ b/base/cvd/cuttlefish/result/error_type.cc
@@ -22,8 +22,8 @@
 #include <utility>
 #include <vector>
 
-#include <android-base/format.h>
-#include <android-base/result.h>
+#include "android-base/format.h"
+#include "android-base/result.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/result/error_type.h
+++ b/base/cvd/cuttlefish/result/error_type.h
@@ -24,8 +24,8 @@
 #include <utility>
 #include <vector>
 
-#include <android-base/format.h>  // IWYU pragma: export
-#include <android-base/result.h>  // IWYU pragma: export
+#include "android-base/format.h"  // IWYU pragma: export
+#include "android-base/result.h"  // IWYU pragma: export
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/result/expect.h
+++ b/base/cvd/cuttlefish/result/expect.h
@@ -19,8 +19,8 @@
 #include <type_traits>
 #include <utility>
 
-#include <android-base/format.h>  // IWYU pragma: export
-#include <android-base/result.h>  // IWYU pragma: export
+#include "android-base/format.h"  // IWYU pragma: export
+#include "android-base/result.h"  // IWYU pragma: export
 
 #include "cuttlefish/result/error_type.h"
 #include "cuttlefish/result/result_type.h"  // IWYU pragma: export

--- a/base/cvd/cuttlefish/result/result_matchers.h
+++ b/base/cvd/cuttlefish/result/result_matchers.h
@@ -17,8 +17,8 @@
 
 #include <type_traits>
 
-#include <android-base/expected.h>
-#include <gmock/gmock.h>
+#include "android-base/expected.h"
+#include "gmock/gmock.h"
 
 #include "cuttlefish/result/result.h"
 

--- a/base/cvd/cuttlefish/result/result_test.cpp
+++ b/base/cvd/cuttlefish/result/result_test.cpp
@@ -18,9 +18,9 @@
 
 #include <string>
 
-#include <android-base/expected.h>
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+#include "android-base/expected.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 #include "cuttlefish/result/result_matchers.h"
 

--- a/base/cvd/cuttlefish/result/result_type.h
+++ b/base/cvd/cuttlefish/result/result_type.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <android-base/result.h>  // IWYU pragma: export
+#include "android-base/result.h"  // IWYU pragma: export
 
 #include "cuttlefish/result/error_type.h"
 


### PR DESCRIPTION
Uses [IncludeCategories](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#includecategories) to group includes, and [IncludeBlocks](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#includeblocks) to actively rearrange them to a style better matching the [style guide](https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes).

Third-party libraries are also converted to double-quotes includes where possible.

Only files currently covered by clang-format tests are modified.

Assisted-by: Jetski:Gemini Next
Bug: b/512215781
