### PR TITLE
webRTC: Set up audio before registering with server

### DIFF
--- a/base/cvd/cuttlefish/host/frontend/webrtc/main.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/main.cpp
@@ -555,6 +555,8 @@ int CuttlefishMain() {
         custom_action.device_states);
   }
 
+  std::shared_ptr<AudioHandler> audio_handler = SetupAudio(instance, *streamer);
+
   std::shared_ptr<webrtc_streaming::OperatorObserver> operator_observer(
       new CfOperatorObserver());
   streamer->Register(operator_observer);
@@ -568,7 +570,6 @@ int CuttlefishMain() {
     VLOG(0) << "Webrtc control thread exiting.";
   });
 
-  auto audio_handler = SetupAudio(instance, *streamer);
   if (audio_handler) {
     audio_handler->Start();
   }


### PR DESCRIPTION
Registering with the server includes sending the list of audio streams. This list is only available after audio has been set up and the audio tracks added to the streamer.

It was still working most of the time because registration is done from a different thread and involves a unix socket connection, so it has been slow enough to allow for audio to be set up before it happens.

Bug: b/527948058