### PR TITLE
cvd selectors: Prompt once to select instance

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
@@ -38,33 +38,19 @@ namespace cuttlefish {
 namespace selector {
 namespace {
 
-enum class DisplayBehavior {
-  LabelGroup,
-  LabelInstance,
-};
-
-std::string GroupDisplay(const std::vector<LocalInstanceGroup>& groups,
-                         const DisplayBehavior behavior) {
+std::string GroupDisplay(const std::vector<LocalInstanceGroup>& groups) {
   std::stringstream result;
   int group_index = 0;
   for (const LocalInstanceGroup& group : groups) {
-    if (behavior == DisplayBehavior::LabelGroup) {
-      fmt::print(result, "[{}] - ", group_index);
-    }
+    fmt::print(result, "[{}] - ", group_index);
     fmt::print(result, "{} (created: {})\n", group.GroupName(),
                Format(group.StartTime()));
 
-    int instance_index = 0;
     for (const LocalInstance& instance : group.Instances()) {
       result << "\t";
-      if (behavior == DisplayBehavior::LabelInstance) {
-        fmt::print(result, "[{}] - ", instance_index);
-      }
       fmt::print(result, "{}-{} (id : {} | status : {})\n", group.GroupName(),
                  instance.Name(), instance.Id(),
                  HumanFriendlyStateName(instance.State()));
-
-      instance_index++;
     }
 
     group_index++;
@@ -104,7 +90,7 @@ Result<LocalInstanceGroup> PromptUserForGroup(
     const InstanceManager& instance_manager) {
   const std::vector<LocalInstanceGroup> groups =
       CF_EXPECT(instance_manager.FindGroups({}));
-  std::cout << GroupDisplay(groups, DisplayBehavior::LabelGroup);
+  std::cout << GroupDisplay(groups);
 
   const int selection = CF_EXPECT(PromptForSelection(groups.size() - 1));
   auto group_filter = InstanceDatabase::Filter{
@@ -114,26 +100,42 @@ Result<LocalInstanceGroup> PromptUserForGroup(
   return CF_EXPECT(instance_manager.FindGroup(group_filter));
 }
 
+std::string FormatInstanceSelectionMenu(
+    const std::vector<
+        std::pair<LocalInstanceGroup, std::vector<LocalInstance>>>&
+        instances_by_group) {
+  std::stringstream result;
+  int global_instance_index = 0;
+  for (const auto& [group, instances] : instances_by_group) {
+    fmt::print(result, "{} (created: {})\n", group.GroupName(),
+               Format(group.StartTime()));
+    for (const LocalInstance& instance : instances) {
+      fmt::print(result, "\t[{}] - {}-{} (id : {} | status: {})\n",
+                 global_instance_index, group.GroupName(), instance.Name(),
+                 instance.Id(), HumanFriendlyStateName(instance.State()));
+      global_instance_index++;
+    }
+  }
+  return result.str();
+}
+
 Result<std::pair<LocalInstance, LocalInstanceGroup>> PromptUserForInstance(
-    const InstanceManager& instance_manager) {
-  const LocalInstanceGroup group =
-      CF_EXPECT(PromptUserForGroup(instance_manager));
-  const std::vector<LocalInstance>& instances = group.Instances();
-  if (instances.size() == 1) {
-    fmt::print(std::cout,
-               "Single instance in group {}, defaulting to that choice.\n",
-               group.GroupName());
-    return std::pair(instances.front(), group);
+    const std::vector<std::pair<LocalInstanceGroup,
+                                std::vector<LocalInstance>>>& found_instances) {
+  std::vector<std::pair<LocalInstance, LocalInstanceGroup>> flat_instances;
+  for (const auto& [group, instances] : found_instances) {
+    for (const LocalInstance& instance : instances) {
+      flat_instances.push_back({instance, group});
+    }
   }
 
-  std::cout << GroupDisplay({group}, DisplayBehavior::LabelInstance);
+  CF_EXPECT(!flat_instances.empty(), "No instances available");
 
-  const int selection = CF_EXPECT(PromptForSelection(instances.size() - 1));
-  auto instance_filter = InstanceDatabase::Filter{
-      .group_name = group.GroupName(),
-      .instance_names = {instances[selection].Name()},
-  };
-  return CF_EXPECT(instance_manager.FindInstanceWithGroup(instance_filter));
+  std::cout << FormatInstanceSelectionMenu(found_instances);
+
+  const int selection =
+      CF_EXPECT(PromptForSelection(flat_instances.size() - 1));
+  return flat_instances[selection];
 }
 
 }  // namespace
@@ -183,7 +185,7 @@ Result<std::pair<LocalInstance, LocalInstanceGroup>> SelectInstance(
   CF_EXPECT(isatty(0),
             "Multiple instances found.  Narrow the selection with selector "
             "arguments.");
-  return CF_EXPECT(PromptUserForInstance(instance_manager));
+  return CF_EXPECT(PromptUserForInstance(found_instances));
 }
 
 Result<std::vector<std::pair<LocalInstanceGroup, std::vector<LocalInstance>>>>

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
@@ -68,8 +68,8 @@ Result<int> PromptForSelection(const int max_selection) {
 
   int selection = -1;
   while (selection < 0 || selection > max_selection) {
-    fmt::print(std::cout, "\nSelect {}[0,{}]{}: ", colors.Cyan(), max_selection,
-               colors.Reset());
+    fmt::print(std::cout, "\nSelect {}[0..{}]{}: ", colors.Cyan(),
+               max_selection, colors.Reset());
     std::cout << std::flush;
     std::string input_line = CF_EXPECT(terminal->ReadLine());
     if (!absl::SimpleAtoi(input_line, &selection)) {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
@@ -38,11 +38,13 @@ namespace cuttlefish {
 namespace selector {
 namespace {
 
-std::string GroupDisplay(const std::vector<LocalInstanceGroup>& groups) {
+std::string GroupDisplay(const std::vector<LocalInstanceGroup>& groups,
+                         const TerminalColors& colors) {
   std::stringstream result;
   int group_index = 0;
   for (const LocalInstanceGroup& group : groups) {
-    fmt::print(result, "[{}] - ", group_index);
+    fmt::print(result, "{}[{}]{} - ", colors.Cyan(), group_index,
+               colors.Reset());
     fmt::print(result, "{} (created: {})\n", group.GroupName(),
                Format(group.StartTime()));
 
@@ -90,7 +92,8 @@ Result<LocalInstanceGroup> PromptUserForGroup(
     const InstanceManager& instance_manager) {
   const std::vector<LocalInstanceGroup> groups =
       CF_EXPECT(instance_manager.FindGroups({}));
-  std::cout << GroupDisplay(groups);
+  const TerminalColors colors(isatty(1));
+  std::cout << GroupDisplay(groups, colors);
 
   const int selection = CF_EXPECT(PromptForSelection(groups.size() - 1));
   auto group_filter = InstanceDatabase::Filter{
@@ -101,18 +104,19 @@ Result<LocalInstanceGroup> PromptUserForGroup(
 }
 
 std::string FormatInstanceSelectionMenu(
-    const std::vector<
-        std::pair<LocalInstanceGroup, std::vector<LocalInstance>>>&
-        instances_by_group) {
+    const std::vector<std::pair<
+        LocalInstanceGroup, std::vector<LocalInstance>>>& instances_by_group,
+    const TerminalColors& colors) {
   std::stringstream result;
   int global_instance_index = 0;
   for (const auto& [group, instances] : instances_by_group) {
     fmt::print(result, "{} (created: {})\n", group.GroupName(),
                Format(group.StartTime()));
     for (const LocalInstance& instance : instances) {
-      fmt::print(result, "\t[{}] - {}-{} (id : {} | status: {})\n",
-                 global_instance_index, group.GroupName(), instance.Name(),
-                 instance.Id(), HumanFriendlyStateName(instance.State()));
+      fmt::print(result, "\t{}[{}]{} - {}-{} (id : {} | status: {})\n",
+                 colors.Cyan(), global_instance_index, colors.Reset(),
+                 group.GroupName(), instance.Name(), instance.Id(),
+                 HumanFriendlyStateName(instance.State()));
       global_instance_index++;
     }
   }
@@ -131,7 +135,8 @@ Result<std::pair<LocalInstance, LocalInstanceGroup>> PromptUserForInstance(
 
   CF_EXPECT(!flat_instances.empty(), "No instances available");
 
-  std::cout << FormatInstanceSelectionMenu(found_instances);
+  const TerminalColors colors(isatty(1));
+  std::cout << FormatInstanceSelectionMenu(found_instances, colors);
 
   const int selection =
       CF_EXPECT(PromptForSelection(flat_instances.size() - 1));

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
@@ -38,26 +38,56 @@ namespace cuttlefish {
 namespace selector {
 namespace {
 
-std::string GroupDisplay(const std::vector<LocalInstanceGroup>& groups,
-                         const TerminalColors& colors) {
+enum class DisplayBehavior {
+  LabelGroup,
+  LabelInstance,
+};
+
+std::string SelectionMenu(
+    const std::vector<std::pair<
+        LocalInstanceGroup, std::vector<LocalInstance>>>& instances_by_group,
+    DisplayBehavior behavior, const TerminalColors& colors) {
   std::stringstream result;
   int group_index = 0;
-  for (const LocalInstanceGroup& group : groups) {
-    fmt::print(result, "{}[{}]{} - ", colors.Cyan(), group_index,
-               colors.Reset());
+  int global_instance_index = 0;
+  for (const auto& [group, instances] : instances_by_group) {
+    if (behavior == DisplayBehavior::LabelGroup) {
+      fmt::print(result, "{}[{}]{} - ", colors.Cyan(), group_index++,
+                 colors.Reset());
+    }
     fmt::print(result, "{} (created: {})\n", group.GroupName(),
                Format(group.StartTime()));
-
-    for (const LocalInstance& instance : group.Instances()) {
-      result << "\t";
-      fmt::print(result, "{}-{} (id : {} | status : {})\n", group.GroupName(),
+    for (const LocalInstance& instance : instances) {
+      fmt::print(result, "\t");
+      if (behavior == DisplayBehavior::LabelInstance) {
+        fmt::print(result, "{}[{}]{} - ", colors.Cyan(),
+                   global_instance_index++, colors.Reset());
+      }
+      fmt::print(result, "{}-{} (id : {} | status: {})\n", group.GroupName(),
                  instance.Name(), instance.Id(),
                  HumanFriendlyStateName(instance.State()));
     }
-
-    group_index++;
   }
   return result.str();
+}
+
+std::string GroupSelectionMenu(const std::vector<LocalInstanceGroup>& groups,
+                               const TerminalColors& colors) {
+  std::vector<std::pair<LocalInstanceGroup, std::vector<LocalInstance>>>
+      instances_by_group;
+  instances_by_group.reserve(groups.size());
+  for (const LocalInstanceGroup& group : groups) {
+    instances_by_group.emplace_back(group, group.Instances());
+  }
+  return SelectionMenu(instances_by_group, DisplayBehavior::LabelGroup, colors);
+}
+
+std::string InstanceSelectionMenu(
+    const std::vector<std::pair<
+        LocalInstanceGroup, std::vector<LocalInstance>>>& instances_by_group,
+    const TerminalColors& colors) {
+  return SelectionMenu(instances_by_group, DisplayBehavior::LabelInstance,
+                       colors);
 }
 
 Result<int> PromptForSelection(const int max_selection) {
@@ -93,7 +123,7 @@ Result<LocalInstanceGroup> PromptUserForGroup(
   const std::vector<LocalInstanceGroup> groups =
       CF_EXPECT(instance_manager.FindGroups({}));
   const TerminalColors colors(isatty(1));
-  std::cout << GroupDisplay(groups, colors);
+  std::cout << GroupSelectionMenu(groups, colors);
 
   const int selection = CF_EXPECT(PromptForSelection(groups.size() - 1));
   auto group_filter = InstanceDatabase::Filter{
@@ -101,26 +131,6 @@ Result<LocalInstanceGroup> PromptUserForGroup(
   };
 
   return CF_EXPECT(instance_manager.FindGroup(group_filter));
-}
-
-std::string FormatInstanceSelectionMenu(
-    const std::vector<std::pair<
-        LocalInstanceGroup, std::vector<LocalInstance>>>& instances_by_group,
-    const TerminalColors& colors) {
-  std::stringstream result;
-  int global_instance_index = 0;
-  for (const auto& [group, instances] : instances_by_group) {
-    fmt::print(result, "{} (created: {})\n", group.GroupName(),
-               Format(group.StartTime()));
-    for (const LocalInstance& instance : instances) {
-      fmt::print(result, "\t{}[{}]{} - {}-{} (id : {} | status: {})\n",
-                 colors.Cyan(), global_instance_index, colors.Reset(),
-                 group.GroupName(), instance.Name(), instance.Id(),
-                 HumanFriendlyStateName(instance.State()));
-      global_instance_index++;
-    }
-  }
-  return result.str();
 }
 
 Result<std::pair<LocalInstance, LocalInstanceGroup>> PromptUserForInstance(
@@ -136,7 +146,7 @@ Result<std::pair<LocalInstance, LocalInstanceGroup>> PromptUserForInstance(
   CF_EXPECT(!flat_instances.empty(), "No instances available");
 
   const TerminalColors colors(isatty(1));
-  std::cout << FormatInstanceSelectionMenu(found_instances, colors);
+  std::cout << InstanceSelectionMenu(found_instances, colors);
 
   const int selection =
       CF_EXPECT(PromptForSelection(flat_instances.size() - 1));

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.cpp
@@ -38,6 +38,9 @@ namespace cuttlefish {
 namespace selector {
 namespace {
 
+// Output is always a TTY when printing the selection menu.
+constexpr bool kIsMenuOnTTY = true;
+
 enum class DisplayBehavior {
   LabelGroup,
   LabelInstance,
@@ -94,13 +97,13 @@ Result<int> PromptForSelection(const int max_selection) {
   std::unique_ptr<InterruptibleTerminal> terminal =
       std::make_unique<InterruptibleTerminal>();
 
-  TerminalColors colors(isatty(2));
+  TerminalColors colors(kIsMenuOnTTY);
 
   int selection = -1;
   while (selection < 0 || selection > max_selection) {
-    fmt::print(std::cout, "\nSelect {}[0..{}]{}: ", colors.Cyan(),
+    fmt::print(std::cerr, "\nSelect {}[0..{}]{}: ", colors.Cyan(),
                max_selection, colors.Reset());
-    std::cout << std::flush;
+    std::cerr << std::flush;
     std::string input_line = CF_EXPECT(terminal->ReadLine());
     if (!absl::SimpleAtoi(input_line, &selection)) {
       selection = -1;
@@ -122,8 +125,8 @@ Result<LocalInstanceGroup> PromptUserForGroup(
     const InstanceManager& instance_manager) {
   const std::vector<LocalInstanceGroup> groups =
       CF_EXPECT(instance_manager.FindGroups({}));
-  const TerminalColors colors(isatty(1));
-  std::cout << GroupSelectionMenu(groups, colors);
+  const TerminalColors colors(kIsMenuOnTTY);
+  std::cerr << GroupSelectionMenu(groups, colors);
 
   const int selection = CF_EXPECT(PromptForSelection(groups.size() - 1));
   auto group_filter = InstanceDatabase::Filter{
@@ -145,12 +148,20 @@ Result<std::pair<LocalInstance, LocalInstanceGroup>> PromptUserForInstance(
 
   CF_EXPECT(!flat_instances.empty(), "No instances available");
 
-  const TerminalColors colors(isatty(1));
-  std::cout << InstanceSelectionMenu(found_instances, colors);
+  const TerminalColors colors(kIsMenuOnTTY);
+  std::cerr << InstanceSelectionMenu(found_instances, colors);
 
   const int selection =
       CF_EXPECT(PromptForSelection(flat_instances.size() - 1));
   return flat_instances[selection];
+}
+
+bool CanShowSelectionMenu() {
+  // Don't display selection menu unless both stdin and stderr are connected to
+  // the terminal. Stderr is used in case the user is piping the output of to
+  // command, for example `cvd status | grep ...` will still show the selection
+  // menu and won't interfere with the grep command.
+  return isatty(0) && isatty(2);
 }
 
 }  // namespace
@@ -180,7 +191,7 @@ Result<LocalInstanceGroup> SelectGroup(const InstanceManager& instance_manager,
     return groups.front();
   }
   CF_EXPECT(
-      isatty(0),
+      CanShowSelectionMenu(),
       "Multiple groups found. Narrow the selection with selector arguments.");
   return CF_EXPECT(PromptUserForGroup(instance_manager));
 }
@@ -197,7 +208,7 @@ Result<std::pair<LocalInstance, LocalInstanceGroup>> SelectInstance(
     auto [group, instances] = found_instances.front();
     return std::make_pair(instances.front(), group);
   }
-  CF_EXPECT(isatty(0),
+  CF_EXPECT(CanShowSelectionMenu(),
             "Multiple instances found.  Narrow the selection with selector "
             "arguments.");
   return CF_EXPECT(PromptUserForInstance(found_instances));

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/selector.h
@@ -36,10 +36,10 @@ InstanceDatabase::Filter BuildFilterFromSelectors(
 Result<LocalInstanceGroup> SelectGroup(const InstanceManager& instance_manager,
                                        const CommandRequest& request);
 
-// Selects a single instance based on the request's selector options. Unlike
-// SelectGroup it doesn't ask the user to refine the selection in case multiple
-// instances match, it just fails instead. Also returns the group the selected
-// instance belongs to.
+// Selects a single instance based on the request's selector options. Asks the
+// user to manually choose a single instance if multiple instances match the
+// selector options and stdin is a terminal. Also returns the group the
+// selected instance belongs to.
 Result<std::pair<LocalInstance, LocalInstanceGroup>> SelectInstance(
     const InstanceManager& instance_manager, const CommandRequest& request);
 


### PR DESCRIPTION
As opposed to asking for a group first.

It also takes into consideration the --group_name flag to narrow the options when present.

And adds more colors to make the selection options even more obvious:

<img width="380" height="129" alt="Screenshot_20260624_150115" src="https://github.com/user-attachments/assets/121d22cd-35e4-4f42-aeeb-9a0f799db3b9" />
