### PR TITLE
Remove `New*` functions for `CommandHandler` subclasses

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/bugreport.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/bugreport.cpp
@@ -19,7 +19,6 @@
 #include <stdlib.h>
 
 #include <iostream>
-#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -35,7 +34,6 @@
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/flag_parser/gflags_compat.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/host/commands/cvd/cli/utils.h"
@@ -157,12 +155,6 @@ Result<std::string> CvdBugreportCommandHandler::DetailedHelp(
     return CF_ERRF("Failed to execute bugreport binary, exit code: {}", res);
   }
   return stdout;
-}
-
-std::unique_ptr<CvdCommandHandler> NewCvdBugreportCommandHandler(
-    InstanceManager& instance_manager) {
-  return std::unique_ptr<CvdCommandHandler>(
-      new CvdBugreportCommandHandler(instance_manager));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/bugreport.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/bugreport.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <memory>
 #include <string>
 
 #include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
@@ -39,8 +38,5 @@ class CvdBugreportCommandHandler : public CvdCommandHandler {
  private:
   InstanceManager& instance_manager_;
 };
-
-std::unique_ptr<CvdCommandHandler> NewCvdBugreportCommandHandler(
-    InstanceManager& instance_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/cache.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/cache.cpp
@@ -18,7 +18,6 @@
 
 #include <stddef.h>
 
-#include <memory>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -33,7 +32,6 @@
 #include "cuttlefish/flag_parser/gflags_compat.h"
 #include "cuttlefish/host/commands/cvd/cache/cache.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/host/commands/cvd/utils/common.h"
 #include "cuttlefish/result/result.h"
@@ -165,10 +163,6 @@ Example usage:
     - prune uses last modification time to remove oldest files first
 )",
                      kDefaultCacheSizeGb);
