### PR TITLE
Attempt suppressing a trace on boot failure.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -448,6 +448,9 @@ Result<void> CvdStartCommandHandler::LaunchDevice(
     // run_cvd processes may be still running in background
     // the order of the following operations should be kept
     CF_EXPECT(CvdResetGroup(group));
+
+    GatherVmBootCompleteMetrics(group);
+    return CF_ERR("Device launch failed.");
   }
   CF_EXPECT(CheckProcessExitedNormally(infop));
   GatherVmBootCompleteMetrics(group);


### PR DESCRIPTION
When a boot fails, we print a trace saying that run_cvd failed. This isn't strictly necessary or informative, so attempt to suppress this by just returning a CF_ERR instead of CF_EXPECT'ing that the executable returned successfully -- because we already know it didn't.