### PR TITLE
Enable include-cleaner for cuttlefish/pretty

### DIFF
--- a/base/cvd/BUILD.bazel
+++ b/base/cvd/BUILD.bazel
@@ -41,6 +41,7 @@ filegroup(
         "//cuttlefish/host/libs/zip/libzip_cc:.clang-tidy",
         "//cuttlefish/io:.clang-tidy",
         "//cuttlefish/posix:.clang-tidy",
+        "//cuttlefish/pretty:.clang-tidy",
         "//cuttlefish/result:.clang-tidy",
     ],
 )

--- a/base/cvd/cuttlefish/pretty/.clang-tidy
+++ b/base/cvd/cuttlefish/pretty/.clang-tidy
@@ -1,0 +1,1 @@
+../../clang_tidy_configs/with_include_cleaner

--- a/base/cvd/cuttlefish/pretty/BUILD.bazel
+++ b/base/cvd/cuttlefish/pretty/BUILD.bazel
@@ -4,6 +4,8 @@ package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
+exports_files([".clang-tidy"])
+
 cf_cc_library(
     name = "container",
     srcs = ["container.cc"],

--- a/base/cvd/cuttlefish/pretty/container.cc
+++ b/base/cvd/cuttlefish/pretty/container.cc
@@ -20,6 +20,8 @@
 #include <string_view>
 #include <vector>
 
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "absl/strings/str_replace.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/pretty/container_test.cc
+++ b/base/cvd/cuttlefish/pretty/container_test.cc
@@ -16,10 +16,12 @@
 
 #include "cuttlefish/pretty/container.h"
 
+#include <sstream>
 #include <string_view>
 #include <vector>
 
 #include "absl/strings/ascii.h"
+#include "absl/strings/str_cat.h"
 #include "fmt/format.h"
 #include "gtest/gtest.h"
 

--- a/base/cvd/cuttlefish/pretty/json.cc
+++ b/base/cvd/cuttlefish/pretty/json.cc
@@ -15,6 +15,8 @@
 
 #include "cuttlefish/pretty/json.h"
 
+#include <string>
+
 #include "json/value.h"
 #include "json/writer.h"
 

--- a/base/cvd/cuttlefish/pretty/json_test.cc
+++ b/base/cvd/cuttlefish/pretty/json_test.cc
@@ -16,6 +16,8 @@
 
 #include "cuttlefish/pretty/json.h"
 
+#include <string>
+
 #include "absl/strings/match.h"
 #include "gtest/gtest.h"
 #include "json/value.h"

--- a/base/cvd/cuttlefish/pretty/liblp/builder.cc
+++ b/base/cvd/cuttlefish/pretty/liblp/builder.cc
@@ -18,10 +18,9 @@
 #include "liblp/builder.h"
 
 #include "cuttlefish/pretty/pretty.h"
-#include "cuttlefish/pretty/string.h"
 #include "cuttlefish/pretty/struct.h"
-#include "cuttlefish/pretty/unique_ptr.h"
-#include "cuttlefish/pretty/vector.h"
+#include "cuttlefish/pretty/unique_ptr.h"  // IWYU pragma: keep
+#include "cuttlefish/pretty/vector.h"      // IWYU pragma: keep
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/pretty/liblp/liblp.cc
+++ b/base/cvd/cuttlefish/pretty/liblp/liblp.cc
@@ -17,10 +17,10 @@
 
 #include "liblp/liblp.h"
 
-#include "cuttlefish/pretty/liblp/metadata_format.h"
+#include "cuttlefish/pretty/liblp/metadata_format.h"  // IWYU pragma: keep
 #include "cuttlefish/pretty/pretty.h"
 #include "cuttlefish/pretty/struct.h"
-#include "cuttlefish/pretty/vector.h"
+#include "cuttlefish/pretty/vector.h"  // IWYU pragma: keep
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/pretty/liblp/metadata_format.cc
+++ b/base/cvd/cuttlefish/pretty/liblp/metadata_format.cc
@@ -15,13 +15,15 @@
 
 #include "cuttlefish/pretty/liblp/metadata_format.h"
 
+#include <cstdint>
+#include <vector>
+
 #include "liblp/liblp.h"
 #include "liblp/metadata_format.h"
 
 #include "cuttlefish/pretty/pretty.h"
-#include "cuttlefish/pretty/string.h"
 #include "cuttlefish/pretty/struct.h"
-#include "cuttlefish/pretty/vector.h"
+#include "cuttlefish/pretty/vector.h"  // IWYU pragma: keep
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/pretty/pretty_test.cc
+++ b/base/cvd/cuttlefish/pretty/pretty_test.cc
@@ -19,18 +19,19 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include "absl/strings/ascii.h"
 #include "absl/strings/str_cat.h"
 #include "gtest/gtest.h"
 
-#include "cuttlefish/pretty/map.h"
-#include "cuttlefish/pretty/optional.h"
-#include "cuttlefish/pretty/string.h"
+#include "cuttlefish/pretty/map.h"       // IWYU pragma: keep
+#include "cuttlefish/pretty/optional.h"  // IWYU pragma: keep
+#include "cuttlefish/pretty/string.h"    // IWYU pragma: keep
 #include "cuttlefish/pretty/struct.h"
-#include "cuttlefish/pretty/unique_ptr.h"
-#include "cuttlefish/pretty/vector.h"
+#include "cuttlefish/pretty/unique_ptr.h"  // IWYU pragma: keep
+#include "cuttlefish/pretty/vector.h"      // IWYU pragma: keep
 
 namespace cuttlefish {
 namespace {

--- a/base/cvd/cuttlefish/pretty/struct.cc
+++ b/base/cvd/cuttlefish/pretty/struct.cc
@@ -18,6 +18,7 @@
 #include <ostream>
 #include <string_view>
 
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_replace.h"
 

--- a/base/cvd/cuttlefish/pretty/struct_test.cc
+++ b/base/cvd/cuttlefish/pretty/struct_test.cc
@@ -16,13 +16,13 @@
 
 #include "cuttlefish/pretty/struct.h"
 
+#include <sstream>
 #include <string_view>
 
 #include "absl/strings/ascii.h"
+#include "absl/strings/str_cat.h"
 #include "fmt/format.h"
 #include "gtest/gtest.h"
-
-#include "cuttlefish/pretty/string.h"
 
 namespace cuttlefish {
 namespace {


### PR DESCRIPTION
This change adds a .clang-tidy symlink to cuttlefish/pretty that enables misc-include-cleaner, registers it in BUILD.bazel, and fixes the resulting lint errors.

Bug: b/523396865
Assisted-by: Jetski:GeminiNext