### PR TITLE
Configure Kokoro to do podcvd E2E tests

### DIFF
--- a/.kokoro/presubmit.sh
+++ b/.kokoro/presubmit.sh
@@ -32,14 +32,31 @@ if [ -f "$CACHE_CONFIG_FILE" ]; then
     source "$CACHE_CONFIG_FILE"
 fi
 
-"${TOOL_DIR}/buildutils/build_packages.sh" -r "${BAZEL_REMOTE_CACHE}" -c "${CACHE_VERSION}"
+if [[ "${ANDROID_CUTTLEFISH_KOKORO_BUILD_SCRIPT_ARGS:-}" == *"-p"* ]]; then
+    retry sudo apt-get install -y docker.io
+    sudo systemctl start docker || true
 
-# Add test user to the kokoro group so it has access to the source dir
-"${TOOL_DIR}/testutils/prepare_host.sh" -d "${REPO_DIR}" -u testrunner -g kokoro
+    sudo docker build -t android-cuttlefish-build:latest -f "${TOOL_DIR}/buildutils/cw/Containerfile" "${REPO_DIR}"
+    sudo docker run --rm --network=host -v="${REPO_DIR}":/mnt/build -w /mnt/build android-cuttlefish-build:latest base -r "${BAZEL_REMOTE_CACHE}" -c "${CACHE_VERSION}"
+    sudo docker run --rm --network=host -v="${REPO_DIR}":/mnt/build -w /mnt/build android-cuttlefish-build:latest container
+    sudo docker run --rm --network=host -v="${REPO_DIR}":/mnt/build -w /mnt/build android-cuttlefish-build:latest frontend
+    # Clean up temporary packaging directories created during debuild
+    sudo rm -rf "${REPO_DIR}"/*/debian/tmp
+
+    "${TOOL_DIR}/testutils/prepare_host.sh" -d "${REPO_DIR}" -u testrunner -g kokoro -p
+    sudo -u testrunner "${REPO_DIR}/container/image/image-builder.sh" -c podman -m dev -t localhost/cuttlefish-orchestration:latest
+
+    sudo "${TOOL_DIR}/buildutils/installbazel.sh"
+else
+    "${TOOL_DIR}/buildutils/build_packages.sh" -r "${BAZEL_REMOTE_CACHE}" -c "${CACHE_VERSION}"
+
+    # Add test user to the kokoro group so it has access to the source dir
+    "${TOOL_DIR}/testutils/prepare_host.sh" -d "${REPO_DIR}" -u testrunner -g kokoro
+fi
 
 # Allow kokoro group to the source dir:
 sudo chmod -R g+w /tmpfs/src
 
 # Run as different user without sudo privileges
 sudo -u testrunner CREDENTIAL_SOURCE=gce "${TOOL_DIR}/testutils/runcvde2etests.sh" \
-    "${ANDROID_CUTTLEFISH_KOKORO_BUILD_SCRIPT_ARGS}"
+    ${ANDROID_CUTTLEFISH_KOKORO_BUILD_SCRIPT_ARGS}

--- a/.kokoro/presubmit_podcvd.cfg
+++ b/.kokoro/presubmit_podcvd.cfg
@@ -1,1 +1,14 @@
-build_file: "android-cuttlefish/.kokoro/no_op.sh"
+build_file: "android-cuttlefish/.kokoro/presubmit.sh"
+env_vars {
+  key: "ANDROID_CUTTLEFISH_KOKORO_BUILD_SCRIPT_ARGS"
+  value: "-p"
+}
+
+action {
+  define_artifacts {
+    regex: "github/android-cuttlefish/*.deb"
+
+    # Matches all files regardless of directory depth:
+    regex: "kokoro_test_results/**"
+  }
+}

--- a/tools/buildutils/cw/Containerfile
+++ b/tools/buildutils/cw/Containerfile
@@ -1,15 +1,9 @@
-FROM mirror.gcr.io/library/debian:bookworm-20250811 AS base
+FROM mirror.gcr.io/library/debian:13 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt update -y && apt upgrade -y
 RUN apt install -y sudo devscripts
-
-# Download newer version of golang with keep using bookworm for building debian
-# packages.
-RUN echo "deb http://deb.debian.org/debian bookworm-backports main" > /etc/apt/sources.list.d/backports.list
-RUN apt update
-RUN apt install -t bookworm-backports -y golang
 
 COPY ./tools/buildutils/installbazel.sh /installbazel.sh
 RUN /installbazel.sh && rm /installbazel.sh

--- a/tools/testutils/cw/Containerfile
+++ b/tools/testutils/cw/Containerfile
@@ -1,4 +1,4 @@
-FROM mirror.gcr.io/library/debian:bookworm-20250811 AS base
+FROM mirror.gcr.io/library/debian:13 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV OVERRIDE_BAZEL_WRAPPER_DOWNLOAD_DIR=/tmp/cw_bazel

--- a/tools/testutils/prepare_host.sh
+++ b/tools/testutils/prepare_host.sh
@@ -31,20 +31,48 @@ function grant_device_access() {
 
 function create_test_user() {
   local username=$1
-  local groups="kvm,cvdnetwork"
-  if [[ "$2" != "" ]]; then
-    groups="${groups},$2"
-  fi
+  local groups=$2
   echo "Creating user: ${username}"
-  sudo useradd -G "${groups}" -m "${username}"
+  if [[ "${groups}" != "" ]]; then
+    sudo useradd -G "${groups}" -m "${username}"
+  else
+    sudo useradd -m "${username}"
+  fi
   sudo chmod a+rx "/home/${username}"
+}
+
+function setup_user_runtime_dir() {
+  local username=$1
+  echo "Setting up XDG_RUNTIME_DIR for user: ${username}"
+  local uid=$(id -u "${username}")
+  sudo mkdir -p -m 0700 "/run/user/${uid}"
+  sudo chown "${username}:${username}" "/run/user/${uid}"
+  sudo loginctl enable-linger "${username}" 2>/dev/null || true
+}
+
+function setup_podman_storage_conf() {
+  local username=$1
+  echo "Setting up Podman storage config for user: ${username}"
+  local uid=$(id -u "${username}")
+  local config_dir="/tmp/podcvd-podman-config"
+  sudo mkdir -p "${config_dir}"
+  local driver=$(sudo -u "${username}" XDG_RUNTIME_DIR="/run/user/${uid}" podman info --format '{{ .Store.GraphDriverName }}')
+  local graphroot=$(sudo -u "${username}" XDG_RUNTIME_DIR="/run/user/${uid}" podman info --format '{{ .Store.GraphRoot }}')
+  sudo tee "${config_dir}/storage.conf" >/dev/null <<EOF
+[storage]
+driver = "${driver}"
+graphroot = "${graphroot}"
+rootless_storage_path = "${graphroot}"
+EOF
+  sudo chown -R "${username}:${username}" "${config_dir}"
 }
 
 
 PKG_DIR=""
 TEST_USER=""
 EXTRA_GROUPS=""
-while getopts "d:u:g:" opt; do
+PODCVD_MODE=false
+while getopts "d:u:g:p" opt; do
   case "${opt}" in
     u)
       TEST_USER="${OPTARG}"
@@ -55,9 +83,12 @@ while getopts "d:u:g:" opt; do
     d)
       PKG_DIR="${OPTARG}"
       ;;
+    p)
+      PODCVD_MODE=true
+      ;;
     *)
     echo "Invalid option: -${opt}"
-    echo "Usage: $0 -d PACKAGE_DIR [-u TEST_USER [-g EXTRA_GROUPS]]"
+    echo "Usage: $0 -d PACKAGE_DIR [-u TEST_USER [-g EXTRA_GROUPS]] [-p]"
     exit 1
     ;;
   esac
@@ -69,13 +100,26 @@ if [[ "${PKG_DIR}" == "" ]] || ! [[ -d "${PKG_DIR}" ]]; then
 fi
 
 sudo apt-get update
-install_pkgs "${PKG_DIR}" cuttlefish-base cuttlefish-metrics cuttlefish-user
 
-check_service_started cuttlefish-host-resources
-load_kernel_modules kvm vhost-vsock vhost-net bridge
-grant_device_access vhost-vsock vhost-net kvm
-check_service_started cuttlefish-operator
+if [[ "${PODCVD_MODE}" == true ]]; then
+  install_pkgs "${PKG_DIR}" cuttlefish-podcvd
+  load_kernel_modules kvm vhost-vsock vhost-net bridge
+  grant_device_access vhost-vsock vhost-net kvm
+  if [[ "${TEST_USER}" != "" ]]; then
+    create_test_user "${TEST_USER}" "${EXTRA_GROUPS}"
+    setup_user_runtime_dir "${TEST_USER}"
+    setup_podman_storage_conf "${TEST_USER}"
+    sudo /usr/bin/podcvd-setup "${TEST_USER}"
+  fi
+else
+  install_pkgs "${PKG_DIR}" cuttlefish-base cuttlefish-metrics cuttlefish-user
 
-if [[ "${TEST_USER}" != "" ]]; then
-  create_test_user "${TEST_USER}" "${EXTRA_GROUPS}"
+  check_service_started cuttlefish-host-resources
+  load_kernel_modules kvm vhost-vsock vhost-net bridge
+  grant_device_access vhost-vsock vhost-net kvm
+  check_service_started cuttlefish-operator
+
+  if [[ "${TEST_USER}" != "" ]]; then
+    create_test_user "${TEST_USER}" "kvm,cvdnetwork${EXTRA_GROUPS:+,${EXTRA_GROUPS}}"
+  fi
 fi

--- a/tools/testutils/runcvde2etests.sh
+++ b/tools/testutils/runcvde2etests.sh
@@ -6,18 +6,23 @@ REPO_DIR="$(realpath "$(dirname "$0")/../..")"
 OUTPUT_DIR="$(pwd)"
 CREDENTIAL_SOURCE="${CREDENTIAL_SOURCE:-}"
 
-bazel_test_tag_filter_arg="--test_tag_filters=-requires_gpu"
-while getopts "g" opt; do
+gpu_enabled=false
+podcvd_enabled=false
+while getopts "gp" opt; do
   case "${opt}" in
     g)
-      bazel_test_tag_filter_arg="--test_tag_filters=requires_gpu"
+      gpu_enabled=true
+      ;;
+    p)
+      podcvd_enabled=true
       ;;
     *)
     echo "Invalid option: -${opt}"
-    echo "Usage: $0 [-g]"
+    echo "Usage: $0 [-g] [-p]"
     echo ""
     echo "Options"
     echo " -g  only run tests with the 'requires_gpu' tag"
+    echo " -p  test podcvd instead of cvd"
     exit 1
     ;;
   esac
@@ -53,6 +58,20 @@ cd "${REPO_DIR}/e2etests"
 # those tests
 trap gather_test_results EXIT
 
+test_tags="-requires_gpu"
+if [[ "${gpu_enabled}" == true ]]; then
+  test_tags="requires_gpu"
+fi
+podcvd_args=""
+if [[ "${podcvd_enabled}" == true ]]; then
+  test_tags+=",podcvd"
+  podcvd_args+=" --test_env=CONTAINERS_STORAGE_CONF=/tmp/podcvd-podman-config/storage.conf"
+  podcvd_args+=" --test_env=HOME=${HOME}"
+  podcvd_args+=" --test_env=USE_PODCVD=true"
+  podcvd_args+=" --test_env=XDG_RUNTIME_DIR=/run/user/$(id -u)"
+fi
+bazel_test_tag_filter_arg="--test_tag_filters=${test_tags}"
+
 credential_arg=""
 if [[ -n "$CREDENTIAL_SOURCE" ]]; then
     credential_arg="--test_env=CREDENTIAL_SOURCE=${CREDENTIAL_SOURCE}"
@@ -63,5 +82,6 @@ fi
 bazel test \
   ${bazel_test_tag_filter_arg} \
   ${credential_arg} \
+  ${podcvd_args} \
   --zip_undeclared_test_outputs \
   cvd/...


### PR DESCRIPTION
I originally implemented to trigger podcvd E2E tests from GitHub action, but some limitations were observed.
- (Critical reason) A lot of test cases weren't able to fetch required artifacts. For example, when the branch is git_main.
- GitHub runner has very limited computing resources. I'm expecting that as the root cause of current flakiness of bugreport test. (90 seconds locally, about 300 seconds on GitHub runner)
- Looking forward to make test cases non-exclusive on Kokoro-based podcvd testing, as podcvd can deal with concurrent instance creation.

So I suggest to move podcvd E2E test into Kokoro. GitHub action should be kept during transition period for keeping podcvd stable, and will be cleaned up afterwards.

Context: b/527644057