### PR TITLE
Enforce misc-include-cleaner and clang-format in console_forwarder

### DIFF
--- a/base/cvd/BUILD.bazel
+++ b/base/cvd/BUILD.bazel
@@ -34,6 +34,7 @@ filegroup(
         "//cuttlefish/common/libs/transport:.clang-tidy",
         "//cuttlefish/host:.clang-tidy",
         "//cuttlefish/host/commands/assemble_cvd/android_build:.clang-tidy",
+        "//cuttlefish/host/commands/console_forwarder:.clang-tidy",
         "//cuttlefish/host/commands/cvd/cli/commands:.clang-tidy",
         "//cuttlefish/host/commands/kernel_log_monitor:.clang-tidy",
         "//cuttlefish/host/commands/mkenvimage_slim:.clang-tidy",

--- a/base/cvd/cuttlefish/host/commands/console_forwarder/.clang-tidy
+++ b/base/cvd/cuttlefish/host/commands/console_forwarder/.clang-tidy
@@ -1,0 +1,1 @@
+../../../../clang_tidy_configs/with_include_cleaner

--- a/base/cvd/cuttlefish/host/commands/console_forwarder/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/console_forwarder/BUILD.bazel
@@ -4,6 +4,8 @@ package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
+exports_files([".clang-tidy"])
+
 cf_cc_binary(
     name = "console_forwarder",
     srcs = [

--- a/base/cvd/cuttlefish/host/commands/console_forwarder/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/console_forwarder/BUILD.bazel
@@ -11,7 +11,6 @@ cf_cc_binary(
     srcs = [
         "main.cpp",
     ],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/host/commands/kernel_log_monitor:kernel_log_monitor_utils",

--- a/base/cvd/cuttlefish/host/commands/console_forwarder/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/console_forwarder/main.cpp
@@ -42,11 +42,9 @@
 #include "cuttlefish/host/libs/config/logging.h"
 #include "cuttlefish/posix/strerror.h"
 
-DEFINE_int32(console_in_fd,
-             -1,
+DEFINE_int32(console_in_fd, -1,
              "File descriptor for the console's input channel");
-DEFINE_int32(console_out_fd,
-             -1,
+DEFINE_int32(console_out_fd, -1,
              "File descriptor for the console's output channel");
 
 namespace cuttlefish {
@@ -77,6 +75,7 @@ class ConsoleForwarder {
     // reading the console's output and input from the client.
     ReadLoop();
   }
+
  private:
   SharedFD OpenPTY() {
     // Remove any stale symlink to a pts device
@@ -137,8 +136,9 @@ class ConsoleForwarder {
           bytes_written =
               fd->Write(buf_ptr->data() + bytes_written, bytes_to_write);
           if (bytes_written < 0) {
-            // It is expected for writes to the PTY to fail if nothing is connected
-            if(fd->GetErrno() != EAGAIN) {
+            // It is expected for writes to the PTY to fail if nothing is
+            // connected
+            if (fd->GetErrno() != EAGAIN) {
               LOG(ERROR) << "Error writing to fd: " << fd->StrError();
             }
 
@@ -176,7 +176,8 @@ class ConsoleForwarder {
 
       Select(&read_set, nullptr, &error_set, nullptr);
       if (read_set.IsSet(console_out_)) {
-        std::shared_ptr<std::vector<char>> buf_ptr = std::make_shared<std::vector<char>>(4096);
+        std::shared_ptr<std::vector<char>> buf_ptr =
+            std::make_shared<std::vector<char>>(4096);
         auto bytes_read = console_out_->Read(buf_ptr->data(), buf_ptr->size());
         // This is likely unrecoverable, so exit here
         CHECK(bytes_read > 0) << "Error reading from console output: "
@@ -189,7 +190,8 @@ class ConsoleForwarder {
         EnqueueWrite(buf_ptr, kernel_log_);
       }
       if (read_set.IsSet(client_fd) || error_set.IsSet(client_fd)) {
-        std::shared_ptr<std::vector<char>> buf_ptr = std::make_shared<std::vector<char>>(4096);
+        std::shared_ptr<std::vector<char>> buf_ptr =
+            std::make_shared<std::vector<char>>(4096);
         auto bytes_read = client_fd->Read(buf_ptr->data(), buf_ptr->size());
         if (bytes_read <= 0) {
           // If this happens, it's usually because the PTY controller went away

--- a/base/cvd/cuttlefish/host/commands/console_forwarder/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/console_forwarder/main.cpp
@@ -14,20 +14,26 @@
  * limitations under the License.
  */
 
-#include <termios.h>
-#include <stdlib.h>
+#include <asm/ioctls.h>
+#include <errno.h>
+#include <fcntl.h>
 #include <signal.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
 #include <unistd.h>
 
 #include <condition_variable>
 #include <deque>
+#include <memory>
 #include <mutex>
+#include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
-#include <gflags/gflags.h>
 #include "absl/log/check.h"
 #include "absl/log/log.h"
+#include "gflags/gflags.h"
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/fs/shared_select.h"
@@ -85,6 +91,7 @@ class ConsoleForwarder {
     CHECK_EQ(unlockpt(pty), 0) << StrError(errno);
 
     int packet_mode_enabled = 1;
+    // NOLINTNEXTLINE(misc-include-cleaner)
     CHECK_EQ(ioctl(pty, TIOCPKT, &packet_mode_enabled), 0) << StrError(errno);
 
     auto pty_dev_name = ptsname(pty);


### PR DESCRIPTION
Assisted-by: Jetski <jetski@google.com>
Bug: b/512215781