### PR TITLE
Enable trixie backports

### DIFF
--- a/gigabyte-ampere-cuttlefish-installer/preseed/preseed.cfg
+++ b/gigabyte-ampere-cuttlefish-installer/preseed/preseed.cfg
@@ -299,7 +299,7 @@ d-i partman-partitioning/default_label string gpt
 # (default: false).
 d-i apt-setup/cdrom/set-first boolean false
 # Backport selection
-# d-i apt-setup/services-select multiselect backports
+d-i apt-setup/services-select multiselect backports
 # You can choose to install non-free firmware.
 d-i apt-setup/non-free-firmware boolean true
 # You can choose to install non-free and contrib software.

--- a/gigabyte-ampere-cuttlefish-installer/utils/download-ci-cf.sh
+++ b/gigabyte-ampere-cuttlefish-installer/utils/download-ci-cf.sh
@@ -6,9 +6,23 @@ set -o errexit
 
 URL=https://ci.android.com/builds/latest/branches/aosp-android-latest-release/targets/aosp_cf_arm64_only_phone-userdebug/view/BUILD_INFO
 RURL=$(curl -Ls -o /dev/null -w %{url_effective} ${URL})
-echo $RURL
+echo "RURL = ${RURL}"
 
-FILENAME=$(wget -nv -O - ${RURL%/view/BUILD_INFO}/ | grep aosp_cf_arm64_only_phone-img- | sed 's/.*\(aosp_cf_arm64_only_phone-img-[0-9]*[.]zip\).*/\1/g')
+BUILD_ID=$(echo "${RURL}" | sed -n 's/.*\/builds\/submitted\/\([^\/]*\)\/.*/\1/p')
+echo "BUILD_ID = ${BUILD_ID}"
+
+if [ x"${BUILD_ID}" = x"" ]; then
+    echo "Error: BUILD_ID empty."
+    exit 1
+fi
+
+FILENAME="aosp_cf_arm64_only_phone-img-${BUILD_ID}.zip"
+echo "FILENAME = ${FILENAME}"
+
+if [ x"${FILENAME}" = x"" ]; then
+    echo "Error: FILENAME empty."
+    exit 1
+fi
 
 wget -nv -c ${RURL%/view/BUILD_INFO}/raw/${FILENAME}
 wget -nv -c ${RURL%/view/BUILD_INFO}/raw/cvd-host_package.tar.gz


### PR DESCRIPTION
We enable backports on Trixie so that we can install newer kernel. 
Also we fix the unit tests because the download scripts needs to be updated.