### PR TITLE
Use v4l2_emulated_camera_mplane in cts test.

### DIFF
--- a/e2etests/cvd/media_tests/cts/main_test.go
+++ b/e2etests/cvd/media_tests/cts/main_test.go
@@ -31,8 +31,8 @@ func TestEmulatedCamera(t *testing.T) {
 			},
 			Create: e2etests.CreateArgs{
 				Args: []string{
-					"--media=type=v4l2_emulated_camera_splane,lens_facing=BACK",
-					"--media=type=v4l2_emulated_camera_splane,lens_facing=FRONT",
+					"--media=type=v4l2_emulated_camera_mplane,lens_facing=BACK",
+					"--media=type=v4l2_emulated_camera_mplane,lens_facing=FRONT",
 				},
 			},
 		},


### PR DESCRIPTION
v4l2_emulated_camera_mplane is the actual device would be used in production.

Bug: b/533512719