### PR TITLE
Fix double-write of bootconfig partition.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/generate_persistent_bootconfig.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/generate_persistent_bootconfig.cpp
@@ -88,7 +88,7 @@ Result<std::optional<BootConfigPartition>> BootConfigPartition::CreateIfNeeded(
 
   VLOG(0) << "bootconfig size is " << bootconfig.size();
   ssize_t bytesWritten = WriteAll(bootconfig_fd, bootconfig);
-  CF_EXPECT(WriteAll(bootconfig_fd, bootconfig) == bootconfig.size(),
+  CF_EXPECT(bytesWritten == bootconfig.size(),
             "Failed to write bootconfig to \"" << bootconfig_path << "\"");
   VLOG(0) << "Bootconfig parameters from vendor boot image and config are "
           << ReadFile(bootconfig_path);


### PR DESCRIPTION
WriteAll(bootconfig_fd, bootconfig) was being called twice in
BootConfigPartition::CreateIfNeeded -- once to capture bytesWritten,
once inside the CF_EXPECT() comparison. The second call appended
duplicate bytes to the partition file, corrupting it. Drop the second
call and compare bytesWritten directly.
