### PR TITLE
Enable misc-include-cleaner in cuttlefish/posix

### DIFF
--- a/base/cvd/BUILD.bazel
+++ b/base/cvd/BUILD.bazel
@@ -28,6 +28,7 @@ filegroup(
     srcs = [
         ".clang-tidy",
         "//cuttlefish/io:.clang-tidy",
+        "//cuttlefish/posix:.clang-tidy",
         "//cuttlefish/common/libs/key_equals_value:.clang-tidy",
         "//cuttlefish/flag_parser:.clang-tidy",
         "//cuttlefish/host/commands/assemble_cvd/android_build:.clang-tidy",

--- a/base/cvd/cuttlefish/posix/.clang-tidy
+++ b/base/cvd/cuttlefish/posix/.clang-tidy
@@ -1,0 +1,1 @@
+../../clang_tidy_configs/with_include_cleaner

--- a/base/cvd/cuttlefish/posix/BUILD.bazel
+++ b/base/cvd/cuttlefish/posix/BUILD.bazel
@@ -4,6 +4,8 @@ package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
+exports_files([".clang-tidy"])
+
 cf_cc_library(
     name = "rename",
     srcs = ["rename.cc"],

--- a/base/cvd/cuttlefish/posix/readlink.cc
+++ b/base/cvd/cuttlefish/posix/readlink.cc
@@ -15,9 +15,11 @@
  */
 #include "cuttlefish/posix/readlink.h"
 
-#include <errno.h>
+#include <sys/types.h>
 #include <unistd.h>
 
+#include <cerrno>
+#include <cstddef>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/base/cvd/cuttlefish/posix/rename.cc
+++ b/base/cvd/cuttlefish/posix/rename.cc
@@ -15,6 +15,8 @@
  */
 #include "cuttlefish/posix/rename.h"
 
+#include <cerrno>
+#include <cstdio>
 #include <string>
 #include <string_view>
 

--- a/base/cvd/cuttlefish/posix/symlink.cc
+++ b/base/cvd/cuttlefish/posix/symlink.cc
@@ -15,6 +15,9 @@
  */
 #include "cuttlefish/posix/symlink.h"
 
+#include <unistd.h>
+
+#include <cerrno>
 #include <string>
 
 #include "cuttlefish/posix/strerror.h"


### PR DESCRIPTION
Created a .clang-tidy symlink in cuttlefish/posix pointing to the config with include cleaner enabled. Fixed resulting lint errors.

Bug: b/523396865
Assisted-by: Jetski:Gemini-Next
TAG=agy
CONV=cb2ffb17-d633-4d51-a78c-6b729547fedc