### PR TITLE
Deduplicate ANSI constants around the codebase

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/BUILD.bazel
@@ -184,6 +184,7 @@ cf_cc_library(
     deps = [
         ":command_request",
         ":types",
+        "//cuttlefish/ansi_codes",
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:files",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/utils.cpp
@@ -33,6 +33,7 @@
 #include "fmt/format.h"
 #include "fmt/ranges.h"  // NOLINT(misc-include-cleaner): version difference
 
+#include "cuttlefish/ansi_codes/ansi_codes.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/contains.h"
 #include "cuttlefish/common/libs/utils/files.h"
@@ -247,25 +248,20 @@ Result<std::vector<Flag>> GetSiblingCommandFlags(const std::string& bin_name,
   return flags;
 }
 
-static constexpr char kTerminalBoldRed[] = "\033[0;1;31m";
-static constexpr char kTerminalCyan[] = "\033[0;36m";
-static constexpr char kTerminalRed[] = "\033[0;31m";
-static constexpr char kTerminalReset[] = "\033[0m";
-
 std::string_view TerminalColors::Reset() const {
-  return is_tty_ ? kTerminalReset : "";
+  return is_tty_ ? kAnsiReset : "";
 }
 
 std::string_view TerminalColors::BoldRed() const {
-  return is_tty_ ? kTerminalBoldRed : "";
+  return is_tty_ ? kAnsiRed : "";
 }
 
 std::string_view TerminalColors::Red() const {
-  return is_tty_ ? kTerminalRed : "";
+  return is_tty_ ? kAnsiRed : "";
 }
 
 std::string_view TerminalColors::Cyan() const {
-  return is_tty_ ? kTerminalCyan : "";
+  return is_tty_ ? kAnsiCyan : "";
 }
 
 std::string NoGroupMessage(const CommandRequest& request) {

--- a/base/cvd/cuttlefish/host/commands/run_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/BUILD.bazel
@@ -46,6 +46,7 @@ cf_cc_library(
     srcs = ["reporting.cpp"],
     hdrs = ["reporting.h"],
     deps = [
+        "//cuttlefish/ansi_codes",
         "//libbase",
         "@abseil-cpp//absl/log",
         "@fruit",

--- a/base/cvd/cuttlefish/host/commands/run_cvd/reporting.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/reporting.cpp
@@ -20,20 +20,19 @@
 
 #include "absl/log/log.h"
 
-namespace cuttlefish {
+#include "cuttlefish/ansi_codes/ansi_codes.h"
 
-static constexpr char kGreenColor[] = "\033[1;32m";
-static constexpr char kResetColor[] = "\033[0m";
+namespace cuttlefish {
 
 DiagnosticInformation::~DiagnosticInformation() = default;
 
 void DiagnosticInformation::PrintAll(
     const std::vector<DiagnosticInformation*>& infos) {
-  LOG(INFO) << kGreenColor << "  Run `cvd logs` to report paths to device logs."
-            << kResetColor;
+  LOG(INFO) << kAnsiGreen << "  Run `cvd logs` to report paths to device logs."
+            << kAnsiReset;
   for (const auto& info : infos) {
     for (const auto& line : info->Diagnostics()) {
-      LOG(INFO) << kGreenColor << "  " << line << kResetColor;
+      LOG(INFO) << kAnsiGreen << "  " << line << kAnsiReset;
     }
   }
 }

--- a/base/cvd/cuttlefish/result/BUILD.bazel
+++ b/base/cvd/cuttlefish/result/BUILD.bazel
@@ -9,8 +9,10 @@ cf_cc_library(
     srcs = ["error_type.cc"],
     hdrs = ["error_type.h"],
     deps = [
+        "//cuttlefish/ansi_codes",
         "//libbase",
         "@abseil-cpp//absl/log",
+        "@abseil-cpp//absl/strings",
         "@fmt",
     ],
 )

--- a/base/cvd/cuttlefish/result/error_type.cc
+++ b/base/cvd/cuttlefish/result/error_type.cc
@@ -24,7 +24,10 @@
 #include <utility>
 #include <vector>
 
+#include "absl/strings/str_cat.h"
 #include "fmt/base.h"
+
+#include "cuttlefish/ansi_codes/ansi_codes.h"
 
 namespace cuttlefish {
 
@@ -75,8 +78,6 @@ bool StackTraceEntry::HasMessage() const { return !message_.str().empty(); }
 fmt::format_context::iterator StackTraceEntry::format(
     fmt::format_context& ctx, const std::vector<FormatSpecifier>& specifiers,
     std::optional<int> index) const {
-  static constexpr char kTerminalBoldRed[] = "\033[0;1;31m";
-  static constexpr char kTerminalReset[] = "\033[0m";
   auto out = ctx.out();
   std::vector<FormatSpecifier> filtered_specs;
   bool arrow = false;
@@ -149,8 +150,8 @@ fmt::format_context::iterator StackTraceEntry::format(
         break;
       case FormatSpecifier::kMessage:
         if (color) {
-          out = fmt::format_to(out, "{}{}{}", kTerminalBoldRed, message_.str(),
-                               kTerminalReset);
+          out = fmt::format_to(out, "{}{}{}", kAnsiRed, message_.str(),
+                               kAnsiReset);
         } else {
           out = fmt::format_to(out, "{}", message_.str());
         }
@@ -164,7 +165,7 @@ fmt::format_context::iterator StackTraceEntry::format(
             file_.substr(last_slash == std::string::npos ? 0 : last_slash + 1);
         std::string last;
         if (HasMessage()) {
-          last = color ? kTerminalBoldRed + message_.str() + kTerminalReset
+          last = color ? absl::StrCat(kAnsiRed, message_.str(), kAnsiReset)
                        : message_.str();
         }
         if (color) {


### PR DESCRIPTION
The `ansi_codes` library was exposed in https://www.github.com/google/android-cuttlefish/pull/2743 so it can be reused more.

Bug: b/528061247