### PR TITLE
More descriptive value names when printing flag help messages

### DIFF
--- a/base/cvd/cuttlefish/flag_parser/flag.cpp
+++ b/base/cvd/cuttlefish/flag_parser/flag.cpp
@@ -144,6 +144,8 @@ const std::string& Flag::Description() const { return help_; }
 
 std::string Flag::CurrentValue() const { return getter_(); }
 
+const std::string& Flag::ValueNameHint() const { return value_name_hint_; }
+
 Flag::Flag(std::string name, Flag::Style style) : style_(style) {
   ValidateAlias(name);
   value_name_hint_ = DefaultValueNameHint(name);

--- a/base/cvd/cuttlefish/flag_parser/flag.cpp
+++ b/base/cvd/cuttlefish/flag_parser/flag.cpp
@@ -30,9 +30,11 @@
 
 #include "absl/cleanup/cleanup.h"
 #include "absl/log/check.h"
+#include "absl/strings/ascii.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_replace.h"
+#include "absl/strings/str_split.h"
 #include "absl/strings/strip.h"
 
 #include "cuttlefish/common/libs/utils/contains.h"
@@ -57,6 +59,15 @@ bool MatchNormalized(std::string_view str1, std::string_view str2) {
   return n1 == n2;
 }
 
+std::string DefaultValueNameHint(std::string_view name) {
+  std::vector<std::string_view> parts =
+      absl::StrSplit(name, absl::ByAnyChar("-_"), absl::SkipEmpty());
+  if (parts.empty()) {
+    return "VAL";
+  }
+  return absl::AsciiStrToUpper(parts.back());
+}
+
 }  // namespace
 
 Flag Flag::StringFlag(std::string name) {
@@ -79,6 +90,14 @@ Flag& Flag::Help(std::string help) & {
   return *this;
 }
 Flag Flag::Help(std::string help) && { return std::move(Help(help)); }
+
+Flag& Flag::ValueNameHint(std::string value_name_hint) & {
+  value_name_hint_ = std::move(value_name_hint);
+  return *this;
+}
+Flag Flag::ValueNameHint(std::string value_name_hint) && {
+  return std::move(ValueNameHint(value_name_hint));
+}
 
 Flag& Flag::Getter(std::function<std::string()> getter) & {
   getter_ = std::move(getter);
@@ -111,7 +130,7 @@ std::string Flag::Synopsis() const {
   for (const std::string& alias : aliases_) {
     switch (style_) {
       case Flag::Style::String:
-        options.emplace_back(absl::StrCat("--", alias, "=VAL"));
+        options.emplace_back(absl::StrCat("--", alias, "=", value_name_hint_));
         break;
       case Flag::Style::Bool:
         options.emplace_back("--[no]" + alias);
@@ -127,6 +146,7 @@ std::string Flag::CurrentValue() const { return getter_(); }
 
 Flag::Flag(std::string name, Flag::Style style) : style_(style) {
   ValidateAlias(name);
+  value_name_hint_ = DefaultValueNameHint(name);
   aliases_.emplace_back(std::move(name));
 }
 

--- a/base/cvd/cuttlefish/flag_parser/flag.h
+++ b/base/cvd/cuttlefish/flag_parser/flag.h
@@ -40,6 +40,9 @@ class Flag {
   /* Set help text, visible in the class ostream writer method. Optional. */
   Flag& Help(std::string) &;
   Flag Help(std::string) &&;
+  /* Set the value name hint used in the synopsis. Optional. */
+  Flag& ValueNameHint(std::string) &;
+  Flag ValueNameHint(std::string) &&;
   /* Set a loader that displays the current value in help text. Optional. */
   Flag& Getter(std::function<std::string()>) &;
   Flag Getter(std::function<std::string()>) &&;
@@ -86,6 +89,7 @@ class Flag {
   std::vector<std::string> aliases_;
   Style style_;
   std::string help_;
+  std::string value_name_hint_ = "VAL";
   std::function<std::string()> getter_ = []() { return ""; };
   std::function<Result<void>(std::string_view value)> setter_;
   std::vector<std::function<Result<void>()>> validators_;

--- a/base/cvd/cuttlefish/flag_parser/flag.h
+++ b/base/cvd/cuttlefish/flag_parser/flag.h
@@ -62,6 +62,7 @@ class Flag {
   std::string Synopsis() const;
   const std::string& Description() const;
   std::string CurrentValue() const;
+  const std::string& ValueNameHint() const;
 
  private:
   enum class Style {

--- a/base/cvd/cuttlefish/flag_parser/flag_test.cpp
+++ b/base/cvd/cuttlefish/flag_parser/flag_test.cpp
@@ -84,4 +84,29 @@ TEST(FlagParser, EndOfOptionMark) {
   ASSERT_TRUE(flag);
 }
 
+TEST(FlagParser, ValueNameHint_Customized) {
+  auto flag = Flag::StringFlag("myflag").ValueNameHint("myvalue");
+  EXPECT_EQ(flag.Synopsis(), "--myflag=myvalue");
+}
+
+TEST(FlagParser, ValueNameHint_CustomizedWithAlias) {
+  auto flag = Flag::StringFlag("myflag").Alias("mf").ValueNameHint("myvalue");
+  EXPECT_EQ(flag.Synopsis(), "--myflag=myvalue, --mf=myvalue");
+}
+
+TEST(FlagParser, ValueNameHint_DefaultDerived) {
+  auto flag = Flag::StringFlag("myflag");
+  EXPECT_EQ(flag.Synopsis(), "--myflag=MYFLAG");
+}
+
+TEST(FlagParser, ValueNameHint_DefaultDerivedDashed) {
+  auto flag = Flag::StringFlag("verbosity-level");
+  EXPECT_EQ(flag.Synopsis(), "--verbosity-level=LEVEL");
+}
+
+TEST(FlagParser, ValueNameHint_DefaultDerivedSnaked) {
+  auto flag = Flag::StringFlag("verbosity_level");
+  EXPECT_EQ(flag.Synopsis(), "--verbosity_level=LEVEL");
+}
+
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/flag_parser/gflags_compat.cpp
+++ b/base/cvd/cuttlefish/flag_parser/gflags_compat.cpp
@@ -26,10 +26,12 @@
 #include <string>
 #include <string_view>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "absl/log/log.h"
 #include "absl/strings/numbers.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_replace.h"
 #include "absl/strings/str_split.h"
@@ -202,6 +204,11 @@ std::string XmlEscape(const std::string& s) {
   return absl::StrReplaceAll(s, {{"<", "&lt;"}, {">", "&gt;"}});
 }
 
+Flag WithVectorNameValueHint(Flag flag) {
+  std::string hint = flag.ValueNameHint();
+  return std::move(flag).ValueNameHint(absl::StrCat(hint, "[,", hint, "...]"));
+}
+
 }  // namespace
 
 void WriteGflagsCompatXml(const Flag& flag, std::ostream& out) {
@@ -299,16 +306,19 @@ Flag GflagsCompatFlag(const std::string& name, bool& value) {
 
 Flag GflagsCompatFlag(const std::string& name,
                       std::vector<std::string>& value) {
-  return GflagsCompatFlagImpl<std::string>(name, value, "");
+  return WithVectorNameValueHint(
+      GflagsCompatFlagImpl<std::string>(name, value, ""));
 }
 
 Flag GflagsCompatFlag(const std::string& name, std::vector<unsigned>& value) {
-  return GflagsCompatFlagImpl<unsigned>(name, value, 0);
+  return WithVectorNameValueHint(
+      GflagsCompatFlagImpl<unsigned>(name, value, 0));
 }
 
 Flag GflagsCompatFlag(const std::string& name, std::vector<bool>& value,
                       const bool default_value) {
-  return GflagsCompatFlagImpl(name, value, default_value);
+  return WithVectorNameValueHint(
+      GflagsCompatFlagImpl(name, value, default_value));
 }
 
 Flag GflagsCompatFlag(const std::string& name,
@@ -351,13 +361,13 @@ Flag GflagsCompatFlag(const std::string& name, std::optional<bool>& value,
 Flag GflagsCompatFlag(const std::string& name,
                       std::optional<std::vector<std::string>>& value,
                       CoerceToNullopt opt) {
-  return GflagsCompatFlagImpl(name, value, opt);
+  return WithVectorNameValueHint(GflagsCompatFlagImpl(name, value, opt));
 }
 
 Flag GflagsCompatFlag(const std::string& name,
                       std::optional<std::vector<unsigned>>& value,
                       CoerceToNullopt opt) {
-  return GflagsCompatFlagImpl(name, value, opt);
+  return WithVectorNameValueHint(GflagsCompatFlagImpl(name, value, opt));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/flag_parser/gflags_compat_test.cpp
+++ b/base/cvd/cuttlefish/flag_parser/gflags_compat_test.cpp
@@ -561,4 +561,34 @@ TEST(FlagParser, OptionalInt64Flag_NotPresent) {
   ASSERT_FALSE(value.has_value());
 }
 
+TEST(FlagParser, VectorFlagValueNameHint_StringVector) {
+  std::vector<std::string> string_vec;
+  auto flag = GflagsCompatFlag("string-vec", string_vec);
+  EXPECT_EQ(flag.Synopsis(), "--string-vec=VEC[,VEC...]");
+}
+
+TEST(FlagParser, VectorFlagValueNameHint_UnsignedVector) {
+  std::vector<unsigned> unsigned_vec;
+  auto flag = GflagsCompatFlag("unsigned-vec", unsigned_vec);
+  EXPECT_EQ(flag.Synopsis(), "--unsigned-vec=VEC[,VEC...]");
+}
+
+TEST(FlagParser, VectorFlagValueNameHint_BoolVector) {
+  std::vector<bool> bool_vec;
+  auto flag = GflagsCompatFlag("bool-vec", bool_vec, true);
+  EXPECT_EQ(flag.Synopsis(), "--bool-vec=VEC[,VEC...]");
+}
+
+TEST(FlagParser, VectorFlagValueNameHint_OptionalStringVector) {
+  std::optional<std::vector<std::string>> opt_string_vec;
+  auto flag = GflagsCompatFlag("opt-string-vec", opt_string_vec);
+  EXPECT_EQ(flag.Synopsis(), "--opt-string-vec=VEC[,VEC...]");
+}
+
+TEST(FlagParser, VectorFlagValueNameHint_OptionalUnsignedVector) {
+  std::optional<std::vector<unsigned>> opt_unsigned_vec;
+  auto flag = GflagsCompatFlag("opt-unsigned-vec", opt_unsigned_vec);
+  EXPECT_EQ(flag.Synopsis(), "--opt-unsigned-vec=VEC[,VEC...]");
+}
+
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
@@ -226,6 +226,7 @@ std::vector<Flag> BuildSelectorFlagsForCreateHelp(
                 selectors.instance_names.value_or(std::vector<std::string>()),
                 ",");
           })
+          .ValueNameHint("NAME[,NAME...]")
           .Help("Comma separated list of instance names. When provided, this "
                 "flag determines the number of instaces to have in the group, "
                 "so it must match the --num_instances flag. Valid names will "


### PR DESCRIPTION
Prints `--instance-name=NAME[,NAME...]` instead of `--instance-name=VAL` by default. Allows customizing it.

Assisted-by: Gemini