### PR TITLE
Don't silently drop --extra_bootconfig_args overrides.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/bootconfig_args.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/bootconfig_args.cpp
@@ -380,7 +380,8 @@ Result<std::unordered_map<std::string, std::string>> BootconfigArgsFromConfig(
     const std::vector<std::string_view> parts = absl::StrSplit(kv, '=');
     CF_EXPECT_EQ(parts.size(), 2,
                  "Failed to parse --extra_bootconfig_args: \"" << kv << "\"");
-    bootconfig_args.emplace(parts[0], parts[1]);
+    bootconfig_args.insert_or_assign(std::string(parts[0]),
+                                     std::string(parts[1]));
   }
 
   return bootconfig_args;


### PR DESCRIPTION
The loop parsing --extra_bootconfig_args was using emplace(), which is
a no-op when the key already exists. If the user passed an override for
a key already set by hardcoded defaults earlier in the same map, their
value was silently discarded. Switch to insert_or_assign so user values
win, matching the documented intent of the flag.
