### PR TITLE
Trim fetch output

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/fetch.cpp
@@ -70,7 +70,7 @@ Result<void> RunCacheCleanup(const BuildApiFlags& build_api_flags) {
                  "Error pruning cache at {} to {}GB", cache_directory,
                  build_api_flags.max_cache_size_gb);
   if (prune_result.before > prune_result.after) {
-    LOG(INFO) << fmt::format(
+    VLOG(0) << fmt::format(
         "Cache at \"{}\" pruned from ~{}GB to ~{}GB of {}GB max size",
         cache_directory, prune_result.before, prune_result.after,
         build_api_flags.max_cache_size_gb);

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/build_api_credentials.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/build_api_credentials.cc
@@ -70,8 +70,8 @@ Result<std::unique_ptr<CredentialSource>> GetCredentialSourceLegacy(
                    << oauth_filepath << "\":" << attempt_load.error();
       }
     } else {
-      LOG(INFO) << "\"" << oauth_filepath
-                << "\" is missing, running without credentials";
+      VLOG(0) << "\"" << oauth_filepath
+              << "\" is missing, running without credentials";
     }
   } else if (!FileExists(credential_source)) {
     // If the parameter doesn't point to an existing file it must be the

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_context.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_context.cc
@@ -37,6 +37,7 @@
 #include "cuttlefish/host/commands/cvd/fetch/target_directories.h"
 #include "cuttlefish/host/libs/config/fetcher_config.h"
 #include "cuttlefish/host/libs/config/file_source.h"
+#include "cuttlefish/host/libs/web/android_build.h"
 #include "cuttlefish/host/libs/web/android_build_api.h"
 #include "cuttlefish/host/libs/web/build_api.h"
 #include "cuttlefish/host/libs/web/build_api_zip.h"
@@ -229,7 +230,7 @@ Result<void> FetchBuildContext::AddFileToConfig(std::string file,
 }
 
 std::ostream& operator<<(std::ostream& out, const FetchBuildContext& context) {
-  return out << context.Build();
+  return out << FetchLabel(context.Build());
 }
 
 FetchContext::FetchContext(BuildApi& build_api,

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/host_package.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/host_package.cc
@@ -40,7 +40,7 @@ Result<void> FetchHostPackage(
     const bool keep_archives,
     const std::vector<std::string>& host_substitutions,
     FetchTracer::Trace trace) {
-  LOG(INFO) << "Preparing host package for " << build;
+  LOG(INFO) << "Downloading host package for " << FetchLabel(build);
   // This function is called asynchronously, so it may take a while to start.
   // Complete a phase here to ensure that delay is not counted in the download
   // time.

--- a/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
@@ -46,6 +46,7 @@ cf_cc_library(
         "//libbase",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/log:check",
+        "@fmt",
         "@jsoncpp",
     ],
 )

--- a/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
@@ -15,6 +15,7 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:environment",
         "//libbase",
         "@abseil-cpp//absl/strings",
+        "@fmt",
     ],
 )
 

--- a/base/cvd/cuttlefish/host/libs/web/android_build.cc
+++ b/base/cvd/cuttlefish/host/libs/web/android_build.cc
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "absl/strings/str_join.h"
+#include "fmt/format.h"
 
 #include "cuttlefish/common/libs/utils/environment.h"
 
