### PR TITLE
Remove unused variables from cuttlefish-integration.postinst

### DIFF
--- a/base/cvd/.shellcheckrc
+++ b/base/cvd/.shellcheckrc
@@ -1,10 +1,5 @@
 ### These are turned off so we can submit shellcheck without breaking the presubmit. They should be fixed eventually.
 
-## Warning:
-# Warning: 'foo appears unused. Verify it or export it.'
-# Reason:
-disable=SC2034
-
 # Warning: 'Prefer [ p ] && [ q ] as [ p -a q ] is not well-defined.'
 # Reason:
 disable=SC2166

--- a/base/debian/cuttlefish-integration.postinst
+++ b/base/debian/cuttlefish-integration.postinst
@@ -2,13 +2,6 @@
 
 set -e
 
-# Number of AVD accounts to create. 8 may be the limit imposed by the
-# VHCI HCD driver used for adb connections
-num_cvd_accounts=8
-
-# cvd accounts only invoke adb, so limit their access via groups
-cvd_account_groups=plugdev
-
 case "$1" in
     (configure)
     # Update the installed version of the diverted file with the


### PR DESCRIPTION
These variables seem to be completely unused, since a few years ago. This surfaced while whittling away at the shellcheck global disables.