### PR TITLE
In `cvd start --daemon=false`, delete prior log files before monitoring

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
@@ -418,6 +418,7 @@ cf_cc_library(
         "//cuttlefish/host/commands/cvd/utils",
         "//cuttlefish/host/libs/config:config_constants",
         "//cuttlefish/host/libs/config:cuttlefish_config",
+        "//cuttlefish/host/libs/log_names",
         "//cuttlefish/host/libs/metrics:device_metrics_orchestration",
         "//cuttlefish/posix:symlink",
         "//cuttlefish/result",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
@@ -296,7 +296,8 @@ CvdCreateCommandHandler::FindReusableGroup(
   if (groups.empty()) {
     return std::nullopt;
   }
-  CF_EXPECT_EQ(groups.size(), 1, "Unclear which group to reuse");
+  CF_EXPECT_EQ(groups.size(), 1,
+               "Unclear which group to reuse, try `cvd reset -y`");
 
   auto target_host_it = envs.find(kAndroidHostOut);
   CF_EXPECT(target_host_it != envs.end());

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -39,6 +39,7 @@
 #include <vector>
 
 #include "absl/log/log.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
 #include "fmt/core.h"
@@ -73,6 +74,7 @@
 #include "cuttlefish/host/commands/cvd/utils/subprocess_waiter.h"
 #include "cuttlefish/host/libs/config/config_constants.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/log_names/log_names.h"
 #include "cuttlefish/host/libs/metrics/device_metrics_orchestration.h"
 #include "cuttlefish/posix/symlink.h"
 #include "cuttlefish/result/result.h"
@@ -455,6 +457,13 @@ Result<void> CvdStartCommandHandler::Handle(const CommandRequest& request) {
   Result<void> monitor_res;
 
   if (!own_flags_.daemon) {
+    const LocalInstance& instance = *group.Instances().begin();
+    const std::string assemble_log =
+        absl::StrCat(instance.AssemblyDirectory(), "/", kLogNameAssembleCvd);
+    Result<void> unused = RemoveFile(assemble_log);
+    for (const auto& log : CF_EXPECT(instance.LogsFilenames())) {
+      Result<void> unused = RemoveFile(log);
+    }
     monitor_thread = std::thread([&group, stop_eventfd, &monitor_res]() {
       const LocalInstance& first_instance = *group.Instances().begin();
       monitor_res = MonitorLogs(first_instance, stop_eventfd);


### PR DESCRIPTION
This avoids a conflict where `cvd monitor` holds file descriptors to old log files, and is detected by `assemble_cvd` as a process still holding a file from the previous launch. This is falsely identified as a lingering process from a previous launch.

Bug: b/527153791
Test: cvd fetch && HOME=$PWD bin/launch_cvd, ctrl-c, HOME=$PWD bin/launch_cvd