### PR TITLE
feat(cvd): Add modem_simulator_sim_type as enum to cvd load config

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/flags_parser_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/flags_parser_test.cc
@@ -473,4 +473,131 @@ TEST(FlagsParserTest, ParseMediaV4l2Proxy) {
       << "media flag is missing or wrongly formatted";
 }
 
+TEST(ConnectivityFlagsParserTest, ParseModemSimulatorSimTypeValidInt) {
+  const char* test_string = R""""(
+{
+    "instances" :
+    [
+        {
+          "connectivity": {
+            "modem_simulator_sim_type": 2
+          }
+        },
+        {
+          "connectivity": {
+          }
+        }
+    ]
+}
+  )"""";
+
+  Json::Value json_configs;
+  std::string json_text(test_string);
+
+  EXPECT_TRUE(ParseJsonString(json_text, json_configs))
+      << "Invalid Json string";
+  const Result<std::vector<std::string>> serialized_data = LaunchCvdParserTester(json_configs);
+  EXPECT_THAT(serialized_data, IsOk());
+  EXPECT_TRUE(FindConfig(*serialized_data, "--modem_simulator_sim_type=2,1"))
+      << "modem_simulator_sim_type flag is missing or wrongly formatted";
+}
+
+TEST(ConnectivityFlagsParserTest, ParseModemSimulatorSimTypeValidString) {
+  const char* test_string = R""""(
+{
+    "instances" :
+    [
+        {
+          "connectivity": {
+            "modem_simulator_sim_type": "MODEM_SIMULATOR_SIM_TYPE_CTS_CARRIER_API"
+          }
+        }
+    ]
+}
+  )"""";
+
+  Json::Value json_configs;
+  std::string json_text(test_string);
+
+  EXPECT_TRUE(ParseJsonString(json_text, json_configs))
+      << "Invalid Json string";
+  const Result<std::vector<std::string>> serialized_data = LaunchCvdParserTester(json_configs);
+  EXPECT_THAT(serialized_data, IsOk());
+  EXPECT_TRUE(FindConfig(*serialized_data, "--modem_simulator_sim_type=2"))
+      << "modem_simulator_sim_type flag is missing or wrongly formatted";
+}
+
+TEST(ConnectivityFlagsParserTest, ParseModemSimulatorSimTypeUnspecified) {
+  const char* test_string = R""""(
+{
+    "instances" :
+    [
+        {
+          "connectivity": {
+            "modem_simulator_sim_type": "MODEM_SIMULATOR_SIM_TYPE_UNSPECIFIED"
+          }
+        }
+    ]
+}
+  )"""";
+
+  Json::Value json_configs;
+  std::string json_text(test_string);
+
+  EXPECT_TRUE(ParseJsonString(json_text, json_configs))
+      << "Invalid Json string";
+  const Result<std::vector<std::string>> serialized_data = LaunchCvdParserTester(json_configs);
+  EXPECT_THAT(serialized_data, IsOk());
+  EXPECT_TRUE(FindConfig(*serialized_data, "--modem_simulator_sim_type=1"))
+      << "modem_simulator_sim_type flag is missing or wrongly formatted";
+}
+
+TEST(ConnectivityFlagsParserTest, ParseModemSimulatorSimTypeInvalidString) {
+  const char* test_string = R""""(
+{
+    "instances" :
+    [
+        {
+          "connectivity": {
+            "modem_simulator_sim_type": "INVALID_VALUE"
+          }
+        }
+    ]
+}
+  )"""";
+
+  Json::Value json_configs;
+  std::string json_text(test_string);
+
+  EXPECT_TRUE(ParseJsonString(json_text, json_configs))
+      << "Invalid Json string";
+  const Result<std::vector<std::string>> serialized_data = LaunchCvdParserTester(json_configs);
+  EXPECT_FALSE(serialized_data.ok());
+}
+
+TEST(ConnectivityFlagsParserTest, ParseModemSimulatorSimTypeInvalidInt) {
+  const char* test_string = R""""(
+{
+    "instances" :
+    [
+        {
+          "connectivity": {
+            "modem_simulator_sim_type": 3
+          }
+        }
+    ]
+}
+  )"""";
+
+  Json::Value json_configs;
+  std::string json_text(test_string);
+
+  EXPECT_TRUE(ParseJsonString(json_text, json_configs))
+      << "Invalid Json string";
+  const Result<std::vector<std::string>> serialized_data = LaunchCvdParserTester(json_configs);
+  EXPECT_THAT(serialized_data, IsOk());
+  EXPECT_TRUE(FindConfig(*serialized_data, "--modem_simulator_sim_type=1"))
+      << "modem_simulator_sim_type flag is missing or wrongly formatted";
+}
+
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang/load_config.pb.go
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang/load_config.pb.go
@@ -70,6 +70,55 @@ func (UserPageSize) EnumDescriptor() ([]byte, []int) {
 	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{0}
 }
 
