### PR TITLE
Cherry-pick of ag/40371614

### DIFF
--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/netsim_server.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/netsim_server.cpp
@@ -137,6 +137,9 @@ class NetsimServer : public CommandSource {
     hci_vsock_proxy.AddParameter("--client_tcp_host=127.0.0.1");
     hci_vsock_proxy.AddParameter("--client_tcp_port=",
                                  config_.rootcanal_hci_port());
+    if (instance_.vhost_user_vsock()) {
+      hci_vsock_proxy.AddParameter("--vhost_user_vsock=true");
+    }
 
     // Add command for forwarding the test port to a vsock server.
     Command test_vsock_proxy(SocketVsockProxyBinary());
@@ -149,6 +152,9 @@ class NetsimServer : public CommandSource {
     test_vsock_proxy.AddParameter("--client_tcp_host=127.0.0.1");
     test_vsock_proxy.AddParameter("--client_tcp_port=",
                                   config_.rootcanal_test_port());
+    if (instance_.vhost_user_vsock()) {
+      test_vsock_proxy.AddParameter("--vhost_user_vsock=true");
+    }
 
     std::vector<MonitorCommand> commands;
     commands.emplace_back(std::move(netsimd));


### PR DESCRIPTION
Fix netsim vsock proxy parameters for vhost-user-vsock

Cuttlefish host launcher run_cvd fails to pass --vhost_user_vsock=true to socket_vsock_proxy helper processes (hci_vsock_proxy and test_vsock_proxy).

This results in the proxy processes binding to the host kernel vsock interface rather than the vhost-user Unix domain socket when vhost_user_vsock is enabled, causing guest vsock connections to hang.

Bug: b/520342656
Test: Manual verification on CF target with vhost-user-vsock