### PR TITLE
Validate clang-format and misc-include-cleaner on allocd

### DIFF
--- a/base/cvd/allocd/.clang-tidy
+++ b/base/cvd/allocd/.clang-tidy
@@ -1,1 +1,1 @@
-../clang_tidy_configs/base_config
+../clang_tidy_configs/with_include_cleaner

--- a/base/cvd/allocd/BUILD.bazel
+++ b/base/cvd/allocd/BUILD.bazel
@@ -49,15 +49,10 @@ cf_cc_library(
     ],
 )
 
-cc_library(
+cf_cc_library(
     name = "alloc_iproute2",
-    srcs = [
-        "alloc_iproute2.cpp",
-    ],
-    hdrs = [
-        "alloc_driver.h",
-    ],
-    copts = ["-std=c++20"],
+    srcs = ["alloc_iproute2.cpp"],
+    hdrs = ["alloc_driver.h"],
     deps = [
         "//cuttlefish/common/libs/utils:subprocess",
         "//cuttlefish/result",

--- a/base/cvd/allocd/BUILD.bazel
+++ b/base/cvd/allocd/BUILD.bazel
@@ -62,15 +62,10 @@ cf_cc_library(
     ],
 )
 
-cc_library(
+cf_cc_library(
     name = "alloc_netlink",
-    srcs = [
-        "alloc_netlink.cpp",
-    ],
-    hdrs = [
-        "alloc_driver.h",
-    ],
-    copts = ["-std=c++20"],
+    srcs = ["alloc_netlink.cpp"],
+    hdrs = ["alloc_driver.h"],
     deps = [
         "//allocd/net:netlink",
         "//cuttlefish/common/libs/fs",

--- a/base/cvd/allocd/BUILD.bazel
+++ b/base/cvd/allocd/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//cuttlefish/bazel:rules.bzl", "cf_cc_binary", "cf_cc_library")
 
 package(
     default_visibility = ["//:android_cuttlefish"],
@@ -26,15 +27,10 @@ config_setting(
     },
 )
 
-cc_library(
+cf_cc_library(
     name = "alloc_utils",
-    srcs = [
-        "alloc_utils.cpp",
-    ],
-    hdrs = [
-        "alloc_utils.h",
-    ],
-    copts = ["-std=c++20"],
+    srcs = ["alloc_utils.cpp"],
+    hdrs = ["alloc_utils.h"],
     deps = select({
         ":netlink": [":alloc_netlink"],
         "//conditions:default": [":alloc_iproute2"],

--- a/base/cvd/allocd/BUILD.bazel
+++ b/base/cvd/allocd/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
-load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//cuttlefish/bazel:rules.bzl", "cf_cc_binary", "cf_cc_library")
 
 package(

--- a/base/cvd/allocd/alloc_iproute2.cpp
+++ b/base/cvd/allocd/alloc_iproute2.cpp
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "allocd/alloc_driver.h"
-
+#include <string>
 #include <string_view>
 
 #include "absl/strings/str_cat.h"
 
+#include "allocd/alloc_driver.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"
 #include "cuttlefish/result/result.h"
 

--- a/base/cvd/allocd/alloc_netlink.cpp
+++ b/base/cvd/allocd/alloc_netlink.cpp
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "allocd/alloc_driver.h"
 
 #include <arpa/inet.h>
+#include <asm/types.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <grp.h>
 #include <linux/if_tun.h>
@@ -25,11 +26,10 @@
 #include <net/if_arp.h>
 #include <netinet/in.h>
 #include <string.h>
-#include <sys/ioctl.h>
-#include <sys/socket.h>
-#include <sys/types.h>
+#include <sys/socket.h>  // IWYU pragma: keep
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <string_view>
 
@@ -37,10 +37,11 @@
 #include "absl/log/log.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
-#include "absl/strings/str_format.h"
 #include "absl/strings/strip.h"
 
+#include "allocd/alloc_driver.h"
 #include "allocd/net/netlink_client.h"
+#include "allocd/net/netlink_request.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"
 #include "cuttlefish/result/result.h"
@@ -100,8 +101,10 @@ Result<void> ShutdownIface(std::string_view name) {
   auto factory = NetlinkClientFactory::Default();
   std::unique_ptr<NetlinkClient> nl = factory->New(NETLINK_ROUTE);
 
+  // NOLINTNEXTLINE(misc-include-cleaner): rtnetlink
   NetlinkRequest req(RTM_NEWLINK, NLM_F_REQUEST | NLM_F_ACK);
   req.AddIfInfo(0, false);
+  // NOLINTNEXTLINE(misc-include-cleaner): rtnetlink
   req.AddString(IFLA_IFNAME, std::string(name));
   CF_EXPECT(nl->Send(req), "ShutdownIface");
   return {};
@@ -112,6 +115,7 @@ Result<void> BringUpIface(std::string_view name) {
   auto factory = NetlinkClientFactory::Default();
   std::unique_ptr<NetlinkClient> nl = factory->New(NETLINK_ROUTE);
 
+  // NOLINTNEXTLINE(misc-include-cleaner): rtnetlink
   NetlinkRequest req(RTM_NEWLINK, NLM_F_REQUEST | NLM_F_ACK);
   req.AddIfInfo(0, true);
   req.AddString(IFLA_IFNAME, std::string(name));
@@ -131,8 +135,8 @@ Result<void> AddGateway(std::string_view name, std::string_view gateway,
   NetlinkRequest req(RTM_NEWADDR, NLM_F_REQUEST | NLM_F_ACK);
   req.AddAddrInfo(*index, Prefix(netmask));
   in_addr_t inaddr = inet_addr(std::string(gateway).c_str());
-  req.AddInAddr(IFA_LOCAL, &inaddr);
-  req.AddInAddr(IFA_ADDRESS, &inaddr);
+  req.AddInAddr(IFA_LOCAL, &inaddr);    // NOLINT(misc-include-cleaner): netlink
+  req.AddInAddr(IFA_ADDRESS, &inaddr);  // NOLINT(misc-include-cleaner): netlink
 
   CF_EXPECT(nl->Send(req), "AddGateway");
   return {};
@@ -221,12 +225,14 @@ Result<void> CreateBridge(std::string_view name) {
   req.Append(ifinfomsg{
       .ifi_type = ARPHRD_NETROM,
   });
+  // NOLINTBEGIN(misc-include-cleaner): rtnetlink
   req.AddString(IFLA_IFNAME, std::string(name));
   req.PushList(IFLA_LINKINFO);
   req.AddString(IFLA_INFO_KIND, "bridge");
   req.PushList(IFLA_INFO_DATA);
   req.AddInt(IFLA_BR_FORWARD_DELAY, 0);
   req.AddInt(IFLA_BR_STP_STATE, 0);
+  // NOLINTEND(misc-include-cleaner): rtnetlink
   req.PopList();
   req.PopList();
 

--- a/base/cvd/allocd/alloc_utils.cpp
+++ b/base/cvd/allocd/alloc_utils.cpp
@@ -15,12 +15,17 @@
  */
 #include "allocd/alloc_utils.h"
 
+#include <fcntl.h>
+#include <net/if.h>
+#include <pwd.h>
 #include <stdint.h>
+#include <string.h>
 
 #include <fstream>
+#include <optional>
+#include <sstream>
 #include <string>
 #include <string_view>
-#include <sstream>
 
 #include "absl/base/no_destructor.h"
 #include "absl/log/log.h"
@@ -28,9 +33,10 @@
 #include "absl/strings/str_format.h"
 
 #include "allocd/alloc_driver.h"
+#include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/network.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"
-#include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/commands/cvd/utils/common.h"
 #include "cuttlefish/result/result.h"
 
@@ -38,23 +44,20 @@
 #include <linux/if_tun.h>
 #endif
 
-#include <net/if.h>
+namespace cuttlefish {
 
 namespace {
 
-cuttlefish::Result<std::string> SearchForIptables() {
-  cuttlefish::Result<std::string> p =
-      cuttlefish::Search(cuttlefish::Path(), "iptables");
+Result<std::string> SearchForIptables() {
+  Result<std::string> p = Search(Path(), "iptables");
   if (p.ok()) {
     return p;
   }
 
-  return cuttlefish::Search({"/usr/sbin", "/sbin"}, "iptables");
+  return CF_EXPECT(Search({"/usr/sbin", "/sbin"}, "iptables"));
 }
 
 }  // namespace
-
-namespace cuttlefish {
 
 bool CreateEthernetIface(std::string_view name, std::string_view bridge_name) {
   // assume bridge exists
@@ -77,8 +80,8 @@ std::string MobileGatewayName(std::string_view ipaddr, uint16_t id) {
   return ss.str();
 }
 
-std::string MobileNetworkName(std::string_view ipaddr,
-                              std::string_view netmask, uint16_t id) {
+std::string MobileNetworkName(std::string_view ipaddr, std::string_view netmask,
+                              uint16_t id) {
   std::stringstream ss;
   ss << ipaddr << "." << (4 * id - 4) << netmask;
   return ss.str();
@@ -109,8 +112,8 @@ bool CreateMobileIface(std::string_view name, uint16_t id,
   }
 
   if (!IptableConfig(*iptables_path, network, true).ok()) {
-    DestroyGateway(name, gateway, netmask);
-    DestroyIface(name);
+    (void)DestroyGateway(name, gateway, netmask);
+    (void)DestroyIface(name);
     return false;
   };
 
@@ -132,8 +135,8 @@ bool DestroyMobileIface(std::string_view name, uint16_t id,
   if (!iptables_path.ok()) {
     return false;
   }
-  IptableConfig(*iptables_path, network, false);
-  DestroyGateway(name, gateway, netmask);
+  (void)IptableConfig(*iptables_path, network, false);
+  (void)DestroyGateway(name, gateway, netmask);
   return DestroyIface(name);
 }
 
@@ -150,7 +153,7 @@ bool CreateTap(std::string_view name) {
 
   if (!BringUpIface(name).ok()) {
     LOG(WARNING) << "Failed to bring up tap interface: " << name;
-    DeleteIface(name);
+    (void)DeleteIface(name);
     return false;
   }
 
@@ -160,9 +163,9 @@ bool CreateTap(std::string_view name) {
 #ifdef __linux__
 Result<void> ValidateTapInterfaceIsUsable(const std::string& interface_name) {
   CF_EXPECT(NetworkInterfaceExists(interface_name),
-             "Tap interface does not exist. Ensure "
-             "\"cuttlefish-host-resources.service\" is running (start with "
-             "\"sudo systemctl start cuttlefish-host-resources.service\").");
+            "Tap interface does not exist. Ensure "
+            "\"cuttlefish-host-resources.service\" is running (start with "
+            "\"sudo systemctl start cuttlefish-host-resources.service\").");
 
   constexpr auto kTunTapDev = "/dev/net/tun";
 
@@ -222,8 +225,7 @@ bool DestroyBridge(std::string_view name) {
   return DeleteIface(name).ok();
 }
 
-bool SetupBridgeGateway(std::string_view bridge_name,
-                        std::string_view ipaddr) {
+bool SetupBridgeGateway(std::string_view bridge_name, std::string_view ipaddr) {
   Result<std::string> iptables_path = IptablesPath();
   if (!iptables_path.ok()) {
     return false;
@@ -267,7 +269,7 @@ void CleanupBridgeGateway(std::string_view name, std::string_view ipaddr,
   if (config.has_iptable) {
     Result<std::string> iptables_path = IptablesPath();
     if (iptables_path.ok()) {
-      IptableConfig(*iptables_path, network, false);
+      (void)IptableConfig(*iptables_path, network, false);
     }
   }
 
@@ -276,7 +278,7 @@ void CleanupBridgeGateway(std::string_view name, std::string_view ipaddr,
   }
 
   if (config.has_gateway) {
-    DestroyGateway(name, gateway, netmask);
+    (void)DestroyGateway(name, gateway, netmask);
   }
 }
 
@@ -302,8 +304,8 @@ bool StartDnsmasq(std::string_view bridge_name, std::string_view gateway,
 
 bool StopDnsmasq(std::string_view name) {
   std::ifstream file;
-  std::string filename = absl::StrFormat(
-      "/var/run/cuttlefish-dnsmasq-%s.pid", name);
+  std::string filename =
+      absl::StrFormat("/var/run/cuttlefish-dnsmasq-%s.pid", name);
   LOG(INFO) << "stopping dnsmasq for interface: " << name;
   file.open(filename);
   if (file.is_open()) {
@@ -326,8 +328,7 @@ bool StopDnsmasq(std::string_view name) {
   return ret;
 }
 
-bool CreateEthernetBridgeIface(std::string_view name,
-                               std::string_view ipaddr) {
+bool CreateEthernetBridgeIface(std::string_view name, std::string_view ipaddr) {
   auto exists = BridgeExists(name);
   if (exists.ok() && *exists) {
     LOG(INFO) << "Bridge " << name << " exists already, doing nothing.";
@@ -359,7 +360,7 @@ bool DestroyEthernetBridgeIface(std::string_view name,
 
 Result<std::string> IptablesPath() {
   static const absl::NoDestructor<std::string> iptables_path(
-     SearchForIptables().value_or(""));
+      SearchForIptables().value_or(""));
 
   CF_EXPECT(!iptables_path->empty(), "could not find iptables");
   return *iptables_path;

--- a/base/cvd/allocd/alloc_utils.h
+++ b/base/cvd/allocd/alloc_utils.h
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <stdint.h>
 #include <pwd.h>
+#include <stdint.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -61,7 +61,6 @@ bool CreateTap(std::string_view name);
 Result<void> ValidateTapInterfaceIsUsable(const std::string& interface_name);
 #endif
 
-
 bool DestroyIface(std::string_view name);
 
 bool DestroyBridge(std::string_view name);
@@ -79,10 +78,8 @@ bool SetupBridgeGateway(std::string_view name, std::string_view ipaddr);
 void CleanupBridgeGateway(std::string_view name, std::string_view ipaddr,
                           const GatewayConfig& config);
 
-bool CreateEthernetBridgeIface(std::string_view name,
-                               std::string_view ipaddr);
-bool DestroyEthernetBridgeIface(std::string_view name,
-                                std::string_view ipaddr);
+bool CreateEthernetBridgeIface(std::string_view name, std::string_view ipaddr);
+bool DestroyEthernetBridgeIface(std::string_view name, std::string_view ipaddr);
 
 bool StartDnsmasq(std::string_view bridge_name, std::string_view gateway,
                   std::string_view dhcp_range);

--- a/base/cvd/allocd/net/BUILD.bazel
+++ b/base/cvd/allocd/net/BUILD.bazel
@@ -14,7 +14,6 @@ cf_cc_library(
         "netlink_client.h",
         "netlink_request.h",
     ],
-    clang_format_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "@abseil-cpp//absl/log",

--- a/base/cvd/allocd/net/netlink_client.cc
+++ b/base/cvd/allocd/net/netlink_client.cc
@@ -26,8 +26,8 @@
 
 #include "absl/log/log.h"
 
-#include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "allocd/net/netlink_request.h"
+#include "cuttlefish/common/libs/fs/shared_fd.h"
 
 namespace cuttlefish {
 namespace {
@@ -57,10 +57,10 @@ class NetlinkClientImpl : public NetlinkClient {
 bool NetlinkClientImpl::CheckResponse(uint32_t seq_no) {
   uint32_t len;
   char buf[4096];
-  struct iovec iov = { buf, sizeof(buf) };  // NOLINT(misc-include-cleaner)
+  struct iovec iov = {buf, sizeof(buf)};  // NOLINT(misc-include-cleaner)
   struct sockaddr_nl sa;
-  struct msghdr msg {};
-  struct nlmsghdr *nh;
+  struct msghdr msg{};
+  struct nlmsghdr* nh;
 
   msg.msg_name = &sa;
   msg.msg_namelen = sizeof(sa);
@@ -68,7 +68,7 @@ bool NetlinkClientImpl::CheckResponse(uint32_t seq_no) {
   msg.msg_iovlen = 1;
 
   int result = netlink_fd_->RecvMsg(&msg, 0);
-  if (result  < 0) {
+  if (result < 0) {
     LOG(ERROR) << "Netlink error: " << strerror(errno);
     return false;
   }
@@ -76,15 +76,14 @@ bool NetlinkClientImpl::CheckResponse(uint32_t seq_no) {
   len = static_cast<uint32_t>(result);
   LOG(INFO) << "Received netlink response (" << len << " bytes)";
 
-  for (nh = reinterpret_cast<nlmsghdr*>(buf);
-       NLMSG_OK(nh, len);
+  for (nh = reinterpret_cast<nlmsghdr*>(buf); NLMSG_OK(nh, len);
        nh = NLMSG_NEXT(nh, len)) {
     if (nh->nlmsg_seq != seq_no) {
       // This really shouldn't happen. If we see this, it means somebody is
       // issuing netlink requests using the same socket as us, and ignoring
       // responses.
-      LOG(WARNING) << "Sequence number mismatch: "
-                   << nh->nlmsg_seq << " != " << seq_no;
+      LOG(WARNING) << "Sequence number mismatch: " << nh->nlmsg_seq
+                   << " != " << seq_no;
       continue;
     }
 
@@ -116,10 +115,8 @@ bool NetlinkClientImpl::CheckResponse(uint32_t seq_no) {
 
 bool NetlinkClientImpl::Send(const NetlinkRequest& message) {
   struct sockaddr_nl netlink_addr;
-  struct iovec netlink_iov = {  // NOLINT(misc-include-cleaner)
-    message.RequestData(),
-    message.RequestLength()
-  };
+  struct iovec netlink_iov = {// NOLINT(misc-include-cleaner)
+                              message.RequestData(), message.RequestLength()};
   struct msghdr msg;
   memset(&msg, 0, sizeof(msg));
   memset(&netlink_addr, 0, sizeof(netlink_addr));
@@ -131,8 +128,7 @@ bool NetlinkClientImpl::Send(const NetlinkRequest& message) {
   msg.msg_iovlen = sizeof(netlink_iov) / sizeof(iovec);
 
   if (netlink_fd_->SendMsg(&msg, 0) < 0) {
-    LOG(ERROR) << "Failed to send netlink message: "
-               << strerror(errno);
+    LOG(ERROR) << "Failed to send netlink message: " << strerror(errno);
 
     return false;
   }
@@ -175,7 +171,7 @@ class NetlinkClientFactoryImpl : public NetlinkClientFactory {
 }  // namespace
 
 NetlinkClientFactory* NetlinkClientFactory::Default() {
-  static NetlinkClientFactory &factory = *new NetlinkClientFactoryImpl();
+  static NetlinkClientFactory& factory = *new NetlinkClientFactoryImpl();
   return &factory;
 }
 

--- a/base/cvd/allocd/net/netlink_client.cc
+++ b/base/cvd/allocd/net/netlink_client.cc
@@ -18,13 +18,11 @@
 #include <errno.h>
 #include <linux/netlink.h>
 #include <sys/socket.h>
-#include <sys/uio.h>
+#include <sys/uio.h>  // IWYU pragma: keep // iovec
 
 #include <cstdint>
 #include <cstring>
 #include <memory>
-#include <string>
-#include "ostream"  // for operator<<, basic_ostream
 
 #include "absl/log/log.h"
 
@@ -59,7 +57,7 @@ class NetlinkClientImpl : public NetlinkClient {
 bool NetlinkClientImpl::CheckResponse(uint32_t seq_no) {
   uint32_t len;
   char buf[4096];
-  struct iovec iov = { buf, sizeof(buf) };
+  struct iovec iov = { buf, sizeof(buf) };  // NOLINT(misc-include-cleaner)
   struct sockaddr_nl sa;
   struct msghdr msg {};
   struct nlmsghdr *nh;
@@ -118,7 +116,7 @@ bool NetlinkClientImpl::CheckResponse(uint32_t seq_no) {
 
 bool NetlinkClientImpl::Send(const NetlinkRequest& message) {
   struct sockaddr_nl netlink_addr;
-  struct iovec netlink_iov = {
+  struct iovec netlink_iov = {  // NOLINT(misc-include-cleaner)
     message.RequestData(),
     message.RequestLength()
   };
@@ -129,6 +127,7 @@ bool NetlinkClientImpl::Send(const NetlinkRequest& message) {
   msg.msg_name = &address_;
   msg.msg_namelen = sizeof(address_);
   msg.msg_iov = &netlink_iov;
+  // NOLINTNEXTLINE(misc-include-cleaner)
   msg.msg_iovlen = sizeof(netlink_iov) / sizeof(iovec);
 
   if (netlink_fd_->SendMsg(&msg, 0) < 0) {

--- a/base/cvd/allocd/net/netlink_client.h
+++ b/base/cvd/allocd/net/netlink_client.h
@@ -33,7 +33,7 @@ class NetlinkClient {
 
  private:
   NetlinkClient(const NetlinkClient&);
-  NetlinkClient& operator= (const NetlinkClient&);
+  NetlinkClient& operator=(const NetlinkClient&);
 };
 
 class NetlinkClientFactory {

--- a/base/cvd/allocd/net/netlink_request.cc
+++ b/base/cvd/allocd/net/netlink_request.cc
@@ -19,17 +19,16 @@
 #include <linux/if_link.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
-#include <net/if.h>
-#include <sys/socket.h>
+#include <net/if.h>  // IWYU pragma: keep // IFF_UP
 #include <netinet/in.h>
+#include <stddef.h>
+#include <sys/socket.h>
 #include <unistd.h>
+#include <stdint.h>
 
 #include <algorithm>
 #include <array>
-#include <cstdint>  // for int32_t
-#include <ostream>  // for operator<<, basic_ostream
 #include <string>
-#include <type_traits>  // for swap
 #include <utility>
 #include <vector>
 

--- a/base/cvd/allocd/net/netlink_request.cc
+++ b/base/cvd/allocd/net/netlink_request.cc
@@ -22,9 +22,9 @@
 #include <net/if.h>  // IWYU pragma: keep // IFF_UP
 #include <netinet/in.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <sys/socket.h>
 #include <unistd.h>
-#include <stdint.h>
 
 #include <algorithm>
 #include <array>
@@ -39,9 +39,7 @@ namespace {
 uint32_t kRequestSequenceNumber = 0;
 }  // namespace
 
-uint32_t NetlinkRequest::SeqNo() const {
-  return header_->nlmsg_seq;
-}
+uint32_t NetlinkRequest::SeqNo() const { return header_->nlmsg_seq; }
 
 void* NetlinkRequest::AppendRaw(const void* data, size_t length) {
   auto* output = static_cast<char*>(ReserveRaw(length));
@@ -56,8 +54,8 @@ void* NetlinkRequest::ReserveRaw(size_t length) {
   return reinterpret_cast<void*>(request_.data() + original_size);
 }
 
-nlattr* NetlinkRequest::AppendTag(
-    uint16_t type, const void* data, uint16_t data_length) {
+nlattr* NetlinkRequest::AppendTag(uint16_t type, const void* data,
+                                  uint16_t data_length) {
   nlattr* attr = Reserve<nlattr>();
   attr->nla_type = type;
   attr->nla_len = RTA_LENGTH(data_length);
@@ -103,11 +101,12 @@ void NetlinkRequest::AddAddrInfo(int32_t if_index, int prefix_len) {
   ad_info->ifa_index = if_index;
 }
 
-void NetlinkRequest::AddMacAddress(const std::array<unsigned char, 6>& address) {
+void NetlinkRequest::AddMacAddress(
+    const std::array<unsigned char, 6>& address) {
   AppendTag(IFLA_ADDRESS, address.data(), 6);
 }
 
-void NetlinkRequest::AddInAddr(uint16_t type, in_addr_t *addr) {
+void NetlinkRequest::AddInAddr(uint16_t type, in_addr_t* addr) {
   AppendTag(type, addr, sizeof(in_addr_t));
 }
 
@@ -134,8 +133,6 @@ void* NetlinkRequest::RequestData() const {
   return header_;
 }
 
-size_t NetlinkRequest::RequestLength() const {
-  return request_.size();
-}
+size_t NetlinkRequest::RequestLength() const { return request_.size(); }
 
 }  // namespace cuttlefish

--- a/base/cvd/allocd/net/netlink_request.h
+++ b/base/cvd/allocd/net/netlink_request.h
@@ -16,10 +16,9 @@
 #ifndef ALLOCD_NET_NETLINK_REQUEST_H_
 #define ALLOCD_NET_NETLINK_REQUEST_H_
 
-#include <stddef.h>
-
 #include <linux/netlink.h>
 #include <netinet/in.h>
+#include <stddef.h>
 
 #include <array>
 #include <cstdint>
@@ -66,7 +65,7 @@ class NetlinkRequest {
   void AddMacAddress(const std::array<unsigned char, 6>& address);
 
   // Add an ipv4 address
-  void AddInAddr(uint16_t type, in_addr_t *addr);
+  void AddInAddr(uint16_t type, in_addr_t* addr);
 
   // Creates new list.
   // List mimic recursive structures in a flat, continuous representation.
@@ -96,12 +95,14 @@ class NetlinkRequest {
   void* ReserveRaw(size_t length);
 
   // Append specialized data.
-  template <typename T> T* Append(const T& data) {
+  template <typename T>
+  T* Append(const T& data) {
     return static_cast<T*>(AppendRaw(&data, sizeof(T)));
   }
 
   // Reserve specialized data.
-  template <typename T> T* Reserve() {
+  template <typename T>
+  T* Reserve() {
     return static_cast<T*>(ReserveRaw(sizeof(T)));
   }
 
@@ -113,7 +114,7 @@ class NetlinkRequest {
   nlmsghdr* header_;
 
   NetlinkRequest(const NetlinkRequest&) = delete;
-  NetlinkRequest& operator= (const NetlinkRequest&) = delete;
+  NetlinkRequest& operator=(const NetlinkRequest&) = delete;
 };
 }  // namespace cuttlefish
 #endif  // COMMON_LIBS_NET_NETLINK_REQUEST_H_


### PR DESCRIPTION
Converts some targets to `cf_cc_library`, adds stricter lint rules, and clang-formats changes.

Bug: b/512215781
Bug: b/523396865