### PR TITLE
Apply misc-include-cleaner to cuttlefish/common/transport

### DIFF
--- a/base/cvd/BUILD.bazel
+++ b/base/cvd/BUILD.bazel
@@ -29,6 +29,7 @@ filegroup(
     srcs = [
         ".clang-tidy",
         "//cuttlefish/common/libs/key_equals_value:.clang-tidy",
+        "//cuttlefish/common/libs/transport:.clang-tidy",
         "//cuttlefish/flag_parser:.clang-tidy",
         "//cuttlefish/host/commands/assemble_cvd/android_build:.clang-tidy",
         "//cuttlefish/host/commands/cvd/cli/commands:.clang-tidy",

--- a/base/cvd/cuttlefish/common/libs/transport/.clang-tidy
+++ b/base/cvd/cuttlefish/common/libs/transport/.clang-tidy
@@ -1,0 +1,1 @@
+../../../../clang_tidy_configs/with_include_cleaner

--- a/base/cvd/cuttlefish/common/libs/transport/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/transport/BUILD.bazel
@@ -4,6 +4,8 @@ package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
+exports_files([".clang-tidy"])
+
 cf_cc_library(
     name = "transport",
     srcs = [
@@ -16,7 +18,8 @@ cf_cc_library(
     ],
     deps = [
         "//cuttlefish/common/libs/fs",
-        "//cuttlefish/result",
+        "//cuttlefish/result:expect",
+        "//cuttlefish/result:result_type",
         "//libbase",
         "@abseil-cpp//absl/log",
     ],

--- a/base/cvd/cuttlefish/common/libs/transport/channel.cpp
+++ b/base/cvd/cuttlefish/common/libs/transport/channel.cpp
@@ -16,12 +16,19 @@
 
 #include "cuttlefish/common/libs/transport/channel.h"
 
-namespace cuttlefish {
-namespace transport {
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "cuttlefish/result/expect.h"
+#include "cuttlefish/result/result_type.h"
+
+namespace cuttlefish::transport {
 
 void MessageDestroyer::operator()(RawMessage* ptr) {
-  std::memset(ptr, 0, sizeof(RawMessage) + ptr->payload_size);
-  std::free(ptr);
+  memset(ptr, 0, sizeof(RawMessage) + ptr->payload_size);
+  free(ptr);
 }
 
 /**
@@ -30,12 +37,12 @@ void MessageDestroyer::operator()(RawMessage* ptr) {
  */
 Result<ManagedMessage> CreateMessage(uint32_t command, bool is_response,
                                      size_t payload_size) {
-  const auto bytes_to_allocate = sizeof(RawMessage) + payload_size;
-  auto memory = std::malloc(bytes_to_allocate);
-  CF_EXPECT(memory != nullptr, "Cannot allocate "
-                                   << bytes_to_allocate
-                                   << " bytes for secure_env RPC message");
-  auto message = reinterpret_cast<RawMessage*>(memory);
+  const size_t bytes_to_allocate = sizeof(RawMessage) + payload_size;
+  void* memory = malloc(bytes_to_allocate);
+  CF_EXPECTF(memory != nullptr,
+             "Cannot allocate {} bytes for secure_env RPC message",
+             bytes_to_allocate);
+  RawMessage* message = reinterpret_cast<RawMessage*>(memory);
   message->command = command;
   message->is_response = is_response;
   message->payload_size = payload_size;
@@ -43,8 +50,7 @@ Result<ManagedMessage> CreateMessage(uint32_t command, bool is_response,
 }
 
 Result<ManagedMessage> CreateMessage(uint32_t command, size_t payload_size) {
-  return CreateMessage(command, false, payload_size);
+  return CF_EXPECT(CreateMessage(command, false, payload_size));
 }
 
-}  // namespace transport
-}  // namespace cuttlefish
+}  // namespace cuttlefish::transport

--- a/base/cvd/cuttlefish/common/libs/transport/channel.h
+++ b/base/cvd/cuttlefish/common/libs/transport/channel.h
@@ -18,10 +18,9 @@
 
 #include <memory>
 
-#include "cuttlefish/result/result.h"
+#include "cuttlefish/result/result_type.h"
 
-namespace cuttlefish {
-namespace transport {
+namespace cuttlefish::transport {
 
 /**
  * RawMessage - Header and raw byte payload for a serialized
@@ -73,5 +72,4 @@ class Channel {
   virtual ~Channel() {}
 };
 
-}  // namespace transport
-}  // namespace cuttlefish
+}  // namespace cuttlefish::transport

--- a/base/cvd/cuttlefish/common/libs/transport/channel_sharedfd.cpp
+++ b/base/cvd/cuttlefish/common/libs/transport/channel_sharedfd.cpp
@@ -17,39 +17,47 @@
 #include "cuttlefish/common/libs/transport/channel_sharedfd.h"
 
 #include <poll.h>
+#include <stddef.h>
+#include <sys/types.h>
 
+#include <utility>
 #include <vector>
 
 #include "absl/log/log.h"
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
+#include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/common/libs/transport/channel.h"
+#include "cuttlefish/result/expect.h"
+#include "cuttlefish/result/result_type.h"
 
-namespace cuttlefish {
-namespace transport {
+namespace cuttlefish::transport {
 
 SharedFdChannel::SharedFdChannel(SharedFD input, SharedFD output)
     : input_(std::move(input)), output_(std::move(output)) {}
 
 Result<void> SharedFdChannel::SendRequest(RawMessage& message) {
-  return SendMessage(message, false);
+  CF_EXPECT(SendMessage(message, false));
+  return {};
 }
 
 Result<void> SharedFdChannel::SendResponse(RawMessage& message) {
-  return SendMessage(message, true);
+  CF_EXPECT(SendMessage(message, true));
+  return {};
 }
 
 Result<ManagedMessage> SharedFdChannel::ReceiveMessage() {
   struct RawMessage message_header;
-  auto read = ReadExactBinary(input_, &message_header);
+  ssize_t read = ReadExactBinary(input_, &message_header);
   CF_EXPECT(read == sizeof(RawMessage),
             "Expected " << sizeof(RawMessage) << ", received " << read << "\n"
                         << "Could not read message: " << input_->StrError());
   VLOG(0) << "Received message with id: " << message_header.command;
 
-  auto message = CF_EXPECT(CreateMessage(message_header.command,
-                                         message_header.is_response,
-                                         message_header.payload_size));
-  auto message_bytes = reinterpret_cast<char*>(message->payload);
+  ManagedMessage message = CF_EXPECT(
+      CreateMessage(message_header.command, message_header.is_response,
+                    message_header.payload_size));
+  char* message_bytes = reinterpret_cast<char*>(message->payload);
   read = ReadExact(input_, message_bytes, message->payload_size);
   CF_EXPECT(read == message->payload_size,
             "Could not read message: " << input_->StrError());
@@ -59,25 +67,24 @@ Result<ManagedMessage> SharedFdChannel::ReceiveMessage() {
 
 Result<int> SharedFdChannel::WaitForMessage() {
   std::vector<PollSharedFd> input_poll = {
-      {.fd = input_, .events = POLLIN},
+      {.fd = input_, .events = POLLIN},  // NOLINT(misc-include-cleaner): poll.h
   };
   const int poll_result = SharedFD::Poll(input_poll, -1);
 
-  CF_EXPECT(poll_result >= 0,
-            "Cannot execute poll on input stream to wait for incoming message");
+  CF_EXPECT_GE(poll_result, 0,
+               "Cannot poll on input stream to wait for incoming message");
 
   return poll_result;
 }
 
 Result<void> SharedFdChannel::SendMessage(RawMessage& message, bool response) {
   message.is_response = response;
-  auto write_size = sizeof(RawMessage) + message.payload_size;
-  auto message_bytes = reinterpret_cast<const char*>(&message);
-  auto written = WriteAll(output_, message_bytes, write_size);
-  CF_EXPECT(written == write_size,
-            "Could not write message: " << output_->StrError());
+  const size_t write_size = sizeof(RawMessage) + message.payload_size;
+  const char* message_bytes = reinterpret_cast<const char*>(&message);
+  const size_t written = WriteAll(output_, message_bytes, write_size);
+  CF_EXPECT_EQ(written, write_size,
+               "Could not write message: " << output_->StrError());
   return {};
 }
 
-}  // namespace transport
-}  // namespace cuttlefish
+}  // namespace cuttlefish::transport

--- a/base/cvd/cuttlefish/common/libs/transport/channel_sharedfd.h
+++ b/base/cvd/cuttlefish/common/libs/transport/channel_sharedfd.h
@@ -19,8 +19,7 @@
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/transport/channel.h"
 
-namespace cuttlefish {
-namespace transport {
+namespace cuttlefish::transport {
 
 class SharedFdChannel : public Channel {
  public:
@@ -37,5 +36,4 @@ class SharedFdChannel : public Channel {
   Result<void> SendMessage(RawMessage& message, bool response);
 };
 
-}  // namespace transport
-}  // namespace cuttlefish
+}  // namespace cuttlefish::transport


### PR DESCRIPTION
Also uses more `const` and less `auto`.

Bug: b/523396865
Test: bazel test //...