-}
-
-std::unique_ptr<CvdCommandHandler> NewCvdCacheCommandHandler() {
-  return std::unique_ptr<CvdCommandHandler>(new CvdCacheCommandHandler());
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/cache.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/cache.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <memory>
 #include <string>
 
 #include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
@@ -24,8 +23,6 @@
 #include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
-
-class CommandRequest;
 
 class CvdCacheCommandHandler : public CvdCommandHandler {
  public:
@@ -36,7 +33,5 @@ class CvdCacheCommandHandler : public CvdCommandHandler {
   std::string SummaryHelp() const override;
   Result<std::string> DetailedHelp(const CommandRequest& request) override;
 };
-
-std::unique_ptr<CvdCommandHandler> NewCvdCacheCommandHandler();
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/clear.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/clear.cpp
@@ -16,13 +16,11 @@
 
 #include "cuttlefish/host/commands/cvd/cli/commands/clear.h"
 
-#include <memory>
 #include <string>
 #include <vector>
 
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/host/commands/cvd/instances/instance_manager.h"
 #include "cuttlefish/result/result.h"
@@ -56,12 +54,6 @@ std::string CvdClearCommandHandler::SummaryHelp() const {
 Result<std::string> CvdClearCommandHandler::DetailedHelp(
     const CommandRequest& request) {
   return kSummaryHelpText;
-}
-
-std::unique_ptr<CvdCommandHandler> NewCvdClearCommandHandler(
-    InstanceManager& instance_manager) {
-  return std::unique_ptr<CvdCommandHandler>(
-      new CvdClearCommandHandler(instance_manager));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/clear.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/clear.h
@@ -16,14 +16,12 @@
 
 #pragma once
 
-#include <memory>
 #include <string>
 
 #include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
+#include "cuttlefish/host/commands/cvd/instances/instance_manager.h"
 
 namespace cuttlefish {
-
-class InstanceManager;
 
 class CvdClearCommandHandler : public CvdCommandHandler {
  public:
@@ -40,8 +38,5 @@ class CvdClearCommandHandler : public CvdCommandHandler {
  private:
   InstanceManager& instance_manager_;
 };
-
-std::unique_ptr<CvdCommandHandler> NewCvdClearCommandHandler(
-    InstanceManager& instance_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.cpp
@@ -125,7 +125,7 @@ Result<void> StartGroup(const LocalInstanceGroup& group,
   const CommandRequest start_cmd =
       CF_EXPECT(CreateStartCommand(group, subcmd_args, envs));
   std::unique_ptr<CvdCommandHandler> start_handler =
-      NewCvdStartCommandHandler(instance_manager);
+      std::make_unique<CvdStartCommandHandler>(instance_manager);
   CF_EXPECT(start_handler->Handle(start_cmd));
   return {};
 }
@@ -327,7 +327,7 @@ Result<void> CvdCreateCommandHandler::Handle(const CommandRequest& request) {
     CommandRequest subrequest = CF_EXPECT(
         CreateLoadCommand(request, subcmd_args, own_flags_.config_file));
     std::unique_ptr<CvdCommandHandler> load_handler =
-        NewLoadConfigsCommand(instance_manager_);
+        std::make_unique<LoadConfigsCommand>(instance_manager_);
     CF_EXPECT(load_handler->Handle(subrequest));
     return {};
   }
@@ -503,11 +503,6 @@ std::vector<Flag> CvdCreateCommandHandler::FlagModeFlags(
                 "there are multiple matching groups, or the chosen group has a "
                 "host tools / guest image mismatch."));
   return flags;
-}
-
-std::unique_ptr<CvdCommandHandler> NewCvdCreateCommandHandler(
-    InstanceManager& instance_manager) {
-  return std::make_unique<CvdCreateCommandHandler>(instance_manager);
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
@@ -61,8 +60,5 @@ class CvdCreateCommandHandler : public CvdCommandHandler {
   CreateFlags own_flags_;
   selector::NumInstancesParser num_instances_parser_;
 };
-
-std::unique_ptr<CvdCommandHandler> NewCvdCreateCommandHandler(
-    InstanceManager& instance_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/display.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/display.cpp
@@ -20,7 +20,6 @@
 #include <stdlib.h>
 
 #include <iostream>
-#include <memory>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -33,7 +32,6 @@
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/flag_parser/gflags_compat.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/host/commands/cvd/cli/utils.h"
@@ -147,12 +145,6 @@ bool CvdDisplayCommandHandler::RequiresDeviceExists() const { return true; }
 Result<std::string> CvdDisplayCommandHandler::DetailedHelp(
     const CommandRequest& request) {
   return kDetailedHelpText;
-}
-
-std::unique_ptr<CvdCommandHandler> NewCvdDisplayCommandHandler(
-    InstanceManager& instance_manager) {
-  return std::unique_ptr<CvdCommandHandler>(
-      new CvdDisplayCommandHandler(instance_manager));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/display.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/display.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <memory>
 #include <string>
 
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
@@ -44,8 +43,5 @@ class CvdDisplayCommandHandler : public CvdCommandHandler {
  private:
   InstanceManager& instance_manager_;
 };
-
-std::unique_ptr<CvdCommandHandler> NewCvdDisplayCommandHandler(
-    InstanceManager& instance_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/env.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/env.cpp
@@ -19,7 +19,6 @@
 #include <signal.h>  // IWYU pragma: keep
 #include <stdlib.h>
 
-#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -29,7 +28,6 @@
 #include "cuttlefish/common/libs/utils/subprocess.h"
 #include "cuttlefish/common/libs/utils/subprocess_managed_stdio.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/host/commands/cvd/cli/utils.h"
@@ -136,9 +134,4 @@ Result<std::string> CvdEnvCommandHandler::DetailedHelp(
   return stdout;
 }
 
-std::unique_ptr<CvdCommandHandler> NewCvdEnvCommandHandler(
-    InstanceManager& instance_manager) {
-  return std::unique_ptr<CvdCommandHandler>(
-      new CvdEnvCommandHandler(instance_manager));
-}
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/env.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/env.h
@@ -16,14 +16,13 @@
 
 #pragma once
 
-#include <memory>
+#include <string>
 
 #include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/instances/instance_manager.h"
+#include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
-
-class Command;
 
 class CvdEnvCommandHandler : public CvdCommandHandler {
  public:
@@ -39,8 +38,5 @@ class CvdEnvCommandHandler : public CvdCommandHandler {
  private:
   InstanceManager& instance_manager_;
 };
-
-std::unique_ptr<CvdCommandHandler> NewCvdEnvCommandHandler(
-    InstanceManager& instance_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.cpp
@@ -16,7 +16,6 @@
 
 #include "cuttlefish/host/commands/cvd/cli/commands/fetch.h"
 
-#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -29,7 +28,6 @@
 #include "cuttlefish/common/libs/utils/tee_logging.h"
 #include "cuttlefish/host/commands/cvd/cache/cache.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/host/commands/cvd/fetch/auto_login.h"
 #include "cuttlefish/host/commands/cvd/fetch/build_api_flags.h"
@@ -124,10 +122,6 @@ Result<std::string> CvdFetchCommandHandler::DetailedHelp(
   // TODO: b/389119573 - Should return the help text instead of printing it
   CF_EXPECT(FetchFlags::Parse(args));
   return {};
-}
-
-std::unique_ptr<CvdCommandHandler> NewCvdFetchCommandHandler() {
-  return std::unique_ptr<CvdCommandHandler>(new CvdFetchCommandHandler());
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.h
@@ -16,9 +16,10 @@
 
 #pragma once
 
-#include <memory>
+#include <string>
 
 #include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
+#include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
 
@@ -30,7 +31,5 @@ class CvdFetchCommandHandler : public CvdCommandHandler {
   std::string SummaryHelp() const override;
   Result<std::string> DetailedHelp(const CommandRequest& request) override;
 };
-
-std::unique_ptr<CvdCommandHandler> NewCvdFetchCommandHandler();
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fleet.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fleet.cpp
@@ -17,7 +17,6 @@
 #include "cuttlefish/host/commands/cvd/cli/commands/fleet.h"
 
 #include <iostream>
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -25,7 +24,6 @@
 
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/host/commands/cvd/instances/instance_manager.h"
 #include "cuttlefish/result/result.h"
@@ -75,12 +73,6 @@ Result<void> CvdFleetCommandHandler::Handle(const CommandRequest& request) {
   std::cout << output_json.toStyledString();
 
   return {};
-}
-
-std::unique_ptr<CvdCommandHandler> NewCvdFleetCommandHandler(
-    InstanceManager& instance_manager) {
-  return std::unique_ptr<CvdCommandHandler>(
-      new CvdFleetCommandHandler(instance_manager));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fleet.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fleet.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <memory>
 #include <string>
 
 #include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
@@ -44,8 +43,5 @@ class CvdFleetCommandHandler : public CvdCommandHandler {
  private:
   InstanceManager& instance_manager_;
 };
-
-std::unique_ptr<CvdCommandHandler> NewCvdFleetCommandHandler(
-    InstanceManager& instance_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/help.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/help.cpp
@@ -271,10 +271,4 @@ Result<std::string> CvdHelpHandler::SubCommandHelp(
   return help_message.str();
 }
 
-std::unique_ptr<CvdCommandHandler> NewCvdHelpHandler(
-    const std::vector<std::unique_ptr<CvdCommandHandler>>& server_handlers) {
-  return std::unique_ptr<CvdCommandHandler>(
-      new CvdHelpHandler(server_handlers));
-}
-
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/help.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/help.h
@@ -46,6 +46,4 @@ class CvdHelpHandler : public CvdCommandHandler {
   const std::vector<std::unique_ptr<CvdCommandHandler>>& request_handlers_;
 };
 
-std::unique_ptr<CvdCommandHandler> NewCvdHelpHandler(
-    const std::vector<std::unique_ptr<CvdCommandHandler>>& server_handlers);
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/lint.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/lint.cpp
@@ -17,13 +17,11 @@
 #include "cuttlefish/host/commands/cvd/cli/commands/lint.h"
 
 #include <iostream>
-#include <memory>
 #include <string>
 #include <vector>
 
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/parser/load_configs_parser.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/result/result.h"
@@ -74,10 +72,6 @@ Result<std::string> LintCommandHandler::ValidateConfig(
   std::string& config_path = args.front();
   CF_EXPECT(GetEnvironmentSpecification(config_path, load_flags.overrides));
   return config_path;
-}
-
-std::unique_ptr<CvdCommandHandler> NewLintCommand() {
-  return std::unique_ptr<CvdCommandHandler>(new LintCommandHandler());
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/lint.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/lint.h
@@ -15,7 +15,6 @@
  */
 #pragma once
 
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -36,7 +35,5 @@ class LintCommandHandler : public CvdCommandHandler {
  private:
   Result<std::string> ValidateConfig(std::vector<std::string>& args);
 };
-
-std::unique_ptr<CvdCommandHandler> NewLintCommand();
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.cpp
@@ -211,7 +211,7 @@ Result<void> LoadConfigsCommand::LoadGroup(const CommandRequest& request,
   if (!cvd_flags.fetch_cvd_flags.empty()) {
     CommandRequest fetch_cmd = CF_EXPECT(BuildFetchCmd(request, cvd_flags));
     std::unique_ptr<CvdCommandHandler> fetch_handler =
-        NewCvdFetchCommandHandler();
+        std::make_unique<CvdFetchCommandHandler>();
     Result<void> fetch_res = fetch_handler->Handle(fetch_cmd);
     if (!fetch_res.ok()) {
       group.SetAllStates(cvd::INSTANCE_STATE_PREPARE_FAILED);
@@ -230,7 +230,7 @@ Result<void> LoadConfigsCommand::LoadGroup(const CommandRequest& request,
   CommandRequest start_cmd =
       CF_EXPECT(BuildStartCommand(request, cvd_flags, group));
   std::unique_ptr<CvdCommandHandler> start_handler =
-      NewCvdStartCommandHandler(instance_manager_);
+      std::make_unique<CvdStartCommandHandler>(instance_manager_);
   CF_EXPECT(start_handler->Handle(start_cmd));
   return {};
 }
@@ -319,12 +319,6 @@ std::vector<HelpParagraph> LoadConfigsCommand::CommonCommandDescription() {
 Result<std::vector<Flag>> LoadConfigsCommand::Flags(
     const CommandRequest& request) {
   return BuildCvdLoadFlags(flags_);
-}
-
-std::unique_ptr<CvdCommandHandler> NewLoadConfigsCommand(
-    InstanceManager& instance_manager) {
-  return std::unique_ptr<CvdCommandHandler>(
-      new LoadConfigsCommand(instance_manager));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.h
@@ -15,7 +15,6 @@
  */
 #pragma once
 
-#include <memory>
 #include <string>
 
 #include "cuttlefish/flag_parser/flag.h"
@@ -29,6 +28,10 @@
 
 namespace cuttlefish {
 
+/*
+cvd load component is responsible of loading, translation and creation of
+cuttlefish instances based on input json configuration file
+*/
 class LoadConfigsCommand : public CvdCommandHandler {
  public:
   LoadConfigsCommand(InstanceManager& instance_manager);
@@ -49,12 +52,5 @@ class LoadConfigsCommand : public CvdCommandHandler {
   InstanceManager& instance_manager_;
   LoadFlags flags_;
 };
-
-/*
-cvd load component is responsible of loading, translation and creation of
-cuttlefish instances based on input json configuration file
-*/
-std::unique_ptr<CvdCommandHandler> NewLoadConfigsCommand(
-    InstanceManager& instance_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/login.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/login.cpp
@@ -25,7 +25,6 @@
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/flag_parser/gflags_compat.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/host/libs/web/http_client/curl_global_init.h"
 #include "cuttlefish/host/libs/web/http_client/curl_http_client.h"
@@ -100,11 +99,6 @@ Result<std::string> CvdLoginCommand::DetailedHelp(
         "google3/cloud/android/login";
   }
   return kHelpMessage + google_appendix;
-}
-
-/** Create a credentials file */
-std::unique_ptr<CvdCommandHandler> NewLoginCommand() {
-  return std::make_unique<CvdLoginCommand>();
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/login.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/login.h
@@ -15,7 +15,6 @@
  */
 #pragma once
 
-#include <memory>
 #include <string>
 
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
@@ -25,6 +24,7 @@
 
 namespace cuttlefish {
 
+/** Create a credentials file */
 class CvdLoginCommand : public CvdCommandHandler {
  public:
   Result<void> Handle(const CommandRequest& request) override;
@@ -33,8 +33,5 @@ class CvdLoginCommand : public CvdCommandHandler {
   std::string SummaryHelp() const override;
   Result<std::string> DetailedHelp(const CommandRequest& request) override;
 };
-
-/** Create a credentials file */
-std::unique_ptr<CvdCommandHandler> NewLoginCommand();
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/logs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/logs.cpp
@@ -6,7 +6,6 @@
 #include <cerrno>
 #include <cstring>
 #include <iostream>
-#include <memory>
 #include <optional>
 #include <string>
 #include <utility>
@@ -19,7 +18,6 @@
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/flag_parser/gflags_compat.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/help_format.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
@@ -314,12 +312,6 @@ Result<std::vector<Flag>> CvdLogsHandler::Flags(const CommandRequest&) {
           .Help("Use a pager when printing log files. The default when output "
                 "is a terminal."),
   };
-}
-
-std::unique_ptr<CvdCommandHandler> NewCvdLogsHandler(
-    InstanceManager& instance_manager) {
-  return std::unique_ptr<CvdCommandHandler>(
-      new CvdLogsHandler(instance_manager));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/logs.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/logs.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <optional>
 #include <string>
 
@@ -31,8 +30,5 @@ class CvdLogsHandler : public CvdCommandHandler {
   bool pretty_;
   bool pager_;
 };
-
-std::unique_ptr<CvdCommandHandler> NewCvdLogsHandler(
-    InstanceManager& instance_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/power_btn.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/power_btn.cpp
@@ -16,13 +16,11 @@
 
 #include "cuttlefish/host/commands/cvd/cli/commands/power_btn.h"
 
-#include <memory>
 #include <string>
 #include <vector>
 
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/host/commands/cvd/instances/instance_manager.h"
@@ -67,12 +65,6 @@ bool CvdDevicePowerBtnCommandHandler::RequiresDeviceExists() const {
 Result<std::string> CvdDevicePowerBtnCommandHandler::DetailedHelp(
     const CommandRequest& request) {
   return kSummaryHelpText;
-}
-
-std::unique_ptr<CvdCommandHandler> NewCvdDevicePowerBtnCommandHandler(
-    InstanceManager& instance_manager) {
-  return std::unique_ptr<CvdCommandHandler>(
-      new CvdDevicePowerBtnCommandHandler(instance_manager));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/power_btn.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/power_btn.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <memory>
 #include <string>
 
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
@@ -41,8 +40,5 @@ class CvdDevicePowerBtnCommandHandler : public CvdCommandHandler {
  private:
   InstanceManager& instance_manager_;
 };
-
-std::unique_ptr<CvdCommandHandler> NewCvdDevicePowerBtnCommandHandler(
-    InstanceManager& instance_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/powerwash.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/powerwash.cpp
@@ -17,14 +17,12 @@
 #include "cuttlefish/host/commands/cvd/cli/commands/powerwash.h"
 
 #include <chrono>
-#include <memory>
 #include <string>
 #include <vector>
 
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/flag_parser/gflags_compat.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/host/commands/cvd/instances/instance_manager.h"
@@ -96,12 +94,6 @@ bool CvdDevicePowerwashCommandHandler::RequiresDeviceExists() const {
 Result<std::string> CvdDevicePowerwashCommandHandler::DetailedHelp(
     const CommandRequest& request) {
   return kDetailedHelpText;
-}
-
-std::unique_ptr<CvdCommandHandler> NewCvdDevicePowerwashCommandHandler(
-    InstanceManager& instance_manager) {
-  return std::unique_ptr<CvdCommandHandler>(
-      new CvdDevicePowerwashCommandHandler(instance_manager));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/powerwash.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/powerwash.h
@@ -16,8 +16,6 @@
 
 #pragma once
 
-#include <memory>
-
 #include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/instances/instance_manager.h"
 
@@ -37,8 +35,5 @@ class CvdDevicePowerwashCommandHandler : public CvdCommandHandler {
  private:
   InstanceManager& instance_manager_;
 };
-
-std::unique_ptr<CvdCommandHandler> NewCvdDevicePowerwashCommandHandler(
-    InstanceManager& instance_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/ps.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/ps.cpp
@@ -21,7 +21,6 @@
 #include <iomanip>
 #include <iostream>
 #include <map>
-#include <memory>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -32,7 +31,6 @@
 
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/host/commands/cvd/instances/instance_database_types.h"
 #include "cuttlefish/host/commands/cvd/instances/instance_manager.h"
@@ -162,12 +160,6 @@ PsRow CvdPsCommandHandler::InstanceToRow(const LocalInstanceGroup& group,
   row[PsColumns::kWebAccess] = web_access_str;
 
   return row;
-}
-
-std::unique_ptr<CvdCommandHandler> NewCvdPsCommandHandler(
-    InstanceManager& instance_manager) {
-  return std::unique_ptr<CvdCommandHandler>(
-      new CvdPsCommandHandler(instance_manager));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/ps.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/ps.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <map>
-#include <memory>
 #include <string>
 
 #include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
@@ -57,8 +56,5 @@ class CvdPsCommandHandler : public CvdCommandHandler {
   PsRow InstanceToRow(const LocalInstanceGroup& group,
                       LocalInstance& instance) const;
 };
-
-std::unique_ptr<CvdCommandHandler> NewCvdPsCommandHandler(
-    InstanceManager& instance_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/remove.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/remove.cpp
@@ -17,7 +17,6 @@
 #include "cuttlefish/host/commands/cvd/cli/commands/remove.h"
 
 #include <chrono>
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -25,7 +24,6 @@
 
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/help_format.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
@@ -99,12 +97,6 @@ Result<void> RemoveCvdCommandHandler::StopGroup(
   CF_EXPECT(instance_manager_.StopInstanceGroup(
       group, std::chrono::seconds(5), InstanceDirActionOnStop::Clear));
   return {};
-}
-
-std::unique_ptr<CvdCommandHandler> NewRemoveCvdCommandHandler(
-    InstanceManager& instance_manager) {
-  return std::unique_ptr<CvdCommandHandler>(
-      new RemoveCvdCommandHandler(instance_manager));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/remove.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/remove.h
@@ -16,7 +16,8 @@
 
 #pragma once
 
-#include <memory>
+#include <string>
+#include <vector>
 
 #include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/instances/instance_manager.h"
@@ -40,8 +41,5 @@ class RemoveCvdCommandHandler : public CvdCommandHandler {
 
   InstanceManager& instance_manager_;
 };
-
-std::unique_ptr<CvdCommandHandler> NewRemoveCvdCommandHandler(
-    InstanceManager& instance_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/reset.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/reset.cpp
@@ -17,18 +17,17 @@
 #include "cuttlefish/host/commands/cvd/cli/commands/reset.h"
 
 #include <ctype.h>
-#include <fmt/format.h>
 
 #include <algorithm>
 #include <iostream>
-#include <memory>
 #include <string>
 #include <vector>
+
+#include "fmt/format.h"
 
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/flag_parser/gflags_compat.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/help_format.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/host/commands/cvd/instances/instance_manager.h"
@@ -143,12 +142,6 @@ Result<std::vector<Flag>> CvdResetCommandHandler::Flags(const CommandRequest&) {
               "Clean up the runtime directory for untracked devices (not "
               "members of any known instance group)");
   return std::vector<Flag>{y_flag, clean_runtime_dir_flag};
-}
-
-std::unique_ptr<CvdCommandHandler> NewCvdResetCommandHandler(
-    InstanceManager& instance_manager) {
-  return std::unique_ptr<CvdCommandHandler>(
-      new CvdResetCommandHandler(instance_manager));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/reset.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/reset.h
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <memory>
 #include <string>
+#include <vector>
 
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
@@ -47,8 +47,5 @@ class CvdResetCommandHandler : public CvdCommandHandler {
   InstanceManager& instance_manager_;
   ResetFlags flags_;
 };
-
-std::unique_ptr<CvdCommandHandler> NewCvdResetCommandHandler(
-    InstanceManager& instance_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/restart.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/restart.cpp
@@ -17,14 +17,12 @@
 #include "cuttlefish/host/commands/cvd/cli/commands/restart.h"
 
 #include <chrono>
-#include <memory>
 #include <string>
 #include <vector>
 
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/flag_parser/gflags_compat.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/host/commands/cvd/instances/instance_manager.h"
@@ -113,12 +111,6 @@ bool CvdDeviceRestartCommandHandler::RequiresDeviceExists() const {
 Result<std::string> CvdDeviceRestartCommandHandler::DetailedHelp(
     const CommandRequest& request) {
   return kDetailedHelpText;
-}
-
-std::unique_ptr<CvdCommandHandler> NewCvdDeviceRestartCommandHandler(
-    InstanceManager& instance_manager) {
-  return std::unique_ptr<CvdCommandHandler>(
-      new CvdDeviceRestartCommandHandler(instance_manager));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/restart.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/restart.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <memory>
 #include <string>
 
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
@@ -27,6 +26,7 @@
 
 namespace cuttlefish {
 
+// restart, powerwash, powerbtn
 class CvdDeviceRestartCommandHandler : public CvdCommandHandler {
  public:
   CvdDeviceRestartCommandHandler(InstanceManager& instance_manager);
@@ -41,9 +41,5 @@ class CvdDeviceRestartCommandHandler : public CvdCommandHandler {
  private:
   InstanceManager& instance_manager_;
 };
-
-// restart, powerwash, powerbtn
-std::unique_ptr<CvdCommandHandler> NewCvdDeviceRestartCommandHandler(
-    InstanceManager& instance_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/screen_recording.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/screen_recording.cpp
@@ -18,7 +18,6 @@
 
 #include <chrono>
 #include <iostream>
-#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -29,7 +28,6 @@
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/flag_parser/gflags_compat.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/host/commands/cvd/instances/instance_manager.h"
@@ -190,12 +188,6 @@ ScreenRecordingCommandHandler::SelectInstances(const CommandRequest& request) {
     return std::pair<LocalInstanceGroup, std::vector<LocalInstance>>(
         group, group.Instances());
   }
-}
-
-std::unique_ptr<CvdCommandHandler> NewScreenRecordingCommandHandler(
-    InstanceManager& instance_manager) {
-  return std::unique_ptr<CvdCommandHandler>(
-      new ScreenRecordingCommandHandler(instance_manager));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/screen_recording.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/screen_recording.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -43,8 +43,5 @@ class ScreenRecordingCommandHandler : public CvdCommandHandler {
 
   InstanceManager& instance_manager_;
 };
-
-std::unique_ptr<CvdCommandHandler> NewScreenRecordingCommandHandler(
-    InstanceManager& instance_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/setup.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/setup.cc
@@ -17,7 +17,6 @@
 #include "cuttlefish/host/commands/cvd/cli/commands/setup.h"
 
 #include <iostream>
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -25,7 +24,6 @@
 
 #include "cuttlefish/common/libs/utils/subprocess.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/help_format.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/host/libs/vm_manager/host_configuration.h"
@@ -89,9 +87,5 @@ std::vector<HelpParagraph> CvdSetupHandler::Description() const {
 bool CvdSetupHandler::RequiresDeviceExists() const { return false; }
 
 bool CvdSetupHandler::RequiresHostConfiguration() const { return false; }
-
-std::unique_ptr<CvdCommandHandler> NewCvdSetupHandler() {
-  return std::unique_ptr<CvdCommandHandler>(new CvdSetupHandler());
-}
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/setup.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/setup.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -40,7 +39,5 @@ class CvdSetupHandler : public CvdCommandHandler {
   bool RequiresDeviceExists() const override;
   bool RequiresHostConfiguration() const override;
 };
-
-std::unique_ptr<CvdCommandHandler> NewCvdSetupHandler();
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/snapshot.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/snapshot.cpp
@@ -20,7 +20,6 @@
 #include <stdlib.h>
 
 #include <iostream>
-#include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -31,7 +30,6 @@
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/subprocess.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/host_tool_target.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
@@ -151,12 +149,6 @@ Result<Command> CvdSnapshotCommandHandler::GenerateCommand(
   };
   Command command = CF_EXPECT(ConstructCommand(construct_cmd_param));
   return command;
-}
-
-std::unique_ptr<CvdCommandHandler> NewCvdSnapshotCommandHandler(
-    InstanceManager& instance_manager) {
-  return std::unique_ptr<CvdCommandHandler>(
-      new CvdSnapshotCommandHandler(instance_manager));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/snapshot.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/snapshot.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <memory>
 #include <string>
 
 #include "cuttlefish/common/libs/utils/subprocess.h"
@@ -26,8 +25,6 @@
 #include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
-
-class CommandRequest;
 
 class CvdSnapshotCommandHandler : public CvdCommandHandler {
  public:
@@ -48,8 +45,5 @@ class CvdSnapshotCommandHandler : public CvdCommandHandler {
 
   InstanceManager& instance_manager_;
 };
-
-std::unique_ptr<CvdCommandHandler> NewCvdSnapshotCommandHandler(
-    InstanceManager& instance_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -55,7 +55,6 @@
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/flag_parser/gflags_compat.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/host_tool_target.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/monitor/monitor.h"
 #include "cuttlefish/host/commands/cvd/cli/help_format.h"
@@ -702,12 +701,6 @@ std::vector<Flag> CvdStartCommandHandler::BuildOwnFlags() {
                            own_flags_.report_anonymous_usage_stats)
               .Help("Report anonymous usage stats. In foreground mode, "
                     "defaults to 'n' if not specified.")};
-}
-
-std::unique_ptr<CvdCommandHandler> NewCvdStartCommandHandler(
-    InstanceManager& instance_manager) {
-  return std::unique_ptr<CvdCommandHandler>(
-      new CvdStartCommandHandler(instance_manager));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <memory>
 #include <optional>
 #include <string>
 
@@ -68,8 +67,5 @@ class CvdStartCommandHandler : public CvdCommandHandler {
     std::optional<std::string> report_anonymous_usage_stats;
   } own_flags_;
 };
-
-std::unique_ptr<CvdCommandHandler> NewCvdStartCommandHandler(
-    InstanceManager& instance_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/status.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/status.cpp
@@ -18,7 +18,6 @@
 
 #include <chrono>
 #include <iostream>
-#include <memory>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -31,7 +30,6 @@
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/flag_parser/gflags_compat.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/host/commands/cvd/cli/utils.h"
@@ -175,12 +173,6 @@ Result<void> CvdStatusCommandHandler::Handle(const CommandRequest& request) {
   }
 
   return {};
-}
-
-std::unique_ptr<CvdCommandHandler> NewCvdStatusCommandHandler(
-    InstanceManager& instance_manager) {
-  return std::unique_ptr<CvdCommandHandler>(
-      new CvdStatusCommandHandler(instance_manager));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/status.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/status.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <memory>
 #include <string>
 
 #include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
@@ -39,8 +38,5 @@ class CvdStatusCommandHandler : public CvdCommandHandler {
  private:
   InstanceManager& instance_manager_;
 };
-
-std::unique_ptr<CvdCommandHandler> NewCvdStatusCommandHandler(
-    InstanceManager& instance_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/stop.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/stop.cpp
@@ -20,7 +20,6 @@
 #include <stdlib.h>
 
 #include <chrono>
-#include <memory>
 #include <optional>
 #include <string>
 #include <utility>
@@ -29,7 +28,6 @@
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/flag_parser/gflags_compat.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/help_format.h"
 #include "cuttlefish/host/commands/cvd/cli/selector/selector.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
@@ -139,12 +137,6 @@ Result<std::vector<Flag>> CvdStopCommandHandler::Flags(const CommandRequest&) {
                 "not delete the original disk images, but reverts any "
                 "changes the instance may have written to disk."),
   };
-}
-
-std::unique_ptr<CvdCommandHandler> NewCvdStopCommandHandler(
-    InstanceManager& instance_manager) {
-  return std::unique_ptr<CvdCommandHandler>(
-      new CvdStopCommandHandler(instance_manager));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/stop.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/stop.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -50,8 +49,5 @@ class CvdStopCommandHandler : public CvdCommandHandler {
 
   InstanceManager& instance_manager_;
 };
-
-std::unique_ptr<CvdCommandHandler> NewCvdStopCommandHandler(
-    InstanceManager& instance_manager);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/version.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/version.cpp
@@ -17,7 +17,6 @@
 #include "cuttlefish/host/commands/cvd/cli/commands/version.h"
 
 #include <iostream>
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -28,7 +27,6 @@
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/flag_parser/gflags_compat.h"
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/command_handler.h"
 #include "cuttlefish/host/commands/cvd/cli/types.h"
 #include "cuttlefish/host/commands/cvd/version/version.h"
 #include "cuttlefish/result/result.h"
@@ -77,10 +75,6 @@ std::string CvdVersionHandler::SummaryHelp() const { return kSummaryHelpText; }
 Result<std::string> CvdVersionHandler::DetailedHelp(
     const CommandRequest& request) {
   return kSummaryHelpText;
-}
-
-std::unique_ptr<CvdCommandHandler> NewCvdVersionHandler() {
-  return std::unique_ptr<CvdCommandHandler>(new CvdVersionHandler());
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/version.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/version.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <memory>
 #include <string>
 
 #include "cuttlefish/host/commands/cvd/cli/command_request.h"
@@ -36,7 +35,5 @@ class CvdVersionHandler : public CvdCommandHandler {
   std::string SummaryHelp() const override;
   Result<std::string> DetailedHelp(const CommandRequest& request) override;
 };
-
-std::unique_ptr<CvdCommandHandler> NewCvdVersionHandler();
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/request_context.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/request_context.cpp
@@ -88,40 +88,55 @@ std::vector<std::string> GetPossibleCommands(
 
 RequestContext::RequestContext(InstanceManager& instance_manager,
                                InstanceLockFileManager& lock_file_manager) {
-  request_handlers_.emplace_back(NewCvdCacheCommandHandler());
+  request_handlers_.emplace_back(std::make_unique<CvdCacheCommandHandler>());
 
-  request_handlers_.emplace_back(NewCvdCreateCommandHandler(instance_manager));
-  request_handlers_.emplace_back(NewCvdDisplayCommandHandler(instance_manager));
-  request_handlers_.emplace_back(NewCvdEnvCommandHandler(instance_manager));
-  request_handlers_.emplace_back(NewCvdFetchCommandHandler());
-  request_handlers_.emplace_back(NewCvdFleetCommandHandler(instance_manager));
-  request_handlers_.emplace_back(NewCvdClearCommandHandler(instance_manager));
   request_handlers_.emplace_back(
-      NewCvdBugreportCommandHandler(instance_manager));
-  request_handlers_.emplace_back(NewCvdStopCommandHandler(instance_manager));
-  request_handlers_.emplace_back(NewCvdHelpHandler(this->request_handlers_));
-  request_handlers_.emplace_back(NewLintCommand());
-  request_handlers_.emplace_back(NewLoadConfigsCommand(instance_manager));
-  request_handlers_.emplace_back(NewLoginCommand());
+      std::make_unique<CvdCreateCommandHandler>(instance_manager));
   request_handlers_.emplace_back(
-      NewCvdDevicePowerBtnCommandHandler(instance_manager));
+      std::make_unique<CvdDisplayCommandHandler>(instance_manager));
   request_handlers_.emplace_back(
-      NewCvdDevicePowerwashCommandHandler(instance_manager));
-  request_handlers_.emplace_back(NewCvdMonitorCommandHandler(instance_manager));
+      std::make_unique<CvdEnvCommandHandler>(instance_manager));
+  request_handlers_.emplace_back(std::make_unique<CvdFetchCommandHandler>());
   request_handlers_.emplace_back(
-      NewCvdDeviceRestartCommandHandler(instance_manager));
-  request_handlers_.emplace_back(NewRemoveCvdCommandHandler(instance_manager));
-  request_handlers_.emplace_back(NewCvdResetCommandHandler(instance_manager));
+      std::make_unique<CvdFleetCommandHandler>(instance_manager));
   request_handlers_.emplace_back(
-      NewScreenRecordingCommandHandler(instance_manager));
+      std::make_unique<CvdClearCommandHandler>(instance_manager));
   request_handlers_.emplace_back(
-      NewCvdSnapshotCommandHandler(instance_manager));
-  request_handlers_.emplace_back(NewCvdSetupHandler());
-  request_handlers_.emplace_back(NewCvdStartCommandHandler(instance_manager));
-  request_handlers_.emplace_back(NewCvdStatusCommandHandler(instance_manager));
-  request_handlers_.emplace_back(NewCvdPsCommandHandler(instance_manager));
-  request_handlers_.emplace_back(NewCvdVersionHandler());
-  request_handlers_.emplace_back(NewCvdLogsHandler(instance_manager));
+      std::make_unique<CvdBugreportCommandHandler>(instance_manager));
+  request_handlers_.emplace_back(
+      std::make_unique<CvdStopCommandHandler>(instance_manager));
+  request_handlers_.emplace_back(
+      std::make_unique<CvdHelpHandler>(this->request_handlers_));
+  request_handlers_.emplace_back(std::make_unique<LintCommandHandler>());
+  request_handlers_.emplace_back(
+      std::make_unique<LoadConfigsCommand>(instance_manager));
+  request_handlers_.emplace_back(std::make_unique<CvdLoginCommand>());
+  request_handlers_.emplace_back(
+      std::make_unique<CvdDevicePowerBtnCommandHandler>(instance_manager));
+  request_handlers_.emplace_back(
+      std::make_unique<CvdDevicePowerwashCommandHandler>(instance_manager));
+  request_handlers_.emplace_back(
+      std::make_unique<CvdMonitorCommandHandler>(instance_manager));
+  request_handlers_.emplace_back(
+      std::make_unique<CvdDeviceRestartCommandHandler>(instance_manager));
+  request_handlers_.emplace_back(
+      std::make_unique<RemoveCvdCommandHandler>(instance_manager));
+  request_handlers_.emplace_back(
+      std::make_unique<CvdResetCommandHandler>(instance_manager));
+  request_handlers_.emplace_back(
+      std::make_unique<ScreenRecordingCommandHandler>(instance_manager));
+  request_handlers_.emplace_back(
+      std::make_unique<CvdSnapshotCommandHandler>(instance_manager));
+  request_handlers_.emplace_back(std::make_unique<CvdSetupHandler>());
+  request_handlers_.emplace_back(
+      std::make_unique<CvdStartCommandHandler>(instance_manager));
+  request_handlers_.emplace_back(
+      std::make_unique<CvdStatusCommandHandler>(instance_manager));
+  request_handlers_.emplace_back(
+      std::make_unique<CvdPsCommandHandler>(instance_manager));
+  request_handlers_.emplace_back(std::make_unique<CvdVersionHandler>());
+  request_handlers_.emplace_back(
+      std::make_unique<CvdLogsHandler>(instance_manager));
 }
 
 Result<CvdCommandHandler*> RequestContext::Handler(


### PR DESCRIPTION
[PR 2562](https://www.github.com/google/android-cuttlefish/pull/2562) moved the `CommandHandler` subclasses to header files. The headers previously exposed `New*` functions to create the `CommandHandler` types, but these are redundant now that the constructor functions are themselves `public`.

Bug: b/531857302