### PR TITLE
Add vhost_user_vsock support for cvd load configuration

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_vm_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_vm_configs.cpp
@@ -49,6 +49,7 @@ inline constexpr char kFlagEnableSandbox[] = "enable_sandbox";
 inline constexpr char kFlagCrosvmSimpleMediaDevice[] =
     "crosvm_simple_media_device";
 inline constexpr char kFlagCrosvmV4l2Proxy[] = "crosvm_v4l2_proxy";
+inline constexpr char kFlagVhostUserVsock[] = "vhost_user_vsock";
 
 std::set<std::string> GatherFlagNamesUsedInInstanceConfig(const Instance& ins) {
   std::set<std::string> names;
@@ -81,6 +82,10 @@ std::set<std::string> GatherFlagNamesUsedInInstanceConfig(const Instance& ins) {
   if (ins.vm().vmm_case() == Vm::VmmCase::kCrosvm &&
       ins.vm().crosvm().has_v4l2_proxy()) {
     names.insert(kFlagCrosvmV4l2Proxy);
+  }
+  if (ins.vm().vmm_case() == Vm::VmmCase::kCrosvm &&
+      ins.vm().crosvm().has_vhost_user_vsock()) {
+    names.insert(kFlagVhostUserVsock);
   }
   return names;
 }
@@ -175,6 +180,13 @@ static std::string V4l2Proxy(const Instance& instance) {
   return crosvm.has_v4l2_proxy() ? crosvm.v4l2_proxy() : default_val;
 }
 
+static std::string VhostUserVsock(const Instance& instance) {
+  const auto& crosvm = instance.vm().crosvm();
+  const auto& default_val = CF_DEFAULTS_VHOST_USER_VSOCK;
+  return crosvm.has_vhost_user_vsock() ? crosvm.vhost_user_vsock()
+                                       : default_val;
+}
+
 static std::vector<std::string> UserPageSize(
     const EnvironmentSpecification& cfg) {
   std::vector<std::string> ret;
@@ -259,6 +271,10 @@ Result<std::vector<std::string>> GenerateVmFlags(
   if (used_names.contains(kFlagCrosvmV4l2Proxy)) {
     flags.emplace_back(
         GenerateInstanceFlag(kFlagCrosvmV4l2Proxy, cfg, V4l2Proxy));
+  }
+  if (used_names.contains(kFlagVhostUserVsock)) {
+    flags.emplace_back(
+        GenerateInstanceFlag(kFlagVhostUserVsock, cfg, VhostUserVsock));
   }
 
   flags = MergeResults(std::move(flags), CF_EXPECT(CustomConfigsFlags(cfg)));

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/vm_configs_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/vm_configs_test.cc
@@ -743,4 +743,71 @@ TEST(VmFlagsParserTest, ParseTwoInstancesCustomActionsFlagPartialJson) {
   EXPECT_THAT(ParseJson(custom_actions[0]), IsOkAndValue(expected_actions));
 }
 
+TEST(VmFlagsParserTest, ParseTwoInstancesVhostUserVsockFlagPartialJson) {
+  const char* test_string = R""""(
+{
+    "instances" :
+    [
+        {
+            "vm": {
+                "crosvm":{
+                }
+            }
+        },
+        {
+            "vm": {
+                "crosvm":{
+                    "vhost_user_vsock": "true"
+                }
+            }
+        }
+    ]
+}
+  )"""";
+
+  Json::Value json_configs;
+  std::string json_text(test_string);
+
+  EXPECT_TRUE(ParseJsonString(json_text, json_configs))
+      << "Invalid Json string";
+  auto serialized_data = LaunchCvdParserTester(json_configs);
+  EXPECT_TRUE(serialized_data.ok()) << serialized_data.error().Trace();
+  EXPECT_TRUE(FindConfig(*serialized_data, R"(--vhost_user_vsock=auto,true)"))
+      << "vhost_user_vsock flag is missing or wrongly formatted";
+}
+
+TEST(VmFlagsParserTest, ParseTwoInstancesVhostUserVsockFlagFullJson) {
+  const char* test_string = R""""(
+{
+    "instances" :
+    [
+        {
+            "vm": {
+                "crosvm":{
+                    "vhost_user_vsock": "true"
+                }
+            }
+        },
+        {
+            "vm": {
+                "crosvm":{
+                    "vhost_user_vsock": "false"
+                }
+            }
+        }
+    ]
+}
+  )"""";
+
+  Json::Value json_configs;
+  std::string json_text(test_string);
+
+  EXPECT_TRUE(ParseJsonString(json_text, json_configs))
+      << "Invalid Json string";
+  auto serialized_data = LaunchCvdParserTester(json_configs);
+  EXPECT_TRUE(serialized_data.ok()) << serialized_data.error().Trace();
+  EXPECT_TRUE(FindConfig(*serialized_data, R"(--vhost_user_vsock=true,false)"))
+      << "vhost_user_vsock flag is missing or wrongly formatted";
+}
+
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_config.proto
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_config.proto
@@ -189,6 +189,7 @@ message Crosvm {
   optional bool enable_sandbox = 1;
   optional bool simple_media_device = 2;
   optional string v4l2_proxy = 3;
+  optional string vhost_user_vsock = 4;
 }
 
 message Gem5 {}


### PR DESCRIPTION
Since vhost_user_vsock is not enabled by default at x86_64, we need to turn it on manually to support multiple docker instance scenario.

But there is a no way to set it by using Host Orchestrator API. So add support for vhost_user_vsock to cvd load configuration file that can be used for Host Orchestrator API.