+type ModemSimulatorSimType int32
+
+const (
+	ModemSimulatorSimType_MODEM_SIMULATOR_SIM_TYPE_UNSPECIFIED     ModemSimulatorSimType = 0
+	ModemSimulatorSimType_MODEM_SIMULATOR_SIM_TYPE_NORMAL          ModemSimulatorSimType = 1
+	ModemSimulatorSimType_MODEM_SIMULATOR_SIM_TYPE_CTS_CARRIER_API ModemSimulatorSimType = 2
+)
+
+// Enum value maps for ModemSimulatorSimType.
+var (
+	ModemSimulatorSimType_name = map[int32]string{
+		0: "MODEM_SIMULATOR_SIM_TYPE_UNSPECIFIED",
+		1: "MODEM_SIMULATOR_SIM_TYPE_NORMAL",
+		2: "MODEM_SIMULATOR_SIM_TYPE_CTS_CARRIER_API",
+	}
+	ModemSimulatorSimType_value = map[string]int32{
+		"MODEM_SIMULATOR_SIM_TYPE_UNSPECIFIED":     0,
+		"MODEM_SIMULATOR_SIM_TYPE_NORMAL":          1,
+		"MODEM_SIMULATOR_SIM_TYPE_CTS_CARRIER_API": 2,
+	}
+)
+
+func (x ModemSimulatorSimType) Enum() *ModemSimulatorSimType {
+	p := new(ModemSimulatorSimType)
+	*p = x
+	return p
+}
+
+func (x ModemSimulatorSimType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ModemSimulatorSimType) Descriptor() protoreflect.EnumDescriptor {
+	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_enumTypes[1].Descriptor()
+}
+
+func (ModemSimulatorSimType) Type() protoreflect.EnumType {
+	return &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_enumTypes[1]
+}
+
+func (x ModemSimulatorSimType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ModemSimulatorSimType.Descriptor instead.
+func (ModemSimulatorSimType) EnumDescriptor() ([]byte, []int) {
+	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{1}
+}
+
 type EnvironmentSpecification struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Instances     []*Instance            `protobuf:"bytes,1,rep,name=instances,proto3" json:"instances,omitempty"`
@@ -393,6 +442,7 @@ type Instance struct {
 	Streaming      *Streaming             `protobuf:"bytes,7,opt,name=streaming,proto3,oneof" json:"streaming,omitempty"`
 	Connectivity   *Connectivity          `protobuf:"bytes,8,opt,name=connectivity,proto3,oneof" json:"connectivity,omitempty"`
 	ImportTemplate *string                `protobuf:"bytes,9,opt,name=import_template,json=@import,proto3,oneof" json:"import_template,omitempty"`
+	Media          *Media                 `protobuf:"bytes,10,opt,name=media,proto3,oneof" json:"media,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -488,6 +538,13 @@ func (x *Instance) GetImportTemplate() string {
 		return *x.ImportTemplate
 	}
 	return ""
+}
+
+func (x *Instance) GetMedia() *Media {
+	if x != nil {
+		return x.Media
+	}
+	return nil
 }
 
 type Boot struct {
@@ -619,10 +676,11 @@ func (x *Build) GetBuild() string {
 }
 
 type Connectivity struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Vsock         *Vsock                 `protobuf:"bytes,1,opt,name=vsock,proto3,oneof" json:"vsock,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	Vsock                 *Vsock                 `protobuf:"bytes,1,opt,name=vsock,proto3,oneof" json:"vsock,omitempty"`
+	ModemSimulatorSimType *ModemSimulatorSimType `protobuf:"varint,2,opt,name=modem_simulator_sim_type,json=modemSimulatorSimType,proto3,enum=cuttlefish.cvd.config.ModemSimulatorSimType,oneof" json:"modem_simulator_sim_type,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *Connectivity) Reset() {
@@ -660,6 +718,13 @@ func (x *Connectivity) GetVsock() *Vsock {
 		return x.Vsock
 	}
 	return nil
+}
+
+func (x *Connectivity) GetModemSimulatorSimType() ModemSimulatorSimType {
+	if x != nil && x.ModemSimulatorSimType != nil {
+		return *x.ModemSimulatorSimType
+	}
+	return ModemSimulatorSimType_MODEM_SIMULATOR_SIM_TYPE_UNSPECIFIED
 }
 
 type Vsock struct {
@@ -1074,6 +1139,272 @@ func (x *Streaming) GetDeviceId() string {
 	return ""
 }
 
+type Media struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Devices       []*MediaDevice         `protobuf:"bytes,1,rep,name=devices,proto3" json:"devices,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Media) Reset() {
+	*x = Media{}
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Media) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Media) ProtoMessage() {}
+
+func (x *Media) ProtoReflect() protoreflect.Message {
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Media.ProtoReflect.Descriptor instead.
+func (*Media) Descriptor() ([]byte, []int) {
+	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *Media) GetDevices() []*MediaDevice {
+	if x != nil {
+		return x.Devices
+	}
+	return nil
+}
+
+type MediaDevice struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Device:
+	//
+	//	*MediaDevice_V4L2EmulatedCameraSplane
+	//	*MediaDevice_V4L2EmulatedCameraMplane
+	//	*MediaDevice_V4L2Proxy
+	Device        isMediaDevice_Device `protobuf_oneof:"device"`
+	LensFacing    *string              `protobuf:"bytes,4,opt,name=lens_facing,json=lensFacing,proto3,oneof" json:"lens_facing,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MediaDevice) Reset() {
+	*x = MediaDevice{}
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MediaDevice) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MediaDevice) ProtoMessage() {}
+
+func (x *MediaDevice) ProtoReflect() protoreflect.Message {
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MediaDevice.ProtoReflect.Descriptor instead.
+func (*MediaDevice) Descriptor() ([]byte, []int) {
+	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *MediaDevice) GetDevice() isMediaDevice_Device {
+	if x != nil {
+		return x.Device
+	}
+	return nil
+}
+
+func (x *MediaDevice) GetV4L2EmulatedCameraSplane() *V4L2EmulatedCameraSplane {
+	if x != nil {
+		if x, ok := x.Device.(*MediaDevice_V4L2EmulatedCameraSplane); ok {
+			return x.V4L2EmulatedCameraSplane
+		}
+	}
+	return nil
+}
+
+func (x *MediaDevice) GetV4L2EmulatedCameraMplane() *V4L2EmulatedCameraMplane {
+	if x != nil {
+		if x, ok := x.Device.(*MediaDevice_V4L2EmulatedCameraMplane); ok {
+			return x.V4L2EmulatedCameraMplane
+		}
+	}
+	return nil
+}
+
+func (x *MediaDevice) GetV4L2Proxy() *V4L2Proxy {
+	if x != nil {
+		if x, ok := x.Device.(*MediaDevice_V4L2Proxy); ok {
+			return x.V4L2Proxy
+		}
+	}
+	return nil
+}
+
+func (x *MediaDevice) GetLensFacing() string {
+	if x != nil && x.LensFacing != nil {
+		return *x.LensFacing
+	}
+	return ""
+}
+
+type isMediaDevice_Device interface {
+	isMediaDevice_Device()
+}
+
+type MediaDevice_V4L2EmulatedCameraSplane struct {
+	V4L2EmulatedCameraSplane *V4L2EmulatedCameraSplane `protobuf:"bytes,1,opt,name=v4l2_emulated_camera_splane,json=v4l2EmulatedCameraSplane,proto3,oneof"`
+}
+
+type MediaDevice_V4L2EmulatedCameraMplane struct {
+	V4L2EmulatedCameraMplane *V4L2EmulatedCameraMplane `protobuf:"bytes,2,opt,name=v4l2_emulated_camera_mplane,json=v4l2EmulatedCameraMplane,proto3,oneof"`
+}
+
+type MediaDevice_V4L2Proxy struct {
+	V4L2Proxy *V4L2Proxy `protobuf:"bytes,3,opt,name=v4l2_proxy,json=v4l2Proxy,proto3,oneof"`
+}
+
+func (*MediaDevice_V4L2EmulatedCameraSplane) isMediaDevice_Device() {}
+
+func (*MediaDevice_V4L2EmulatedCameraMplane) isMediaDevice_Device() {}
+
+func (*MediaDevice_V4L2Proxy) isMediaDevice_Device() {}
+
+type V4L2EmulatedCameraSplane struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *V4L2EmulatedCameraSplane) Reset() {
+	*x = V4L2EmulatedCameraSplane{}
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *V4L2EmulatedCameraSplane) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*V4L2EmulatedCameraSplane) ProtoMessage() {}
+
+func (x *V4L2EmulatedCameraSplane) ProtoReflect() protoreflect.Message {
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use V4L2EmulatedCameraSplane.ProtoReflect.Descriptor instead.
+func (*V4L2EmulatedCameraSplane) Descriptor() ([]byte, []int) {
+	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{17}
+}
+
+type V4L2EmulatedCameraMplane struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *V4L2EmulatedCameraMplane) Reset() {
+	*x = V4L2EmulatedCameraMplane{}
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *V4L2EmulatedCameraMplane) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*V4L2EmulatedCameraMplane) ProtoMessage() {}
+
+func (x *V4L2EmulatedCameraMplane) ProtoReflect() protoreflect.Message {
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use V4L2EmulatedCameraMplane.ProtoReflect.Descriptor instead.
+func (*V4L2EmulatedCameraMplane) Descriptor() ([]byte, []int) {
+	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{18}
+}
+
+type V4L2Proxy struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DevicePath    *string                `protobuf:"bytes,1,opt,name=device_path,json=devicePath,proto3,oneof" json:"device_path,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *V4L2Proxy) Reset() {
+	*x = V4L2Proxy{}
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *V4L2Proxy) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*V4L2Proxy) ProtoMessage() {}
+
+func (x *V4L2Proxy) ProtoReflect() protoreflect.Message {
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use V4L2Proxy.ProtoReflect.Descriptor instead.
+func (*V4L2Proxy) Descriptor() ([]byte, []int) {
+	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *V4L2Proxy) GetDevicePath() string {
+	if x != nil && x.DevicePath != nil {
+		return *x.DevicePath
+	}
+	return ""
+}
+
 type Vm struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	Cpus            *uint32                `protobuf:"varint,1,opt,name=cpus,proto3,oneof" json:"cpus,omitempty"`
@@ -1095,7 +1426,7 @@ type Vm struct {
 
 func (x *Vm) Reset() {
 	*x = Vm{}
-	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[15]
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1107,7 +1438,7 @@ func (x *Vm) String() string {
 func (*Vm) ProtoMessage() {}
 
 func (x *Vm) ProtoReflect() protoreflect.Message {
-	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[15]
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1120,7 +1451,7 @@ func (x *Vm) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Vm.ProtoReflect.Descriptor instead.
 func (*Vm) Descriptor() ([]byte, []int) {
-	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{15}
+	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *Vm) GetCpus() uint32 {
@@ -1233,13 +1564,14 @@ type Crosvm struct {
 	EnableSandbox     *bool                  `protobuf:"varint,1,opt,name=enable_sandbox,json=enableSandbox,proto3,oneof" json:"enable_sandbox,omitempty"`
 	SimpleMediaDevice *bool                  `protobuf:"varint,2,opt,name=simple_media_device,json=simpleMediaDevice,proto3,oneof" json:"simple_media_device,omitempty"`
 	V4L2Proxy         *string                `protobuf:"bytes,3,opt,name=v4l2_proxy,json=v4l2Proxy,proto3,oneof" json:"v4l2_proxy,omitempty"`
+	VhostUserVsock    *string                `protobuf:"bytes,4,opt,name=vhost_user_vsock,json=vhostUserVsock,proto3,oneof" json:"vhost_user_vsock,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
 
 func (x *Crosvm) Reset() {
 	*x = Crosvm{}
-	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[16]
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1251,7 +1583,7 @@ func (x *Crosvm) String() string {
 func (*Crosvm) ProtoMessage() {}
 
 func (x *Crosvm) ProtoReflect() protoreflect.Message {
-	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[16]
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1264,7 +1596,7 @@ func (x *Crosvm) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Crosvm.ProtoReflect.Descriptor instead.
 func (*Crosvm) Descriptor() ([]byte, []int) {
-	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{16}
+	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *Crosvm) GetEnableSandbox() bool {
@@ -1288,6 +1620,13 @@ func (x *Crosvm) GetV4L2Proxy() string {
 	return ""
 }
 
+func (x *Crosvm) GetVhostUserVsock() string {
+	if x != nil && x.VhostUserVsock != nil {
+		return *x.VhostUserVsock
+	}
+	return ""
+}
+
 type Gem5 struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -1296,7 +1635,7 @@ type Gem5 struct {
 
 func (x *Gem5) Reset() {
 	*x = Gem5{}
-	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[17]
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1308,7 +1647,7 @@ func (x *Gem5) String() string {
 func (*Gem5) ProtoMessage() {}
 
 func (x *Gem5) ProtoReflect() protoreflect.Message {
-	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[17]
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1321,7 +1660,7 @@ func (x *Gem5) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Gem5.ProtoReflect.Descriptor instead.
 func (*Gem5) Descriptor() ([]byte, []int) {
-	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{17}
+	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{22}
 }
 
 type Qemu struct {
@@ -1332,7 +1671,7 @@ type Qemu struct {
 
 func (x *Qemu) Reset() {
 	*x = Qemu{}
-	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[18]
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1344,7 +1683,7 @@ func (x *Qemu) String() string {
 func (*Qemu) ProtoMessage() {}
 
 func (x *Qemu) ProtoReflect() protoreflect.Message {
-	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[18]
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1357,7 +1696,7 @@ func (x *Qemu) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Qemu.ProtoReflect.Descriptor instead.
 func (*Qemu) Descriptor() ([]byte, []int) {
-	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{18}
+	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{23}
 }
 
 type CustomAction struct {
@@ -1373,7 +1712,7 @@ type CustomAction struct {
 
 func (x *CustomAction) Reset() {
 	*x = CustomAction{}
-	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[19]
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1385,7 +1724,7 @@ func (x *CustomAction) String() string {
 func (*CustomAction) ProtoMessage() {}
 
 func (x *CustomAction) ProtoReflect() protoreflect.Message {
-	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[19]
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1398,7 +1737,7 @@ func (x *CustomAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CustomAction.ProtoReflect.Descriptor instead.
 func (*CustomAction) Descriptor() ([]byte, []int) {
-	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{19}
+	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *CustomAction) GetShellCommand() string {
@@ -1447,7 +1786,7 @@ type Button struct {
 
 func (x *Button) Reset() {
 	*x = Button{}
-	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[20]
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1459,7 +1798,7 @@ func (x *Button) String() string {
 func (*Button) ProtoMessage() {}
 
 func (x *Button) ProtoReflect() protoreflect.Message {
-	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[20]
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1472,7 +1811,7 @@ func (x *Button) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Button.ProtoReflect.Descriptor instead.
 func (*Button) Descriptor() ([]byte, []int) {
-	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{20}
+	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *Button) GetCommand() string {
@@ -1506,7 +1845,7 @@ type DeviceState struct {
 
 func (x *DeviceState) Reset() {
 	*x = DeviceState{}
-	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[21]
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1518,7 +1857,7 @@ func (x *DeviceState) String() string {
 func (*DeviceState) ProtoMessage() {}
 
 func (x *DeviceState) ProtoReflect() protoreflect.Message {
-	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[21]
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1531,7 +1870,7 @@ func (x *DeviceState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeviceState.ProtoReflect.Descriptor instead.
 func (*DeviceState) Descriptor() ([]byte, []int) {
-	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{21}
+	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *DeviceState) GetLidSwitchOpen() bool {
@@ -1557,7 +1896,7 @@ type Metrics struct {
 
 func (x *Metrics) Reset() {
 	*x = Metrics{}
-	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[22]
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1569,7 +1908,7 @@ func (x *Metrics) String() string {
 func (*Metrics) ProtoMessage() {}
 
 func (x *Metrics) ProtoReflect() protoreflect.Message {
-	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[22]
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1582,7 +1921,7 @@ func (x *Metrics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Metrics.ProtoReflect.Descriptor instead.
 func (*Metrics) Descriptor() ([]byte, []int) {
-	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{22}
+	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *Metrics) GetEnable() bool {
@@ -1602,7 +1941,7 @@ type DisplayOverlay struct {
 
 func (x *DisplayOverlay) Reset() {
 	*x = DisplayOverlay{}
-	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[23]
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1614,7 +1953,7 @@ func (x *DisplayOverlay) String() string {
 func (*DisplayOverlay) ProtoMessage() {}
 
 func (x *DisplayOverlay) ProtoReflect() protoreflect.Message {
-	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[23]
+	mi := &file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1627,7 +1966,7 @@ func (x *DisplayOverlay) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DisplayOverlay.ProtoReflect.Descriptor instead.
 func (*DisplayOverlay) Descriptor() ([]byte, []int) {
-	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{23}
+	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *DisplayOverlay) GetVmIndex() int32 {
@@ -1703,7 +2042,7 @@ const file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDesc = "
 	"\x1a_wait_retry_period_secondsB\x1b\n" +
 	"\x19_keep_downloaded_archivesB\x0f\n" +
 	"\r_api_base_urlB\r\n" +
-	"\v_project_idJ\x04\b\x04\x10\x05\"\xec\x04\n" +
+	"\v_project_idJ\x04\b\x04\x10\x05\"\xaf\x05\n" +
 	"\bInstance\x12\x17\n" +
 	"\x04name\x18\x01 \x01(\tH\x00R\x04name\x88\x01\x01\x12.\n" +
 	"\x02vm\x18\x02 \x01(\v2\x19.cuttlefish.cvd.config.VmH\x01R\x02vm\x88\x01\x01\x124\n" +
@@ -1713,7 +2052,9 @@ const file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDesc = "
 	"\bgraphics\x18\x06 \x01(\v2\x1f.cuttlefish.cvd.config.GraphicsH\x05R\bgraphics\x88\x01\x01\x12C\n" +
 	"\tstreaming\x18\a \x01(\v2 .cuttlefish.cvd.config.StreamingH\x06R\tstreaming\x88\x01\x01\x12L\n" +
 	"\fconnectivity\x18\b \x01(\v2#.cuttlefish.cvd.config.ConnectivityH\aR\fconnectivity\x88\x01\x01\x12%\n" +
-	"\x0fimport_template\x18\t \x01(\tH\bR\a@import\x88\x01\x01B\a\n" +
+	"\x0fimport_template\x18\t \x01(\tH\bR\a@import\x88\x01\x01\x127\n" +
+	"\x05media\x18\n" +
+	" \x01(\v2\x1c.cuttlefish.cvd.config.MediaH\tR\x05media\x88\x01\x01B\a\n" +
 	"\x05_nameB\x05\n" +
 	"\x03_vmB\a\n" +
 	"\x05_bootB\v\n" +
@@ -1723,7 +2064,8 @@ const file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDesc = "
 	"\n" +
 	"_streamingB\x0f\n" +
 	"\r_connectivityB\x12\n" +
-	"\x10_import_template\"\xcf\x03\n" +
+	"\x10_import_templateB\b\n" +
+	"\x06_media\"\xcf\x03\n" +
 	"\x04Boot\x129\n" +
 	"\x06kernel\x18\x01 \x01(\v2\x1c.cuttlefish.cvd.config.BuildH\x00R\x06kernel\x88\x01\x01\x126\n" +
 	"\x14enable_bootanimation\x18\x02 \x01(\bH\x01R\x13enableBootanimation\x88\x01\x01\x127\n" +
@@ -1741,10 +2083,12 @@ const file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDesc = "
 	"\x13_android_efi_loader\",\n" +
 	"\x05Build\x12\x19\n" +
 	"\x05build\x18\x01 \x01(\tH\x00R\x05build\x88\x01\x01B\b\n" +
-	"\x06_build\"Q\n" +
+	"\x06_build\"\xda\x01\n" +
 	"\fConnectivity\x127\n" +
-	"\x05vsock\x18\x01 \x01(\v2\x1c.cuttlefish.cvd.config.VsockH\x00R\x05vsock\x88\x01\x01B\b\n" +
-	"\x06_vsock\"=\n" +
+	"\x05vsock\x18\x01 \x01(\v2\x1c.cuttlefish.cvd.config.VsockH\x00R\x05vsock\x88\x01\x01\x12j\n" +
+	"\x18modem_simulator_sim_type\x18\x02 \x01(\x0e2,.cuttlefish.cvd.config.ModemSimulatorSimTypeH\x01R\x15modemSimulatorSimType\x88\x01\x01B\b\n" +
+	"\x06_vsockB\x1b\n" +
+	"\x19_modem_simulator_sim_type\"=\n" +
 	"\x05Vsock\x12$\n" +
 	"\vguest_group\x18\x01 \x01(\tH\x00R\n" +
 	"guestGroup\x88\x01\x01B\x0e\n" +
@@ -1791,7 +2135,24 @@ const file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDesc = "
 	"\tStreaming\x12 \n" +
 	"\tdevice_id\x18\x01 \x01(\tH\x00R\bdeviceId\x88\x01\x01B\f\n" +
 	"\n" +
-	"_device_id\"\xb7\x04\n" +
+	"_device_id\"E\n" +
+	"\x05Media\x12<\n" +
+	"\adevices\x18\x01 \x03(\v2\".cuttlefish.cvd.config.MediaDeviceR\adevices\"\xf4\x02\n" +
+	"\vMediaDevice\x12p\n" +
+	"\x1bv4l2_emulated_camera_splane\x18\x01 \x01(\v2/.cuttlefish.cvd.config.V4l2EmulatedCameraSplaneH\x00R\x18v4l2EmulatedCameraSplane\x12p\n" +
+	"\x1bv4l2_emulated_camera_mplane\x18\x02 \x01(\v2/.cuttlefish.cvd.config.V4l2EmulatedCameraMplaneH\x00R\x18v4l2EmulatedCameraMplane\x12A\n" +
+	"\n" +
+	"v4l2_proxy\x18\x03 \x01(\v2 .cuttlefish.cvd.config.V4l2ProxyH\x00R\tv4l2Proxy\x12$\n" +
+	"\vlens_facing\x18\x04 \x01(\tH\x01R\n" +
+	"lensFacing\x88\x01\x01B\b\n" +
+	"\x06deviceB\x0e\n" +
+	"\f_lens_facing\"\x1a\n" +
+	"\x18V4l2EmulatedCameraSplane\"\x1a\n" +
+	"\x18V4l2EmulatedCameraMplane\"A\n" +
+	"\tV4l2Proxy\x12$\n" +
+	"\vdevice_path\x18\x01 \x01(\tH\x00R\n" +
+	"devicePath\x88\x01\x01B\x0e\n" +
+	"\f_device_path\"\xb7\x04\n" +
 	"\x02Vm\x12\x17\n" +
 	"\x04cpus\x18\x01 \x01(\rH\x01R\x04cpus\x88\x01\x01\x12 \n" +
 	"\tmemory_mb\x18\x02 \x01(\rH\x02R\bmemoryMb\x88\x01\x01\x12\"\n" +
@@ -1813,15 +2174,17 @@ const file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDesc = "
 	"\x11_setupwizard_modeB\a\n" +
 	"\x05_uuidB\f\n" +
 	"\n" +
-	"_page_size\"\xc7\x01\n" +
+	"_page_size\"\x8b\x02\n" +
 	"\x06Crosvm\x12*\n" +
 	"\x0eenable_sandbox\x18\x01 \x01(\bH\x00R\renableSandbox\x88\x01\x01\x123\n" +
 	"\x13simple_media_device\x18\x02 \x01(\bH\x01R\x11simpleMediaDevice\x88\x01\x01\x12\"\n" +
 	"\n" +
-	"v4l2_proxy\x18\x03 \x01(\tH\x02R\tv4l2Proxy\x88\x01\x01B\x11\n" +
+	"v4l2_proxy\x18\x03 \x01(\tH\x02R\tv4l2Proxy\x88\x01\x01\x12-\n" +
+	"\x10vhost_user_vsock\x18\x04 \x01(\tH\x03R\x0evhostUserVsock\x88\x01\x01B\x11\n" +
 	"\x0f_enable_sandboxB\x16\n" +
 	"\x14_simple_media_deviceB\r\n" +
-	"\v_v4l2_proxy\"\x06\n" +
+	"\v_v4l2_proxyB\x13\n" +
+	"\x11_vhost_user_vsock\"\x06\n" +
 	"\x04Gem5\"\x06\n" +
 	"\x04Qemu\"\xbb\x02\n" +
 	"\fCustomAction\x12(\n" +
@@ -1856,7 +2219,11 @@ const file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDesc = "
 	"\fUserPageSize\x12\x1e\n" +
 	"\x1aUSER_PAGE_SIZE_UNSPECIFIED\x10\x00\x12\x17\n" +
 	"\x13USER_PAGE_SIZE_16KB\x10\x01\x12\x17\n" +
-	"\x13USER_PAGE_SIZE_64KB\x10\x02B\xba\x01\n" +
+	"\x13USER_PAGE_SIZE_64KB\x10\x02*\x94\x01\n" +
+	"\x15ModemSimulatorSimType\x12(\n" +
+	"$MODEM_SIMULATOR_SIM_TYPE_UNSPECIFIED\x10\x00\x12#\n" +
+	"\x1fMODEM_SIMULATOR_SIM_TYPE_NORMAL\x10\x01\x12,\n" +
+	"(MODEM_SIMULATOR_SIM_TYPE_CTS_CARRIER_API\x10\x02B\xba\x01\n" +
 	"Ncom.google.android_cuttlefish.base.cvd.cuttlefish.host.commands.cvd.cli.parserB\tCvdConfigZ]github.com/google/android_cuttlefish/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang/b\x06proto3"
 
 var (
@@ -1871,70 +2238,82 @@ func file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescGZIP(
 	return file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDescData
 }
 
-var file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
+var file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
 var file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_goTypes = []any{
 	(UserPageSize)(0),                // 0: cuttlefish.cvd.config.UserPageSize
-	(*EnvironmentSpecification)(nil), // 1: cuttlefish.cvd.config.EnvironmentSpecification
-	(*EnvironmentOptions)(nil),       // 2: cuttlefish.cvd.config.EnvironmentOptions
-	(*Common)(nil),                   // 3: cuttlefish.cvd.config.Common
-	(*Fetch)(nil),                    // 4: cuttlefish.cvd.config.Fetch
-	(*Instance)(nil),                 // 5: cuttlefish.cvd.config.Instance
-	(*Boot)(nil),                     // 6: cuttlefish.cvd.config.Boot
-	(*Build)(nil),                    // 7: cuttlefish.cvd.config.Build
-	(*Connectivity)(nil),             // 8: cuttlefish.cvd.config.Connectivity
-	(*Vsock)(nil),                    // 9: cuttlefish.cvd.config.Vsock
-	(*Graphics)(nil),                 // 10: cuttlefish.cvd.config.Graphics
-	(*Display)(nil),                  // 11: cuttlefish.cvd.config.Display
-	(*Disk)(nil),                     // 12: cuttlefish.cvd.config.Disk
-	(*Super)(nil),                    // 13: cuttlefish.cvd.config.Super
-	(*Security)(nil),                 // 14: cuttlefish.cvd.config.Security
-	(*Streaming)(nil),                // 15: cuttlefish.cvd.config.Streaming
-	(*Vm)(nil),                       // 16: cuttlefish.cvd.config.Vm
-	(*Crosvm)(nil),                   // 17: cuttlefish.cvd.config.Crosvm
-	(*Gem5)(nil),                     // 18: cuttlefish.cvd.config.Gem5
-	(*Qemu)(nil),                     // 19: cuttlefish.cvd.config.Qemu
-	(*CustomAction)(nil),             // 20: cuttlefish.cvd.config.CustomAction
-	(*Button)(nil),                   // 21: cuttlefish.cvd.config.Button
-	(*DeviceState)(nil),              // 22: cuttlefish.cvd.config.DeviceState
-	(*Metrics)(nil),                  // 23: cuttlefish.cvd.config.Metrics
-	(*DisplayOverlay)(nil),           // 24: cuttlefish.cvd.config.DisplayOverlay
+	(ModemSimulatorSimType)(0),       // 1: cuttlefish.cvd.config.ModemSimulatorSimType
+	(*EnvironmentSpecification)(nil), // 2: cuttlefish.cvd.config.EnvironmentSpecification
+	(*EnvironmentOptions)(nil),       // 3: cuttlefish.cvd.config.EnvironmentOptions
+	(*Common)(nil),                   // 4: cuttlefish.cvd.config.Common
+	(*Fetch)(nil),                    // 5: cuttlefish.cvd.config.Fetch
+	(*Instance)(nil),                 // 6: cuttlefish.cvd.config.Instance
+	(*Boot)(nil),                     // 7: cuttlefish.cvd.config.Boot
+	(*Build)(nil),                    // 8: cuttlefish.cvd.config.Build
+	(*Connectivity)(nil),             // 9: cuttlefish.cvd.config.Connectivity
+	(*Vsock)(nil),                    // 10: cuttlefish.cvd.config.Vsock
+	(*Graphics)(nil),                 // 11: cuttlefish.cvd.config.Graphics
+	(*Display)(nil),                  // 12: cuttlefish.cvd.config.Display
+	(*Disk)(nil),                     // 13: cuttlefish.cvd.config.Disk
+	(*Super)(nil),                    // 14: cuttlefish.cvd.config.Super
+	(*Security)(nil),                 // 15: cuttlefish.cvd.config.Security
+	(*Streaming)(nil),                // 16: cuttlefish.cvd.config.Streaming
+	(*Media)(nil),                    // 17: cuttlefish.cvd.config.Media
+	(*MediaDevice)(nil),              // 18: cuttlefish.cvd.config.MediaDevice
+	(*V4L2EmulatedCameraSplane)(nil), // 19: cuttlefish.cvd.config.V4l2EmulatedCameraSplane
+	(*V4L2EmulatedCameraMplane)(nil), // 20: cuttlefish.cvd.config.V4l2EmulatedCameraMplane
+	(*V4L2Proxy)(nil),                // 21: cuttlefish.cvd.config.V4l2Proxy
+	(*Vm)(nil),                       // 22: cuttlefish.cvd.config.Vm
+	(*Crosvm)(nil),                   // 23: cuttlefish.cvd.config.Crosvm
+	(*Gem5)(nil),                     // 24: cuttlefish.cvd.config.Gem5
+	(*Qemu)(nil),                     // 25: cuttlefish.cvd.config.Qemu
+	(*CustomAction)(nil),             // 26: cuttlefish.cvd.config.CustomAction
+	(*Button)(nil),                   // 27: cuttlefish.cvd.config.Button
+	(*DeviceState)(nil),              // 28: cuttlefish.cvd.config.DeviceState
+	(*Metrics)(nil),                  // 29: cuttlefish.cvd.config.Metrics
+	(*DisplayOverlay)(nil),           // 30: cuttlefish.cvd.config.DisplayOverlay
 }
 var file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_depIdxs = []int32{
-	5,  // 0: cuttlefish.cvd.config.EnvironmentSpecification.instances:type_name -> cuttlefish.cvd.config.Instance
-	4,  // 1: cuttlefish.cvd.config.EnvironmentSpecification.fetch:type_name -> cuttlefish.cvd.config.Fetch
-	23, // 2: cuttlefish.cvd.config.EnvironmentSpecification.metrics:type_name -> cuttlefish.cvd.config.Metrics
-	3,  // 3: cuttlefish.cvd.config.EnvironmentSpecification.common:type_name -> cuttlefish.cvd.config.Common
-	4,  // 4: cuttlefish.cvd.config.EnvironmentOptions.fetch:type_name -> cuttlefish.cvd.config.Fetch
-	23, // 5: cuttlefish.cvd.config.EnvironmentOptions.metrics:type_name -> cuttlefish.cvd.config.Metrics
-	3,  // 6: cuttlefish.cvd.config.EnvironmentOptions.common:type_name -> cuttlefish.cvd.config.Common
-	16, // 7: cuttlefish.cvd.config.Instance.vm:type_name -> cuttlefish.cvd.config.Vm
-	6,  // 8: cuttlefish.cvd.config.Instance.boot:type_name -> cuttlefish.cvd.config.Boot
-	14, // 9: cuttlefish.cvd.config.Instance.security:type_name -> cuttlefish.cvd.config.Security
-	12, // 10: cuttlefish.cvd.config.Instance.disk:type_name -> cuttlefish.cvd.config.Disk
-	10, // 11: cuttlefish.cvd.config.Instance.graphics:type_name -> cuttlefish.cvd.config.Graphics
-	15, // 12: cuttlefish.cvd.config.Instance.streaming:type_name -> cuttlefish.cvd.config.Streaming
-	8,  // 13: cuttlefish.cvd.config.Instance.connectivity:type_name -> cuttlefish.cvd.config.Connectivity
-	7,  // 14: cuttlefish.cvd.config.Boot.kernel:type_name -> cuttlefish.cvd.config.Build
-	7,  // 15: cuttlefish.cvd.config.Boot.bootloader:type_name -> cuttlefish.cvd.config.Build
-	7,  // 16: cuttlefish.cvd.config.Boot.android_efi_loader:type_name -> cuttlefish.cvd.config.Build
-	9,  // 17: cuttlefish.cvd.config.Connectivity.vsock:type_name -> cuttlefish.cvd.config.Vsock
-	11, // 18: cuttlefish.cvd.config.Graphics.displays:type_name -> cuttlefish.cvd.config.Display
-	24, // 19: cuttlefish.cvd.config.Display.overlays:type_name -> cuttlefish.cvd.config.DisplayOverlay
-	13, // 20: cuttlefish.cvd.config.Disk.super_partition:type_name -> cuttlefish.cvd.config.Super
-	17, // 21: cuttlefish.cvd.config.Vm.crosvm:type_name -> cuttlefish.cvd.config.Crosvm
-	18, // 22: cuttlefish.cvd.config.Vm.gem5:type_name -> cuttlefish.cvd.config.Gem5
-	19, // 23: cuttlefish.cvd.config.Vm.qemu:type_name -> cuttlefish.cvd.config.Qemu
-	20, // 24: cuttlefish.cvd.config.Vm.custom_actions:type_name -> cuttlefish.cvd.config.CustomAction
-	0,  // 25: cuttlefish.cvd.config.Vm.page_size:type_name -> cuttlefish.cvd.config.UserPageSize
-	21, // 26: cuttlefish.cvd.config.CustomAction.button:type_name -> cuttlefish.cvd.config.Button
-	21, // 27: cuttlefish.cvd.config.CustomAction.buttons:type_name -> cuttlefish.cvd.config.Button
-	22, // 28: cuttlefish.cvd.config.CustomAction.device_states:type_name -> cuttlefish.cvd.config.DeviceState
-	29, // [29:29] is the sub-list for method output_type
-	29, // [29:29] is the sub-list for method input_type
-	29, // [29:29] is the sub-list for extension type_name
-	29, // [29:29] is the sub-list for extension extendee
-	0,  // [0:29] is the sub-list for field type_name
+	6,  // 0: cuttlefish.cvd.config.EnvironmentSpecification.instances:type_name -> cuttlefish.cvd.config.Instance
+	5,  // 1: cuttlefish.cvd.config.EnvironmentSpecification.fetch:type_name -> cuttlefish.cvd.config.Fetch
+	29, // 2: cuttlefish.cvd.config.EnvironmentSpecification.metrics:type_name -> cuttlefish.cvd.config.Metrics
+	4,  // 3: cuttlefish.cvd.config.EnvironmentSpecification.common:type_name -> cuttlefish.cvd.config.Common
+	5,  // 4: cuttlefish.cvd.config.EnvironmentOptions.fetch:type_name -> cuttlefish.cvd.config.Fetch
+	29, // 5: cuttlefish.cvd.config.EnvironmentOptions.metrics:type_name -> cuttlefish.cvd.config.Metrics
+	4,  // 6: cuttlefish.cvd.config.EnvironmentOptions.common:type_name -> cuttlefish.cvd.config.Common
+	22, // 7: cuttlefish.cvd.config.Instance.vm:type_name -> cuttlefish.cvd.config.Vm
+	7,  // 8: cuttlefish.cvd.config.Instance.boot:type_name -> cuttlefish.cvd.config.Boot
+	15, // 9: cuttlefish.cvd.config.Instance.security:type_name -> cuttlefish.cvd.config.Security
+	13, // 10: cuttlefish.cvd.config.Instance.disk:type_name -> cuttlefish.cvd.config.Disk
+	11, // 11: cuttlefish.cvd.config.Instance.graphics:type_name -> cuttlefish.cvd.config.Graphics
+	16, // 12: cuttlefish.cvd.config.Instance.streaming:type_name -> cuttlefish.cvd.config.Streaming
+	9,  // 13: cuttlefish.cvd.config.Instance.connectivity:type_name -> cuttlefish.cvd.config.Connectivity
+	17, // 14: cuttlefish.cvd.config.Instance.media:type_name -> cuttlefish.cvd.config.Media
+	8,  // 15: cuttlefish.cvd.config.Boot.kernel:type_name -> cuttlefish.cvd.config.Build
+	8,  // 16: cuttlefish.cvd.config.Boot.bootloader:type_name -> cuttlefish.cvd.config.Build
+	8,  // 17: cuttlefish.cvd.config.Boot.android_efi_loader:type_name -> cuttlefish.cvd.config.Build
+	10, // 18: cuttlefish.cvd.config.Connectivity.vsock:type_name -> cuttlefish.cvd.config.Vsock
+	1,  // 19: cuttlefish.cvd.config.Connectivity.modem_simulator_sim_type:type_name -> cuttlefish.cvd.config.ModemSimulatorSimType
+	12, // 20: cuttlefish.cvd.config.Graphics.displays:type_name -> cuttlefish.cvd.config.Display
+	30, // 21: cuttlefish.cvd.config.Display.overlays:type_name -> cuttlefish.cvd.config.DisplayOverlay
+	14, // 22: cuttlefish.cvd.config.Disk.super_partition:type_name -> cuttlefish.cvd.config.Super
+	18, // 23: cuttlefish.cvd.config.Media.devices:type_name -> cuttlefish.cvd.config.MediaDevice
+	19, // 24: cuttlefish.cvd.config.MediaDevice.v4l2_emulated_camera_splane:type_name -> cuttlefish.cvd.config.V4l2EmulatedCameraSplane
+	20, // 25: cuttlefish.cvd.config.MediaDevice.v4l2_emulated_camera_mplane:type_name -> cuttlefish.cvd.config.V4l2EmulatedCameraMplane
+	21, // 26: cuttlefish.cvd.config.MediaDevice.v4l2_proxy:type_name -> cuttlefish.cvd.config.V4l2Proxy
+	23, // 27: cuttlefish.cvd.config.Vm.crosvm:type_name -> cuttlefish.cvd.config.Crosvm
+	24, // 28: cuttlefish.cvd.config.Vm.gem5:type_name -> cuttlefish.cvd.config.Gem5
+	25, // 29: cuttlefish.cvd.config.Vm.qemu:type_name -> cuttlefish.cvd.config.Qemu
+	26, // 30: cuttlefish.cvd.config.Vm.custom_actions:type_name -> cuttlefish.cvd.config.CustomAction
+	0,  // 31: cuttlefish.cvd.config.Vm.page_size:type_name -> cuttlefish.cvd.config.UserPageSize
+	27, // 32: cuttlefish.cvd.config.CustomAction.button:type_name -> cuttlefish.cvd.config.Button
+	27, // 33: cuttlefish.cvd.config.CustomAction.buttons:type_name -> cuttlefish.cvd.config.Button
+	28, // 34: cuttlefish.cvd.config.CustomAction.device_states:type_name -> cuttlefish.cvd.config.DeviceState
+	35, // [35:35] is the sub-list for method output_type
+	35, // [35:35] is the sub-list for method input_type
+	35, // [35:35] is the sub-list for extension type_name
+	35, // [35:35] is the sub-list for extension extendee
+	0,  // [0:35] is the sub-list for field type_name
 }
 
 func init() { file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_init() }
@@ -1957,23 +2336,29 @@ func file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_init() {
 	file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[12].OneofWrappers = []any{}
 	file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[13].OneofWrappers = []any{}
 	file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[14].OneofWrappers = []any{}
-	file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[15].OneofWrappers = []any{
+	file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[16].OneofWrappers = []any{
+		(*MediaDevice_V4L2EmulatedCameraSplane)(nil),
+		(*MediaDevice_V4L2EmulatedCameraMplane)(nil),
+		(*MediaDevice_V4L2Proxy)(nil),
+	}
+	file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[19].OneofWrappers = []any{}
+	file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[20].OneofWrappers = []any{
 		(*Vm_Crosvm)(nil),
 		(*Vm_Gem5)(nil),
 		(*Vm_Qemu)(nil),
 	}
-	file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[16].OneofWrappers = []any{}
-	file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[19].OneofWrappers = []any{}
-	file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[20].OneofWrappers = []any{}
 	file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[21].OneofWrappers = []any{}
-	file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[22].OneofWrappers = []any{}
+	file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[24].OneofWrappers = []any{}
+	file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[25].OneofWrappers = []any{}
+	file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[26].OneofWrappers = []any{}
+	file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_msgTypes[27].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDesc), len(file_cuttlefish_host_commands_cvd_cli_parser_load_config_proto_rawDesc)),
-			NumEnums:      1,
-			NumMessages:   24,
+			NumEnums:      2,
+			NumMessages:   29,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/BUILD.bazel
@@ -31,6 +31,7 @@ cf_cc_library(
     srcs = ["cf_connectivity_configs.cpp"],
     hdrs = ["cf_connectivity_configs.h"],
     deps = [
+        "//cuttlefish/host/commands/assemble_cvd:flags_defaults",
         "//cuttlefish/host/commands/cvd/cli/parser:cf_configs_common",
         "//cuttlefish/host/commands/cvd/cli/parser:load_config_cc_proto",
     ],

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_connectivity_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_connectivity_configs.cpp
@@ -15,13 +15,17 @@
  */
 #include "cuttlefish/host/commands/cvd/cli/parser/instance/cf_connectivity_configs.h"
 
+#include <algorithm>
 #include <string>
 #include <vector>
 
+#include "cuttlefish/host/commands/assemble_cvd/flags_defaults.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/cf_configs_common.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/load_config.pb.h"
 
 namespace cuttlefish {
+
+inline constexpr char kFlagModemSimulatorSimType[] = "modem_simulator_sim_type";
 
 using cvd::config::EnvironmentSpecification;
 using cvd::config::Instance;
@@ -30,11 +34,32 @@ static std::string VsockGuestGroup(const Instance& instance) {
   return instance.connectivity().vsock().guest_group();
 }
 
+static int32_t ModemSimulatorSimType(const Instance& instance) {
+  switch (instance.connectivity().modem_simulator_sim_type()) {
+    case cvd::config::MODEM_SIMULATOR_SIM_TYPE_NORMAL:
+      return 1;
+    case cvd::config::MODEM_SIMULATOR_SIM_TYPE_CTS_CARRIER_API:
+      return 2;
+    case cvd::config::MODEM_SIMULATOR_SIM_TYPE_UNSPECIFIED:
+    default:
+      return CF_DEFAULTS_MODEM_SIMULATOR_SIM_TYPE;
+  }
+}
+
 std::vector<std::string> GenerateConnectivityFlags(
     const EnvironmentSpecification& cfg) {
-  return std::vector<std::string>{
+  std::vector<std::string> flags = {
       GenerateInstanceFlag("vsock_guest_group", cfg, VsockGuestGroup),
   };
+  const bool has_sim_type = std::any_of(
+      cfg.instances().begin(), cfg.instances().end(), [](const Instance& ins) {
+        return ins.connectivity().has_modem_simulator_sim_type();
+      });
+  if (has_sim_type) {
+    flags.push_back(GenerateInstanceFlag(kFlagModemSimulatorSimType, cfg,
+                                         ModemSimulatorSimType));
+  }
+  return flags;
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_config.proto
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_config.proto
@@ -38,6 +38,12 @@ enum UserPageSize {
   USER_PAGE_SIZE_64KB = 2;
 }
 
+enum ModemSimulatorSimType {
+  MODEM_SIMULATOR_SIM_TYPE_UNSPECIFIED = 0;
+  MODEM_SIMULATOR_SIM_TYPE_NORMAL = 1;
+  MODEM_SIMULATOR_SIM_TYPE_CTS_CARRIER_API = 2;
+}
+
 message EnvironmentSpecification {
   repeated Instance instances = 1;
   optional Fetch fetch = 2;
@@ -104,6 +110,7 @@ message Build {
 
 message Connectivity {
   optional Vsock vsock = 1;
+  optional ModemSimulatorSimType modem_simulator_sim_type = 2;
 }
 
 message Vsock {


### PR DESCRIPTION
- Update load_config.proto to include modem_simulator_sim_type as ModemSimulatorSimType enum in Connectivity.
- Update cf_connectivity_configs.cpp to generate --modem_simulator_sim_type flag from the proto enum, mapping it to integer values.
- Regenerate Go proto code.
- Add unit tests to flags_parser_test.cc covering valid, unspecified, and invalid values.

Bug: b/425371022
Assisted-by: Jetski:GeminiNext