### PR TITLE
Fix cvd start --help

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -319,7 +319,8 @@ Result<std::vector<Flag>> GetCvdInternalStartFlags(
       CF_EXPECT(GetSiblingCommandFlags("cvd_internal_start", env, args));
   // Remove flags set by cvd and intented to be exposed to the user
   const std::vector<std::string> to_remove = {
-      "daemon", "instance_nums", "num_instances", "base_instance_num"};
+      "daemon", "instance_nums", "num_instances", "base_instance_num",
+      "report_anonymous_usage_stats"};
   std::erase_if(flags,
                 [&to_remove](Flag f) { return Contains(to_remove, f.Name()); });
   return flags;


### PR DESCRIPTION
The report_anonymous_usage_stats flag is defined in cvd start and in assemble_cvd. When cvd start loads assemble_cvd's flags it ends up duplicated causing the help handler to fail. This change removes the --report_anonymous_usage_stats flag from the list returned by assemble_cvd.

Bug: b/536128817