### PR TITLE
base/setup-nodejs-env: fail fast on unsupported architectures

### DIFF
--- a/base/setup-nodejs-env.sh
+++ b/base/setup-nodejs-env.sh
@@ -11,6 +11,10 @@ case "$(uname -m)" in
     export NODE_DISTRO=linux-arm64
     export NODE_SHA256SUM=a43100595e7960b9e8364bff5641e0956a9929feee2759e70cbb396a1d827b7c
     ;;
+  *)
+    echo "error: setup-nodejs-env.sh: unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
 esac
 
 export NODE_ROOT=/tmp/nodejs


### PR DESCRIPTION
An unrecognized architecture leaves NODE_DISTRO and NODE_SHA256SUM unset,
which surfaces downstream as a confusing curl 404 against an empty
NODE_DISTRO segment. Add a catch-all that exits with a clear error.

Signed-off-by: Jun Sun <jsun@junsun.net>