@@ -54,6 +55,13 @@ std::ostream& operator<<(std::ostream& out, const DirectoryBuild& build) {
 std::ostream& operator<<(std::ostream& out, const Build& build) {
   std::visit([&out](auto&& arg) { out << arg; }, build);
   return out;
+}
+
+std::string FetchLabel(const Build& build) {
+  // return std::visit((auto&& arg) { return FetchLabel(arg); }, build)
+  return fmt::format("{}/{}",
+                     std::visit([](auto&& arg) { return arg.id; }, build),
+                     std::visit([](auto&& arg) { return arg.target; }, build));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/web/android_build.h
+++ b/base/cvd/cuttlefish/host/libs/web/android_build.h
@@ -54,4 +54,6 @@ using Build = std::variant<DeviceBuild, DirectoryBuild>;
 
 std::ostream& operator<<(std::ostream&, const Build&);
 
+std::string FetchLabel(const Build& build);
+
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/web/android_build_api.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_api.cpp
@@ -39,6 +39,7 @@
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "android-base/file.h"
+#include "fmt/format.h"
 #include "json/value.h"
 
 #include "cuttlefish/common/libs/utils/contains.h"
@@ -121,9 +122,9 @@ Result<Build> AndroidBuildApi::GetBuild(const DeviceBuildString& build_string) {
       CF_EXPECT(LatestBuildId(proposed_build_id, *build_string.target));
   if (latest_build_id) {
     proposed_build_id = *latest_build_id;
-    LOG(INFO) << "Latest build id for branch '" << build_string.branch_or_id
-              << "' and target '" << *build_string.target << "' is '"
-              << proposed_build_id << "'";
+    VLOG(0) << fmt::format(
+        "Build id({}) to be fetched for branch({}), target({}).",
+        proposed_build_id, build_string.branch_or_id, *build_string.target);
   }
 
   AndroidBuildApi::BuildInfo build_info =

--- a/base/cvd/cuttlefish/host/libs/web/cas/cas_downloader.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/cas/cas_downloader.cpp
@@ -297,7 +297,7 @@ Result<std::unique_ptr<CasDownloader>> CasDownloader::Create(
   // Ensure callers and logs clearly indicate that CAS downloading is
   // disabled and why, using the same environment-aware formatting that
   // test helpers use.
-  LOG(INFO) << "CAS downloading disabled, see log for reason.";
+  VLOG(0) << "CAS downloading disabled, see log for reason.";
   VLOG(0) << "CAS downloading disabled: " << result.error();
   return result;
 }
@@ -321,9 +321,9 @@ Result<std::unique_ptr<CasDownloader>> CasDownloader::CreateImpl(
         cas_downloader_flags.cas_config_filepath.value();
     bool is_default_config = (config_filepath == kDefaultCasConfigFilePath);
     if (is_default_config) {
-      LOG(INFO) << "Using default CAS config from: " << config_filepath;
+      VLOG(0) << "Using default CAS config from: " << config_filepath;
     } else {
-      LOG(INFO) << "Using CAS config from: " << config_filepath;
+      VLOG(0) << "Using CAS config from: " << config_filepath;
     }
     std::string config_contents = CF_EXPECT(ReadFileContents(config_filepath));
     Json::Value config = CF_EXPECT(ParseJson(config_contents));
@@ -355,7 +355,7 @@ Result<std::unique_ptr<CasDownloader>> CasDownloader::CreateImpl(
     // No config file available: use CLI values (or defaults if CLI didn't set
     // them). Convert current flag values into config_flags for downstream
     // processing.
-    LOG(INFO) << "Using CAS downloader flags from command line or defaults.";
+    VLOG(0) << "Using CAS downloader flags from command line or defaults.";
     config_flags = ConvertToConfigFlags(cas_downloader_flags);
   }
 
@@ -429,7 +429,7 @@ Result<void> CasDownloader::DownloadFile(
   AppendBuildInfoToInvocationId(build, flags_);
   Command cmd = GetCommand(downloader_path_, flags_, cas_identifier,
                            download_directory, stats_filepath);
-  LOG(INFO) << "CAS Downloader Command: '" << cmd.AsBashScript() << "'";
+  VLOG(0) << "CAS Downloader Command: '" << cmd.AsBashScript() << "'";
   int ret_code = cmd.Start().Wait();
   if (ret_code != 0) {
     return CF_ERRF("Failed to download file with CAS downloader ({}).",


### PR DESCRIPTION
Cut out CLI output for lines more intended for infra and debugging, and edit down some outputs to be more user friendly.  The "Downloading..." lines now match the build flag format and have less symbols to read.  The output still shows each build download step, per fetched group of builds.

All lines removed from the CLI output still show up in the `fetch.log`.

Go from:

```shell
Using CAS downloader flags from command line or defaults.
CAS downloading disabled, see log for reason.
"/usr/local/google/home/chadreynolds/.boto" is missing, running without credentials
Latest build id for branch '<branch>' and target '<target>' is '<build_id>'
Starting fetch to "/var/tmp/cvd/fetch_test"
Preparing host package for (id="<build_id>", branch="<branch>", target="<target>", filepath="")
Downloading image zip for (id="<build_id>", branch="<branch>", target="<target>", filepath="")
Completed target fetch to '/var/tmp/cvd/fetch_test' (1 out of 1)
Completed all fetches
Cache at "/var/tmp/cvd/1035769/cache" pruned from ~28GB to ~24GB of 25GB max size
```

Down to:

```shell
Starting fetch to "/var/tmp/cvd/fetch_test"
Downloading host package for <build_id>/<target>
Downloading image zip for <build_id>/<target>
Completed target fetch to '/var/tmp/cvd/fetch_test' (1 out of 1)
Completed all fetches
```

Bug: 536099091