### PR TITLE
Sandboxes cannot enable tap devices.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
@@ -311,6 +311,7 @@ cf_cc_library(
     hdrs = ["open_wrt.h"],
     clang_format_enabled = False,
     deps = [
+        "//cuttlefish/common/libs/utils:in_sandbox",
         "//cuttlefish/common/libs/utils:json",
         "//cuttlefish/host/commands/run_cvd/launch:cvdalloc",
         "//cuttlefish/host/commands/run_cvd/launch:log_tee_creator",

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/open_wrt.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/open_wrt.cpp
@@ -26,6 +26,7 @@
 #include "absl/log/log.h"
 
 #include "cuttlefish/common/libs/utils/json.h"
+#include "cuttlefish/common/libs/utils/in_sandbox.h"
 #include "cuttlefish/host/commands/run_cvd/launch/cvdalloc.h"
 #include "cuttlefish/host/commands/run_cvd/launch/log_tee_creator.h"
 #include "cuttlefish/host/commands/run_cvd/launch/wmediumd_server.h"
@@ -111,7 +112,7 @@ class OpenWrt : public CommandSource {
       ap_cmd.Cmd().AddParameter("--vhost-user=mac80211-hwsim,socket=",
                                 environment_.vhost_user_mac80211_hwsim());
     }
-    if (environment_.enable_wifi() && instance_.enable_tap_devices()) {
+    if (environment_.enable_wifi() && instance_.enable_tap_devices() && !InSandbox()) {
       ap_cmd.AddTap(instance_.wifi_tap_name());
     }
 

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
@@ -34,6 +34,7 @@
 #include <vulkan/vulkan.h>
 
 #include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/common/libs/utils/in_sandbox.h"
 #include "cuttlefish/common/libs/utils/host_info.h"
 #include "cuttlefish/common/libs/utils/json.h"
 #include "cuttlefish/common/libs/utils/known_paths.h"
@@ -682,7 +683,7 @@ Result<std::vector<MonitorCommand>> CrosvmManager::StartCommands(
   }
 
 #ifdef __linux__
-  if (instance.enable_tap_devices()) {
+  if (instance.enable_tap_devices() && !InSandbox()) {
     // The PCI ordering of tap devices is important. Make sure any change here
     // is reflected in ethprime u-boot variable.
     // TODO(b/218364216, b/322862402): Crosvm occupies 32 PCI devices first and

--- a/base/cvd/cuttlefish/host/libs/vm_manager/qemu_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/qemu_manager.cpp
@@ -35,6 +35,7 @@
 #include "absl/strings/str_split.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/common/libs/utils/in_sandbox.h"
 #include "cuttlefish/common/libs/utils/host_info.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"
 #include "cuttlefish/common/libs/utils/subprocess_managed_stdio.h"
@@ -781,7 +782,7 @@ Result<std::vector<MonitorCommand>> QemuManager::StartCommands(
   bool has_network_devices = false;
   switch (instance.external_network_mode()) {
     case ExternalNetworkMode::kTap:
-      if (instance.enable_tap_devices()) {
+      if (instance.enable_tap_devices() && !InSandbox()) {
         has_network_devices = true;
         qemu_cmd.AddParameter("-netdev");
         qemu_cmd.AddParameter(


### PR DESCRIPTION
Most sandbox environments which we care about likely do not have access to create tap devices. This requires elevated capabilities or root permissions.

This change will enable us to run load tests in sandboxes; the alternative is wiring this control through the load config proto, which is less than ideal.