### PR TITLE
Enforce clang-format on host/libs/config

### DIFF
--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -111,7 +111,6 @@ cf_cc_library(
         "cuttlefish_config_instance.cpp",
     ],
     hdrs = ["cuttlefish_config.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:device_type",
         "//cuttlefish/common/libs/utils:environment",

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -344,7 +344,6 @@ cf_cc_library(
     name = "instance_nums",
     srcs = ["instance_nums.cpp"],
     hdrs = ["instance_nums.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/flag_parser",

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -455,7 +455,6 @@ cf_cc_library(
     name = "vmm_mode",
     srcs = ["vmm_mode.cc"],
     hdrs = ["vmm_mode.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/result",
         "@abseil-cpp//absl/strings",

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -19,7 +19,6 @@ cf_cc_library(
 cf_cc_library(
     name = "config_constants",
     hdrs = ["config_constants.h"],
-    clang_format_enabled = False,
 )
 
 cf_cc_library(

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -223,7 +223,6 @@ cf_cc_library(
     name = "build_archive",
     srcs = ["build_archive.cc"],
     hdrs = ["build_archive.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/libs/config:fetcher_config",

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -66,7 +66,6 @@ cf_cc_library(
     name = "config_utils",
     srcs = ["config_utils.cpp"],
     hdrs = ["config_utils.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:environment",

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -25,7 +25,6 @@ cf_cc_library(
     name = "config_flag",
     srcs = ["config_flag.cpp"],
     hdrs = ["config_flag.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/key_equals_value",
         "//cuttlefish/common/libs/utils:files",

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -441,7 +441,6 @@ cf_cc_library(
     name = "touchpad",
     srcs = ["touchpad.cpp"],
     hdrs = ["touchpad.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/flag_parser",

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -465,7 +465,6 @@ cf_cc_library(
     name = "media",
     srcs = ["media.cpp"],
     hdrs = ["media.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/flag_parser",

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -369,7 +369,6 @@ cf_cc_library(
     name = "known_paths",
     srcs = ["known_paths.cpp"],
     hdrs = ["known_paths.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/libs/config:config_utils",

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -331,7 +331,6 @@ cf_cc_library(
     name = "host_tools_version",
     srcs = ["host_tools_version.cpp"],
     hdrs = ["host_tools_version.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/libs/config:config_utils",

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -147,7 +147,6 @@ cf_cc_library(
     name = "data_image",
     srcs = ["data_image.cpp"],
     hdrs = ["data_image.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -197,7 +197,6 @@ cf_cc_library(
     name = "esp",
     srcs = ["esp.cpp"],
     hdrs = ["esp.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -55,7 +55,6 @@ cf_cc_library(
     name = "config_instance_derived",
     srcs = ["config_instance_derived.cc"],
     hdrs = ["config_instance_derived.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/libs/config:cuttlefish_config",

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -85,7 +85,6 @@ cf_cc_library(
     name = "custom_actions",
     srcs = ["custom_actions.cpp"],
     hdrs = ["custom_actions.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:json",

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -249,7 +249,6 @@ cf_cc_library(
     name = "fetcher_config",
     srcs = ["fetcher_config.cpp"],
     hdrs = ["fetcher_config.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/libs/config:file_source",

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -182,7 +182,6 @@ cf_cc_library(
     name = "display",
     srcs = ["display.cpp"],
     hdrs = ["display.h"],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/flag_parser",

--- a/base/cvd/cuttlefish/host/libs/config/build_archive.cc
+++ b/base/cvd/cuttlefish/host/libs/config/build_archive.cc
@@ -27,10 +27,10 @@
 #include <string_view>
 #include <utility>
 
-#include <android-base/file.h>
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/strip.h"
+#include "android-base/file.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/libs/config/fetcher_config.h"
@@ -157,8 +157,8 @@ Result<std::string> BuildArchive::MemberFilepath(
 Result<std::string> BuildArchive::MemberContents(std::string_view name) {
   CF_EXPECTF(members_.count(name), "'{}' not in archive", name);
   if (auto it = extracted_.find(name); it != extracted_.end()) {
-    return CF_EXPECTF(ReadFileContents(it->second),
-                      "Failed to read '{}'", it->second);
+    return CF_EXPECTF(ReadFileContents(it->second), "Failed to read '{}'",
+                      it->second);
   }
   CF_EXPECT(zip_file_.has_value(), "'{}' not extracted, no source archive");
 

--- a/base/cvd/cuttlefish/host/libs/config/build_archive.h
+++ b/base/cvd/cuttlefish/host/libs/config/build_archive.h
@@ -23,10 +23,9 @@
 #include <string>
 #include <string_view>
 
-#include "cuttlefish/host/libs/zip/libzip_cc/archive.h"
-
 #include "cuttlefish/host/libs/config/fetcher_config.h"
 #include "cuttlefish/host/libs/config/file_source.h"
+#include "cuttlefish/host/libs/zip/libzip_cc/archive.h"
 #include "cuttlefish/pretty/pretty.h"
 #include "cuttlefish/pretty/struct.h"
 #include "cuttlefish/result/result.h"

--- a/base/cvd/cuttlefish/host/libs/config/config_constants.h
+++ b/base/cvd/cuttlefish/host/libs/config/config_constants.h
@@ -74,4 +74,4 @@ inline constexpr char kHwComposerAuto[] = "auto";
 inline constexpr char kHwComposerDrm[] = "drm_hwcomposer";
 inline constexpr char kHwComposerRanchu[] = "ranchu";
 inline constexpr char kHwComposerNone[] = "none";
-}
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/config/config_flag.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/config_flag.cpp
@@ -29,23 +29,23 @@
 #include <utility>
 #include <vector>
 
-#include "absl/strings/strip.h"
-#include <fmt/ranges.h>
-#include <fruit/component.h>
-#include <fruit/fruit_forward_decls.h>
-#include <fruit/macro.h>
-#include <gflags/gflags.h>
-#include <json/value.h>
-#include <json/writer.h>
 #include "absl/log/log.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
+#include "absl/strings/strip.h"
+#include "fmt/ranges.h"
+#include "fruit/component.h"
+#include "fruit/fruit_forward_decls.h"
+#include "fruit/macro.h"
+#include "gflags/gflags.h"
+#include "json/value.h"
+#include "json/writer.h"
 
 #include "cuttlefish/common/libs/key_equals_value/key_equals_value.h"
 #include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/common/libs/utils/json.h"
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/flag_parser/gflags_compat.h"
-#include "cuttlefish/common/libs/utils/json.h"
 #include "cuttlefish/host/commands/assemble_cvd/flags/system_image_dir.h"
 #include "cuttlefish/host/libs/config/config_utils.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"

--- a/base/cvd/cuttlefish/host/libs/config/config_instance_derived.cc
+++ b/base/cvd/cuttlefish/host/libs/config/config_instance_derived.cc
@@ -97,4 +97,3 @@ std::string RestoreAdbdPipeName(const CuttlefishConfig::InstanceSpecific& ins) {
 }
 
 }  // namespace cuttlefish
-

--- a/base/cvd/cuttlefish/host/libs/config/config_instance_derived.h
+++ b/base/cvd/cuttlefish/host/libs/config/config_instance_derived.h
@@ -42,4 +42,3 @@ std::string SwitchesSocketPath(const CuttlefishConfig::InstanceSpecific&);
 std::string RestoreAdbdPipeName(const CuttlefishConfig::InstanceSpecific&);
 
 }  // namespace cuttlefish
-

--- a/base/cvd/cuttlefish/host/libs/config/config_utils.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/config_utils.cpp
@@ -82,9 +82,9 @@ int GetDefaultVsockCid() {
   return default_vsock_cid;
 }
 
-int GetVsockServerPort(const int base,
-                       const int vsock_guest_cid /**< per instance guest cid */) {
-    return base + (vsock_guest_cid - 3);
+int GetVsockServerPort(
+    const int base, const int vsock_guest_cid /**< per instance guest cid */) {
+  return base + (vsock_guest_cid - 3);
 }
 
 std::string GetGlobalConfigFileLink() {
@@ -107,9 +107,7 @@ std::string DefaultHostArtifactsPath(const std::string& file_name) {
          file_name;
 }
 
-std::string HostBinaryDir() {
-  return DefaultHostArtifactsPath("bin");
-}
+std::string HostBinaryDir() { return DefaultHostArtifactsPath("bin"); }
 
 bool UseQemuPrebuilt() {
   const std::string target_prod_str = StringFromEnv("TARGET_PRODUCT", "");
@@ -140,8 +138,8 @@ std::string HostUsrSharePath(const std::string& file) {
 
 std::string HostQemuBiosPath() {
   if (UseQemuPrebuilt()) {
-    return DefaultHostArtifactsPath(
-        "usr/share/qemu/" + HostArchStr() + "-linux-gnu");
+    return DefaultHostArtifactsPath("usr/share/qemu/" + HostArchStr() +
+                                    "-linux-gnu");
   }
   return "/usr/share/qemu";
 }
@@ -183,4 +181,4 @@ std::string GetSeccompPolicyDir() {
       "usr/share/crosvm/" + HostArchStr() + "-linux-gnu/seccomp";
   return DefaultHostArtifactsPath(kSeccompDir);
 }
-}
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/config/config_utils.h
+++ b/base/cvd/cuttlefish/host/libs/config/config_utils.h
@@ -29,8 +29,7 @@ int GetDefaultVsockCid();
 
 // Calculates vsock server port number
 // return base + (vsock_guest_cid - 3)
-int GetVsockServerPort(const int base,
-                       const int vsock_guest_cid);
+int GetVsockServerPort(const int base, const int vsock_guest_cid);
 
 // Returns a path where the launcher puts a link to the config file which makes
 // it easily discoverable regardless of what vm manager is in use

--- a/base/cvd/cuttlefish/host/libs/config/custom_actions.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/custom_actions.cpp
@@ -23,18 +23,18 @@
 #include <utility>
 #include <vector>
 
-#include <fruit/component.h>
-#include <fruit/fruit_forward_decls.h>
-#include <fruit/macro.h>
-#include <json/value.h>
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/strings/match.h"
+#include "fruit/component.h"
+#include "fruit/fruit_forward_decls.h"
+#include "fruit/macro.h"
+#include "json/value.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/common/libs/utils/json.h"
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/flag_parser/gflags_compat.h"
-#include "cuttlefish/common/libs/utils/json.h"
 #include "cuttlefish/host/libs/config/config_flag.h"
 #include "cuttlefish/host/libs/config/config_fragment.h"
 #include "cuttlefish/host/libs/config/config_utils.h"
@@ -70,8 +70,8 @@ CustomShellActionConfig GetCustomShellActionConfigFromJson(
   // Shell command with one button.
   Json::Value button_entry = dictionary[kCustomActionButton];
   config.button = {button_entry[kCustomActionButtonCommand].asString(),
-    button_entry[kCustomActionButtonTitle].asString(),
-    button_entry[kCustomActionButtonIconName].asString()};
+                   button_entry[kCustomActionButtonTitle].asString(),
+                   button_entry[kCustomActionButtonIconName].asString()};
   config.shell_command = dictionary[kCustomActionShellCommand].asString();
   return config;
 }
@@ -83,8 +83,8 @@ CustomActionServerConfig GetCustomActionServerConfigFromJson(
   for (const Json::Value& button_entry : dictionary[kCustomActionButtons]) {
     config.buttons.push_back(
         {button_entry[kCustomActionButtonCommand].asString(),
-        button_entry[kCustomActionButtonTitle].asString(),
-        button_entry[kCustomActionButtonIconName].asString()});
+         button_entry[kCustomActionButtonTitle].asString(),
+         button_entry[kCustomActionButtonIconName].asString()});
   }
   config.server = dictionary[kCustomActionServer].asString();
   return config;
@@ -97,20 +97,18 @@ CustomDeviceStateActionConfig GetCustomDeviceStateActionConfigFromJson(
   // Each button press cycles to the next state, then repeats to the first.
   Json::Value button_entry = dictionary[kCustomActionButton];
   config.button = {button_entry[kCustomActionButtonCommand].asString(),
-    button_entry[kCustomActionButtonTitle].asString(),
-    button_entry[kCustomActionButtonIconName].asString()};
+                   button_entry[kCustomActionButtonTitle].asString(),
+                   button_entry[kCustomActionButtonIconName].asString()};
   for (const Json::Value& device_state_entry :
-      dictionary[kCustomActionDeviceStates]) {
+       dictionary[kCustomActionDeviceStates]) {
     DeviceState state;
-    if (device_state_entry.isMember(
-          kCustomActionDeviceStateLidSwitchOpen)) {
+    if (device_state_entry.isMember(kCustomActionDeviceStateLidSwitchOpen)) {
       state.lid_switch_open =
-        device_state_entry[kCustomActionDeviceStateLidSwitchOpen].asBool();
+          device_state_entry[kCustomActionDeviceStateLidSwitchOpen].asBool();
     }
-    if (device_state_entry.isMember(
-          kCustomActionDeviceStateHingeAngleValue)) {
+    if (device_state_entry.isMember(kCustomActionDeviceStateHingeAngleValue)) {
       state.hinge_angle_value =
-        device_state_entry[kCustomActionDeviceStateHingeAngleValue].asInt();
+          device_state_entry[kCustomActionDeviceStateHingeAngleValue].asInt();
     }
     config.device_states.push_back(state);
   }
@@ -231,8 +229,7 @@ class CustomActionConfigImpl : public CustomActionConfigProvider {
                     "config will be empty as well.")
                 .Getter([this]() { return custom_action_config_[0]; })
                 .Setter([this](std::string_view arg) -> Result<void> {
-                  if (!arg.empty() &&
-                      (arg == "unset" || arg == "\"unset\"")) {
+                  if (!arg.empty() && (arg == "unset" || arg == "\"unset\"")) {
                     custom_action_config_.push_back(
                         DefaultCustomActionConfig());
                   } else if (!arg.empty() && !FileExists(std::string(arg))) {
@@ -445,11 +442,11 @@ class CustomActionConfigImpl : public CustomActionConfigProvider {
     return true;
   }
 
-    ConfigFlag& config_;
-    Flag custom_action_config_flag_;
-    std::vector<std::string> custom_action_config_;
-    Flag custom_actions_flag_;
-    std::vector<InstanceActions> instance_actions_;
+  ConfigFlag& config_;
+  Flag custom_action_config_flag_;
+  std::vector<std::string> custom_action_config_;
+  Flag custom_actions_flag_;
+  std::vector<InstanceActions> instance_actions_;
 };
 
 }  // namespace

--- a/base/cvd/cuttlefish/host/libs/config/custom_actions.h
+++ b/base/cvd/cuttlefish/host/libs/config/custom_actions.h
@@ -19,7 +19,7 @@
 #include <string>
 #include <vector>
 
-#include <fruit/fruit.h>
+#include "fruit/fruit.h"
 
 #include "cuttlefish/host/libs/config/config_flag.h"
 #include "cuttlefish/host/libs/config/config_fragment.h"

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.cpp
@@ -132,7 +132,8 @@ static constexpr char kGem5DebugFlags[] = "gem5_debug_flags";
 std::string CuttlefishConfig::gem5_debug_flags() const {
   return (*dictionary_)[kGem5DebugFlags].asString();
 }
-void CuttlefishConfig::set_gem5_debug_flags(const std::string& gem5_debug_flags) {
+void CuttlefishConfig::set_gem5_debug_flags(
+    const std::string& gem5_debug_flags) {
   (*dictionary_)[kGem5DebugFlags] = gem5_debug_flags;
 }
 
@@ -274,7 +275,8 @@ static constexpr char kNetsimRadios[] = "netsim_radios";
 void CuttlefishConfig::netsim_radio_enable(NetsimRadio flag) {
   if (dictionary_->isMember(kNetsimRadios)) {
     // OR the radio to current set of radios
-    (*dictionary_)[kNetsimRadios] = (*dictionary_)[kNetsimRadios].asInt() | flag;
+    (*dictionary_)[kNetsimRadios] =
+        (*dictionary_)[kNetsimRadios].asInt() | flag;
   } else {
     (*dictionary_)[kNetsimRadios] = flag;
   }
@@ -525,8 +527,8 @@ CuttlefishConfig::GetFromFile(const std::string& path) {
 }
 
 /*static*/ bool CuttlefishConfig::ConfigExists() {
-  auto config_file_path = StringFromEnv(kCuttlefishConfigEnvVarName,
-                                        GetGlobalConfigFileLink());
+  auto config_file_path =
+      StringFromEnv(kCuttlefishConfigEnvVarName, GetGlobalConfigFileLink());
   auto real_file_path = AbsolutePath(config_file_path.c_str());
   return FileExists(real_file_path);
 }
@@ -615,11 +617,13 @@ std::string CuttlefishConfig::EnvironmentsUdsPath(
   return AbsolutePath(absl::StrCat(environments_uds_dir(), "/", file_name));
 }
 
-CuttlefishConfig::MutableInstanceSpecific CuttlefishConfig::ForInstance(int num) {
+CuttlefishConfig::MutableInstanceSpecific CuttlefishConfig::ForInstance(
+    int num) {
   return MutableInstanceSpecific(this, std::to_string(num));
 }
 
-CuttlefishConfig::InstanceSpecific CuttlefishConfig::ForInstance(int num) const {
+CuttlefishConfig::InstanceSpecific CuttlefishConfig::ForInstance(
+    int num) const {
   return InstanceSpecific(this, std::to_string(num));
 }
 
@@ -628,11 +632,13 @@ CuttlefishConfig::InstanceSpecific CuttlefishConfig::ForInstanceName(
   return ForInstance(InstanceFromString(name));
 }
 
-CuttlefishConfig::InstanceSpecific CuttlefishConfig::ForDefaultInstance() const {
+CuttlefishConfig::InstanceSpecific CuttlefishConfig::ForDefaultInstance()
+    const {
   return ForInstance(GetInstance());
 }
 
-std::vector<CuttlefishConfig::InstanceSpecific> CuttlefishConfig::Instances() const {
+std::vector<CuttlefishConfig::InstanceSpecific> CuttlefishConfig::Instances()
+    const {
   const auto& json = (*dictionary_)[kInstances];
   std::vector<CuttlefishConfig::InstanceSpecific> instances;
   for (const auto& name : json.getMemberNames()) {

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_environment.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_environment.cpp
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/libs/config/cuttlefish_config.h"
-
 #include <string>
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/libs/config/config_constants.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
 #include "cuttlefish/host/libs/log_names/log_names.h"
 
 const char* kEnvironments = "environments";

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/host/libs/config/cuttlefish_config.h"
-
 #include <stdint.h>
 
 #include <algorithm>
@@ -46,6 +44,7 @@
 #include "cuttlefish/host/libs/config/ap_boot_flow.h"
 #include "cuttlefish/host/libs/config/boot_flow.h"
 #include "cuttlefish/host/libs/config/config_constants.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
 #include "cuttlefish/host/libs/config/data_image_policy.h"
 #include "cuttlefish/host/libs/config/external_network_mode.h"
 #include "cuttlefish/host/libs/config/gpu_mode.h"
@@ -309,7 +308,8 @@ void CuttlefishConfig::MutableInstanceSpecific::set_fuchsia_multiboot_bin_path(
     const std::string& fuchsia_multiboot_bin_path) {
   (*Dictionary())[kFuchsiaMultibootBinPath] = fuchsia_multiboot_bin_path;
 }
-std::string CuttlefishConfig::InstanceSpecific::fuchsia_multiboot_bin_path() const {
+std::string CuttlefishConfig::InstanceSpecific::fuchsia_multiboot_bin_path()
+    const {
   return (*Dictionary())[kFuchsiaMultibootBinPath].asString();
 }
 static constexpr char kFuchsiaRootImage[] = "fuchsia_root_image";
@@ -408,7 +408,8 @@ int CuttlefishConfig::InstanceSpecific::index() const {
 }
 
 static constexpr char kVirtualDiskPaths[] = "virtual_disk_paths";
-std::vector<std::string> CuttlefishConfig::InstanceSpecific::virtual_disk_paths() const {
+std::vector<std::string>
+CuttlefishConfig::InstanceSpecific::virtual_disk_paths() const {
   std::vector<std::string> virtual_disks;
   auto virtual_disks_json_obj = (*Dictionary())[kVirtualDiskPaths];
   for (const auto& disk : virtual_disks_json_obj) {
@@ -444,7 +445,8 @@ void CuttlefishConfig::MutableInstanceSpecific::set_bootconfig_supported(
 }
 
 static constexpr char kFilenameEncryptionMode[] = "filename_encryption_mode";
-std::string CuttlefishConfig::InstanceSpecific::filename_encryption_mode() const {
+std::string CuttlefishConfig::InstanceSpecific::filename_encryption_mode()
+    const {
   return (*Dictionary())[kFilenameEncryptionMode].asString();
 }
 void CuttlefishConfig::MutableInstanceSpecific::set_filename_encryption_mode(
@@ -480,7 +482,7 @@ std::string CuttlefishConfig::InstanceSpecific::gnss_file_path() const {
   return (*Dictionary())[kGnssFilePath].asString();
 }
 void CuttlefishConfig::MutableInstanceSpecific::set_gnss_file_path(
-  const std::string& gnss_file_path) {
+    const std::string& gnss_file_path) {
   (*Dictionary())[kGnssFilePath] = gnss_file_path;
 }
 
@@ -521,8 +523,12 @@ bool CuttlefishConfig::InstanceSpecific::kgdb() const {
 }
 
 static constexpr char kCpus[] = "cpus";
-void CuttlefishConfig::MutableInstanceSpecific::set_cpus(int cpus) { (*Dictionary())[kCpus] = cpus; }
-int CuttlefishConfig::InstanceSpecific::cpus() const { return (*Dictionary())[kCpus].asInt(); }
+void CuttlefishConfig::MutableInstanceSpecific::set_cpus(int cpus) {
+  (*Dictionary())[kCpus] = cpus;
+}
+int CuttlefishConfig::InstanceSpecific::cpus() const {
+  return (*Dictionary())[kCpus].asInt();
+}
 
 static constexpr char kVcpuInfo[] = "vcpu_config_path";
 void CuttlefishConfig::MutableInstanceSpecific::set_vcpu_config_path(
@@ -591,14 +597,16 @@ static constexpr char kUserdataFormat[] = "userdata_format";
 std::string CuttlefishConfig::InstanceSpecific::userdata_format() const {
   return (*Dictionary())[kUserdataFormat].asString();
 }
-void CuttlefishConfig::MutableInstanceSpecific::set_userdata_format(const std::string& userdata_format) {
+void CuttlefishConfig::MutableInstanceSpecific::set_userdata_format(
+    const std::string& userdata_format) {
   auto fmt = userdata_format;
   std::transform(fmt.begin(), fmt.end(), fmt.begin(), ::tolower);
   (*Dictionary())[kUserdataFormat] = fmt;
 }
 
 static constexpr char kGuestEnforceSecurity[] = "guest_enforce_security";
-void CuttlefishConfig::MutableInstanceSpecific::set_guest_enforce_security(bool guest_enforce_security) {
+void CuttlefishConfig::MutableInstanceSpecific::set_guest_enforce_security(
+    bool guest_enforce_security) {
   (*Dictionary())[kGuestEnforceSecurity] = guest_enforce_security;
 }
 bool CuttlefishConfig::InstanceSpecific::guest_enforce_security() const {
@@ -606,7 +614,8 @@ bool CuttlefishConfig::InstanceSpecific::guest_enforce_security() const {
 }
 
 static constexpr char kUseSdcard[] = "use_sdcard";
-void CuttlefishConfig::MutableInstanceSpecific::set_use_sdcard(bool use_sdcard) {
+void CuttlefishConfig::MutableInstanceSpecific::set_use_sdcard(
+    bool use_sdcard) {
   (*Dictionary())[kUseSdcard] = use_sdcard;
 }
 bool CuttlefishConfig::InstanceSpecific::use_sdcard() const {
@@ -614,7 +623,8 @@ bool CuttlefishConfig::InstanceSpecific::use_sdcard() const {
 }
 
 static constexpr char kPauseInBootloader[] = "pause_in_bootloader";
-void CuttlefishConfig::MutableInstanceSpecific::set_pause_in_bootloader(bool pause_in_bootloader) {
+void CuttlefishConfig::MutableInstanceSpecific::set_pause_in_bootloader(
+    bool pause_in_bootloader) {
   (*Dictionary())[kPauseInBootloader] = pause_in_bootloader;
 }
 bool CuttlefishConfig::InstanceSpecific::pause_in_bootloader() const {
@@ -625,7 +635,8 @@ static constexpr char kRunAsDaemon[] = "run_as_daemon";
 bool CuttlefishConfig::InstanceSpecific::run_as_daemon() const {
   return (*Dictionary())[kRunAsDaemon].asBool();
 }
-void CuttlefishConfig::MutableInstanceSpecific::set_run_as_daemon(bool run_as_daemon) {
+void CuttlefishConfig::MutableInstanceSpecific::set_run_as_daemon(
+    bool run_as_daemon) {
   (*Dictionary())[kRunAsDaemon] = run_as_daemon;
 }
 
@@ -735,7 +746,8 @@ static constexpr char kGpuCaptureBinary[] = "gpu_capture_binary";
 std::string CuttlefishConfig::InstanceSpecific::gpu_capture_binary() const {
   return (*Dictionary())[kGpuCaptureBinary].asString();
 }
-void CuttlefishConfig::MutableInstanceSpecific::set_gpu_capture_binary(const std::string& name) {
+void CuttlefishConfig::MutableInstanceSpecific::set_gpu_capture_binary(
+    const std::string& name) {
   (*Dictionary())[kGpuCaptureBinary] = name;
 }
 
@@ -812,7 +824,8 @@ static constexpr char kRestartSubprocesses[] = "restart_subprocesses";
 bool CuttlefishConfig::InstanceSpecific::restart_subprocesses() const {
   return (*Dictionary())[kRestartSubprocesses].asBool();
 }
-void CuttlefishConfig::MutableInstanceSpecific::set_restart_subprocesses(bool restart_subprocesses) {
+void CuttlefishConfig::MutableInstanceSpecific::set_restart_subprocesses(
+    bool restart_subprocesses) {
   (*Dictionary())[kRestartSubprocesses] = restart_subprocesses;
 }
 
@@ -820,12 +833,14 @@ static constexpr char kHWComposer[] = "hwcomposer";
 std::string CuttlefishConfig::InstanceSpecific::hwcomposer() const {
   return (*Dictionary())[kHWComposer].asString();
 }
-void CuttlefishConfig::MutableInstanceSpecific::set_hwcomposer(const std::string& name) {
+void CuttlefishConfig::MutableInstanceSpecific::set_hwcomposer(
+    const std::string& name) {
   (*Dictionary())[kHWComposer] = name;
 }
 
 static constexpr char kEnableGpuUdmabuf[] = "enable_gpu_udmabuf";
-void CuttlefishConfig::MutableInstanceSpecific::set_enable_gpu_udmabuf(const bool enable_gpu_udmabuf) {
+void CuttlefishConfig::MutableInstanceSpecific::set_enable_gpu_udmabuf(
+    const bool enable_gpu_udmabuf) {
   (*Dictionary())[kEnableGpuUdmabuf] = enable_gpu_udmabuf;
 }
 bool CuttlefishConfig::InstanceSpecific::enable_gpu_udmabuf() const {
@@ -918,7 +933,8 @@ const Json::Value& CuttlefishConfig::InstanceSpecific::domkey_mapping_config()
 }
 
 static constexpr char kEnableGnssGrpcProxy[] = "enable_gnss_grpc_proxy";
-void CuttlefishConfig::MutableInstanceSpecific::set_enable_gnss_grpc_proxy(const bool enable_gnss_grpc_proxy) {
+void CuttlefishConfig::MutableInstanceSpecific::set_enable_gnss_grpc_proxy(
+    const bool enable_gnss_grpc_proxy) {
   (*Dictionary())[kEnableGnssGrpcProxy] = enable_gnss_grpc_proxy;
 }
 bool CuttlefishConfig::InstanceSpecific::enable_gnss_grpc_proxy() const {
@@ -975,7 +991,8 @@ static constexpr char kGem5DebugFile[] = "gem5_debug_file";
 std::string CuttlefishConfig::InstanceSpecific::gem5_debug_file() const {
   return (*Dictionary())[kGem5DebugFile].asString();
 }
-void CuttlefishConfig::MutableInstanceSpecific::set_gem5_debug_file(const std::string& gem5_debug_file) {
+void CuttlefishConfig::MutableInstanceSpecific::set_gem5_debug_file(
+    const std::string& gem5_debug_file) {
   (*Dictionary())[kGem5DebugFile] = gem5_debug_file;
 }
 
@@ -988,7 +1005,8 @@ bool CuttlefishConfig::InstanceSpecific::mte() const {
 }
 
 static constexpr char kEnableKernelLog[] = "enable_kernel_log";
-void CuttlefishConfig::MutableInstanceSpecific::set_enable_kernel_log(bool enable_kernel_log) {
+void CuttlefishConfig::MutableInstanceSpecific::set_enable_kernel_log(
+    bool enable_kernel_log) {
   (*Dictionary())[kEnableKernelLog] = enable_kernel_log;
 }
 bool CuttlefishConfig::InstanceSpecific::enable_kernel_log() const {
@@ -996,7 +1014,8 @@ bool CuttlefishConfig::InstanceSpecific::enable_kernel_log() const {
 }
 
 static constexpr char kBootSlot[] = "boot_slot";
-void CuttlefishConfig::MutableInstanceSpecific::set_boot_slot(const std::string& boot_slot) {
+void CuttlefishConfig::MutableInstanceSpecific::set_boot_slot(
+    const std::string& boot_slot) {
   (*Dictionary())[kBootSlot] = boot_slot;
 }
 std::string CuttlefishConfig::InstanceSpecific::boot_slot() const {
@@ -1040,7 +1059,8 @@ bool CuttlefishConfig::InstanceSpecific::enable_jcard_simulator() const {
 }
 
 static constexpr char kWebRTCAssetsDir[] = "webrtc_assets_dir";
-void CuttlefishConfig::MutableInstanceSpecific::set_webrtc_assets_dir(const std::string& webrtc_assets_dir) {
+void CuttlefishConfig::MutableInstanceSpecific::set_webrtc_assets_dir(
+    const std::string& webrtc_assets_dir) {
   (*Dictionary())[kWebRTCAssetsDir] = webrtc_assets_dir;
 }
 std::string CuttlefishConfig::InstanceSpecific::webrtc_assets_dir() const {
@@ -1055,7 +1075,8 @@ void CuttlefishConfig::MutableInstanceSpecific::set_webrtc_tcp_port_range(
   arr[1] = range.second;
   (*Dictionary())[kWebrtcTcpPortRange] = arr;
 }
-std::pair<uint16_t, uint16_t> CuttlefishConfig::InstanceSpecific::webrtc_tcp_port_range() const {
+std::pair<uint16_t, uint16_t>
+CuttlefishConfig::InstanceSpecific::webrtc_tcp_port_range() const {
   std::pair<uint16_t, uint16_t> ret;
   ret.first = (*Dictionary())[kWebrtcTcpPortRange][0].asInt();
   ret.second = (*Dictionary())[kWebrtcTcpPortRange][1].asInt();
@@ -1070,7 +1091,8 @@ void CuttlefishConfig::MutableInstanceSpecific::set_webrtc_udp_port_range(
   arr[1] = range.second;
   (*Dictionary())[kWebrtcUdpPortRange] = arr;
 }
-std::pair<uint16_t, uint16_t> CuttlefishConfig::InstanceSpecific::webrtc_udp_port_range() const {
+std::pair<uint16_t, uint16_t>
+CuttlefishConfig::InstanceSpecific::webrtc_udp_port_range() const {
   std::pair<uint16_t, uint16_t> ret;
   ret.first = (*Dictionary())[kWebrtcUdpPortRange][0].asInt();
   ret.second = (*Dictionary())[kWebrtcUdpPortRange][1].asInt();
@@ -1142,7 +1164,8 @@ bool CuttlefishConfig::InstanceSpecific::vhost_net() const {
 }
 
 static constexpr char kOpenThreadNodeId[] = "openthread_node_id";
-void CuttlefishConfig::MutableInstanceSpecific::set_openthread_node_id(int node_id) {
+void CuttlefishConfig::MutableInstanceSpecific::set_openthread_node_id(
+    int node_id) {
   (*Dictionary())[kOpenThreadNodeId] = node_id;
 }
 int CuttlefishConfig::InstanceSpecific::openthread_node_id() const {
@@ -1159,7 +1182,8 @@ bool CuttlefishConfig::InstanceSpecific::vhost_user_vsock() const {
 }
 
 static constexpr char kRilDns[] = "ril_dns";
-void CuttlefishConfig::MutableInstanceSpecific::set_ril_dns(const std::string& ril_dns) {
+void CuttlefishConfig::MutableInstanceSpecific::set_ril_dns(
+    const std::string& ril_dns) {
   (*Dictionary())[kRilDns] = ril_dns;
 }
 std::string CuttlefishConfig::InstanceSpecific::ril_dns() const {
@@ -1299,7 +1323,8 @@ DeviceType CuttlefishConfig::InstanceSpecific::device_type() const {
 }
 
 static constexpr char kEnableSandbox[] = "enable_sandbox";
-void CuttlefishConfig::MutableInstanceSpecific::set_enable_sandbox(const bool enable_sandbox) {
+void CuttlefishConfig::MutableInstanceSpecific::set_enable_sandbox(
+    const bool enable_sandbox) {
   (*Dictionary())[kEnableSandbox] = enable_sandbox;
 }
 bool CuttlefishConfig::InstanceSpecific::enable_sandbox() const {
@@ -1368,8 +1393,8 @@ std::string CuttlefishConfig::InstanceSpecific::persistent_composite_disk_path()
   return AbsolutePath(PerInstancePath("persistent_composite.img"));
 }
 
-std::string CuttlefishConfig::InstanceSpecific::persistent_ap_composite_disk_path()
-    const {
+std::string
+CuttlefishConfig::InstanceSpecific::persistent_ap_composite_disk_path() const {
   return AbsolutePath(PerInstancePath("ap_persistent_composite.img"));
 }
 
@@ -1379,17 +1404,16 @@ CuttlefishConfig::InstanceSpecific::persistent_ap_composite_overlay_path()
   return AbsolutePath(PerInstancePath("ap_persistent_composite_overlay.img"));
 }
 
-std::string CuttlefishConfig::InstanceSpecific::os_composite_disk_path()
-    const {
+std::string CuttlefishConfig::InstanceSpecific::os_composite_disk_path() const {
   return AbsolutePath(PerInstancePath("os_composite.img"));
 }
 
-std::string CuttlefishConfig::InstanceSpecific::ap_composite_disk_path()
-    const {
+std::string CuttlefishConfig::InstanceSpecific::ap_composite_disk_path() const {
   return AbsolutePath(PerInstancePath("ap_composite.img"));
 }
 
-std::string CuttlefishConfig::InstanceSpecific::ap_uboot_env_image_path() const {
+std::string CuttlefishConfig::InstanceSpecific::ap_uboot_env_image_path()
+    const {
   return AbsolutePath(PerInstancePath("ap_uboot_env.img"));
 }
 
@@ -1415,13 +1439,13 @@ BootFlow CuttlefishConfig::InstanceSpecific::boot_flow() const {
   const bool chromeos_flow_used =
       !chromeos_kernel_path().empty() || !chromeos_root_image().empty();
 
-  const bool linux_flow_used = !linux_kernel_path().empty()
-    || !linux_initramfs_path().empty()
-    || !linux_root_image().empty();
+  const bool linux_flow_used = !linux_kernel_path().empty() ||
+                               !linux_initramfs_path().empty() ||
+                               !linux_root_image().empty();
 
-  const bool fuchsia_flow_used = !fuchsia_zedboot_path().empty()
-    || !fuchsia_root_image().empty()
-    || !fuchsia_multiboot_bin_path().empty();
+  const bool fuchsia_flow_used = !fuchsia_zedboot_path().empty() ||
+                                 !fuchsia_root_image().empty() ||
+                                 !fuchsia_multiboot_bin_path().empty();
 
   if (android_efi_loader_flow_used) {
     return BootFlow::AndroidEfiLoader;
@@ -1614,7 +1638,8 @@ static constexpr char kUuid[] = "uuid";
 std::string CuttlefishConfig::InstanceSpecific::uuid() const {
   return (*Dictionary())[kUuid].asString();
 }
-void CuttlefishConfig::MutableInstanceSpecific::set_uuid(const std::string& uuid) {
+void CuttlefishConfig::MutableInstanceSpecific::set_uuid(
+    const std::string& uuid) {
   (*Dictionary())[kUuid] = uuid;
 }
 
@@ -1648,7 +1673,8 @@ static constexpr char kFastbootHostPort[] = "fastboot_host_port";
 int CuttlefishConfig::InstanceSpecific::fastboot_host_port() const {
   return (*Dictionary())[kFastbootHostPort].asInt();
 }
-void CuttlefishConfig::MutableInstanceSpecific::set_fastboot_host_port(int port) {
+void CuttlefishConfig::MutableInstanceSpecific::set_fastboot_host_port(
+    int port) {
   (*Dictionary())[kFastbootHostPort] = port;
 }
 
@@ -1691,7 +1717,8 @@ static constexpr char kTombstoneReceiverPort[] = "tombstone_receiver_port";
 int CuttlefishConfig::InstanceSpecific::tombstone_receiver_port() const {
   return (*Dictionary())[kTombstoneReceiverPort].asInt();
 }
-void CuttlefishConfig::MutableInstanceSpecific::set_tombstone_receiver_port(int tombstone_receiver_port) {
+void CuttlefishConfig::MutableInstanceSpecific::set_tombstone_receiver_port(
+    int tombstone_receiver_port) {
   (*Dictionary())[kTombstoneReceiverPort] = tombstone_receiver_port;
 }
 
@@ -1699,7 +1726,8 @@ static constexpr char kAudioControlServerPort[] = "audiocontrol_server_port";
 int CuttlefishConfig::InstanceSpecific::audiocontrol_server_port() const {
   return (*Dictionary())[kAudioControlServerPort].asInt();
 }
-void CuttlefishConfig::MutableInstanceSpecific::set_audiocontrol_server_port(int audiocontrol_server_port) {
+void CuttlefishConfig::MutableInstanceSpecific::set_audiocontrol_server_port(
+    int audiocontrol_server_port) {
   (*Dictionary())[kAudioControlServerPort] = audiocontrol_server_port;
 }
 
@@ -1707,7 +1735,8 @@ static constexpr char kLightsServerPort[] = "lights_server_port";
 int CuttlefishConfig::InstanceSpecific::lights_server_port() const {
   return (*Dictionary())[kLightsServerPort].asInt();
 }
-void CuttlefishConfig::MutableInstanceSpecific::set_lights_server_port(int lights_server_port) {
+void CuttlefishConfig::MutableInstanceSpecific::set_lights_server_port(
+    int lights_server_port) {
   (*Dictionary())[kLightsServerPort] = lights_server_port;
 }
 
@@ -1747,8 +1776,7 @@ bool CuttlefishConfig::InstanceSpecific::start_casimir() const {
 }
 
 static constexpr char kStartPica[] = "start_pica";
-void CuttlefishConfig::MutableInstanceSpecific::set_start_pica(
-    bool start) {
+void CuttlefishConfig::MutableInstanceSpecific::set_start_pica(bool start) {
   (*Dictionary())[kStartPica] = start;
 }
 bool CuttlefishConfig::InstanceSpecific::start_pica() const {
@@ -1774,7 +1802,8 @@ bool CuttlefishConfig::InstanceSpecific::start_wmediumd_instance() const {
 }
 
 static constexpr char kMcu[] = "mcu";
-void CuttlefishConfig::MutableInstanceSpecific::set_mcu(const Json::Value& cfg) {
+void CuttlefishConfig::MutableInstanceSpecific::set_mcu(
+    const Json::Value& cfg) {
   (*Dictionary())[kMcu] = cfg;
 }
 const Json::Value& CuttlefishConfig::InstanceSpecific::mcu() const {
@@ -1782,7 +1811,8 @@ const Json::Value& CuttlefishConfig::InstanceSpecific::mcu() const {
 }
 
 static constexpr char kApBootFlow[] = "ap_boot_flow";
-void CuttlefishConfig::MutableInstanceSpecific::set_ap_boot_flow(APBootFlow flow) {
+void CuttlefishConfig::MutableInstanceSpecific::set_ap_boot_flow(
+    APBootFlow flow) {
   (*Dictionary())[kApBootFlow] = static_cast<int>(flow);
 }
 APBootFlow CuttlefishConfig::InstanceSpecific::ap_boot_flow() const {
@@ -1849,7 +1879,8 @@ std::string CuttlefishConfig::InstanceSpecific::touch_socket_path(
   return PerInstanceInternalUdsPath(name);
 }
 
-std::string CuttlefishConfig::InstanceSpecific::media_socket_path(int index) const {
+std::string CuttlefishConfig::InstanceSpecific::media_socket_path(
+    int index) const {
   return PerInstanceInternalUdsPath(absl::StrCat("media_", index, ".sock"));
 }
 
@@ -2006,4 +2037,3 @@ std::string CuttlefishConfig::InstanceSpecific::instance_name() const {
 std::string CuttlefishConfig::InstanceSpecific::id() const { return id_; }
 
 }  // namespace cuttlefish
-

--- a/base/cvd/cuttlefish/host/libs/config/data_image.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/data_image.cpp
@@ -153,7 +153,7 @@ static Result<DataImageAction> ChooseDataImageAction(
   return DataImageAction::kNoAction;
 }
 
-} // namespace
+}  // namespace
 
 Result<void> CreateBlankEmptyImage(std::string_view image, int num_mb) {
   VLOG(0) << "Creating " << image;
@@ -245,10 +245,13 @@ static bool EspRequiredForAPBootFlow(APBootFlow ap_boot_flow) {
   return ap_boot_flow == APBootFlow::Grub;
 }
 
-static void InitLinuxArgs(Arch target_arch, LinuxEspBuilder& linux_esp_builder) {
+static void InitLinuxArgs(Arch target_arch,
+                          LinuxEspBuilder& linux_esp_builder) {
   linux_esp_builder.Root("/dev/vda2");
 
-  linux_esp_builder.Argument("console", "hvc0").Argument("panic", "-1").Argument("noefi");
+  linux_esp_builder.Argument("console", "hvc0")
+      .Argument("panic", "-1")
+      .Argument("noefi");
 
   switch (target_arch) {
     case Arch::Arm:
@@ -370,4 +373,4 @@ Result<void> InitializeEspImage(
   return {};
 }
 
-} // namespace cuttlefish
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/config/data_image.h
+++ b/base/cvd/cuttlefish/host/libs/config/data_image.h
@@ -33,4 +33,4 @@ Result<void> CreateBlankExt4Image(std::string_view image, int num_mb);
 
 Result<void> CreateBlankSdcardImage(std::string_view image, int num_mb);
 
-} // namespace cuttlefish
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/config/display.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/display.cpp
@@ -22,8 +22,8 @@
 #include <unordered_map>
 #include <vector>
 
-#include "absl/strings/str_split.h"
 #include "absl/strings/numbers.h"
+#include "absl/strings/str_split.h"
 
 #include "cuttlefish/common/libs/utils/contains.h"
 #include "cuttlefish/flag_parser/flag.h"
@@ -83,7 +83,7 @@ Result<std::optional<CuttlefishConfig::DisplayConfig>> ParseDisplayConfig(
   auto display_refresh_rate_hz_it = props.find("refresh_rate_hz");
   if (display_refresh_rate_hz_it != props.end()) {
     CF_EXPECT(absl::SimpleAtoi(display_refresh_rate_hz_it->second,
-                                      &display_refresh_rate_hz),
+                               &display_refresh_rate_hz),
               "Display configuration invalid 'refresh_rate_hz' in \"" << flag
                                                                       << "\"");
   }

--- a/base/cvd/cuttlefish/host/libs/config/esp.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/esp.cpp
@@ -112,8 +112,8 @@ static bool GrubMakeImage(const std::string& prefix, const std::string& format,
                           const std::string& directory,
                           const std::string& output, const T& modules) {
   std::vector<std::string> command = {"grub-mkimage", "--prefix", prefix,
-                                      "--format", format, "--directory", directory,
-                                      "--output", output};
+                                      "--format",     format,     "--directory",
+                                      directory,      "--output", output};
   std::move(modules.begin(), modules.end(), std::back_inserter(command));
 
   const auto success = Execute(command);
@@ -165,13 +165,13 @@ EspBuilder AddGrubConfig(const std::string& config) {
   auto builder = EspBuilder();
 
   builder.Directory("boot")
-         .Directory("EFI/debian")
-         .Directory("EFI/ubuntu")
-         .Directory("boot/grub");
+      .Directory("EFI/debian")
+      .Directory("EFI/ubuntu")
+      .Directory("boot/grub");
 
   builder.File(config, kGrubDebianConfigDestPath, /*required*/ true)
-         .File(config, kGrubUbuntuConfigDestPath, /*required*/ true)
-         .File(config, kGrubConfigDestPath, /*required*/ true);
+      .File(config, kGrubUbuntuConfigDestPath, /*required*/ true)
+      .File(config, kGrubConfigDestPath, /*required*/ true);
 
   return builder;
 }
@@ -214,7 +214,8 @@ bool AndroidEfiLoaderEspBuilder::Build() const {
   return builder.Build();
 }
 
-LinuxEspBuilder& LinuxEspBuilder::Argument(std::string key, std::string value) & {
+LinuxEspBuilder& LinuxEspBuilder::Argument(std::string key,
+                                           std::string value) & {
   arguments_.push_back({std::move(key), std::move(value)});
   return *this;
 }
@@ -323,7 +324,8 @@ FuchsiaEspBuilder& FuchsiaEspBuilder::Architecture(Arch arch) & {
 
 bool FuchsiaEspBuilder::Build() const {
   if (multiboot_bin_.empty()) {
-    LOG(ERROR) << "Multiboot esp path is required argument for FuchsiaEspBuilder";
+    LOG(ERROR)
+        << "Multiboot esp path is required argument for FuchsiaEspBuilder";
     return false;
   }
   if (zedboot_.empty()) {
@@ -370,4 +372,4 @@ std::string FuchsiaEspBuilder::DumpConfig() const {
   return o.str();
 }
 
-} // namespace cuttlefish
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/config/esp.h
+++ b/base/cvd/cuttlefish/host/libs/config/esp.h
@@ -44,7 +44,8 @@ class AndroidEfiLoaderEspBuilder final {
 class LinuxEspBuilder final {
  public:
   LinuxEspBuilder() = delete;
-  LinuxEspBuilder(std::string image_path): image_path_(std::move(image_path)) {}
+  LinuxEspBuilder(std::string image_path)
+      : image_path_(std::move(image_path)) {}
 
   LinuxEspBuilder& Argument(std::string key, std::string value) &;
   LinuxEspBuilder& Argument(std::string value) &;
@@ -70,7 +71,8 @@ class LinuxEspBuilder final {
 class FuchsiaEspBuilder {
  public:
   FuchsiaEspBuilder() = delete;
-  FuchsiaEspBuilder(std::string image_path): image_path_(std::move(image_path)) {}
+  FuchsiaEspBuilder(std::string image_path)
+      : image_path_(std::move(image_path)) {}
 
   FuchsiaEspBuilder& MultibootBinary(std::string multiboot) &;
   FuchsiaEspBuilder& Zedboot(std::string zedboot) &;
@@ -89,4 +91,4 @@ class FuchsiaEspBuilder {
 
 bool CanGenerateGrubEsp(Arch arch);
 
-} // namespace cuttlefish
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/config/fetcher_config.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/fetcher_config.cpp
@@ -16,7 +16,6 @@
 
 #include "cuttlefish/host/libs/config/fetcher_config.h"
 
-#include <cctype>
 #include <fstream>
 #include <map>
 #include <memory>
@@ -26,14 +25,14 @@
 #include <string_view>
 #include <utility>
 
-#include <android-base/file.h>
-#include "absl/strings/strip.h"
-#include <json/reader.h>
-#include <json/value.h>
-#include <json/writer.h>
 #include "absl/log/log.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_replace.h"
+#include "absl/strings/strip.h"
+#include "android-base/file.h"
+#include "json/reader.h"
+#include "json/value.h"
+#include "json/writer.h"
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/libs/config/file_source.h"

--- a/base/cvd/cuttlefish/host/libs/config/host_tools_version.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/host_tools_version.cpp
@@ -16,7 +16,6 @@
 #include "cuttlefish/host/libs/config/host_tools_version.h"
 
 #include <stdint.h>
-#include <zlib.h>
 
 #include <fstream>
 #include <future>
@@ -26,6 +25,7 @@
 #include <vector>
 
 #include "absl/log/check.h"
+#include <zlib.h>
 
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/libs/config/config_utils.h"
@@ -33,12 +33,12 @@
 namespace cuttlefish {
 
 uint32_t FileCrc(const std::string& path) {
-  uint32_t crc = crc32(0, (unsigned char*) path.c_str(), path.size());
+  uint32_t crc = crc32(0, (unsigned char*)path.c_str(), path.size());
   std::ifstream file_stream(path, std::ifstream::binary);
   std::vector<char> data(1024, 0);
   while (file_stream) {
     file_stream.read(data.data(), data.size());
-    crc = crc32(crc, (unsigned char*) data.data(), file_stream.gcount());
+    crc = crc32(crc, (unsigned char*)data.data(), file_stream.gcount());
   }
   return crc;
 }
@@ -54,7 +54,7 @@ static std::map<std::string, uint32_t> DirectoryCrc(const std::string& path) {
   std::vector<std::future<uint32_t>> calculations;
   calculations.reserve(files.size());
   for (auto& file : files) {
-    file = path + "/" + file; // mutate in place in files vector
+    file = path + "/" + file;  // mutate in place in files vector
     calculations.emplace_back(
         std::async(FileCrc, DefaultHostArtifactsPath(file)));
   }
@@ -78,4 +78,4 @@ std::map<std::string, uint32_t> HostToolsCrc() {
   return all_crcs;
 }
 
-} // namespace cuttlefish
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/config/host_tools_version.h
+++ b/base/cvd/cuttlefish/host/libs/config/host_tools_version.h
@@ -24,4 +24,4 @@ namespace cuttlefish {
 uint32_t FileCrc(const std::string& path);
 std::map<std::string, uint32_t> HostToolsCrc();
 
-} // namespace cuttlefish
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/config/instance_nums.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/instance_nums.cpp
@@ -25,9 +25,9 @@
 #include <utility>
 #include <vector>
 
-#include "absl/strings/str_split.h"
-#include <gflags/gflags.h>
 #include "absl/strings/numbers.h"
+#include "absl/strings/str_split.h"
+#include "gflags/gflags.h"
 
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/flag_parser/gflags_compat.h"
@@ -76,7 +76,7 @@ static Result<std::vector<int32_t>> ParseInstanceNums(
               "Unable to parse \"" << instance_num_str << "\" in "
                                    << "`--instance_nums=\"" << instance_nums_str
                                    << "\"`");
-    const auto[_, inserted] = duplication_check_set.insert(instance_num);
+    const auto [_, inserted] = duplication_check_set.insert(instance_num);
     CF_EXPECTF(!!inserted, "{} is duplicated in -instance_nums flag.",
                instance_num);
     instance_nums.push_back(instance_num);

--- a/base/cvd/cuttlefish/host/libs/config/known_paths.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/known_paths.cpp
@@ -114,7 +114,7 @@ std::string MetricsBinary() { return HostBinaryPath("metrics"); }
 std::string MkfsFat() { return HostBinaryPath("mkfs.fat"); }
 
 std::string MkuserimgMke2fsBinary() {
-    return HostBinaryPath("mkuserimg_mke2fs.py");
+  return HostBinaryPath("mkuserimg_mke2fs.py");
 }
 
 std::string MmdBinary() { return HostBinaryPath("mmd"); }
@@ -147,9 +147,7 @@ std::string SensorsSimulatorBinary() {
   return HostBinaryPath("sensors_simulator");
 }
 
-std::string Simg2ImgBinary() {
-  return HostBinaryPath("simg2img");
-}
+std::string Simg2ImgBinary() { return HostBinaryPath("simg2img"); }
 
 std::string SocketVsockProxyBinary() {
   return HostBinaryPath("socket_vsock_proxy");
@@ -164,7 +162,8 @@ std::string TestKeyRsa2048() {
 }
 
 std::string TestKeyRsa4096() {
-  const std::string rsa_4096 = DefaultHostArtifactsPath("etc/cvd_avb_testkey_rsa4096.pem");
+  const std::string rsa_4096 =
+      DefaultHostArtifactsPath("etc/cvd_avb_testkey_rsa4096.pem");
   if (FileExists(rsa_4096)) {
     return rsa_4096;
   } else {
@@ -177,7 +176,8 @@ std::string TestPubKeyRsa2048() {
 }
 
 std::string TestPubKeyRsa4096() {
-  const std::string rsa_4096 = DefaultHostArtifactsPath("etc/cvd_rsa4096.avbpubkey");
+  const std::string rsa_4096 =
+      DefaultHostArtifactsPath("etc/cvd_rsa4096.avbpubkey");
   if (FileExists(rsa_4096)) {
     return rsa_4096;
   } else {
@@ -230,4 +230,3 @@ std::string VhostUserMediaEmulatedCameraMPlaneBinary() {
 }
 
 }  // namespace cuttlefish
-

--- a/base/cvd/cuttlefish/host/libs/config/known_paths.h
+++ b/base/cvd/cuttlefish/host/libs/config/known_paths.h
@@ -78,4 +78,3 @@ std::string WmediumdBinary();
 std::string WmediumdGenConfigBinary();
 
 }  // namespace cuttlefish
-

--- a/base/cvd/cuttlefish/host/libs/config/media.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/media.cpp
@@ -68,7 +68,8 @@ Result<std::optional<CuttlefishConfig::MediaConfig>> ParseMediaConfig(
   auto lens_facing_it = props.find("lens_facing");
   if (lens_facing_it != props.end()) {
     lens_facing = lens_facing_it->second;
-    CF_EXPECT(lens_facing == "FRONT" || lens_facing == "BACK" || lens_facing == "EXTERNAL",
+    CF_EXPECT(lens_facing == "FRONT" || lens_facing == "BACK" ||
+                  lens_facing == "EXTERNAL",
               "Invalid lens_facing value: " << lens_facing);
   }
 
@@ -101,4 +102,3 @@ Result<std::vector<CuttlefishConfig::MediaConfig>> ParseMediaConfigsFromArgs(
 }
 
 }  // namespace cuttlefish
-

--- a/base/cvd/cuttlefish/host/libs/config/media.h
+++ b/base/cvd/cuttlefish/host/libs/config/media.h
@@ -17,8 +17,8 @@
 #include <optional>
 #include <string>
 
-#include "cuttlefish/result/result.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
 
@@ -26,9 +26,12 @@ constexpr const char kMediaFlag[] = "media";
 constexpr const char kMediaHelp[] =
     "Comma separated key=value pairs of media device properties. Supported "
     "properties:\n"
-    " 'type': optional, defaults to 'v4l2_emulated_camera_splane', supported values:\n"
-    "    'v4l2_emulated_camera_splane': emulated media capture device (single-plane)\n"
-    "    'v4l2_emulated_camera_mplane': emulated media capture device (multi-plane)\n"
+    " 'type': optional, defaults to 'v4l2_emulated_camera_splane', supported "
+    "values:\n"
+    "    'v4l2_emulated_camera_splane': emulated media capture device "
+    "(single-plane)\n"
+    "    'v4l2_emulated_camera_mplane': emulated media capture device "
+    "(multi-plane)\n"
     "    'v4l2_proxy': proxy a host V4L2 device into the guest\n"
     " 'lens_facing': optional, supported values: 'FRONT', 'BACK', 'EXTERNAL'\n"
     "Example usage:\n"
@@ -41,4 +44,3 @@ Result<std::vector<CuttlefishConfig::MediaConfig>> ParseMediaConfigsFromArgs(
     std::vector<std::string>& args);
 
 }  // namespace cuttlefish
-

--- a/base/cvd/cuttlefish/host/libs/config/touchpad.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/touchpad.cpp
@@ -21,8 +21,8 @@
 #include <unordered_map>
 #include <vector>
 
-#include "absl/strings/str_split.h"
 #include "absl/strings/numbers.h"
+#include "absl/strings/str_split.h"
 
 #include "cuttlefish/common/libs/utils/contains.h"
 #include "cuttlefish/flag_parser/flag.h"
@@ -67,7 +67,7 @@ ParseTouchpadConfigsFromArgs(std::vector<std::string>& args) {
   std::vector<std::string> repeated_touchpad_flag_values;
 
   const std::vector<Flag> touchpad_flags = {
-    Flag::StringFlag(kTouchpadFlag)
+      Flag::StringFlag(kTouchpadFlag)
           .Help(kTouchpadHelp)
           .Setter([&](std::string_view arg) -> Result<void> {
             repeated_touchpad_flag_values.emplace_back(arg);

--- a/base/cvd/cuttlefish/host/libs/config/vmm_mode.cc
+++ b/base/cvd/cuttlefish/host/libs/config/vmm_mode.cc
@@ -26,9 +26,7 @@
 
 namespace cuttlefish {
 
-std::string ToString(VmmMode mode) {
-  return std::string(format_as(mode));
-}
+std::string ToString(VmmMode mode) { return std::string(format_as(mode)); }
 
 std::ostream& operator<<(std::ostream& out, VmmMode vmm) {
   return out << format_as(vmm);


### PR DESCRIPTION
Doesn't include the `config/` subdirectories.

Bug: b/512215781