### PR TITLE
cvd: Handle broken symlinks in default custom action config

### DIFF
--- a/base/cvd/cuttlefish/host/libs/config/custom_actions.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/custom_actions.cpp
@@ -192,7 +192,13 @@ std::string DefaultCustomActionConfig() {
     } else if (custom_action_configs.size() == 1) {
       for (const auto& config : custom_action_configs) {
         if (absl::EndsWithIgnoreCase(config, ".json")) {
-          return custom_action_config_dir + "/" + config;
+          auto full_path = custom_action_config_dir + "/" + config;
+          if (FileExists(full_path)) {
+            return full_path;
+          }
+          LOG(WARNING)
+              << "Default custom action config " << full_path
+              << " exists in directory but is not accessible (broken symlink?)";
         }
       }
     }


### PR DESCRIPTION
When launching older Android trees, the host tools might contain a broken symlink for cuttlefish_example_action_config.json (pointing to a non-existent /usr/lib/cuttlefish-common/... path on the host).

Previously, DefaultCustomActionConfig() only checked if the parent directory existed and returned the first .json file found, without verifying if the file itself was accessible. This caused assemble_cvd to abort when trying to read the broken symlink.

This change adds a FileExists() check before returning the detected config path. If the file is not accessible (e.g., a broken symlink), it logs a warning and safely ignores it, falling back to an empty custom action configuration and allowing the launch to proceed.

Test: Local launch of older tree (simulated with broken symlink)
TAG=agy
CONV=9c0d5aa1-08b9-492f-a8dd-54472559c2d3