### PR TITLE
Fallback to looking at the parent process cmdline if parent process exe is locked down

### DIFF
--- a/base/cvd/cuttlefish/host/commands/start/main.cc
+++ b/base/cvd/cuttlefish/host/commands/start/main.cc
@@ -15,7 +15,6 @@
 
 #include <unistd.h>
 
-#include <iostream>
 #include <optional>
 #include <sstream>
 #include <unordered_set>
@@ -210,10 +209,18 @@ Result<void> LinkLogs2InstanceDir(
 }
 
 bool ParentIsCvd() {
-  const std::string exe_link = absl::StrCat("/proc/", getppid(), "/exe");
+  const std::string ppid_path = absl::StrCat("/proc/", getppid());
+  const std::string exe_link = absl::StrCat(ppid_path, "/exe");
   const Result<std::string> exe_path = ReadLink(exe_link);
-  CHECK(exe_path.ok()) << exe_path.error();
-  return exe_path->ends_with("/cvd");
+  if (exe_path.ok()) {
+    return exe_path->ends_with("/cvd");
+  }
+  const std::string cmdline_path = absl::StrCat(ppid_path, "/cmdline");
+  Result<std::string> cmdline_res = ReadFileContents(cmdline_path);
+  CHECK(cmdline_res.ok()) << cmdline_res.error();
+  std::vector<std::string> cmdline = absl::StrSplit(*cmdline_res, '\0');
+  CHECK(!cmdline.empty());
+  return cmdline[0] == "cvd" || cmdline[0].ends_with("/cvd");
 }
 
 std::string CvdPath() {


### PR DESCRIPTION
When the parent process is `sshd` running as root, it seems to be impossible to readlink /proc/getppid()/exe to find what the parent process is. However, in practice it looks like /proc/getppid()/cmdline is available so it is still possible to examine that.

Bug: b/530299540
Test: Run with only fallback logic