### PR TITLE
Fix a mostly harmless typo in the resource init script.

### DIFF
--- a/base/debian/cuttlefish-base.cuttlefish-host-resources.init
+++ b/base/debian/cuttlefish-base.cuttlefish-host-resources.init
@@ -300,7 +300,7 @@ destroy_bridged_interfaces() {
         manage_nft_rule delete masq "br-${2}"
         stop_dnsmasq "${2}"
         if [ -n "${ipv6_prefix}" -a -n "${ipv6_prefix_length}" ]; then
-            ip -6 addr del "${ipv6_prefix}1/${ipv6_prefix_len}" dev "${2}"
+            ip -6 addr del "${ipv6_prefix}1/${ipv6_prefix_length}" dev "${2}"
         fi
         ip addr del "${gateway}${netmask}" dev "${2}"
     fi


### PR DESCRIPTION
The typo here is actually harmless because the bridge gets deleted immediately after anyways, but shellcheck will surface it later anyways once that's set up.