### PR TITLE
Apply include-cleaner clang-tidy config to flag_parser

### DIFF
--- a/base/cvd/BUILD.bazel
+++ b/base/cvd/BUILD.bazel
@@ -29,6 +29,7 @@ filegroup(
         ".clang-tidy",
         "//cuttlefish/io:.clang-tidy",
         "//cuttlefish/common/libs/key_equals_value:.clang-tidy",
+        "//cuttlefish/flag_parser:.clang-tidy",
         "//cuttlefish/host/commands/assemble_cvd/android_build:.clang-tidy",
         "//cuttlefish/host/commands/cvd/cli/commands:.clang-tidy",
         "//cuttlefish/host/commands/kernel_log_monitor:.clang-tidy",

--- a/base/cvd/cuttlefish/flag_parser/.clang-tidy
+++ b/base/cvd/cuttlefish/flag_parser/.clang-tidy
@@ -1,0 +1,1 @@
+../../clang_tidy_configs/with_include_cleaner

--- a/base/cvd/cuttlefish/flag_parser/BUILD.bazel
+++ b/base/cvd/cuttlefish/flag_parser/BUILD.bazel
@@ -4,6 +4,8 @@ package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
+exports_files([".clang-tidy"])
+
 cf_cc_library(
     name = "flag_parser",
     srcs = [

--- a/base/cvd/cuttlefish/flag_parser/flag.cpp
+++ b/base/cvd/cuttlefish/flag_parser/flag.cpp
@@ -17,16 +17,20 @@
 #include "cuttlefish/flag_parser/flag.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <functional>
 #include <iostream>
 #include <ostream>
+#include <span>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 #include <utility>
 #include <vector>
 
 #include "absl/cleanup/cleanup.h"
 #include "absl/log/check.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_replace.h"
 #include "absl/strings/strip.h"

--- a/base/cvd/cuttlefish/flag_parser/flag_test.cpp
+++ b/base/cvd/cuttlefish/flag_parser/flag_test.cpp
@@ -17,16 +17,16 @@
 
 #include "cuttlefish/flag_parser/flag.h"
 
-#include <stdint.h>
-
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "gmock/gmock-matchers.h"
 #include "gtest/gtest.h"
 
 #include "cuttlefish/flag_parser/gflags_compat.h"
+#include "cuttlefish/result/result.h"
 #include "cuttlefish/result/result_matchers.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/flag_parser/gflags_compat.cpp
+++ b/base/cvd/cuttlefish/flag_parser/gflags_compat.cpp
@@ -17,6 +17,9 @@
 #include "cuttlefish/flag_parser/gflags_compat.h"
 
 #include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
 #include <iostream>
 #include <optional>
 #include <ostream>

--- a/base/cvd/cuttlefish/flag_parser/gflags_compat_test.cpp
+++ b/base/cvd/cuttlefish/flag_parser/gflags_compat_test.cpp
@@ -19,6 +19,7 @@
 #include <stdint.h>
 
 #include <map>
+#include <memory>
 #include <optional>
 #include <sstream>
 #include <string>

--- a/base/cvd/cuttlefish/flag_parser/shared_fd_flag.cpp
+++ b/base/cvd/cuttlefish/flag_parser/shared_fd_flag.cpp
@@ -18,10 +18,12 @@
 #include <unistd.h>
 
 #include <string>
+#include <string_view>
 
 #include "absl/strings/numbers.h"
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/result/result.h"
 
 namespace cuttlefish {


### PR DESCRIPTION
Add .clang-tidy symlink pointing to with_include_cleaner and add necessary includes to make it pass.

Assisted-by: Jetski:Gemini Next
Bug: 523396865
Test: bazel test //...