### PR TITLE
Install `aapt` in container image used for running e2e tests.

### DIFF
--- a/tools/testutils/cw/Containerfile
+++ b/tools/testutils/cw/Containerfile
@@ -6,6 +6,9 @@ ENV OVERRIDE_BAZEL_WRAPPER_DOWNLOAD_DIR=/tmp/cw_bazel
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y sudo systemd init systemd-journal-remote nginx jq adb
 
+# Packages needed to run CTS
+RUN apt-get install -y aapt
+
 RUN groupadd kvm
 COPY tools/testutils/cw/setup.service /etc/systemd/system/setup.service
 RUN systemctl enable setup


### PR DESCRIPTION
- `aapt` is required to run CTS tests.

Bug: b/502639876