### PR TITLE
assemble_cvd: default riscv64 to guest-side keymint+gatekeeper

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -409,17 +409,10 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
   tmp_config_obj.set_ap_vm_manager(ToString(vm_manager_flag.Mode()) +
                                    "_openwrt");
 
-  // TODO: schuffelen - fix behavior on riscv64
-  if (guest_configs[0].target_arch == Arch::RiscV64) {
-    static constexpr char kRiscv64Secure[] = "keymint,gatekeeper,oemlock";
-    SetCommandLineOptionWithMode("secure_hals", kRiscv64Secure,
-                                 google::FlagSettingMode::SET_FLAGS_DEFAULT);
-  } else {
-    static constexpr char kDefaultSecure[] =
-        "oemlock,guest_keymint_insecure,guest_gatekeeper_insecure";
-    SetCommandLineOptionWithMode("secure_hals", kDefaultSecure,
-                                 google::FlagSettingMode::SET_FLAGS_DEFAULT);
-  }
+  static constexpr char kDefaultSecure[] =
+      "oemlock,guest_keymint_insecure,guest_gatekeeper_insecure";
+  SetCommandLineOptionWithMode("secure_hals", kDefaultSecure,
+                               google::FlagSettingMode::SET_FLAGS_DEFAULT);
   auto secure_hals = CF_EXPECT(ParseSecureHals(FLAGS_secure_hals));
   CF_EXPECT(ValidateSecureHals(secure_hals));
   tmp_config_obj.set_secure_hals(secure_hals);


### PR DESCRIPTION
Mirror the x86_64/arm64 default so launch_cvd on riscv64 runs the
in-guest keymint (rust_nonsecure) and gatekeeper (nonsecure) instead of
host-side cf_remote variants over vsock. Closes the schuffelen TODO.
oemlock and the libtpms TPM stay in host-side secure_env.

Signed-off-by: Jun Sun <jsun@junsun.net>
