### PR TITLE
Clarify proxy port vs. non-proxy port + show the non-proxy port to the user

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -1244,9 +1244,13 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
               "Error in looking up num to webrtc_device_id_flag_map");
     instance.set_webrtc_device_id(num_to_webrtc_device_id_flag_map[num]);
 
-    auto port = 8443 + num - 1;
-    // Change the signaling server port for all instances
-    tmp_config_obj.set_sig_server_proxy_port(port);
+    // TODO(b/522400327): It would be nice to consolidate the port definitions around here.
+    auto sig_server_port = 1443;
+    tmp_config_obj.set_sig_server_port(sig_server_port);
+
+    auto sig_server_proxy_port = 8443 + num - 1;
+    // Change the signaling server proxy port for all instances
+    tmp_config_obj.set_sig_server_proxy_port(sig_server_proxy_port);
     instance.set_start_netsim(is_first_instance && is_any_netsim);
 
     instance.set_start_rootcanal(is_first_instance && any_not_netsim_bt &&

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/streamer.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/streamer.cpp
@@ -221,7 +221,7 @@ class WebRtcServer : public virtual CommandSource,
     }
     std::ostringstream out;
     out << "Point your browser to https://localhost:"
-        << config_.sig_server_proxy_port() << " to interact with the device.";
+        << config_.sig_server_port() << " to interact with the device.";
     return {out.str()};
   }
 

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.cpp
@@ -137,11 +137,19 @@ void CuttlefishConfig::set_gem5_debug_flags(const std::string& gem5_debug_flags)
 }
 
 static constexpr char kSigServerPort[] = "webrtc_sig_server_port";
-void CuttlefishConfig::set_sig_server_proxy_port(int port) {
+void CuttlefishConfig::set_sig_server_port(int port) {
   (*dictionary_)[kSigServerPort] = port;
 }
-int CuttlefishConfig::sig_server_proxy_port() const {
+int CuttlefishConfig::sig_server_port() const {
   return (*dictionary_)[kSigServerPort].asInt();
+}
+
+static constexpr char kSigServerProxyPort[] = "webrtc_sig_server_proxy_port";
+void CuttlefishConfig::set_sig_server_proxy_port(int port) {
+  (*dictionary_)[kSigServerProxyPort] = port;
+}
+int CuttlefishConfig::sig_server_proxy_port() const {
+  return (*dictionary_)[kSigServerProxyPort].asInt();
 }
 
 static constexpr char kSigServerAddress[] = "webrtc_sig_server_addr";

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
@@ -191,6 +191,10 @@ class CuttlefishConfig {
   void set_extra_kernel_cmdline(const std::string& extra_cmdline);
   std::vector<std::string> extra_kernel_cmdline() const;
 
+  // The port for the signaling (operator) server.
+  void set_sig_server_port(int port);
+  int sig_server_port() const;
+
   // The port for the webrtc signaling server proxy.
   void set_sig_server_proxy_port(int port);
   int sig_server_proxy_port() const;


### PR DESCRIPTION
It seemed as though the naming was conflating the proxy port with the actual operator port, so I renamed the proxy port to suit what it actually was. Also changed streamer.cpp to show the non-proxy port to the user instead of the proxy port. 