### PR TITLE
cvd logs: Allow printing logs without --print

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/logs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/logs.cpp
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <iostream>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -173,9 +174,16 @@ CvdLogsHandler::CvdLogsHandler(InstanceManager& instance_manager)
 Result<void> CvdLogsHandler::Handle(const CommandRequest& request) {
   std::vector<std::string> args = request.SubcommandArguments();
   std::vector<Flag> flags = CF_EXPECT(Flags(request));
-  CF_EXPECT(ConsumeFlags(flags, args, {.fail_on_unexpected_argument = true}));
+  CF_EXPECT(ConsumeFlags(flags, args, {.fail_on_unexpected_argument = false}));
+  if (!print_target_flag_ && !args.empty()) {
+    print_target_flag_ = args[0];
+    args.erase(args.begin());
+  }
+  // Check for unexpected arguments only, flags were consumed on the previous
+  // call
+  CF_EXPECT(ConsumeFlags({}, args, {.fail_on_unexpected_argument = true}));
 
-  if (!print_target_flag_.empty()) {
+  if (print_target_flag_) {
     CF_EXPECT(HandlePrint(request));
     return {};
   }
@@ -184,8 +192,11 @@ Result<void> CvdLogsHandler::Handle(const CommandRequest& request) {
 }
 
 Result<void> CvdLogsHandler::HandlePrint(const CommandRequest& request) {
+  if (print_target_flag_.value().empty()) {
+    return CF_ERR("Invalid log file name: ''");
+  }
   std::vector<std::string> log_filenames;
-  if (IsGroupLevelLog(print_target_flag_)) {
+  if (IsGroupLevelLog(*print_target_flag_)) {
     const LocalInstanceGroup group =
         CF_EXPECT(selector::SelectGroup(instance_manager_, request));
     log_filenames = group.LogsFilenames();
@@ -198,12 +209,13 @@ Result<void> CvdLogsHandler::HandlePrint(const CommandRequest& request) {
   log_filenames = RemoveInaccessibleFilenames(std::move(log_filenames));
   for (const std::string& filename : log_filenames) {
     const std::string basename = android::base::Basename(filename);
-    if (basename == print_target_flag_) {
+    if (basename == *print_target_flag_) {
       CF_EXPECT(PrintLog(filename, pager_));
       return {};
     }
   }
-  return CF_ERRF("Not found `{}` logs", print_target_flag_);
+  return CF_ERRF("Could not find `{}` in the logs directories",
+                 *print_target_flag_);
 }
 
 Result<void> CvdLogsHandler::HandleList(const CommandRequest& request) {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/logs.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/logs.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
@@ -26,7 +27,7 @@ class CvdLogsHandler : public CvdCommandHandler {
   Result<void> HandleList(const CommandRequest& request);
 
   InstanceManager& instance_manager_;
-  std::string print_target_flag_;
+  std::optional<std::string> print_target_flag_;
   bool pretty_;
   bool pager_;
 };

--- a/e2etests/cvd/logs_tests/main_test.go
+++ b/e2etests/cvd/logs_tests/main_test.go
@@ -85,7 +85,7 @@ func TestPrintLogs(t *testing.T) {
 			t.Fatal(res.Stderr)
 		}
 		names := strings.Split(fields[0], ":")
-		logName := names[len(names) - 1]
+		logName := names[len(names)-1]
 		listedNames = append(listedNames, logName)
 	}
 	keyExpectedNames := []string{
@@ -110,6 +110,28 @@ func TestPrintLogs(t *testing.T) {
 	stdOut = res.Stdout
 	if len(stdOut) == 0 {
 		t.Fatalf("empty launcher.log")
+	}
+
+	// Test cvd logs <logfilename> (equivalent to --print)
+	res, err = c.RunCmd(c.TargetBin(), "logs", "launcher.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdOut = res.Stdout
+	if len(stdOut) == 0 {
+		t.Fatalf("empty launcher.log when printed without --print flag")
+	}
+
+	// Test cvd logs <file1> <file2> (should fail)
+	_, err = c.RunCmd(c.TargetBin(), "logs", "launcher.log", "kernel.log")
+	if err == nil {
+		t.Fatalf("expected cvd logs with multiple positional arguments to fail")
+	}
+
+	// Test cvd logs --print <file1> <file2> (should fail)
+	_, err = c.RunCmd(c.TargetBin(), "logs", "--print", "launcher.log", "kernel.log")
+	if err == nil {
+		t.Fatalf("expected cvd logs --print with extra positional arguments to fail")
 	}
 
 }


### PR DESCRIPTION
by making `cvd logs foo` equivalent to `cvd logs --print=foo`

Assisted-by: Jetski:Gemini-Next