### PR TITLE
Enable include-cleaner for cuttlefish/result

### DIFF
--- a/base/cvd/BUILD.bazel
+++ b/base/cvd/BUILD.bazel
@@ -27,8 +27,6 @@ filegroup(
     name = "clang_tidy_config",
     srcs = [
         ".clang-tidy",
-        "//cuttlefish/io:.clang-tidy",
-        "//cuttlefish/posix:.clang-tidy",
         "//cuttlefish/common/libs/key_equals_value:.clang-tidy",
         "//cuttlefish/flag_parser:.clang-tidy",
         "//cuttlefish/host/commands/assemble_cvd/android_build:.clang-tidy",
@@ -41,6 +39,9 @@ filegroup(
         "//cuttlefish/host/libs/web:.clang-tidy",
         "//cuttlefish/host/libs/zip:.clang-tidy",
         "//cuttlefish/host/libs/zip/libzip_cc:.clang-tidy",
+        "//cuttlefish/io:.clang-tidy",
+        "//cuttlefish/posix:.clang-tidy",
+        "//cuttlefish/result:.clang-tidy",
     ],
 )
 

--- a/base/cvd/cuttlefish/result/.clang-tidy
+++ b/base/cvd/cuttlefish/result/.clang-tidy
@@ -1,0 +1,1 @@
+../../clang_tidy_configs/with_include_cleaner

--- a/base/cvd/cuttlefish/result/BUILD.bazel
+++ b/base/cvd/cuttlefish/result/BUILD.bazel
@@ -4,6 +4,8 @@ package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
+exports_files([".clang-tidy"])
+
 cf_cc_library(
     name = "error_type",
     srcs = ["error_type.cc"],

--- a/base/cvd/cuttlefish/result/error_type.cc
+++ b/base/cvd/cuttlefish/result/error_type.cc
@@ -15,6 +15,8 @@
 
 #include "cuttlefish/result/error_type.h"
 
+#include <cstddef>
+#include <cstdlib>
 #include <optional>
 #include <ostream>
 #include <sstream>
@@ -22,8 +24,7 @@
 #include <utility>
 #include <vector>
 
-#include "android-base/format.h"
-#include "android-base/result.h"
+#include "fmt/base.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/result/error_type.h
+++ b/base/cvd/cuttlefish/result/error_type.h
@@ -24,8 +24,8 @@
 #include <utility>
 #include <vector>
 
-#include "android-base/format.h"  // IWYU pragma: export
-#include "android-base/result.h"  // IWYU pragma: export
+#include "android-base/expected.h"  // IWYU pragma: export
+#include "fmt/core.h"               // IWYU pragma: export
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/result/result_test.cpp
+++ b/base/cvd/cuttlefish/result/result_test.cpp
@@ -18,7 +18,6 @@
 
 #include <string>
 
-#include "android-base/expected.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
Created a .clang-tidy symlink in cuttlefish/result pointing to the with_include_cleaner configuration, and registered it. Fixed misc-include-cleaner violations in error_type and result_test.

Bug: b/523396865
Assisted-by: Jetski:GeminiNext
TAG=agy
CONV=663b0ad6-9f8a-4795-adf9-ba651ce25607