### PR TITLE
Update container image into trixie

### DIFF
--- a/container/image/Containerfile
+++ b/container/image/Containerfile
@@ -5,7 +5,7 @@
 ARG BUILD_OPTION=prod
 
 
-FROM mirror.gcr.io/library/debian:12 AS runner-base
+FROM mirror.gcr.io/library/debian:13 AS runner-base
 
 # Expose Operator Port (HTTP:1080, HTTPS:1443)
 EXPOSE 1080 1443


### PR DESCRIPTION
In advance of supporting cache command on podcvd, I observed an issue that behavior of `podcvd cache prune` and `cvd cache prune` is different, as the version of `du` is different between bookworm and trixie.

Context: b/491256959