### PR TITLE
Split //cuttlefish/host/libs/wayland

### DIFF
--- a/base/cvd/cuttlefish/host/libs/screen_connector/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/screen_connector/BUILD.bazel
@@ -48,7 +48,7 @@ cf_cc_library(
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:gpu_mode",
         "//cuttlefish/host/libs/confui:host_confui",
-        "//cuttlefish/host/libs/wayland:cuttlefish_wayland_server",
+        "//cuttlefish/host/libs/wayland:wayland_server",
         "//cuttlefish/host/libs/wayland:wayland_server_callbacks",
         "//cuttlefish/result",
         "//libbase",

--- a/base/cvd/cuttlefish/host/libs/screen_connector/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/screen_connector/BUILD.bazel
@@ -49,6 +49,7 @@ cf_cc_library(
         "//cuttlefish/host/libs/config:gpu_mode",
         "//cuttlefish/host/libs/confui:host_confui",
         "//cuttlefish/host/libs/wayland:cuttlefish_wayland_server",
+        "//cuttlefish/host/libs/wayland:wayland_server_callbacks",
         "//cuttlefish/result",
         "//libbase",
         "@abseil-cpp//absl/log",

--- a/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
@@ -22,7 +22,6 @@ cf_cc_library(
         "wayland_server.h",
         "wayland_surface.h",
         "wayland_surfaces.h",
-        "wayland_utils.h",
         "wayland_virtio_gpu_metadata.h",
     ],
     deps = [
@@ -30,6 +29,7 @@ cf_cc_library(
         "//cuttlefish/host/libs/wayland:wayland_server_callbacks",
         "//cuttlefish/host/libs/wayland:wayland_shell",
         "//cuttlefish/host/libs/wayland:wayland_subcompositor",
+        "//cuttlefish/host/libs/wayland:wayland_utils",
         "//libbase",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/log:check",
@@ -62,6 +62,15 @@ cf_cc_library(
     hdrs = ["wayland_subcompositor.h"],
     deps = [
         "@abseil-cpp//absl/log",
+        "@wayland//:wayland_server",
+    ],
+)
+
+cf_cc_library(
+    name = "wayland_utils",
+    hdrs = ["wayland_utils.h"],
+    deps = [
+        "@abseil-cpp//absl/log:check",
         "@wayland//:wayland_server",
     ],
 )

--- a/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
@@ -9,15 +9,11 @@ cf_cc_library(
     srcs = [
         "wayland_compositor.cpp",
         "wayland_server.cpp",
-        "wayland_surface.cpp",
-        "wayland_surfaces.cpp",
         "wayland_virtio_gpu_metadata.cpp",
     ],
     hdrs = [
         "wayland_compositor.h",
         "wayland_server.h",
-        "wayland_surface.h",
-        "wayland_surfaces.h",
         "wayland_virtio_gpu_metadata.h",
     ],
     deps = [
@@ -27,6 +23,7 @@ cf_cc_library(
         "//cuttlefish/host/libs/wayland:wayland_server_callbacks",
         "//cuttlefish/host/libs/wayland:wayland_shell",
         "//cuttlefish/host/libs/wayland:wayland_subcompositor",
+        "//cuttlefish/host/libs/wayland:wayland_surface",
         "//cuttlefish/host/libs/wayland:wayland_utils",
         "//libbase",
         "@abseil-cpp//absl/log",
@@ -84,6 +81,27 @@ cf_cc_library(
     hdrs = ["wayland_subcompositor.h"],
     deps = [
         "@abseil-cpp//absl/log",
+        "@wayland//:wayland_server",
+    ],
+)
+
+cf_cc_library(
+    name = "wayland_surface",
+    srcs = [
+        "wayland_surface.cpp",
+        "wayland_surfaces.cpp",
+    ],
+    hdrs = [
+        "wayland_surface.h",
+        "wayland_surfaces.h",
+    ],
+    deps = [
+        "//cuttlefish/host/libs/wayland:wayland_dmabuf",
+        "//cuttlefish/host/libs/wayland:wayland_server_callbacks",
+        "//cuttlefish/host/libs/wayland:wayland_utils",
+        "@abseil-cpp//absl/log",
+        "@abseil-cpp//absl/log:check",
+        "@libdrm//:libdrm_fourcc",
         "@wayland//:wayland_server",
     ],
 )

--- a/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
@@ -9,12 +9,10 @@ cf_cc_library(
     srcs = [
         "wayland_compositor.cpp",
         "wayland_server.cpp",
-        "wayland_virtio_gpu_metadata.cpp",
     ],
     hdrs = [
         "wayland_compositor.h",
         "wayland_server.h",
-        "wayland_virtio_gpu_metadata.h",
     ],
     deps = [
         "//cuttlefish/common/libs/fs",
@@ -25,6 +23,7 @@ cf_cc_library(
         "//cuttlefish/host/libs/wayland:wayland_subcompositor",
         "//cuttlefish/host/libs/wayland:wayland_surface",
         "//cuttlefish/host/libs/wayland:wayland_utils",
+        "//cuttlefish/host/libs/wayland:wayland_virtio_gpu_metadata",
         "//libbase",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/log:check",
@@ -111,6 +110,18 @@ cf_cc_library(
     hdrs = ["wayland_utils.h"],
     deps = [
         "@abseil-cpp//absl/log:check",
+        "@wayland//:wayland_server",
+    ],
+)
+
+cf_cc_library(
+    name = "wayland_virtio_gpu_metadata",
+    srcs = ["wayland_virtio_gpu_metadata.cpp"],
+    hdrs = ["wayland_virtio_gpu_metadata.h"],
+    deps = [
+        "//cuttlefish/host/libs/wayland:wayland_surface",
+        "//cuttlefish/host/libs/wayland:wayland_utils",
+        "@crosvm//:crosvm_gpu_display_wayland_protocols",
         "@wayland//:wayland_server",
     ],
 )

--- a/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
@@ -1,8 +1,10 @@
-load("//cuttlefish/bazel:rules.bzl", "cf_cc_library")
+load("//cuttlefish/bazel:rules.bzl", "cf_build_test", "cf_cc_library")
 
 package(
     default_visibility = ["//:android_cuttlefish"],
 )
+
+cf_build_test(name = "cf_build_test")
 
 cf_cc_library(
     name = "wayland_compositor",

--- a/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
@@ -5,31 +5,6 @@ package(
 )
 
 cf_cc_library(
-    name = "cuttlefish_wayland_server",
-    srcs = ["wayland_server.cpp"],
-    hdrs = ["wayland_server.h"],
-    deps = [
-        "//cuttlefish/common/libs/fs",
-        "//cuttlefish/host/libs/wayland:wayland_compositor",
-        "//cuttlefish/host/libs/wayland:wayland_dmabuf",
-        "//cuttlefish/host/libs/wayland:wayland_seat",
-        "//cuttlefish/host/libs/wayland:wayland_server_callbacks",
-        "//cuttlefish/host/libs/wayland:wayland_shell",
-        "//cuttlefish/host/libs/wayland:wayland_subcompositor",
-        "//cuttlefish/host/libs/wayland:wayland_surface",
-        "//cuttlefish/host/libs/wayland:wayland_utils",
-        "//cuttlefish/host/libs/wayland:wayland_virtio_gpu_metadata",
-        "//libbase",
-        "@abseil-cpp//absl/log",
-        "@abseil-cpp//absl/log:check",
-        "@crosvm//:crosvm_gpu_display_wayland_protocols",
-        "@libdrm//:libdrm_fourcc",
-        "@libffi",
-        "@wayland//:wayland_server",
-    ],
-)
-
-cf_cc_library(
     name = "wayland_compositor",
     srcs = ["wayland_compositor.cpp"],
     hdrs = ["wayland_compositor.h"],
@@ -61,6 +36,25 @@ cf_cc_library(
     hdrs = ["wayland_seat.h"],
     deps = [
         "@abseil-cpp//absl/log",
+        "@wayland//:wayland_server",
+    ],
+)
+
+cf_cc_library(
+    name = "wayland_server",
+    srcs = ["wayland_server.cpp"],
+    hdrs = ["wayland_server.h"],
+    deps = [
+        "//cuttlefish/host/libs/wayland:wayland_compositor",
+        "//cuttlefish/host/libs/wayland:wayland_dmabuf",
+        "//cuttlefish/host/libs/wayland:wayland_seat",
+        "//cuttlefish/host/libs/wayland:wayland_server_callbacks",
+        "//cuttlefish/host/libs/wayland:wayland_shell",
+        "//cuttlefish/host/libs/wayland:wayland_subcompositor",
+        "//cuttlefish/host/libs/wayland:wayland_surface",
+        "//cuttlefish/host/libs/wayland:wayland_virtio_gpu_metadata",
+        "@abseil-cpp//absl/log",
+        "@abseil-cpp//absl/log:check",
         "@wayland//:wayland_server",
     ],
 )

--- a/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
@@ -8,7 +8,6 @@ cf_cc_library(
     name = "cuttlefish_wayland_server",
     srcs = [
         "wayland_compositor.cpp",
-        "wayland_dmabuf.cpp",
         "wayland_seat.cpp",
         "wayland_server.cpp",
         "wayland_surface.cpp",
@@ -17,7 +16,6 @@ cf_cc_library(
     ],
     hdrs = [
         "wayland_compositor.h",
-        "wayland_dmabuf.h",
         "wayland_seat.h",
         "wayland_server.h",
         "wayland_surface.h",
@@ -26,6 +24,7 @@ cf_cc_library(
     ],
     deps = [
         "//cuttlefish/common/libs/fs",
+        "//cuttlefish/host/libs/wayland:wayland_dmabuf",
         "//cuttlefish/host/libs/wayland:wayland_server_callbacks",
         "//cuttlefish/host/libs/wayland:wayland_shell",
         "//cuttlefish/host/libs/wayland:wayland_subcompositor",
@@ -36,6 +35,20 @@ cf_cc_library(
         "@crosvm//:crosvm_gpu_display_wayland_protocols",
         "@libdrm//:libdrm_fourcc",
         "@libffi",
+        "@wayland//:wayland_server",
+    ],
+)
+
+cf_cc_library(
+    name = "wayland_dmabuf",
+    srcs = ["wayland_dmabuf.cpp"],
+    hdrs = ["wayland_dmabuf.h"],
+    deps = [
+        "//cuttlefish/host/libs/wayland:wayland_utils",
+        "//libbase",
+        "@abseil-cpp//absl/log",
+        "@crosvm//:crosvm_gpu_display_wayland_protocols",
+        "@libdrm//:libdrm_fourcc",
         "@wayland//:wayland_server",
     ],
 )

--- a/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
@@ -20,7 +20,6 @@ cf_cc_library(
         "wayland_dmabuf.h",
         "wayland_seat.h",
         "wayland_server.h",
-        "wayland_server_callbacks.h",
         "wayland_surface.h",
         "wayland_surfaces.h",
         "wayland_utils.h",
@@ -28,6 +27,7 @@ cf_cc_library(
     ],
     deps = [
         "//cuttlefish/common/libs/fs",
+        "//cuttlefish/host/libs/wayland:wayland_server_callbacks",
         "//cuttlefish/host/libs/wayland:wayland_shell",
         "//cuttlefish/host/libs/wayland:wayland_subcompositor",
         "//libbase",
@@ -38,6 +38,11 @@ cf_cc_library(
         "@libffi",
         "@wayland//:wayland_server",
     ],
+)
+
+cf_cc_library(
+    name = "wayland_server_callbacks",
+    hdrs = ["wayland_server_callbacks.h"],
 )
 
 cf_cc_library(

--- a/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
@@ -12,7 +12,6 @@ cf_cc_library(
         "wayland_seat.cpp",
         "wayland_server.cpp",
         "wayland_shell.cpp",
-        "wayland_subcompositor.cpp",
         "wayland_surface.cpp",
         "wayland_surfaces.cpp",
         "wayland_virtio_gpu_metadata.cpp",
@@ -24,7 +23,6 @@ cf_cc_library(
         "wayland_server.h",
         "wayland_server_callbacks.h",
         "wayland_shell.h",
-        "wayland_subcompositor.h",
         "wayland_surface.h",
         "wayland_surfaces.h",
         "wayland_utils.h",
@@ -32,12 +30,23 @@ cf_cc_library(
     ],
     deps = [
         "//cuttlefish/common/libs/fs",
+        "//cuttlefish/host/libs/wayland:wayland_subcompositor",
         "//libbase",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/log:check",
         "@crosvm//:crosvm_gpu_display_wayland_protocols",
         "@libdrm//:libdrm_fourcc",
         "@libffi",
+        "@wayland//:wayland_server",
+    ],
+)
+
+cf_cc_library(
+    name = "wayland_subcompositor",
+    srcs = ["wayland_subcompositor.cpp"],
+    hdrs = ["wayland_subcompositor.h"],
+    deps = [
+        "@abseil-cpp//absl/log",
         "@wayland//:wayland_server",
     ],
 )

--- a/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
@@ -8,7 +8,6 @@ cf_cc_library(
     name = "cuttlefish_wayland_server",
     srcs = [
         "wayland_compositor.cpp",
-        "wayland_seat.cpp",
         "wayland_server.cpp",
         "wayland_surface.cpp",
         "wayland_surfaces.cpp",
@@ -16,7 +15,6 @@ cf_cc_library(
     ],
     hdrs = [
         "wayland_compositor.h",
-        "wayland_seat.h",
         "wayland_server.h",
         "wayland_surface.h",
         "wayland_surfaces.h",
@@ -25,6 +23,7 @@ cf_cc_library(
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/host/libs/wayland:wayland_dmabuf",
+        "//cuttlefish/host/libs/wayland:wayland_seat",
         "//cuttlefish/host/libs/wayland:wayland_server_callbacks",
         "//cuttlefish/host/libs/wayland:wayland_shell",
         "//cuttlefish/host/libs/wayland:wayland_subcompositor",
@@ -49,6 +48,16 @@ cf_cc_library(
         "@abseil-cpp//absl/log",
         "@crosvm//:crosvm_gpu_display_wayland_protocols",
         "@libdrm//:libdrm_fourcc",
+        "@wayland//:wayland_server",
+    ],
+)
+
+cf_cc_library(
+    name = "wayland_seat",
+    srcs = ["wayland_seat.cpp"],
+    hdrs = ["wayland_seat.h"],
+    deps = [
+        "@abseil-cpp//absl/log",
         "@wayland//:wayland_server",
     ],
 )

--- a/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
@@ -11,7 +11,6 @@ cf_cc_library(
         "wayland_dmabuf.cpp",
         "wayland_seat.cpp",
         "wayland_server.cpp",
-        "wayland_shell.cpp",
         "wayland_surface.cpp",
         "wayland_surfaces.cpp",
         "wayland_virtio_gpu_metadata.cpp",
@@ -22,7 +21,6 @@ cf_cc_library(
         "wayland_seat.h",
         "wayland_server.h",
         "wayland_server_callbacks.h",
-        "wayland_shell.h",
         "wayland_surface.h",
         "wayland_surfaces.h",
         "wayland_utils.h",
@@ -30,6 +28,7 @@ cf_cc_library(
     ],
     deps = [
         "//cuttlefish/common/libs/fs",
+        "//cuttlefish/host/libs/wayland:wayland_shell",
         "//cuttlefish/host/libs/wayland:wayland_subcompositor",
         "//libbase",
         "@abseil-cpp//absl/log",
@@ -37,6 +36,17 @@ cf_cc_library(
         "@crosvm//:crosvm_gpu_display_wayland_protocols",
         "@libdrm//:libdrm_fourcc",
         "@libffi",
+        "@wayland//:wayland_server",
+    ],
+)
+
+cf_cc_library(
+    name = "wayland_shell",
+    srcs = ["wayland_shell.cpp"],
+    hdrs = ["wayland_shell.h"],
+    deps = [
+        "@abseil-cpp//absl/log",
+        "@crosvm//:crosvm_gpu_display_wayland_protocols",
         "@wayland//:wayland_server",
     ],
 )

--- a/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/wayland/BUILD.bazel
@@ -6,16 +6,11 @@ package(
 
 cf_cc_library(
     name = "cuttlefish_wayland_server",
-    srcs = [
-        "wayland_compositor.cpp",
-        "wayland_server.cpp",
-    ],
-    hdrs = [
-        "wayland_compositor.h",
-        "wayland_server.h",
-    ],
+    srcs = ["wayland_server.cpp"],
+    hdrs = ["wayland_server.h"],
     deps = [
         "//cuttlefish/common/libs/fs",
+        "//cuttlefish/host/libs/wayland:wayland_compositor",
         "//cuttlefish/host/libs/wayland:wayland_dmabuf",
         "//cuttlefish/host/libs/wayland:wayland_seat",
         "//cuttlefish/host/libs/wayland:wayland_server_callbacks",
@@ -30,6 +25,18 @@ cf_cc_library(
         "@crosvm//:crosvm_gpu_display_wayland_protocols",
         "@libdrm//:libdrm_fourcc",
         "@libffi",
+        "@wayland//:wayland_server",
+    ],
+)
+
+cf_cc_library(
+    name = "wayland_compositor",
+    srcs = ["wayland_compositor.cpp"],
+    hdrs = ["wayland_compositor.h"],
+    deps = [
+        "//cuttlefish/host/libs/wayland:wayland_surface",
+        "//cuttlefish/host/libs/wayland:wayland_utils",
+        "@abseil-cpp//absl/log",
         "@wayland//:wayland_server",
     ],
 )


### PR DESCRIPTION
Bazel recommends one compilation unit per cc_library target: https://bazel.build/docs/bazel-and-cpp

Bug: b/533538882