### PR TITLE
web ui: Better handling when device has no audio

### DIFF
--- a/base/cvd/cuttlefish/host/frontend/webrtc/html_client/controls.css
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/html_client/controls.css
@@ -25,9 +25,16 @@ body.light-theme {
   --toggle-off-fg: white;
 }
 
-.toggle-control.toggle-off {
+.toggle-control.toggle-off:enabled {
   background-color: var(--toggle-off-bg);
   color: var(--toggle-off-fg);
   border-radius: 10px;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  background-color: var(--button-bg);
+  color: var(--button-fg);
 }
 

--- a/base/cvd/cuttlefish/host/frontend/webrtc/html_client/js/app.js
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/html_client/js/app.js
@@ -185,11 +185,14 @@ class DeviceControlApp {
 
     this.#showDeviceUI();
 
+    const hasAudio = deviceHasAudio(this.#deviceConnection.description);
+
     // Enable non-ADB buttons, these buttons use data channels to communicate
     // with the host, so they're ready to go as soon as the webrtc connection is
     // established.
     this.#getControlPanelButtons()
         .filter(b => !b.dataset.adb)
+        .filter(b => hasAudio || (b.id !== 'volume_off_btn' && b.id !== 'mic_btn'))
         .forEach(b => b.disabled = false);
   }
 
@@ -382,23 +385,37 @@ class DeviceControlApp {
     this.#updateDeviceDisplays();
     this.#deviceConnection.onStreamChange(stream => this.#onStreamChange(stream));
 
-    // Set up audio
     let audioPlaybackCtrl = createToggleControl(
         document.getElementById('volume_off_btn'),
         enabled => this.#onAudioPlaybackToggle(enabled));
-    for (const audio_desc of this.#deviceConnection.description.audio_streams) {
-      let stream_id = audio_desc.stream_id;
-      this.#addAudioStream(stream_id, audioPlaybackCtrl);
-      this.#deviceConnection.onStream(stream_id)
-          .then(stream => {
-            const deviceAudio = document.getElementById(`device-${stream_id}`);
-            if (!deviceAudio) {
-              throw `Element with id device-${stream_id} not found`;
-            }
-            deviceAudio.srcObject = stream;
-            deviceAudio.play();
-          })
-          .catch(e => console.error('Unable to get audio stream: ', e));
+
+    // Set up audio
+    if (deviceHasAudio(this.#deviceConnection.description)) {
+      for (const audio_desc of this.#deviceConnection.description.audio_streams) {
+        let stream_id = audio_desc.stream_id;
+        this.#addAudioStream(stream_id, audioPlaybackCtrl);
+        this.#deviceConnection.onStream(stream_id)
+            .then(stream => {
+              const deviceAudio = document.getElementById(`device-${stream_id}`);
+              if (!deviceAudio) {
+                throw `Element with id device-${stream_id} not found`;
+              }
+              deviceAudio.srcObject = stream;
+              deviceAudio.play();
+            })
+            .catch(e => console.error('Unable to get audio stream: ', e));
+      }
+    } else {
+      const noAudioMsg = 'Device has no audio';
+      const volumeOffBtn = document.getElementById('volume_off_btn');
+      volumeOffBtn.disabled = true;
+      volumeOffBtn.title = noAudioMsg;
+      document.getElementById('volume_up_btn').style.display = 'none';
+      document.getElementById('volume_down_btn').style.display = 'none';
+
+      const micBtn = document.getElementById('mic_btn');
+      micBtn.disabled = true;
+      micBtn.title = noAudioMsg;
     }
 
     // Set up keyboard and wheel capture
@@ -1362,4 +1379,9 @@ function getStyleAfterRotation(rotationDeg, ar) {
       rightFactor})) rotate(${rotationDeg}deg)`;
 
   return {transform, maxWidth, maxHeight};
+}
+
+// Checks if the device description contains any active audio streams.
+function deviceHasAudio(description) {
+  return description.audio_streams && description.audio_streams.length > 0;
 }


### PR DESCRIPTION
When the device registers with the signaling server it includes information about its supported audio streams. The client uses this information to decide whether to add audio capabilities to the webRTC connection.

When no audio streams are reported by the device, the web UI won't show the volume UP/DOWN buttons and the button the enable/disable audio is "disabled": shows a different cursor, doesn't react to mouse events and displays a message when hovered over.

<img width="271" height="297" alt="Screenshot_20260629_115123" src="https://github.com/user-attachments/assets/d99ae86a-cfb3-4466-857d-7b3a9714425f" />

<img width="381" height="207" alt="Screenshot_20260629_141712" src="https://github.com/user-attachments/assets/22eca835-7a0e-48d9-89ff-cc1130bca8ee" />

