### PR TITLE
podcvd: Support trusted TLS for operator on container instances

### DIFF
--- a/container/debian/control
+++ b/container/debian/control
@@ -14,6 +14,7 @@ Depends: acl,
          adb,
          android-sdk-platform-tools-common,
          crun,
+         mkcert,
          podman (>= 4.4),
          yq,
 Pre-Depends: ${misc:Pre-Depends}

--- a/container/debian/cuttlefish-podcvd.cuttlefish-podcvd.init
+++ b/container/debian/cuttlefish-podcvd.cuttlefish-podcvd.init
@@ -33,6 +33,31 @@ podcvd_cidr=${podcvd_cidr:-192.168.112.0/20}
 
 podcvd_ifname="podcvd"
 
+gen_cert() {
+    local CA_DIR="/etc/cuttlefish-podcvd/ca"
+    local PUB_DIR="/etc/cuttlefish-podcvd/pub"
+    local CERT_DIR="/etc/cuttlefish-podcvd"
+    mkdir -p "$CA_DIR" "$PUB_DIR" "$CERT_DIR"
+    CAROOT="$CA_DIR" mkcert -install >/dev/null
+    ln -sf "$CA_DIR/rootCA.pem" "$PUB_DIR/rootCA.pem"
+
+    # Generate server certificates
+    local ip mask a b c d
+    IFS='/ ' read -r ip mask <<< "$podcvd_cidr"
+    IFS='.' read -r a b c d <<< "$ip"
+    local num_subnets=$(( 2 ** (24 - mask) ))
+    local start_c=$(( c & ~ (num_subnets - 1) ))
+    local end_c=$(( start_c + num_subnets - 1 ))
+    local ips=("127.0.0.1" "localhost")
+    for ((i=start_c; i<=end_c; i++)); do
+        for j in {0..255}; do
+            ips+=("${a}.${b}.${i}.${j}")
+        done
+    done
+    CAROOT="$CA_DIR" mkcert -cert-file "$CERT_DIR/cert.pem" -key-file "$CERT_DIR/key.pem" "${ips[@]}" >/dev/null
+    chmod 644 "$CERT_DIR/cert.pem" "$CERT_DIR/key.pem"
+}
+
 start() {
     modprobe vhost_net || true
     modprobe vhost_vsock || true
@@ -40,6 +65,8 @@ start() {
     ip link add "${podcvd_ifname}" type dummy
     ip link set "${podcvd_ifname}" up
     ip route add local "${podcvd_cidr}" dev "${podcvd_ifname}"
+
+    gen_cert
 }
 
 stop() {

--- a/container/debian/cuttlefish-podcvd.postrm
+++ b/container/debian/cuttlefish-podcvd.postrm
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = "purge" ]; then
+    CAROOT=/etc/cuttlefish-podcvd/ca mkcert -uninstall >/dev/null 2>&1 || true
+    rm -rf /etc/cuttlefish-podcvd
+fi
+
+#DEBHELPER#

--- a/container/debian/podcvd-setup
+++ b/container/debian/podcvd-setup
@@ -186,6 +186,11 @@ setup_nvidia_gpu() {
     done
 }
 
+trust_ca_in_browsers() {
+    echo "Registering Podcvd Root CA into browser trust stores..."
+    sudo -H -u "$username" TRUST_STORES="nss" CAROOT="/etc/cuttlefish-podcvd/pub" mkcert -install >/dev/null
+}
+
 USER_CONFIG="/etc/podcvd.users"
 username="${1:-${SUDO_USER:-$(id -un)}}"
 if [ -z "$username" ] || ! id "$username" >/dev/null 2>&1; then
@@ -202,5 +207,6 @@ setup_device_permissions
 setup_rootless_podman
 # This is working only when both nvidia-smi and nvidia-ctk works fine.
 setup_nvidia_gpu || echo "Skipping NVIDIA GPU setup."
+trust_ca_in_browsers
 
 echo "Setup complete! You can now run 'podcvd'."

--- a/container/src/podcvd/internal/host.go
+++ b/container/src/podcvd/internal/host.go
@@ -267,6 +267,8 @@ func collectMountSpecs(pathsToMount []string, hostOut, productOut, cvdDataHome, 
 	bindMap["/root/.local/share/cvd"] = fmt.Sprintf("%s:/root/.local/share/cvd:ro", cvdDataHome)
 	bindMap["/podcvd_home"] = fmt.Sprintf("%s:/podcvd_home:rw", podcvdHomeDir)
 	bindMap["/var/tmp/cvd/0/cache"] = fmt.Sprintf("%s:/var/tmp/cvd/0/cache:rw", cacheDir)
+	bindMap["/etc/cuttlefish-common/operator/cert/cert.pem"] = "/etc/cuttlefish-podcvd/cert.pem:/etc/cuttlefish-common/operator/cert/cert.pem:ro"
+	bindMap["/etc/cuttlefish-common/operator/cert/key.pem"] = "/etc/cuttlefish-podcvd/key.pem:/etc/cuttlefish-common/operator/cert/key.pem:ro"
 	for _, p := range pathsToMount {
 		if spec, ok := bindMap[p]; ok {
 			host := strings.SplitN(spec, ":", 2)[0]


### PR DESCRIPTION
Accessing operator living in container instances by chrome browser(or any other browsers perhaps) is so annoying, as certification procedure is not prepared so that the browser displays the warning message in advance of accessing the operator. This is even worse experience than operator working with `cvd`, as the lifecycle of operator is not permanent, but bound to the container's lifecycle.

Context: b/532008913