### PR TITLE
Remove host configuration checks from most commands

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/command_handler.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/command_handler.h
@@ -39,7 +39,7 @@ class CvdCommandHandler {
   virtual std::vector<HelpParagraph> Description() const;
   virtual Result<std::vector<Flag>> Flags(const CommandRequest&);
 
-  virtual bool RequiresHostConfiguration() const { return true; }
+  virtual bool RequiresHostConfiguration() const { return false; }
 };
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/create.h
@@ -37,6 +37,7 @@ class CvdCreateCommandHandler : public CvdCommandHandler {
   std::vector<std::string> CmdList() const override { return {"create"}; }
   std::string SummaryHelp() const override;
   Result<std::string> DetailedHelp(const CommandRequest&) override;
+  bool RequiresHostConfiguration() const override { return true; }
 
  private:
   struct CreateFlags {

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/help.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/help.cpp
@@ -139,8 +139,6 @@ std::vector<std::string> CvdHelpHandler::CmdList() const { return {"help"}; }
 
 std::string CvdHelpHandler::SummaryHelp() const { return kSummaryHelpText; }
 
-bool CvdHelpHandler::RequiresHostConfiguration() const { return false; }
-
 std::vector<HelpParagraph> CvdHelpHandler::Description() const {
   return {
       HelpParagraph("Example usage:"),

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/help.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/help.h
@@ -35,7 +35,6 @@ class CvdHelpHandler : public CvdCommandHandler {
   std::vector<std::string> CmdList() const override;
 
   std::string SummaryHelp() const override;
-  bool RequiresHostConfiguration() const override;
   std::vector<HelpParagraph> Description() const override;
 
  private:

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/load_configs.h
@@ -42,6 +42,7 @@ class LoadConfigsCommand : public CvdCommandHandler {
   std::string SummaryHelp() const override;
   std::vector<HelpParagraph> Description() const override;
   Result<std::vector<Flag>> Flags(const CommandRequest&) override;
+  bool RequiresHostConfiguration() const override { return true; }
 
   static std::vector<HelpParagraph> CommonCommandDescription();
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/setup.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/setup.cc
@@ -85,6 +85,4 @@ std::vector<HelpParagraph> CvdSetupHandler::Description() const {
 
 bool CvdSetupHandler::RequiresDeviceExists() const { return false; }
 
-bool CvdSetupHandler::RequiresHostConfiguration() const { return false; }
-
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/setup.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/setup.h
@@ -36,7 +36,6 @@ class CvdSetupHandler : public CvdCommandHandler {
   std::string SummaryHelp() const override;
   std::vector<HelpParagraph> Description() const override;
   bool RequiresDeviceExists() const override;
-  bool RequiresHostConfiguration() const override;
 };
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.h
@@ -41,6 +41,7 @@ class CvdStartCommandHandler : public CvdCommandHandler {
   Result<std::vector<Flag>> Flags(const CommandRequest&) override;
 
   bool RequiresDeviceExists() const override { return true; }
+  bool RequiresHostConfiguration() const override { return true; }
 
  private:
   Result<void> LaunchSingleInstance(LocalInstance& instance,

--- a/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
@@ -39,6 +39,7 @@ Cvd::Cvd(InstanceManager& instance_manager,
 static Result<void> EnforceHostConfigured() {
   std::vector<vm_manager::HostConfigurationAction> actions =
       CF_EXPECT(vm_manager::ValidateHostConfiguration());
+  // TODO: chadreynolds - exit, then only print a message and not a stacktrace
   CF_EXPECT(actions.empty(), "Run `cvd setup` to configure the host.");
   return {};
 }

--- a/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cvd.cpp
@@ -39,8 +39,7 @@ Cvd::Cvd(InstanceManager& instance_manager,
 static Result<void> EnforceHostConfigured() {
   std::vector<vm_manager::HostConfigurationAction> actions =
       CF_EXPECT(vm_manager::ValidateHostConfiguration());
-  // TODO: chadreynolds - exit, then only print a message and not a stacktrace
-  CF_EXPECT(actions.empty(), "Run `cvd setup` to configure the host.");
+  CF_EXPECT(actions.empty(), "Host configuration is invalid.");
   return {};
 }
 
@@ -64,7 +63,13 @@ Result<void> Cvd::HandleCommand(
   }
 
   if (handler->RequiresHostConfiguration()) {
-    CF_EXPECT(EnforceHostConfigured());
+    Result<void> enforce_result = EnforceHostConfigured();
+    if (!enforce_result.ok()) {
+      std::cerr << "Host configuration requirements not met.  Run `cvd setup` "
+                   "to configure the host."
+                << std::endl;
+      CF_EXPECT(std::move(enforce_result));
+    }
   }
 
   CF_EXPECT(handler->Handle(request));


### PR DESCRIPTION
When the host configuration is invalid, we would output an error message that included a suggestion to run `cvd version` in the bug report.  Running `cvd version` would then fail with the same enforcement message.

Most commands are not reliant on the host configuration, so I limited it to `create`, `start`, and `load`.

Bug: 535255932