### PR TITLE
Create 1.56.2 release

### DIFF
--- a/base/cvd/cuttlefish/host/commands/start/main.cc
+++ b/base/cvd/cuttlefish/host/commands/start/main.cc
@@ -15,7 +15,6 @@
 
 #include <unistd.h>
 
-#include <iostream>
 #include <optional>
 #include <sstream>
 #include <unordered_set>
@@ -210,10 +209,18 @@ Result<void> LinkLogs2InstanceDir(
 }
 
 bool ParentIsCvd() {
-  const std::string exe_link = absl::StrCat("/proc/", getppid(), "/exe");
+  const std::string ppid_path = absl::StrCat("/proc/", getppid());
+  const std::string exe_link = absl::StrCat(ppid_path, "/exe");
   const Result<std::string> exe_path = ReadLink(exe_link);
-  CHECK(exe_path.ok()) << exe_path.error();
-  return exe_path->ends_with("/cvd");
+  if (exe_path.ok()) {
+    return exe_path->ends_with("/cvd");
+  }
+  const std::string cmdline_path = absl::StrCat(ppid_path, "/cmdline");
+  Result<std::string> cmdline_res = ReadFileContents(cmdline_path);
+  CHECK(cmdline_res.ok()) << cmdline_res.error();
+  std::vector<std::string> cmdline = absl::StrSplit(*cmdline_res, '\0');
+  CHECK(!cmdline.empty());
+  return cmdline[0] == "cvd" || cmdline[0].ends_with("/cvd");
 }
 
 std::string CvdPath() {

--- a/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
@@ -43,6 +43,7 @@ cf_cc_library(
         "//cuttlefish/result",
         "//libbase",
         "@abseil-cpp//absl/log",
+        "@abseil-cpp//absl/log:check",
         "@jsoncpp",
     ],
 )

--- a/base/cvd/cuttlefish/host/libs/web/android_build_api.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_api.cpp
@@ -16,12 +16,17 @@
 #include "cuttlefish/host/libs/web/android_build_api.h"
 
 #include <dirent.h>
+#include <time.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <chrono>
+#include <iomanip>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <set>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -31,6 +36,7 @@
 #include <variant>
 #include <vector>
 
+#include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "android-base/file.h"
 #include "json/value.h"
@@ -82,6 +88,15 @@ Result<Json::Value> GetResponseJson(const HttpResponse<Json::Value>& response,
             "Response was successful, but contains error information.  Check "
             "log file for full response.");
   return response.data;
+}
+
+Result<std::chrono::system_clock::time_point> ParseTime(std::string_view str) {
+  std::stringstream stream = std::stringstream(std::string(str));
+  tm time_tm;
+  stream >> std::get_time(&time_tm, "%Y-%m-%dT%H:%M:%S.");
+  CF_EXPECTF(!!stream, "Failed to parse time '{}'", str);
+
+  return std::chrono::system_clock::from_time_t(mktime(&time_tm));
 }
 
 }  // namespace
