### PR TITLE
Use host monotonic clock for timestamp

### DIFF
--- a/base/cvd/cuttlefish/host/commands/vhost_user_media/emulated_camera_mplane/src/device.rs
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_media/emulated_camera_mplane/src/device.rs
@@ -123,9 +123,17 @@ impl Buffer {
                     }
                 }
                 self.v4l2_buffer.set_sequence(sequence);
+                let mut ts = libc::timespec {
+                    tv_sec: 0,
+                    tv_nsec: 0,
+                };
+                // SAFETY: clock_gettime is a standard POSIX libc call with a valid pointer.
+                unsafe {
+                    libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts);
+                }
                 self.v4l2_buffer.set_timestamp(bindings::timeval {
-                    tv_sec: (sequence + 1) as bindings::__time_t / 1000,
-                    tv_usec: (sequence + 1) as bindings::__time_t % 1000,
+                    tv_sec: ts.tv_sec as bindings::__time_t,
+                    tv_usec: (ts.tv_nsec / 1000) as bindings::__time_t,
                 });
                 flags &= !BufferFlags::QUEUED;
             }

--- a/base/cvd/cuttlefish/host/commands/vhost_user_media/emulated_camera_splane/src/device.rs
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_media/emulated_camera_splane/src/device.rs
@@ -137,9 +137,17 @@ impl Buffer {
             }
             BufferState::Outgoing { sequence } => {
                 self.v4l2_buffer.set_sequence(sequence);
+                let mut ts = libc::timespec {
+                    tv_sec: 0,
+                    tv_nsec: 0,
+                };
+                // SAFETY: clock_gettime is a standard POSIX libc call with a valid pointer.
+                unsafe {
+                    libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts);
+                }
                 self.v4l2_buffer.set_timestamp(bindings::timeval {
-                    tv_sec: (sequence + 1) as bindings::__time_t / 1000,
-                    tv_usec: (sequence + 1) as bindings::__time_t % 1000,
+                    tv_sec: ts.tv_sec as bindings::__time_t,
+                    tv_usec: (ts.tv_nsec / 1000) as bindings::__time_t,
                 });
                 Self::unset_flag(&mut flags, BufferFlags::QUEUED);
             }


### PR DESCRIPTION
Previously, outgoing buffer timestamps in emulated_camera_mplane and emulated_camera_splane were calculated directly from the frame sequence index:

tv_sec = (sequence + 1) / 1000
tv_usec = (sequence + 1) % 1000

This formula caused severe clock drift due to two issues:
1. Incorrect Time Scaling: sequence increments by 1 per frame. Dividing by 1000 caused tv_sec to advance by 1 second only after 1,000 frames (~33.3 seconds of real wall-clock time at 30 FPS).
2. Microsecond Miscalculation: In timeval, tv_usec is measured in microseconds (10^-6 s). Doing % 1000 without scaling caused the timestamp to advance by only 1 microsecond per frame.

This change replaces the sequence-based calculation with the host's actual monotonic clock, avoiding timestamp drift and buffer rejections in the guest.

Bug: b/474406105