### PR TITLE
Revert Ensure Proper FIFO Provisioning for Shared UWB Services

### DIFF
--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/uwb_connector.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/uwb_connector.cpp
@@ -40,7 +40,7 @@ namespace cuttlefish {
 Result<std::optional<MonitorCommand>> UwbConnector(
     const CuttlefishConfig& config,
     const CuttlefishConfig::InstanceSpecific& instance) {
-  if (!config.enable_host_uwb()) {
+  if (!instance.enable_host_uwb_connector()) {
     return {};
   }
   std::vector<std::string> fifo_paths = {
@@ -50,9 +50,6 @@ Result<std::optional<MonitorCommand>> UwbConnector(
   std::vector<SharedFD> fifos;
   for (const auto& path : fifo_paths) {
     fifos.push_back(CF_EXPECT(CreateOrReuseAndDrainFifo(path, 0660)));
-  }
-  if (!instance.enable_host_uwb_connector()) {
-    return {};
   }
   return Command(HostBinaryPath("tcp_connector"))
       .AddParameter("-fifo_out=", fifos[0])


### PR DESCRIPTION
 Fix timeout on non-primary instance restart due to missing UWB FIFO
 
 Partial revert of https://github.com/google/android-cuttlefish/pull/2581