### PR TITLE
depend-on-what-you-use fixes: `pretty`, `io`, `flag_parser`, `result`

### DIFF
--- a/base/cvd/cuttlefish/flag_parser/BUILD.bazel
+++ b/base/cvd/cuttlefish/flag_parser/BUILD.bazel
@@ -14,11 +14,9 @@ cf_cc_library(
         "flag.h",
         "gflags_compat.h",
     ],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/cleanup",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/log:check",

--- a/base/cvd/cuttlefish/flag_parser/BUILD.bazel
+++ b/base/cvd/cuttlefish/flag_parser/BUILD.bazel
@@ -54,12 +54,10 @@ cf_cc_library(
     name = "shared_fd_flag",
     srcs = ["shared_fd_flag.cpp"],
     hdrs = ["shared_fd_flag.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         ":flag_parser",
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/strings",
     ],
 )

--- a/base/cvd/cuttlefish/io/BUILD.bazel
+++ b/base/cvd/cuttlefish/io/BUILD.bazel
@@ -129,9 +129,7 @@ cf_cc_library(
     name = "disjoint_range_set",
     srcs = ["disjoint_range_set.cc"],
     hdrs = ["disjoint_range_set.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
-        "//libbase",
         "@abseil-cpp//absl/log:check",
     ],
 )

