### PR TITLE
Don't show monitor errors for a missing `assemble_cvd.log`

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/BUILD.bazel
@@ -152,6 +152,7 @@ cf_cc_library(
         "//cuttlefish/host/commands/cvd/cli:utils",
         "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/libs/log_names",
+        "//cuttlefish/io:in_memory",
         "//cuttlefish/io:shared_fd",
         "//cuttlefish/result",
         "@abseil-cpp//absl/strings",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/monitor.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/monitor.cc
@@ -41,6 +41,7 @@
 #include "cuttlefish/host/commands/cvd/cli/utils.h"
 #include "cuttlefish/host/commands/cvd/instances/local_instance.h"
 #include "cuttlefish/host/libs/log_names/log_names.h"
+#include "cuttlefish/io/in_memory.h"
 #include "cuttlefish/io/shared_fd.h"
 #include "cuttlefish/result/result.h"
 
@@ -165,7 +166,12 @@ Result<void> MonitorLogs(const LocalInstance& instance, SharedFD stop_eventfd) {
       kernel_lines = total_content / 3;
       logcat_lines = total_content - launcher_lines - kernel_lines;
     }
-    display.DrawFile(SharedFdIo(launcher_fd), launcher_name, launcher_lines);
+    if (!FileExists(assemble_log)) {
+      display.DrawFile(*InMemoryIo("Waiting for assemble_cvd.log creation"),
+                       launcher_name, launcher_lines);
+    } else {
+      display.DrawFile(SharedFdIo(launcher_fd), launcher_name, launcher_lines);
+    }
     display.DrawFile(SharedFdIo(kernel_fd), kLogNameKernel, kernel_lines);
     display.DrawFile(SharedFdIo(logcat_fd), kLogNameLogcat, logcat_lines);
 


### PR DESCRIPTION
This file is expected to be missing until the device starts launching.

Bug: b/533115150