### PR TITLE
Add instance_names alias to instance_name selector

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector_common_parser.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector_common_parser.cpp
@@ -75,6 +75,7 @@ std::vector<Flag> BuildCommonSelectorFlags(SelectorOptions& opts) {
               "to that when no group name is provided.");
   Flag instance_name_flag =
       GflagsCompatFlag(SelectorFlags::kInstanceName, opts.instance_names)
+          .Alias(SelectorFlags::kInstanceNames)
           .AddValidator([&opts]() -> Result<void> {
             CF_EXPECT(ValidateInstanceNamesOpt(opts.instance_names));
             return {};

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector_constants.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector_constants.h
@@ -42,6 +42,7 @@ class SelectorFlags {
  public:
   static constexpr char kGroupName[] = "group_name";
   static constexpr char kInstanceName[] = "instance_name";
+  static constexpr char kInstanceNames[] = "instance_names";
 };
 
 }  // namespace selector


### PR DESCRIPTION
Both of this are valid now:
--instance_name=n1,n2
--instance_names=n1,n2
The second one is more intuitive when using more than one name