### PR TITLE
Remove accidentally split bootconfig arg constant

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/bootconfig_args.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/bootconfig_args.cpp
@@ -45,14 +45,13 @@ using vm_manager::QemuManager;
 namespace {
 
 static constexpr std::string_view kLegacyBoardBootconfigKeysShared[] = {
+    // clang-format off
     "androidboot.hardware",
     "androidboot.vendor.apex.com.android.wifi.hal",
     "androidboot.vendor.apex.com.google.emulated.camera.provider.hal",
-    "buf_size",
     "kernel.mac80211_hwsim.radios",
-    "kernel.vmw_vsock_virtio_transport_common.virtio_transport_max_vsock_pkt_",
-    "kernel.vmw_vsock_virtio_transport_common.virtio_transport_max_vsock_pkt_"
-    "buf_size",
+    "kernel.vmw_vsock_virtio_transport_common.virtio_transport_max_vsock_pkt_buf_size",
+    // clang-format on
 };
 
 static constexpr std::string_view kLegacyBoardBootconfigKeysAuto[] = {


### PR DESCRIPTION
https://github.com/google/android-cuttlefish/pull/2765 accidentally butchered the constant that was split across 2 lines.

Adds clang-format off and on statements to allow folks to sort lines more easily when adding newer constants.

Bug: b/527976081