### PR TITLE
Skip TAP device validation for cvdalloc launches.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/run_cvd/validate.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/validate.cpp
@@ -37,7 +37,8 @@ namespace cuttlefish {
 static Result<void> TestTapDevices(
     const CuttlefishConfig::InstanceSpecific& instance) {
 #ifdef __linux__
-  if (InSandbox()) {
+  if (InSandbox()
+  || instance.use_cvdalloc()) { // cvdalloc owns its own resources. those resources can't be validated this way.
     return {};
   }
   auto wifi = instance.wifi_tap_name();


### PR DESCRIPTION
Some recent changes tightened tap device validation in the current path, but unfortunately tightening up tap device validation isn't really compatible with how cvdalloc owns the resources it creates, so currently this halts device boot.. Ideally, we will be able to trust cvdalloc to validate its own resources at some point.