--- a/base/cvd/cuttlefish/io/BUILD.bazel
+++ b/base/cvd/cuttlefish/io/BUILD.bazel
@@ -331,14 +331,12 @@ cf_cc_library(
 cf_cc_test(
     name = "read_window_view_test",
     srcs = ["read_window_view_test.cc"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:in_memory",
         "//cuttlefish/io:read_window_view",
         "//cuttlefish/io:string",
         "//cuttlefish/result:result_matchers",
-        "//cuttlefish/result:result_type",
     ],
 )
 

--- a/base/cvd/cuttlefish/io/BUILD.bazel
+++ b/base/cvd/cuttlefish/io/BUILD.bazel
@@ -206,12 +206,10 @@ cf_cc_library(
 cf_cc_test(
     name = "in_memory_test",
     srcs = ["in_memory_test.cc"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:in_memory",
         "//cuttlefish/result:result_matchers",
-        "//cuttlefish/result:result_type",
         "@abseil-cpp//absl/strings",
     ],
 )

--- a/base/cvd/cuttlefish/io/BUILD.bazel
+++ b/base/cvd/cuttlefish/io/BUILD.bazel
@@ -101,12 +101,10 @@ cf_cc_library(
 cf_cc_test(
     name = "cpio_test",
     srcs = ["cpio_test.cc"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:cpio",
         "//cuttlefish/io:in_memory",
-        "//cuttlefish/io:read_exact",
         "//cuttlefish/io:string",
         "//cuttlefish/result",
         "//cuttlefish/result:result_matchers",

--- a/base/cvd/cuttlefish/io/BUILD.bazel
+++ b/base/cvd/cuttlefish/io/BUILD.bazel
@@ -278,13 +278,11 @@ cf_cc_library(
 cf_cc_test(
     name = "lz4_legacy_test",
     srcs = ["lz4_legacy_test.cc"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/io",
         "//cuttlefish/io:filesystem",
         "//cuttlefish/io:in_memory",
         "//cuttlefish/io:lz4_legacy",
-        "//cuttlefish/io:read_exact",
         "//cuttlefish/io:string",
         "//cuttlefish/io:write_exact",
         "//cuttlefish/result",

--- a/base/cvd/cuttlefish/io/BUILD.bazel
+++ b/base/cvd/cuttlefish/io/BUILD.bazel
@@ -354,11 +354,9 @@ cf_cc_library(
 cf_cc_test(
     name = "serialize_disjoint_range_set_test",
     srcs = ["serialize_disjoint_range_set_test.cc"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/io:disjoint_range_set",
         "//cuttlefish/io:serialize_disjoint_range_set",
-        "//cuttlefish/result",
         "//cuttlefish/result:result_matchers",
     ],
 )

--- a/base/cvd/cuttlefish/pretty/BUILD.bazel
+++ b/base/cvd/cuttlefish/pretty/BUILD.bazel
@@ -149,7 +149,6 @@ cf_cc_library(
 cf_cc_test(
     name = "struct_test",
     srcs = ["struct_test.cc"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/pretty:string",
         "//cuttlefish/pretty:struct",

--- a/base/cvd/cuttlefish/pretty/BUILD.bazel
+++ b/base/cvd/cuttlefish/pretty/BUILD.bazel
@@ -92,7 +92,6 @@ cf_cc_library(
 cf_cc_test(
     name = "pretty_test",
     srcs = ["pretty_test.cc"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/pretty",
         "//cuttlefish/pretty:map",
@@ -102,7 +101,6 @@ cf_cc_test(
         "//cuttlefish/pretty:unique_ptr",
         "//cuttlefish/pretty:vector",
         "@abseil-cpp//absl/strings",
-        "@fmt",
     ],
 )
 

--- a/base/cvd/cuttlefish/pretty/BUILD.bazel
+++ b/base/cvd/cuttlefish/pretty/BUILD.bazel
@@ -50,7 +50,6 @@ cf_cc_test(
 cf_cc_library(
     name = "map",
     hdrs = ["map.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/pretty",
         "//cuttlefish/pretty:container",

--- a/base/cvd/cuttlefish/pretty/liblp/BUILD.bazel
+++ b/base/cvd/cuttlefish/pretty/liblp/BUILD.bazel
@@ -8,10 +8,8 @@ cf_cc_library(
     name = "builder",
     srcs = ["builder.cc"],
     hdrs = ["builder.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/pretty",
-        "//cuttlefish/pretty:string",
         "//cuttlefish/pretty:struct",
         "//cuttlefish/pretty:unique_ptr",
         "//cuttlefish/pretty:vector",

--- a/base/cvd/cuttlefish/pretty/liblp/BUILD.bazel
+++ b/base/cvd/cuttlefish/pretty/liblp/BUILD.bazel
@@ -34,10 +34,8 @@ cf_cc_library(
     name = "metadata_format",
     srcs = ["metadata_format.cc"],
     hdrs = ["metadata_format.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/pretty",
-        "//cuttlefish/pretty:string",
         "//cuttlefish/pretty:struct",
         "//cuttlefish/pretty:vector",
         "@android_system_core//:liblp",

--- a/base/cvd/cuttlefish/pretty/map.h
+++ b/base/cvd/cuttlefish/pretty/map.h
@@ -17,6 +17,8 @@
 
 #include <map>
 
+#include "absl/strings/str_cat.h"
+
 #include "cuttlefish/pretty/container.h"
 #include "cuttlefish/pretty/pretty.h"
 

--- a/base/cvd/cuttlefish/pretty/struct_test.cc
+++ b/base/cvd/cuttlefish/pretty/struct_test.cc
@@ -24,6 +24,8 @@
 #include "fmt/format.h"
 #include "gtest/gtest.h"
 
+#include "cuttlefish/pretty/string.h"  // IWYU pragma: keep: overload used
+
 namespace cuttlefish {
 namespace {
 

--- a/base/cvd/cuttlefish/result/BUILD.bazel
+++ b/base/cvd/cuttlefish/result/BUILD.bazel
@@ -8,12 +8,10 @@ cf_cc_library(
     name = "error_type",
     srcs = ["error_type.cc"],
     hdrs = ["error_type.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/ansi_codes",
         "//cuttlefish/ansi_codes:should_color",
         "//libbase",
-        "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/strings",
         "@fmt",
     ],

--- a/base/cvd/cuttlefish/result/BUILD.bazel
+++ b/base/cvd/cuttlefish/result/BUILD.bazel
@@ -40,11 +40,9 @@ cf_cc_library(
 cf_cc_test(
     name = "result_test",
     srcs = ["result_test.cpp"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/result",
         "//cuttlefish/result:result_matchers",
-        "//libbase",
     ],
 )
 

--- a/base/cvd/cuttlefish/result/BUILD.bazel
+++ b/base/cvd/cuttlefish/result/BUILD.bazel
@@ -49,11 +49,9 @@ cf_cc_test(
 cf_cc_library(
     name = "result_type",
     hdrs = ["result_type.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/result:error_type",
         "//libbase",
-        "@fmt",
     ],
 )
 

--- a/base/cvd/cuttlefish/result/BUILD.bazel
+++ b/base/cvd/cuttlefish/result/BUILD.bazel
@@ -20,12 +20,10 @@ cf_cc_library(
 cf_cc_library(
     name = "expect",
     hdrs = ["expect.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/result:error_type",
         "//cuttlefish/result:result_type",
         "//libbase",
-        "@abseil-cpp//absl/log",
         "@fmt",
     ],
 )

--- a/base/cvd/cuttlefish/result/expect.h
+++ b/base/cvd/cuttlefish/result/expect.h
@@ -21,6 +21,7 @@
 
 #include "android-base/format.h"  // IWYU pragma: export
 #include "android-base/result.h"  // IWYU pragma: export
+#include "fmt/format.h"           // IWYU pragma: keep: preprocessor
 
 #include "cuttlefish/result/error_type.h"
 #include "cuttlefish/result/result_type.h"  // IWYU pragma: export


### PR DESCRIPTION
Bug: b/534499070