### PR TITLE
Do not launch WebRtcServer for GpuMode::None

### DIFF
--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/streamer.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/streamer.cpp
@@ -265,7 +265,7 @@ class WebRtcServer : public virtual CommandSource,
 
   // SetupFeature
   bool Enabled() const override {
-    return sockets_.Enabled() &&
+    return sockets_.Enabled() && instance_.gpu_mode() != GpuMode::None &&
            (VmManagerIsCrosvm(config_) || VmManagerIsQemu(config_));
   }
 


### PR DESCRIPTION
When instance.gpu_mode() is GpuMode::None (headless mode), ScreenConnector explicitly rejects initialization and aborts process execution with: LOG(FATAL) << "Invalid gpu mode: none".

Commit 63c95186c ("Remove the start_webrtc flag behavior") inadvertently caused WebRtcServer to launch even when `start_webrtc` is explicitly set to `false` on sdv_core targets. To fix this issue, let's skip enabling WebRtcServer whenever instance_.gpu_mode() == GpuMode::None.

Bug: b/532203075