### PR TITLE
Support podcvd load

### DIFF
--- a/container/src/podcvd/internal/container.go
+++ b/container/src/podcvd/internal/container.go
@@ -126,6 +126,8 @@ func (m *CuttlefishContainerManagerImpl) InspectContainer(ctx context.Context, n
 
 func (m *CuttlefishContainerManagerImpl) CreateAndStartContainer(ctx context.Context, extraFlags []string, name string) (string, error) {
 	args := []string{"run", "-d", "-t", "--cap-add", "NET_ADMIN"}
+	// TODO(b/383428636): Remove this when vhost_user_vsock is enabled by default.
+	args = append(args, "--security-opt", "seccomp=unconfined")
 	devices := []string{
 		"/dev/kvm",
 		"/dev/net/tun",

--- a/container/src/podcvd/internal/host.go
+++ b/container/src/podcvd/internal/host.go
@@ -130,6 +130,56 @@ func cvdDataHome() (string, error) {
 	}
 	return "", fmt.Errorf("failed to find cvd data home dir")
 }
+
+func resolveHostPath(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return ""
+	}
+	if _, err := os.Stat(absPath); err != nil {
+		return ""
+	}
+	if strings.HasPrefix(absPath, "/dev/") || strings.HasPrefix(absPath, "/sys/") || strings.HasPrefix(absPath, "/proc/") {
+		return ""
+	}
+	return absPath
+}
+
+func collectMountSpecs(pathsToMount []string, hostOut, productOut, cvdDataHome, podcvdHomeDir string) []string {
+	bindMap := make(map[string]string)
+	bindMap["/host_out"] = fmt.Sprintf("%s:/host_out:O", hostOut)
+	bindMap["/product_out"] = fmt.Sprintf("%s:/product_out:O", productOut)
+	bindMap["/root/.local/share/cvd"] = fmt.Sprintf("%s:/root/.local/share/cvd:ro", cvdDataHome)
+	bindMap["/podcvd_home"] = fmt.Sprintf("%s:/podcvd_home:rw", podcvdHomeDir)
+	for _, p := range pathsToMount {
+		if spec, ok := bindMap[p]; ok {
+			host := strings.SplitN(spec, ":", 2)[0]
+			if host != p {
+				log.Printf("warning: container path %q is already mounted to %q, cannot mount %q\n", p, host, p)
+			}
+			continue
+		}
+		pInfo, err := os.Stat(p)
+		if err != nil {
+			log.Printf("warning: failed to stat path %q to mount: %v\n", p, err)
+			continue
+		}
+		opt := "ro"
+		if pInfo.IsDir() {
+			opt = "O"
+		}
+		bindMap[p] = fmt.Sprintf("%s:%s:%s", p, p, opt)
+	}
+	var specs []string
+	for _, spec := range bindMap {
+		specs = append(specs, spec)
+	}
+	return specs
+}
+
 func appendPortFlags(flags []string, hostIP string, protocol string, portStart int, portEnd int) []string {
 	for port := portStart; port <= portEnd; port++ {
 		flags = append(flags, "-p", fmt.Sprintf("%s:%d:%d/%s", hostIP, port, port, protocol))
@@ -219,6 +269,22 @@ func createAndStartContainer(ccm CuttlefishContainerManager, cvdArgs *CvdArgs) (
 	if err := os.MkdirAll(podcvdHomeDir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create podcvd home dir: %w", err)
 	}
+	var pathsToMount []string
+	for _, arg := range cvdArgs.SubCommandArgs {
+		path := arg
+		if strings.Contains(arg, "=") {
+			path = strings.SplitN(arg, "=", 2)[1]
+		}
+		absPath := resolveHostPath(path)
+		if absPath == "" {
+			continue
+		}
+		pathsToMount = append(pathsToMount, absPath)
+		if realPath, err := filepath.EvalSymlinks(absPath); err == nil && realPath != absPath {
+			pathsToMount = append(pathsToMount, realPath)
+		}
+	}
+	mountSpecs := collectMountSpecs(pathsToMount, hostOut, productOut, cvdDataHome, podcvdHomeDir)
 
 	extraFlags := []string{
 		"-e", "ANDROID_HOST_OUT=/host_out",
@@ -230,69 +296,12 @@ func createAndStartContainer(ccm CuttlefishContainerManager, cvdArgs *CvdArgs) (
 		"--cap-add", "NET_RAW",
 		"--pids-limit", "8192",
 	}
+	for _, spec := range mountSpecs {
+		extraFlags = append(extraFlags, "-v", spec)
+	}
 	clientID := os.Getenv(envClientID)
 	if clientID != "" {
 		extraFlags = append(extraFlags, "--label", fmt.Sprintf("%s=%s", labelClientID, clientID))
-	}
-
-	bindMap := make(map[string]string)
-	bindMap["/host_out"] = fmt.Sprintf("%s:/host_out:O", hostOut)
-	bindMap["/product_out"] = fmt.Sprintf("%s:/product_out:O", productOut)
-	bindMap["/root/.local/share/cvd"] = fmt.Sprintf("%s:/root/.local/share/cvd:ro", cvdDataHome)
-	bindMap["/podcvd_home"] = fmt.Sprintf("%s:/podcvd_home:rw", podcvdHomeDir)
-	for _, arg := range cvdArgs.SubCommandArgs {
-		path := arg
-		if strings.Contains(arg, "=") {
-			path = strings.SplitN(arg, "=", 2)[1]
-		}
-
-		// 1. Filter out empty strings which would incorrectly mount the CWD
-		if strings.TrimSpace(path) == "" {
-			continue
-		}
-
-		absPath, err := filepath.Abs(path)
-		if err != nil {
-			continue
-		}
-		if _, err := os.Stat(absPath); err != nil {
-			continue
-		}
-		// Prevent mounting critical system directories
-		if strings.HasPrefix(absPath, "/dev/") || strings.HasPrefix(absPath, "/sys/") || strings.HasPrefix(absPath, "/proc/") {
-			continue
-		}
-
-		pathsToMount := []string{absPath}
-
-		// 2. Resolve symlinks and track the target file to ensure it's accessible inside
-		if realPath, err := filepath.EvalSymlinks(absPath); err == nil && realPath != absPath {
-			pathsToMount = append(pathsToMount, realPath)
-		}
-
-		// 3. Add to mount configuration while preventing duplicates
-		for _, p := range pathsToMount {
-			if spec, ok := bindMap[p]; ok {
-				host := strings.SplitN(spec, ":", 2)[0]
-				if host != p {
-					log.Printf("warning: container path %q is already mounted to %q, cannot mount %q\n", p, host, p)
-				}
-				continue
-			}
-			pInfo, err := os.Stat(p)
-			if err != nil {
-				log.Printf("warning: failed to stat path %q to mount: %v\n", p, err)
-				continue
-			}
-			opt := "ro"
-			if pInfo.IsDir() {
-				opt = "O"
-			}
-			bindMap[p] = fmt.Sprintf("%s:%s:%s", p, p, opt)
-		}
-	}
-	for _, mountSpec := range bindMap {
-		extraFlags = append(extraFlags, "-v", mountSpec)
 	}
 
 	var lastErr error

--- a/container/src/podcvd/internal/host.go
+++ b/container/src/podcvd/internal/host.go
@@ -227,10 +227,6 @@ func createAndStartContainer(ccm CuttlefishContainerManager, cvdArgs *CvdArgs) (
 		"--label", fmt.Sprintf("%s=%s", labelCreatedBy, valueCreatedBy),
 		"--label", fmt.Sprintf("%s=%s", labelAttemptID, attemptID),
 		"--annotation", "run.oci.keep_original_groups=1",
-		"-v", fmt.Sprintf("%s:/host_out:O", hostOut),
-		"-v", fmt.Sprintf("%s:/product_out:O", productOut),
-		"-v", fmt.Sprintf("%s:/root/.local/share/cvd:ro", cvdDataHome),
-		"-v", fmt.Sprintf("%s:/podcvd_home:rw", podcvdHomeDir),
 		"--cap-add", "NET_RAW",
 		"--pids-limit", "8192",
 	}
@@ -239,12 +235,11 @@ func createAndStartContainer(ccm CuttlefishContainerManager, cvdArgs *CvdArgs) (
 		extraFlags = append(extraFlags, "--label", fmt.Sprintf("%s=%s", labelClientID, clientID))
 	}
 
-	bindSet := make(map[string]bool)
-	bindSet[hostOut+":/host_out"] = true
-	bindSet[productOut+":/product_out"] = true
-	bindSet[cvdDataHome+":/root/.local/share/cvd"] = true
-	bindSet[podcvdHomeDir+":/podcvd_home"] = true
-
+	bindMap := make(map[string]string)
+	bindMap["/host_out"] = fmt.Sprintf("%s:/host_out:O", hostOut)
+	bindMap["/product_out"] = fmt.Sprintf("%s:/product_out:O", productOut)
+	bindMap["/root/.local/share/cvd"] = fmt.Sprintf("%s:/root/.local/share/cvd:ro", cvdDataHome)
+	bindMap["/podcvd_home"] = fmt.Sprintf("%s:/podcvd_home:rw", podcvdHomeDir)
 	for _, arg := range cvdArgs.SubCommandArgs {
 		path := arg
 		if strings.Contains(arg, "=") {
@@ -277,21 +272,27 @@ func createAndStartContainer(ccm CuttlefishContainerManager, cvdArgs *CvdArgs) (
 
 		// 3. Add to mount configuration while preventing duplicates
 		for _, p := range pathsToMount {
-			key := fmt.Sprintf("%s:%s", p, p)
-			if !bindSet[key] {
-				pInfo, err := os.Stat(p)
-				if err != nil {
-					log.Printf("warning: failed to stat path %q to mount: %v\n", p, err)
-					continue
+			if spec, ok := bindMap[p]; ok {
+				host := strings.SplitN(spec, ":", 2)[0]
+				if host != p {
+					log.Printf("warning: container path %q is already mounted to %q, cannot mount %q\n", p, host, p)
 				}
-				opt := "ro"
-				if pInfo.IsDir() {
-					opt = "O"
-				}
-				extraFlags = append(extraFlags, "-v", fmt.Sprintf("%s:%s:%s", p, p, opt))
-				bindSet[key] = true
+				continue
 			}
+			pInfo, err := os.Stat(p)
+			if err != nil {
+				log.Printf("warning: failed to stat path %q to mount: %v\n", p, err)
+				continue
+			}
+			opt := "ro"
+			if pInfo.IsDir() {
+				opt = "O"
+			}
+			bindMap[p] = fmt.Sprintf("%s:%s:%s", p, p, opt)
 		}
+	}
+	for _, mountSpec := range bindMap {
+		extraFlags = append(extraFlags, "-v", mountSpec)
 	}
 
 	var lastErr error

--- a/container/src/podcvd/internal/host.go
+++ b/container/src/podcvd/internal/host.go
@@ -270,14 +270,22 @@ func createAndStartContainer(ccm CuttlefishContainerManager, cvdArgs *CvdArgs) (
 		return "", fmt.Errorf("failed to create podcvd home dir: %w", err)
 	}
 	var pathsToMount []string
-	for _, arg := range cvdArgs.SubCommandArgs {
+	for idx, arg := range cvdArgs.SubCommandArgs {
 		path := arg
+		var flagPrefix string
 		if strings.Contains(arg, "=") {
-			path = strings.SplitN(arg, "=", 2)[1]
+			parts := strings.SplitN(arg, "=", 2)
+			flagPrefix = parts[0]
+			path = parts[1]
 		}
 		absPath := resolveHostPath(path)
 		if absPath == "" {
 			continue
+		}
+		if flagPrefix != "" {
+			cvdArgs.SubCommandArgs[idx] = flagPrefix + "=" + absPath
+		} else {
+			cvdArgs.SubCommandArgs[idx] = absPath
 		}
 		pathsToMount = append(pathsToMount, absPath)
 		if realPath, err := filepath.EvalSymlinks(absPath); err == nil && realPath != absPath {

--- a/container/src/podcvd/internal/main.go
+++ b/container/src/podcvd/internal/main.go
@@ -32,7 +32,10 @@ import (
 )
 
 func Main(args []string) error {
-	cvdArgs := ParseCvdArgs(args)
+	cvdArgs, err := ParseCvdArgs(args)
+	if err != nil {
+		return err
+	}
 	if len(cvdArgs.SubCommandArgs) == 0 {
 		cvdArgs.SubCommandArgs = []string{"help"}
 	}
@@ -72,7 +75,7 @@ func Main(args []string) error {
 		}
 	case "setup":
 		return setupPodcvd()
-	case "cache", "load":
+	case "cache":
 		// TODO(seungjaeyoo): Support other subcommands of cvd as well.
 		return fmt.Errorf("subcommand %q is not implemented yet", subcommand)
 	default:

--- a/container/src/podcvd/internal/parser.go
+++ b/container/src/podcvd/internal/parser.go
@@ -17,6 +17,7 @@ package internal
 import (
 	"flag"
 	"fmt"
+	"path/filepath"
 	"strings"
 )
 
@@ -33,7 +34,7 @@ type CvdArgs struct {
 	flagSet        *flag.FlagSet
 }
 
-func ParseCvdArgs(allArgs []string) *CvdArgs {
+func ParseCvdArgs(allArgs []string) (*CvdArgs, error) {
 	fs := flag.NewFlagSet("podcvd", flag.ExitOnError)
 	commonArgs := CvdCommonArgs{}
 	fs.StringVar(&commonArgs.GroupName, "group_name", "", "Cuttlefish instance group")
@@ -44,6 +45,13 @@ func ParseCvdArgs(allArgs []string) *CvdArgs {
 	subcommandArgs := fs.Args()
 	if len(subcommandArgs) > 0 {
 		subcommandArgs[0] = mapSubcommand(subcommandArgs[0])
+		if subcommandArgs[0] == "load" {
+			var err error
+			subcommandArgs, err = substituteLoadWithCreateArgs(subcommandArgs)
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 	return &CvdArgs{
 		CommonArgs: &commonArgs,
@@ -53,7 +61,7 @@ func ParseCvdArgs(allArgs []string) *CvdArgs {
 		// or starting with subcommand name.
 		SubCommandArgs: subcommandArgs,
 		flagSet:        fs,
-	}
+	}, nil
 }
 
 func (a *CvdArgs) SerializeCommonArgs() []string {
@@ -151,4 +159,24 @@ func mapSubcommand(subcmd string) string {
 		return mapped
 	}
 	return subcmd
+}
+
+func substituteLoadWithCreateArgs(subcmdArgs []string) ([]string, error) {
+	subcmdArgs[0] = "create"
+	for idx := 1; idx < len(subcmdArgs); idx++ {
+		arg := subcmdArgs[idx]
+		if strings.HasPrefix(arg, "-") {
+			if !strings.Contains(arg, "=") {
+				idx++
+			}
+			continue
+		}
+		absPath, err := filepath.Abs(arg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get absolute path for %q: %w", arg, err)
+		}
+		subcmdArgs[idx] = "--config_file=" + absPath
+		return subcmdArgs, nil
+	}
+	return nil, fmt.Errorf("missing config file path for load command")
 }


### PR DESCRIPTION
Reason for adding security option on podman container creation rather than enabling `vhost_user_vsock` was not to break suspend/resume feature on podcvd worked without `vhost_user_vsock`, and `podcvd load` doesn't support configuration field to enable `vhost_user_vsock` within canonical configuration.

Not only supported `podcvd load`, but also refactored logic which is about mounting proper paths by reading flag values. This is required in advance of dealing with `--config_file` flag of `podcvd create` which is highly-related to `podcvd load`, but I couldn't complete it in this PR. This should be followed in the next one.

Context: b/491256959