### PR TITLE
Implement cvd ps command for human-readable status output

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
@@ -133,6 +133,7 @@ cf_cc_library(
         "//cuttlefish/host/commands/cvd/cli/commands:logs",
         "//cuttlefish/host/commands/cvd/cli/commands:power_btn",
         "//cuttlefish/host/commands/cvd/cli/commands:powerwash",
+        "//cuttlefish/host/commands/cvd/cli/commands:ps",
         "//cuttlefish/host/commands/cvd/cli/commands:remove",
         "//cuttlefish/host/commands/cvd/cli/commands:reset",
         "//cuttlefish/host/commands/cvd/cli/commands:restart",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
@@ -180,6 +180,23 @@ cf_cc_library(
 )
 
 cf_cc_library(
+    name = "ps",
+    srcs = ["ps.cpp"],
+    hdrs = ["ps.h"],
+    deps = [
+        "//cuttlefish/flag_parser",
+        "//cuttlefish/host/commands/cvd/cli:command_request",
+        "//cuttlefish/host/commands/cvd/cli:types",
+        "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
+        "//cuttlefish/host/commands/cvd/instances",
+        "//cuttlefish/host/commands/cvd/instances:instance_manager",
+        "//cuttlefish/result",
+        "@fmt",
+        "@jsoncpp",
+    ],
+)
+
+cf_cc_library(
     name = "host_tool_target",
     srcs = ["host_tool_target.cpp"],
     hdrs = ["host_tool_target.h"],

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/ps.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/ps.cpp
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/host/commands/cvd/cli/commands/ps.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "fmt/format.h"
+#include "json/value.h"
+
+#include "cuttlefish/flag_parser/flag.h"
+#include "cuttlefish/host/commands/cvd/cli/command_request.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
+#include "cuttlefish/host/commands/cvd/cli/types.h"
+#include "cuttlefish/host/commands/cvd/instances/instance_database_types.h"
+#include "cuttlefish/host/commands/cvd/instances/instance_manager.h"
+#include "cuttlefish/host/commands/cvd/instances/local_instance.h"
+#include "cuttlefish/host/commands/cvd/instances/local_instance_group.h"
+#include "cuttlefish/result/result.h"
+
+namespace cuttlefish {
+namespace {
+
+constexpr char kPsSubcmd[] = "ps";
+constexpr char kSummaryHelpText[] =
+    "lists active devices in a human-readable table format";
+constexpr char kHelpMessage[] = R"(
+usage: cvd ps [--help]
+
+  cvd ps will list the active devices in a clean table format.
+)";
+
+const std::map<PsColumns, std::string_view> kHeaders = {
+    {PsColumns::kNames, "NAMES"},   {PsColumns::kId, "ID"},
+    {PsColumns::kStatus, "STATUS"}, {PsColumns::kCreated, "CREATED"},
+    {PsColumns::kPorts, "PORTS"},   {PsColumns::kWebAccess, "WEB_ACCESS"},
+};
+
+void PrintTable(const std::map<PsColumns, std::string_view>& headers,
+                const std::vector<PsRow>& rows) {
+  std::map<PsColumns, size_t> col_widths;
+  for (const std::pair<const PsColumns, std::string_view>& pair : headers) {
+    col_widths[pair.first] = pair.second.size();
+  }
+
+  for (const PsRow& row : rows) {
+    for (const std::pair<const PsColumns, std::string>& pair : row) {
+      col_widths[pair.first] =
+          std::max(col_widths[pair.first], pair.second.size());
+    }
+  }
+
+  // Print headers
+  for (const std::pair<const PsColumns, std::string_view>& pair : headers) {
+    std::cout << std::left << std::setw(col_widths[pair.first] + 3)
+              << pair.second;
+  }
+  std::cout << "\n";
+
+  // Print rows
+  for (const PsRow& row : rows) {
+    for (const std::pair<const PsColumns, std::string_view>& pair : headers) {
+      std::string val = "";
+      std::map<PsColumns, std::string>::const_iterator it =
+          row.find(pair.first);
+      if (it != row.end()) {
+        val = it->second;
+      }
+      std::cout << std::left << std::setw(col_widths[pair.first] + 3) << val;
+    }
+    std::cout << "\n";
+  }
+}
+
+}  // namespace
+
+CvdPsCommandHandler::CvdPsCommandHandler(InstanceManager& instance_manager)
+    : instance_manager_(instance_manager) {}
+
+cvd_common::Args CvdPsCommandHandler::CmdList() const { return {kPsSubcmd}; }
+
+std::string CvdPsCommandHandler::SummaryHelp() const {
+  return kSummaryHelpText;
+}
+
+Result<std::string> CvdPsCommandHandler::DetailedHelp(const CommandRequest&) {
+  return kHelpMessage;
+}
+
+Result<void> CvdPsCommandHandler::Handle(const CommandRequest& request) {
+  std::vector<std::string> args = request.SubcommandArguments();
+  CF_EXPECT(ConsumeFlags({}, args, {.fail_on_unexpected_argument = true}));
+
+  std::vector<LocalInstanceGroup> all_groups =
+      CF_EXPECT(instance_manager_.FindGroups({}));
+
+  std::vector<PsRow> rows;
+
+  for (LocalInstanceGroup& group : all_groups) {
+    for (LocalInstance& instance : group.Instances()) {
+      rows.push_back(InstanceToRow(group, instance));
+    }
+  }
+
+  PrintTable(kHeaders, rows);
+  return {};
+}
+
+PsRow CvdPsCommandHandler::InstanceToRow(const LocalInstanceGroup& group,
+                                         LocalInstance& instance) const {
+  PsRow row;
+
+  row[PsColumns::kNames] =
+      fmt::format("{}/{}", group.GroupName(), instance.Name());
+  row[PsColumns::kId] = std::to_string(instance.Id());
+
+  // Fetch live status
+  const Result<Json::Value> status_json_res = instance.FetchStatus();
+  std::string status_str = "Unknown (Fetch Failed)";
+  std::string ports_str = "-";
+  std::string web_access_str = "-";
+
+  if (status_json_res.ok()) {
+    const Json::Value status_json = *status_json_res;
+    status_str = status_json["status"].asString();
+
+    if (instance.IsActive()) {
+      if (status_json.isMember("adb_port")) {
+        ports_str = fmt::format("adb:{}", status_json["adb_port"].asInt());
+      }
+      if (status_json.isMember("web_access")) {
+        web_access_str = status_json["web_access"].asString();
+      }
+    }
+  }
+
+  row[PsColumns::kStatus] = status_str;
+  row[PsColumns::kCreated] = Format(group.StartTime());
+  row[PsColumns::kPorts] = ports_str;
+  row[PsColumns::kWebAccess] = web_access_str;
+
+  return row;
+}
+
+std::unique_ptr<CvdCommandHandler> NewCvdPsCommandHandler(
+    InstanceManager& instance_manager) {
+  return std::unique_ptr<CvdCommandHandler>(
+      new CvdPsCommandHandler(instance_manager));
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/ps.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/ps.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
+#include "cuttlefish/host/commands/cvd/cli/types.h"
+#include "cuttlefish/host/commands/cvd/instances/instance_manager.h"
+#include "cuttlefish/result/result.h"
+
+namespace cuttlefish {
+
+enum class PsColumns {
+  kNames = 0,
+  kId,
+  kStatus,
+  kCreated,
+  kPorts,
+  kWebAccess,
+};
+
+using PsRow = std::map<PsColumns, std::string>;
+
+class CvdPsCommandHandler : public CvdCommandHandler {
+ public:
+  CvdPsCommandHandler(InstanceManager& instance_manager);
+
+  Result<void> Handle(const CommandRequest& request) override;
+  cvd_common::Args CmdList() const override;
+
+  std::string SummaryHelp() const override;
+
+  bool RequiresDeviceExists() const override { return true; }
+
+  Result<std::string> DetailedHelp(const CommandRequest& request) override;
+
+ private:
+  InstanceManager& instance_manager_;
+
+  PsRow InstanceToRow(const LocalInstanceGroup& group,
+                      LocalInstance& instance) const;
+};
+
+std::unique_ptr<CvdCommandHandler> NewCvdPsCommandHandler(
+    InstanceManager& instance_manager);
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/request_context.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/request_context.cpp
@@ -48,6 +48,7 @@
 #include "cuttlefish/host/commands/cvd/cli/commands/setup.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/snapshot.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/start.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/ps.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/status.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/stop.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/version.h"
@@ -118,6 +119,7 @@ RequestContext::RequestContext(InstanceManager& instance_manager,
   request_handlers_.emplace_back(NewCvdSetupHandler());
   request_handlers_.emplace_back(NewCvdStartCommandHandler(instance_manager));
   request_handlers_.emplace_back(NewCvdStatusCommandHandler(instance_manager));
+  request_handlers_.emplace_back(NewCvdPsCommandHandler(instance_manager));
   request_handlers_.emplace_back(NewCvdVersionHandler());
   request_handlers_.emplace_back(NewCvdLogsHandler(instance_manager));
 }


### PR DESCRIPTION
Example:

```
arjundhaliwal@hanashirube:/mnt/more/abfs/abfs-1$ cvd fleet
{
	"groups" : []
}
arjundhaliwal@hanashirube:/mnt/more/abfs/abfs-1$ cvd ps
NAMES   ID   STATUS   CREATED   PORTS   WEB_ACCESS

arjundhaliwal@hanashirube:/mnt/more/abfs/abfs-1$ cvd create
...
Virtual device booted successfully
group:cvd_1|instance(s):1

arjundhaliwal@hanashirube:/mnt/more/abfs/abfs-1$ cvd ps
Requesting status for instance cvd-1
run_cvd is active for instance cvd-1
NAMES     ID   STATUS    CREATED               PORTS      WEB_ACCESS
cvd_1/1   1    Running   2026-06-23 15:01:58   adb:6520   https://localhost:1443/devices/cvd_1-1-1/files/client.html

arjundhaliwal@hanashirube:/mnt/more/abfs/abfs-1$ cvd create
...
Virtual device booted successfully
group:cvd_2|instance(s):2

arjundhaliwal@hanashirube:/mnt/more/abfs/abfs-1$ cvd ps
Requesting status for instance cvd-1
run_cvd is active for instance cvd-1
Requesting status for instance cvd-2
run_cvd is active for instance cvd-2
NAMES     ID   STATUS    CREATED               PORTS      WEB_ACCESS
cvd_1/1   1    Running   2026-06-23 15:01:58   adb:6520   https://localhost:1443/devices/cvd_1-1-1/files/client.html
cvd_2/2   2    Running   2026-06-23 15:04:49   adb:6521   https://localhost:1443/devices/cvd_2-2-2/files/client.html

arjundhaliwal@hanashirube:/mnt/more/abfs/abfs-1$ cvd create
...
Virtual device booted successfully
group:cvd_3|instance(s):3

arjundhaliwal@hanashirube:/mnt/more/abfs/abfs-1$ cvd ps
Requesting status for instance cvd-1
run_cvd is active for instance cvd-1
Requesting status for instance cvd-2
run_cvd is active for instance cvd-2
Requesting status for instance cvd-3
run_cvd is active for instance cvd-3
NAMES     ID   STATUS    CREATED               PORTS      WEB_ACCESS
cvd_1/1   1    Running   2026-06-23 15:01:58   adb:6520   https://localhost:1443/devices/cvd_1-1-1/files/client.html
cvd_2/2   2    Running   2026-06-23 15:04:49   adb:6521   https://localhost:1443/devices/cvd_2-2-2/files/client.html
cvd_3/3   3    Running   2026-06-23 15:07:48   adb:6522   https://localhost:1443/devices/cvd_3-3-3/files/client.html

arjundhaliwal@hanashirube:/mnt/more/abfs/abfs-1$ cvd stop
[0] - cvd_1 (created: 2026-06-23 15:01:58)
	cvd_1-1 (id : 1)
[1] - cvd_2 (created: 2026-06-23 15:04:49)
	cvd_2-2 (id : 2)
[2] - cvd_3 (created: 2026-06-23 15:07:48)
	cvd_3-3 (id : 3)

Select [0,2]: 1
...

arjundhaliwal@hanashirube:/mnt/more/abfs/abfs-1$ cvd ps
Requesting status for instance cvd-1
run_cvd is active for instance cvd-1
Requesting status for instance cvd-3
run_cvd is active for instance cvd-3
NAMES     ID   STATUS    CREATED               PORTS      WEB_ACCESS
cvd_1/1   1    Running   2026-06-23 15:01:58   adb:6520   https://localhost:1443/devices/cvd_1-1-1/files/client.html
cvd_2/2   2    Stopped   2026-06-23 15:04:49   -          -
cvd_3/3   3    Running   2026-06-23 15:07:48   adb:6522   https://localhost:1443/devices/cvd_3-3-3/files/client.html

arjundhaliwal@hanashirube:/mnt/more/abfs/abfs-1$ cvd remove
[0] - cvd_1 (created: 2026-06-23 15:01:58)
	cvd_1-1 (id : 1)
[1] - cvd_2 (created: 2026-06-23 15:04:49)
	cvd_2-2 (id : 2)
[2] - cvd_3 (created: 2026-06-23 15:07:48)
	cvd_3-3 (id : 3)

Select [0,2]: 1

arjundhaliwal@hanashirube:/mnt/more/abfs/abfs-1$ cvd ps
Requesting status for instance cvd-1
run_cvd is active for instance cvd-1
Requesting status for instance cvd-3
run_cvd is active for instance cvd-3
NAMES     ID   STATUS    CREATED               PORTS      WEB_ACCESS
cvd_1/1   1    Running   2026-06-23 15:01:58   adb:6520   https://localhost:1443/devices/cvd_1-1-1/files/client.html
cvd_3/3   3    Running   2026-06-23 15:07:48   adb:6522   https://localhost:1443/devices/cvd_3-3-3/files/client.html
arjundhaliwal@hanashirube:/mnt/more/abfs/abfs-1$ cvd remove
[0] - cvd_1 (created: 2026-06-23 15:01:58)
	cvd_1-1 (id : 1)
[1] - cvd_3 (created: 2026-06-23 15:07:48)
	cvd_3-3 (id : 3)

Select [0,1]: 0
...

arjundhaliwal@hanashirube:/mnt/more/abfs/abfs-1$ cvd ps
Requesting status for instance cvd-3
run_cvd is active for instance cvd-3
NAMES     ID   STATUS    CREATED               PORTS      WEB_ACCESS
cvd_3/3   3    Running   2026-06-23 15:07:48   adb:6522   https://localhost:1443/devices/cvd_3-3-3/files/client.html
arjundhaliwal@hanashirube:/mnt/more/abfs/abfs-1$ cvd reset
Are you sure to reset all the devices, runtime files, and the cvd server if any [y/n]? y
...

arjundhaliwal@hanashirube:/mnt/more/abfs/abfs-1$ cvd ps
NAMES   ID   STATUS   CREATED   PORTS   WEB_ACCESS
arjundhaliwal@hanashirube:/mnt/more/abfs/abfs-1$
```

The extra logspam from CvdStatusMain is unfortunate, perhaps we can make that possible to optionally mute in a follow-up change.
