### PR TITLE
Return a Result<siginfo_t> from Subprocess::Wait

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/display.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/display.cpp
@@ -125,8 +125,8 @@ Result<void> CvdDisplayCommandHandler::Handle(const CommandRequest& request) {
   Command command =
       CF_EXPECT(BuildCommand(instance_manager_, request, subcmd_args, env));
 
-  siginfo_t infop;  // NOLINT(misc-include-cleaner)
-  command.Start().Wait(&infop, WEXITED);
+  // NOLINTNEXTLINE(misc-include-cleaner)
+  siginfo_t infop = CF_EXPECT(command.Start().Wait(WEXITED));
 
   CF_EXPECT(CheckProcessExitedNormally(infop));
   return {};

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/env.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/env.cpp
@@ -103,8 +103,8 @@ Result<void> CvdEnvCommandHandler::Handle(const CommandRequest& request) {
                         ? CF_EXPECT(HelpCommand(request))
                         : CF_EXPECT(NonHelpCommand(instance_manager_, request));
 
-  siginfo_t infop;  // NOLINT(misc-include-cleaner)
-  command.Start().Wait(&infop, WEXITED);
+  // NOLINTNEXTLINE(misc-include-cleaner)
+  siginfo_t infop = CF_EXPECT(command.Start().Wait(WEXITED));
 
   CF_EXPECT(CheckProcessExitedNormally(infop));
   return {};

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/snapshot.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/snapshot.cpp
@@ -91,8 +91,8 @@ Result<void> CvdSnapshotCommandHandler::Handle(const CommandRequest& request) {
   Command command =
       CF_EXPECT(GenerateCommand(request, subcmd, subcmd_args, request.Env()));
 
-  siginfo_t infop;  // NOLINT(misc-include-cleaner)
-  command.Start().Wait(&infop, WEXITED);
+  // NOLINTNEXTLINE(misc-include-cleaner)
+  siginfo_t infop = CF_EXPECT(command.Start().Wait(WEXITED));
 
   CF_EXPECT(CheckProcessExitedNormally(infop));
   return {};

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/local_instance.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/local_instance.cpp
@@ -146,8 +146,7 @@ Result<void> LocalInstance::PressPowerBtnLegacy() {
 
   VLOG(0) << "Executing: " << cmd.ToString();
 
-  siginfo_t infop;
-  cmd.Start().Wait(&infop, WEXITED);
+  siginfo_t infop = CF_EXPECT(cmd.Start().Wait(WEXITED));
   CF_EXPECT(CheckProcessExitedNormally(infop));
 
   return {};

--- a/base/cvd/cuttlefish/host/commands/cvd/utils/subprocess_waiter.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/utils/subprocess_waiter.cpp
@@ -39,17 +39,13 @@ Result<siginfo_t> SubprocessWaiter::Wait() {
   CF_EXPECT(!interrupted_, "Interrupted");
   CF_EXPECT(subprocess_.has_value());
 
-  siginfo_t infop{};
-
   interrupt_lock.unlock();
 
   // This blocks until the process exits, but doesn't reap it.
-  auto result = subprocess_->Wait(&infop, WEXITED | WNOWAIT);
-  CF_EXPECTF(result != -1, "Lost track of subprocess pid: {}", StrError(errno));
+  siginfo_t infop = CF_EXPECT(subprocess_->Wait(WEXITED | WNOWAIT));
   interrupt_lock.lock();
   // Perform a reaping wait on the process (which should already have exited).
-  result = subprocess_->Wait(&infop, WEXITED);
-  CF_EXPECT(result != -1, "Lost track of subprocess pid");
+  infop = CF_EXPECT(subprocess_->Wait(WEXITED));
   // The double wait avoids a race around the kernel reusing pids. Waiting
   // with WNOWAIT won't cause the child process to be reaped, so the kernel
   // won't reuse the pid until the Wait call below, and any kill signals won't

--- a/base/cvd/cuttlefish/host/libs/process_monitor/process_monitor.cc
+++ b/base/cvd/cuttlefish/host/libs/process_monitor/process_monitor.cc
@@ -159,14 +159,14 @@ Result<void> StopSubprocesses(std::vector<MonitorEntry>& monitored) {
       LOG(WARNING) << "Error in stopping \"" << it.cmd->GetShortName() << "\"";
       return false;
     }
-    siginfo_t infop;
-    auto success = it.proc->Wait(&infop, WEXITED);
-    if (success < 0) {
-      LOG(WARNING) << "Failed to wait for process " << it.cmd->GetShortName();
+    Result<siginfo_t> infop = it.proc->Wait(WEXITED);
+    if (!infop.has_value()) {
+      LOG(WARNING) << "Failed to wait for process " << it.cmd->GetShortName()
+                   << ": " << infop.error();
       return false;
     }
     if (stop_result == StopperResult::kCrash) {
-      LogSubprocessExit(it.cmd->GetShortName(), infop);
+      LogSubprocessExit(it.cmd->GetShortName(), *infop);
     }
     return true;
   };

--- a/base/cvd/cuttlefish/process/BUILD.bazel
+++ b/base/cvd/cuttlefish/process/BUILD.bazel
@@ -92,6 +92,7 @@ cf_cc_library(
     srcs = ["subprocess.cc"],
     hdrs = ["subprocess.h"],
     deps = [
+        "//cuttlefish/posix:strerror",
         "//cuttlefish/result:expect",
         "//cuttlefish/result:result_type",
         "@abseil-cpp//absl/log",

--- a/base/cvd/cuttlefish/process/execute.cc
+++ b/base/cvd/cuttlefish/process/execute.cc
@@ -52,10 +52,7 @@ Result<siginfo_t> Execute(std::vector<std::string> command,
   Subprocess subprocess = cmd.Start(std::move(subprocess_options));
   CF_EXPECT(subprocess.Started(), "Subprocess failed to start.");
 
-  siginfo_t info;
-  CF_EXPECT_EQ(subprocess.Wait(&info, wait_options), 0);
-
-  return info;
+  return CF_EXPECT(subprocess.Wait(wait_options));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/process/subprocess.cc
+++ b/base/cvd/cuttlefish/process/subprocess.cc
@@ -27,6 +27,7 @@
 
 #include "absl/log/log.h"
 
+#include "cuttlefish/posix/strerror.h"
 #include "cuttlefish/result/expect.h"
 #include "cuttlefish/result/result_type.h"
 
@@ -85,23 +86,22 @@ int Subprocess::Wait() {
   return retval;
 }
 // NOLINTNEXTLINE(misc-include-cleaner): <signal.h>
-int Subprocess::Wait(siginfo_t* infop, int options) {
-  if (pid_ < 0) {
-    LOG(ERROR)
-        << "Attempt to wait on invalid pid(has it been waited on already?): "
-        << pid_;
-    return -1;
-  }
-  *infop = {};
-  // NOLINTNEXTLINE(misc-include-cleaner): <sys/wait.h>
-  auto retval = TEMP_FAILURE_RETRY(waitid(P_PID, pid_, infop, options));
+Result<siginfo_t> Subprocess::Wait(int options) {
+  CF_EXPECT_GE(pid_, 0,
+               "Attempt to wait on invalid pid(has it been waited on already?");
+  siginfo_t infop = {};
+  // NOLINTNEXTLINE(misc-include-cleaner): P_PID
+  int retval = TEMP_FAILURE_RETRY(waitid(P_PID, pid_, &infop, options));
   // We don't want to wait twice for the same process
-  bool exited = infop->si_code == CLD_EXITED || infop->si_code == CLD_DUMPED;
+  bool exited = infop.si_code == CLD_EXITED || infop.si_code == CLD_DUMPED;
   bool reaped = !(options & WNOWAIT);
+  pid_t tracked = pid_;
   if (exited && reaped) {
     pid_ = -1;
   }
-  return retval;
+  CF_EXPECT_EQ(retval, 0,
+               "Lost track of process " << tracked << ": " << StrError(errno));
+  return infop;
 }
 
 static Result<void> SendSignalImpl(const int signal, const pid_t pid,

--- a/base/cvd/cuttlefish/process/subprocess.h
+++ b/base/cvd/cuttlefish/process/subprocess.h
@@ -55,7 +55,7 @@ class Subprocess {
   // successfully, non-zero otherwise.
   int Wait();
   // Same as waitid(2)
-  int Wait(siginfo_t* infop, int options);
+  Result<siginfo_t> Wait(int options);
   // Whether the command started successfully. It only says whether the call to
   // fork() succeeded or not, it says nothing about exec or successful
   // completion of the command, that's what Wait is for.


### PR DESCRIPTION
The return value was only ever 0 or -1 based on the result of waitid. Using a Result avoids the output argument in favor of using the return value to produce the outcome of the function call.

There were some callers that ignored the return value of Wait that now check it for errors as well.

Bug: b/531812844