### PR TITLE
Show instance status in instance selection menu

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
@@ -32,6 +32,7 @@
 #include "cuttlefish/host/commands/cvd/cli/utils.h"
 #include "cuttlefish/host/commands/cvd/instances/local_instance.h"
 #include "cuttlefish/host/commands/cvd/instances/local_instance_group.h"
+#include "cuttlefish/host/commands/cvd/instances/status_fetcher.h"
 
 namespace cuttlefish {
 namespace selector {
@@ -59,8 +60,9 @@ std::string GroupDisplay(const std::vector<LocalInstanceGroup>& groups,
       if (behavior == DisplayBehavior::LabelInstance) {
         fmt::print(result, "[{}] - ", instance_index);
       }
-      fmt::print(result, "{}-{} (id : {})\n", group.GroupName(),
-                 instance.Name(), instance.Id());
+      fmt::print(result, "{}-{} (id : {} | status : {})\n", group.GroupName(),
+                 instance.Name(), instance.Id(),
+                 HumanFriendlyStateName(instance.State()));
 
       instance_index++;
     }

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/status_fetcher.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/status_fetcher.cpp
@@ -49,33 +49,6 @@ struct IdAndPerInstanceName {
   unsigned id;
 };
 
-// The most important thing this function does is turn "INSTANCE_STATE_RUNNING"
-// into "Running". Some external tools (like the host orchestrator) already
-// depend on this string.
-std::string HumanFriendlyStateName(cvd::InstanceState state) {
-  std::string name = cvd::InstanceState_Name(state);
-  // Drop the enum name prefix
-  std::string_view prefix = "INSTANCE_STATE_";
-  if (absl::StartsWith(name, prefix)) {
-    name = name.substr(prefix.size());
-  }
-
-  for (size_t i = 0; i < name.size(); ++i) {
-    // Replace underscores with spaces
-    if (name[i] == '_') {
-      name[i] = ' ';
-      continue;
-    }
-    // All characters but the first of each word should be lowercase
-    bool first = (i == 0 || name[i - 1] == ' ');
-    if (!first) {
-      name[i] = std::tolower(static_cast<unsigned char>(name[i]));
-    }
-  }
-
-  return name;
-}
-
 // Adds more information to the json object returned by cvd_internal_status,
 // including some that cvd_internal_status normally returns but doesn't when the
 // instance is not running.
@@ -197,6 +170,30 @@ Result<Json::Value> FetchInstanceStatus(LocalInstance& instance,
   OverrideInstanceJson(instance, instance_status_json);
 
   return instance_status_json;
+}
+
+std::string HumanFriendlyStateName(cvd::InstanceState state) {
+  std::string name = cvd::InstanceState_Name(state);
+  // Drop the enum name prefix
+  std::string_view prefix = "INSTANCE_STATE_";
+  if (absl::StartsWith(name, prefix)) {
+    name = name.substr(prefix.size());
+  }
+
+  for (size_t i = 0; i < name.size(); ++i) {
+    // Replace underscores with spaces
+    if (name[i] == '_') {
+      name[i] = ' ';
+      continue;
+    }
+    // All characters but the first of each word should be lowercase
+    bool first = (i == 0 || name[i - 1] == ' ');
+    if (!first) {
+      name[i] = std::tolower(static_cast<unsigned char>(name[i]));
+    }
+  }
+
+  return name;
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/status_fetcher.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/status_fetcher.h
@@ -20,6 +20,7 @@
 
 #include <chrono>
 
+#include "cuttlefish/host/commands/cvd/instances/cvd_persistent_data.pb.h"
 #include "cuttlefish/host/commands/cvd/instances/local_instance.h"
 #include "cuttlefish/result/result.h"
 
@@ -29,5 +30,10 @@ namespace cuttlefish {
 // respond within the given timeout.
 Result<Json::Value> FetchInstanceStatus(LocalInstance& instance,
                                         std::chrono::seconds timeout);
+
+// The most important thing this function does is turn "INSTANCE_STATE_RUNNING"
+// into "Running". Some external tools (like the host orchestrator) already
+// depend on this string.
+std::string HumanFriendlyStateName(cvd::InstanceState state);
 
 }  // namespace cuttlefish


### PR DESCRIPTION
Operations like `cvd stop` or `cvd powerwash` will not succeed on stopped devices, for instance.  To help users avoid selecting those instances, this is a quick workaround.

A future update will filter groups based on something like `LocalInstance.IsActive()` depending on the command.

Bug: 526732996