### PR TITLE
Rearrange top-level .clang-tidy symlinks

### DIFF
--- a/base/cvd/.clang-tidy
+++ b/base/cvd/.clang-tidy
@@ -1,1 +1,1 @@
-clang_tidy_configs/base_config
+clang_tidy_configs/with_include_cleaner

--- a/base/cvd/BUILD.bazel
+++ b/base/cvd/BUILD.bazel
@@ -28,9 +28,11 @@ filegroup(
     name = "clang_tidy_config",
     srcs = [
         ".clang-tidy",
+        "//allocd:.clang-tidy",
+        "//cuttlefish/common:.clang-tidy",
         "//cuttlefish/common/libs/key_equals_value:.clang-tidy",
         "//cuttlefish/common/libs/transport:.clang-tidy",
-        "//cuttlefish/flag_parser:.clang-tidy",
+        "//cuttlefish/host:.clang-tidy",
         "//cuttlefish/host/commands/assemble_cvd/android_build:.clang-tidy",
         "//cuttlefish/host/commands/cvd/cli/commands:.clang-tidy",
         "//cuttlefish/host/commands/kernel_log_monitor:.clang-tidy",
@@ -41,10 +43,7 @@ filegroup(
         "//cuttlefish/host/libs/web:.clang-tidy",
         "//cuttlefish/host/libs/zip:.clang-tidy",
         "//cuttlefish/host/libs/zip/libzip_cc:.clang-tidy",
-        "//cuttlefish/io:.clang-tidy",
-        "//cuttlefish/posix:.clang-tidy",
-        "//cuttlefish/pretty:.clang-tidy",
-        "//cuttlefish/result:.clang-tidy",
+        "//teeui/libteeui:.clang-tidy",
     ],
 )
 

--- a/base/cvd/allocd/.clang-tidy
+++ b/base/cvd/allocd/.clang-tidy
@@ -1,0 +1,1 @@
+../clang_tidy_configs/base_config

--- a/base/cvd/allocd/BUILD.bazel
+++ b/base/cvd/allocd/BUILD.bazel
@@ -5,6 +5,8 @@ package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
+exports_files([".clang-tidy"])
+
 string_flag(
     name = "driver",
     build_setting_default = "iproute2",

--- a/base/cvd/cuttlefish/common/.clang-tidy
+++ b/base/cvd/cuttlefish/common/.clang-tidy
@@ -1,0 +1,1 @@
+../../clang_tidy_configs/base_config

--- a/base/cvd/cuttlefish/common/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files([".clang-tidy"])

--- a/base/cvd/cuttlefish/flag_parser/.clang-tidy
+++ b/base/cvd/cuttlefish/flag_parser/.clang-tidy
@@ -1,1 +1,0 @@
-../../clang_tidy_configs/with_include_cleaner

--- a/base/cvd/cuttlefish/flag_parser/BUILD.bazel
+++ b/base/cvd/cuttlefish/flag_parser/BUILD.bazel
@@ -4,8 +4,6 @@ package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
-exports_files([".clang-tidy"])
-
 cf_cc_library(
     name = "flag_parser",
     srcs = [

--- a/base/cvd/cuttlefish/host/.clang-tidy
+++ b/base/cvd/cuttlefish/host/.clang-tidy
@@ -1,0 +1,1 @@
+../../clang_tidy_configs/base_config

--- a/base/cvd/cuttlefish/host/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files([".clang-tidy"])

--- a/base/cvd/cuttlefish/io/.clang-tidy
+++ b/base/cvd/cuttlefish/io/.clang-tidy
@@ -1,1 +1,0 @@
-../../clang_tidy_configs/with_include_cleaner

--- a/base/cvd/cuttlefish/io/BUILD.bazel
+++ b/base/cvd/cuttlefish/io/BUILD.bazel
@@ -6,8 +6,6 @@ package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
-exports_files([".clang-tidy"])
-
 cf_cc_library(
     name = "chroot",
     srcs = ["chroot.cc"],

--- a/base/cvd/cuttlefish/posix/.clang-tidy
+++ b/base/cvd/cuttlefish/posix/.clang-tidy
@@ -1,1 +1,0 @@
-../../clang_tidy_configs/with_include_cleaner

--- a/base/cvd/cuttlefish/posix/BUILD.bazel
+++ b/base/cvd/cuttlefish/posix/BUILD.bazel
@@ -4,8 +4,6 @@ package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
-exports_files([".clang-tidy"])
-
 cf_cc_library(
     name = "rename",
     srcs = ["rename.cc"],

--- a/base/cvd/cuttlefish/pretty/.clang-tidy
+++ b/base/cvd/cuttlefish/pretty/.clang-tidy
@@ -1,1 +1,0 @@
-../../clang_tidy_configs/with_include_cleaner

--- a/base/cvd/cuttlefish/pretty/BUILD.bazel
+++ b/base/cvd/cuttlefish/pretty/BUILD.bazel
@@ -4,8 +4,6 @@ package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
-exports_files([".clang-tidy"])
-
 cf_cc_library(
     name = "container",
     srcs = ["container.cc"],

--- a/base/cvd/cuttlefish/result/.clang-tidy
+++ b/base/cvd/cuttlefish/result/.clang-tidy
@@ -1,1 +1,0 @@
-../../clang_tidy_configs/with_include_cleaner

--- a/base/cvd/cuttlefish/result/BUILD.bazel
+++ b/base/cvd/cuttlefish/result/BUILD.bazel
@@ -4,8 +4,6 @@ package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
-exports_files([".clang-tidy"])
-
 cf_cc_library(
     name = "error_type",
     srcs = ["error_type.cc"],

--- a/base/cvd/teeui/libteeui/.clang-tidy
+++ b/base/cvd/teeui/libteeui/.clang-tidy
@@ -1,0 +1,1 @@
+../../clang_tidy_configs/base_config

--- a/base/cvd/teeui/libteeui/BUILD.bazel
+++ b/base/cvd/teeui/libteeui/BUILD.bazel
@@ -4,6 +4,8 @@ package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
+exports_files([".clang-tidy"])
+
 cc_library(
     name = "libteeui",
     srcs = [


### PR DESCRIPTION
base/cvd/.clang-tidy now applies misc-include-cleaner, and lower level directories override it back to the base config.

Bug: b/523396865