### PR TITLE
package: handle empty common prefix in _remove_prefix

### DIFF
--- a/base/cvd/cuttlefish/package/rules.bzl
+++ b/base/cvd/cuttlefish/package/rules.bzl
@@ -18,6 +18,11 @@ def _get_common_prefix(paths):
     return "/".join(prefix)
 
 def _remove_prefix(path, path_prefix):
+    # Empty prefix is a no-op (caller's common-prefix computation may return
+    # "" when two paths share no leading directory, e.g. lib64/x vs bin/y).
+    if not path_prefix:
+        return path
+
     path_parts = path.split("/")
 
     for path_prefix_part in path_prefix.split("/"):


### PR DESCRIPTION
_get_common_prefix() returns "" when two paths share no leading
component (e.g. lib64/x.so -> bin/y.so).  _remove_prefix() then
aborted.  Return path unchanged for empty prefix.
