### PR TITLE
Disable crosvm sandboxing inside a sandbox.

### DIFF
--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
@@ -35,6 +35,7 @@
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/host_info.h"
+#include "cuttlefish/common/libs/utils/in_sandbox.h"
 #include "cuttlefish/common/libs/utils/json.h"
 #include "cuttlefish/common/libs/utils/known_paths.h"
 #include "cuttlefish/common/libs/utils/network.h"
@@ -714,7 +715,7 @@ Result<std::vector<MonitorCommand>> CrosvmManager::StartCommands(
                                   ",size=", FileSize(PstorePath(instance)));
   }
 
-  if (instance.enable_sandbox()) {
+  if (instance.enable_sandbox() && !InSandbox()) {
     const bool seccomp_exists = DirectoryExists(instance.seccomp_policy_dir());
     const std::string& var_empty_dir = kCrosvmVarEmptyDir;
     const bool var_empty_available = DirectoryExists(var_empty_dir);


### PR DESCRIPTION
The sandbox may not have the seccomp policy directory set up; this may be redundant anyway.