### PR TITLE
Define a `should_color` library and use it

### DIFF
--- a/base/cvd/cuttlefish/ansi_codes/BUILD.bazel
+++ b/base/cvd/cuttlefish/ansi_codes/BUILD.bazel
@@ -14,6 +14,15 @@ cf_cc_library(
 )
 
 cf_cc_library(
+    name = "should_color",
+    srcs = ["should_color.cc"],
+    hdrs = ["should_color.h"],
+    deps = [
+        "//cuttlefish/common/libs/utils:environment",
+    ],
+)
+
+cf_cc_library(
     name = "terminal_colors",
     srcs = ["terminal_colors.cc"],
     hdrs = ["terminal_colors.h"],

--- a/base/cvd/cuttlefish/ansi_codes/should_color.cc
+++ b/base/cvd/cuttlefish/ansi_codes/should_color.cc
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/ansi_codes/should_color.h"
+
+#include <unistd.h>
+
+#include "cuttlefish/common/libs/utils/environment.h"
+
+namespace cuttlefish {
+namespace {
+
+bool ColorDefault(int fd) {
+  // https://no-color.org/
+  if (!StringFromEnv("NO_COLOR").value_or("").empty()) {
+    return false;
+  }
+  // https://force-color.org/
+  if (!StringFromEnv("FORCE_COLOR").value_or("").empty()) {
+    return true;
+  }
+  return isatty(fd);
+}
+
+}  // namespace
+
+bool ShouldColorStdout() { return ColorDefault(STDOUT_FILENO); }
+
+bool ShouldColorStderr() { return ColorDefault(STDERR_FILENO); }
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/ansi_codes/should_color.h
+++ b/base/cvd/cuttlefish/ansi_codes/should_color.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace cuttlefish {
+
+bool ShouldColorStdout();
+bool ShouldColorStderr();
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/BUILD.bazel
@@ -30,6 +30,7 @@ cf_cc_binary(
     srcs = ["main.cc"],
     deps = [
         ":libcvd",
+        "//cuttlefish/ansi_codes:should_color",
         "//cuttlefish/ansi_codes:terminal_colors",
         "//cuttlefish/common/libs/utils:environment",
         "//cuttlefish/common/libs/utils:files",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/BUILD.bazel
@@ -33,6 +33,7 @@ cf_cc_library(
         ":log_tee",
         ":logcat",
         ":truncate",
+        "//cuttlefish/ansi_codes:should_color",
         "//cuttlefish/common/libs/utils:environment",
         "//cuttlefish/common/libs/utils:tee_logging",
         "//cuttlefish/host/libs/log_names",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/display.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/display.cc
@@ -18,7 +18,6 @@
 
 #include <stdint.h>
 #include <sys/types.h>
-#include <unistd.h>
 
 #include <algorithm>
 #include <cstddef>
@@ -35,7 +34,7 @@
 #include "absl/strings/str_replace.h"
 #include "absl/strings/str_split.h"
 
-#include "cuttlefish/common/libs/utils/environment.h"
+#include "cuttlefish/ansi_codes/should_color.h"
 #include "cuttlefish/common/libs/utils/tee_logging.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/monitor/kernel.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/monitor/launcher.h"
@@ -86,17 +85,10 @@ Result<std::vector<std::string>> GetLastNLines(ReaderSeeker& rs, size_t n) {
   return all_lines;
 }
 
-bool ShouldColorizeOutput(int fd) {
-  return !StringFromEnv("NO_COLOR").has_value() &&
-         (StringFromEnv("FORCE_COLOR").has_value() || isatty(fd));
-}
-
 }  // namespace
 
 LogMonitorDisplay::LogMonitorDisplay(size_t width)
-    : width_(width),
-      total_lines_drawn_(0),
-      colorize_(ShouldColorizeOutput(1)) {}
+    : width_(width), total_lines_drawn_(0), colorize_(ShouldColorStdout()) {}
 
 void LogMonitorDisplay::DrawFile(ReaderSeeker& rs, const std::string& title,
                                  size_t max_lines) {

--- a/base/cvd/cuttlefish/host/commands/cvd/main.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/main.cc
@@ -32,6 +32,7 @@
 #include "android-base/file.h"
 #include "fmt/format.h"
 
+#include "cuttlefish/ansi_codes/should_color.h"
 #include "cuttlefish/ansi_codes/terminal_colors.h"
 #include "cuttlefish/common/libs/utils/environment.h"
 #include "cuttlefish/common/libs/utils/files.h"
@@ -168,7 +169,7 @@ Result<void> CvdMain(cvd_common::Args all_args) {
  * is red.
  */
 std::string ColoredUrl(const std::string& url) {
-  if (!isatty(STDERR_FILENO)) {
+  if (!ShouldColorStderr()) {
     return url;
   }
   std::string coloring_prefix = "\033[01;31m";
@@ -236,7 +237,7 @@ int main(int argc, char** argv) {
     return 0;
   } else if (log_file.has_value() && isatty(2)) {
     VLOG(0) << result.error();
-    cuttlefish::TerminalColors colors(isatty(2));
+    cuttlefish::TerminalColors colors(cuttlefish::ShouldColorStderr());
     std::cerr << colors.Red() << "'cvd' encountered an error." << colors.Reset()
               << " Please see '" << colors.Cyan() << *log_file << colors.Reset()
               << "' for the complete failure report.\n";

--- a/base/cvd/cuttlefish/host/commands/run_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/BUILD.bazel
@@ -46,6 +46,7 @@ cf_cc_library(
     hdrs = ["reporting.h"],
     deps = [
         "//cuttlefish/ansi_codes",
+        "//cuttlefish/ansi_codes:should_color",
         "//libbase",
         "@abseil-cpp//absl/log",
         "@fruit",

--- a/base/cvd/cuttlefish/host/commands/run_cvd/reporting.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/reporting.cpp
@@ -21,6 +21,7 @@
 #include "absl/log/log.h"
 
 #include "cuttlefish/ansi_codes/ansi_codes.h"
+#include "cuttlefish/ansi_codes/should_color.h"
 
 namespace cuttlefish {
 
@@ -28,11 +29,20 @@ DiagnosticInformation::~DiagnosticInformation() = default;
 
 void DiagnosticInformation::PrintAll(
     const std::vector<DiagnosticInformation*>& infos) {
-  LOG(INFO) << kAnsiGreen << "  Run `cvd logs` to report paths to device logs."
-            << kAnsiReset;
+  static constexpr char kCvdLogsMsg[] =
+      "  Run `cvd logs` to report paths to device logs.";
+  if (ShouldColorStderr()) {
+    LOG(INFO) << kAnsiGreen << kCvdLogsMsg << kAnsiReset;
+  } else {
+    LOG(INFO) << kCvdLogsMsg;
+  }
   for (const auto& info : infos) {
     for (const auto& line : info->Diagnostics()) {
-      LOG(INFO) << kAnsiGreen << "  " << line << kAnsiReset;
+      if (ShouldColorStderr()) {
+        LOG(INFO) << kAnsiGreen << "  " << line << kAnsiReset;
+      } else {
+        LOG(INFO) << "  " << line;
+      }
     }
   }
 }

--- a/base/cvd/cuttlefish/result/BUILD.bazel
+++ b/base/cvd/cuttlefish/result/BUILD.bazel
@@ -10,6 +10,7 @@ cf_cc_library(
     hdrs = ["error_type.h"],
     deps = [
         "//cuttlefish/ansi_codes",
+        "//cuttlefish/ansi_codes:should_color",
         "//libbase",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/strings",

--- a/base/cvd/cuttlefish/result/error_type.h
+++ b/base/cvd/cuttlefish/result/error_type.h
@@ -27,6 +27,8 @@
 #include "android-base/expected.h"  // IWYU pragma: export
 #include "fmt/core.h"               // IWYU pragma: export
 
+#include "cuttlefish/ansi_codes/should_color.h"
+
 namespace cuttlefish {
 
 class StackTraceError;
@@ -188,7 +190,7 @@ class StackTraceError {
 
   std::string Trace() const { return fmt::format(fmt::runtime("{:v}"), *this); }
 
-  std::string FormatForEnv(bool color = (isatty(STDERR_FILENO) == 1)) const {
+  std::string FormatForEnv(bool color = ShouldColorStdout()) const {
     return fmt::format(fmt::runtime(ResultErrorFormat(color)), *this);
   }
 


### PR DESCRIPTION
Honors NO_COLOR, FORCE_COLOR, and defaults to whether the terminal is
interactive.

Bug: b/533162913