### PR TITLE
Fix artifact downloading in cloud-init workflow

### DIFF
--- a/.github/workflows/cloud-init-image-for-cuttlefish.yaml
+++ b/.github/workflows/cloud-init-image-for-cuttlefish.yaml
@@ -5,7 +5,7 @@ on:
     paths:
       - 'cloud-init-image-for-cuttlefish/**'
   push:
-    branchs:
+    branches:
       - '**'
 
 permissions:

--- a/gigabyte-ampere-cuttlefish-installer/utils/download-ci-cf.sh
+++ b/gigabyte-ampere-cuttlefish-installer/utils/download-ci-cf.sh
@@ -6,11 +6,40 @@ set -o errexit
 
 URL=https://ci.android.com/builds/latest/branches/aosp-android-latest-release/targets/aosp_cf_arm64_only_phone-userdebug/view/BUILD_INFO
 RURL=$(curl -Ls -o /dev/null -w %{url_effective} ${URL})
-echo $RURL
+echo "RURL: $RURL"
 
-FILENAME=$(wget -nv -O - ${RURL%/view/BUILD_INFO}/ | grep aosp_cf_arm64_only_phone-img- | sed 's/.*\(aosp_cf_arm64_only_phone-img-[0-9]*[.]zip\).*/\1/g')
+BASE_URL=${RURL%/view/BUILD_INFO}
+BUILD_ID=$(echo "$RURL" | cut -d'/' -f6)
+echo "BUILD_ID: $BUILD_ID"
 
-wget -nv -c ${RURL%/view/BUILD_INFO}/raw/${FILENAME}
-wget -nv -c ${RURL%/view/BUILD_INFO}/raw/cvd-host_package.tar.gz
+if [[ ! "$BUILD_ID" =~ ^[0-9]+$ ]]; then
+  echo "Error: Failed to resolve latest build ID. RURL was $RURL" >&2
+  exit 1
+fi
+
+FILENAME="aosp_cf_arm64_only_phone-img-${BUILD_ID}.zip"
+
+download_artifact() {
+  local filename=$1
+  local view_url="${BASE_URL}/view/${filename}"
+  
+  echo "Fetching signed URL for ${filename} from ${view_url}..."
+  local html
+  html=$(curl -s "${view_url}")
+  
+  local signed_url
+  signed_url=$(echo "$html" | grep -oP '"artifactUrl":"[^"]+"' | sed 's/"artifactUrl":"\(.*\)"/\1/' | sed 's/\\u0026/\&/g')
+  
+  if [ -z "$signed_url" ]; then
+    echo "Error: Failed to get signed URL for ${filename}" >&2
+    exit 1
+  fi
+  
+  echo "Downloading ${filename}..."
+  wget -nv -c "$signed_url" -O "${filename}"
+}
+
+download_artifact "${FILENAME}"
+download_artifact "cvd-host_package.tar.gz"
 
 exit 0


### PR DESCRIPTION
This PR fixes the broken artifact downloading script in the cloud-init workflow. The script was failing because ci.android.com changed its HTML structure. We now use the artifact view page to get a signed GCS URL.