@@ -263,6 +278,12 @@ Result<std::vector<std::string>> AndroidBuildApi::Headers() {
 
 Result<std::optional<std::string>> AndroidBuildApi::LatestBuildId(
     const std::string& branch, const std::string& target) {
+  struct CandidateBuild {
+    std::string build_id;
+    std::chrono::system_clock::time_point creation_time;
+  };
+  // Find the latest build at every safe level
+  std::vector<CandidateBuild> candidates;
   for (const SafeLevel safe_level : kAllSafeLevels) {
     VLOG(0) << "Attempting to download build at safe level '" << safe_level
             << "' for branch '" << branch << "' and target '" << target << "'";
@@ -276,7 +297,7 @@ Result<std::optional<std::string>> AndroidBuildApi::LatestBuildId(
     if (!json_res.ok()) {
       continue;
     }
-    const Json::Value json = *json_res;
+    const Json::Value& json = *json_res;
 
     if (!json.isMember("builds")) {
       continue;
@@ -287,9 +308,29 @@ Result<std::optional<std::string>> AndroidBuildApi::LatestBuildId(
                "target \"{}\" in the response array, "
                "but found {}",
                branch, target, json["builds"].size());
-    return CF_EXPECT(GetValue<std::string>(json["builds"][0], {"buildId"}));
+
+    const Json::Value& build = json["builds"][0];
+    const std::string& completion = build["completionTimestamp"].asString();
+    candidates.emplace_back(CandidateBuild{
+        .build_id = build["buildId"].asString(),
+        .creation_time = CF_EXPECT(ParseTime(completion)),
+    });
   }
-  return std::nullopt;
+  if (candidates.empty()) {
+    return std::nullopt;
+  }
+  // Drop candidate builds 1 week older than the latest
+  auto creation = [](const auto& cd) { return cd.creation_time; };
+  std::chrono::system_clock::time_point latest =
+      std::ranges::max(std::views::transform(candidates, creation));
+  auto recent = [latest](const auto& cd) {
+    // NOLINTNEXTLINE(misc-include-cleaner): <chrono>
+    return latest - cd.creation_time < std::chrono::weeks(1);
+  };
+  // Return the first valid build (which will have the highest safe level)
+  auto it = std::find_if(candidates.begin(), candidates.end(), recent);
+  CHECK(it != candidates.end());
+  return it->build_id;
 }
 
 Result<std::unordered_set<std::string>> AndroidBuildApi::Artifacts(

--- a/base/debian/changelog
+++ b/base/debian/changelog
@@ -1,8 +1,15 @@
-cuttlefish-common (1.56.1) UNRELEASED; urgency=medium
+cuttlefish-common (1.56.2) unstable; urgency=medium
+
+  * Fallback to looking at the parent process cmdline if parent process exe is locked down by @Databean in https://github.com/google/android-cuttlefish/pull/2804
+  * Ignore ancient builds with higher safe levels by @Databean in https://github.com/google/android-cuttlefish/pull/2776
+
+ -- Cody Schuffelen <schuffelen@google.com>  Tue, 07 Jul 2026 14:09:33 -0700
+
+cuttlefish-common (1.56.1) unstable; urgency=medium
 
   * Revert substitute-all logic
 
- -- Cody Schuffelen <schuffelen@google.com>  Thu, 25 Jun 2026 20:44:43 -0700
+ -- Cody Schuffelen <schuffelen@google.com>  Tue, 07 Jul 2026 14:07:37 -0700
 
 cuttlefish-common (1.56.0) unstable; urgency=medium
 

--- a/container/debian/changelog
+++ b/container/debian/changelog
@@ -1,8 +1,14 @@
-cuttlefish-container (1.56.1) UNRELEASED; urgency=medium
+cuttlefish-container (1.56.2) unstable; urgency=medium
 
   * N/A
 
- -- Cody Schuffelen <schuffelen@google.com>  Thu, 25 Jun 2026 20:45:16 -0700
+ -- Cody Schuffelen <schuffelen@google.com>  Tue, 07 Jul 2026 14:11:11 -0700
+
+cuttlefish-container (1.56.1) unstable; urgency=medium
+
+  * N/A
+
+ -- Cody Schuffelen <schuffelen@google.com>  Tue, 07 Jul 2026 14:08:00 -0700
 
 cuttlefish-container (1.56.0) unstable; urgency=medium
 

--- a/cuttlefish-integration-gigabyte-arm64/debian/changelog
+++ b/cuttlefish-integration-gigabyte-arm64/debian/changelog
@@ -1,8 +1,14 @@
-cuttlefish-integration-gigabyte-arm64 (1.56.1) UNRELEASED; urgency=medium
+cuttlefish-integration-gigabyte-arm64 (1.56.2) unstable; urgency=medium
 
   * N/A
 
- -- Cody Schuffelen <schuffelen@google.com>  Thu, 25 Jun 2026 20:45:33 -0700
+ -- Cody Schuffelen <schuffelen@google.com>  Tue, 07 Jul 2026 14:11:31 -0700
+
+cuttlefish-integration-gigabyte-arm64 (1.56.1) unstable; urgency=medium
+
+  * N/A
+
+ -- Cody Schuffelen <schuffelen@google.com>  Tue, 07 Jul 2026 14:07:55 -0700
 
 cuttlefish-integration-gigabyte-arm64 (1.56.0) unstable; urgency=medium
 

--- a/frontend/debian/changelog
+++ b/frontend/debian/changelog
@@ -1,8 +1,14 @@
-cuttlefish-frontend (1.56.1) UNRELEASED; urgency=medium
+cuttlefish-frontend (1.56.2) unstable; urgency=medium
 
   * N/A
 
- -- Cody Schuffelen <schuffelen@google.com>  Thu, 25 Jun 2026 20:45:02 -0700
+ -- Cody Schuffelen <schuffelen@google.com>  Tue, 07 Jul 2026 14:11:53 -0700
+
+cuttlefish-frontend (1.56.1) unstable; urgency=medium
+
+  * N/A
+
+ -- Cody Schuffelen <schuffelen@google.com>  Tue, 07 Jul 2026 14:08:08 -0700
 
 cuttlefish-frontend (1.56.0) unstable; urgency=medium
 


### PR DESCRIPTION
Includes cherry-picks:

- Ignore ancient builds with higher safe levels
- Fallback to looking at the parent process cmdline if parent process exe is locked down

Bug: b/528079156
