### PR TITLE
Revert "Disable all Kokoro test cases which requires ab"

### DIFF
--- a/tools/testutils/runcvde2etests.sh
+++ b/tools/testutils/runcvde2etests.sh
@@ -23,10 +23,6 @@ while getopts "g" opt; do
   esac
 done
 
-# TODO(b/532409657): Disable all test cases requiring ab for a moment as
-# they're not working.
-bazel_test_tag_filter_arg+=",-requires_ab"
-
 function gather_test_results() {
   # Don't immediately exit on error anymore
   set +e


### PR DESCRIPTION
This reverts commit 40aed894992b6c6d992dd3613fbd9bc1b5790545.

When everything goes again, we could enable Kokoro tests requiring ab again.