### PR TITLE
Add support for Guest Lavapipe GPU mode

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/bootconfig_args.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/bootconfig_args.cpp
@@ -325,6 +325,26 @@ Result<std::unordered_map<std::string, std::string>> BootconfigArgsFromConfig(
               ? "com.android.hardware.graphics.composer.drm_hwcomposer"
               : "com.android.hardware.graphics.composer.ranchu";
 
+  const GpuMode gpu_mode = instance.gpu_mode();
+  if (gpu_mode != GpuMode::None) {
+    if (IsGfxstreamMode(gpu_mode)) {
+      if (instance.has_vulkan_gfxstream_apex()) {
+        bootconfig_args["androidboot.vendor.apex.com.google.cf.vulkan"] =
+            "com.google.cf.vulkan.gfxstream";
+      }
+    } else if (gpu_mode == GpuMode::GuestLavapipe) {
+      if (instance.has_vulkan_lavapipe_apex()) {
+        bootconfig_args["androidboot.vendor.apex.com.google.cf.vulkan"] =
+            "com.google.cf.vulkan.lavapipe";
+      }
+    } else if (gpu_mode == GpuMode::GuestSwiftshader) {
+      if (instance.has_vulkan_swiftshader_apex()) {
+        bootconfig_args["androidboot.vendor.apex.com.google.cf.vulkan"] =
+            "com.google.cf.vulkan.swiftshader";
+      }
+    }
+  }
+
   if (instance.vhal_proxy_server_port()) {
     bootconfig_args["androidboot.vhal_proxy_server_port"] =
         std::to_string(instance.vhal_proxy_server_port());

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/graphics_flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/graphics_flags.cc
@@ -135,12 +135,25 @@ GetGpuModeRequirementsMap() {
   const RequirementWithReason kGuestSupportsGfxstream{
       .func =
           [](const CommonState& common) {
-            return common.guest_config.gfxstream_supported;
+            return common.guest_config.gfxstream_supported ||
+                   common.guest_config.has_vulkan_gfxstream_apex;
           },
       .success_explanation = "The guest supports Gfxstream.",
       .failure_explanation =
           "The guest does not support Gfxstream. This is configured in the "
           "`android-info.txt` file associated with the guest target build.",
+  };
+  const RequirementWithReason kGuestSupportsLavapipe{
+      .func =
+          [](const CommonState& common) {
+            return common.guest_config.guest_lavapipe_supported ||
+                   common.guest_config.has_vulkan_lavapipe_apex;
+          },
+      .success_explanation = "The guest supports Lavapipe.",
+      .failure_explanation =
+          "The guest does not claim support for Lavapipe. This is "
+          "configured in the `android-info.txt` file associated with the guest "
+          "target build.",
   };
   const RequirementWithReason kHostGlesAvailable{
       .func =
@@ -301,6 +314,12 @@ GetGpuModeRequirementsMap() {
                   kHostIsNonArm,
                   kHostVulkanLoaderAvailable,
                   kNotUsingHostQemu,
+              },
+          },
+          {
+              GpuMode::GuestLavapipe,
+              {
+                  kGuestSupportsLavapipe,
               },
           },
           {
@@ -487,12 +506,18 @@ std::vector<GpuMode> GetGpuModeCandidates(const GuestConfig& guest_config) {
     gpu_mode_candidates.push_back(GpuMode::GfxstreamGuestAngleHostSwiftshader);
     gpu_mode_candidates.push_back(GpuMode::GfxstreamGuestAngleHostLavapipe);
     gpu_mode_candidates.push_back(GpuMode::GuestSwiftshader);
+    if (guest_config.guest_lavapipe_supported) {
+      gpu_mode_candidates.push_back(GpuMode::GuestLavapipe);
+    }
   } else {
     gpu_mode_candidates.push_back(GpuMode::Gfxstream);
     gpu_mode_candidates.push_back(GpuMode::GuestSwiftshader);
     gpu_mode_candidates.push_back(GpuMode::GfxstreamGuestAngle);
     gpu_mode_candidates.push_back(GpuMode::GfxstreamGuestAngleHostSwiftshader);
     gpu_mode_candidates.push_back(GpuMode::GfxstreamGuestAngleHostLavapipe);
+    if (guest_config.guest_lavapipe_supported) {
+      gpu_mode_candidates.push_back(GpuMode::GuestLavapipe);
+    }
   }
 
   gpu_mode_candidates.push_back(GpuMode::None);
@@ -596,7 +621,7 @@ Result<bool> SelectGpuVhostUserMode(const GpuMode gpu_mode,
             gpu_vhost_user_mode_arg == kGpuVhostUserModeOn ||
             gpu_vhost_user_mode_arg == kGpuVhostUserModeOff);
   if (gpu_vhost_user_mode_arg == kGpuVhostUserModeAuto) {
-    if (gpu_mode == GpuMode::GuestSwiftshader) {
+    if (IsGuestRenderingMode(gpu_mode)) {
       VLOG(0) << "GPU vhost user auto mode: not needed for --gpu_mode="
               << GpuModeString(gpu_mode) << ". Not enabling vhost user gpu.";
       return false;
@@ -844,6 +869,12 @@ Result<GpuMode> ConfigureGpuSettings(
     const std::string& guest_renderer_preload_arg, VmmMode vmm,
     const GuestConfig& guest_config,
     CuttlefishConfig::MutableInstanceSpecific& instance) {
+  instance.set_has_vulkan_gfxstream_apex(
+      guest_config.has_vulkan_gfxstream_apex);
+  instance.set_has_vulkan_lavapipe_apex(guest_config.has_vulkan_lavapipe_apex);
+  instance.set_has_vulkan_swiftshader_apex(
+      guest_config.has_vulkan_swiftshader_apex);
+
 #ifdef __APPLE__
   (void)graphics_availability;
   (void)gpu_vhost_user_mode_arg;

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/guest_config.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/guest_config.cc
@@ -130,6 +130,19 @@ Result<void> ParseGuestConfigTextProto(const std::string& guest_config_path,
     guest_config.gpu_mode_candidates.push_back(it->second);
   }
 
+  if (graphics_config.has_vulkan_gfxstream_apex_supported()) {
+    guest_config.has_vulkan_gfxstream_apex =
+        graphics_config.vulkan_gfxstream_apex_supported();
+  }
+  if (graphics_config.has_vulkan_lavapipe_apex_supported()) {
+    guest_config.has_vulkan_lavapipe_apex =
+        graphics_config.vulkan_lavapipe_apex_supported();
+  }
+  if (graphics_config.has_vulkan_swiftshader_apex_supported()) {
+    guest_config.has_vulkan_swiftshader_apex =
+        graphics_config.vulkan_swiftshader_apex_supported();
+  }
+
   const auto& input_config = proto_config.input();
   if (input_config.has_mouse_supported()) {
     guest_config.mouse_supported = input_config.mouse_supported();
@@ -205,7 +218,6 @@ Result<void> ParseGuestConfigTxt(const std::string& guest_config_path,
 
   guest_config.gfxstream_supported =
       MapHasValue(info, "gfxstream", "supported");
-
   guest_config.gfxstream_gl_program_binary_link_status_supported =
       MapHasValue(info, "gfxstream_gl_program_binary_link_status", "supported");
 
@@ -220,6 +232,13 @@ Result<void> ParseGuestConfigTxt(const std::string& guest_config_path,
       guest_config.gpu_mode_candidates.push_back(candidate);
     }
   }
+
+  guest_config.has_vulkan_gfxstream_apex =
+      MapHasValue(info, "vulkan_gfxstream_apex", "supported");
+  guest_config.has_vulkan_lavapipe_apex =
+      MapHasValue(info, "vulkan_lavapipe_apex", "supported");
+  guest_config.has_vulkan_swiftshader_apex =
+      MapHasValue(info, "vulkan_swiftshader_apex", "supported");
 
   guest_config.mouse_supported = MapHasValue(info, "mouse", "supported");
 

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/guest_config.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/guest_config.h
@@ -40,6 +40,7 @@ struct GuestConfig {
   std::string android_version_number;
   bool gfxstream_supported = false;
   bool gfxstream_gl_program_binary_link_status_supported = false;
+  bool guest_lavapipe_supported = false;
   bool vhost_user_vsock = false;
   bool supports_bgra_framebuffers = false;
   bool prefer_drm_virgl_when_supported = false;
@@ -54,6 +55,9 @@ struct GuestConfig {
   int blank_data_image_mb = 0;
   bool lights_server_enabled = true;  // true for backwards compatibility
   std::vector<GpuMode> gpu_mode_candidates;
+  bool has_vulkan_lavapipe_apex = false;
+  bool has_vulkan_gfxstream_apex = false;
+  bool has_vulkan_swiftshader_apex = false;
 };
 
 PrettyStruct Pretty(const GuestConfig&,

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/proto/guest_config.proto
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/proto/guest_config.proto
@@ -48,6 +48,15 @@ message Graphics {
 
   // The list of gpu modes supported by the guest in order of preference.
   repeated GpuMode gpu_mode_candidates = 5;
+
+  // Whether the guest has a separate apex for the Gfxstream Vulkan driver.
+  bool vulkan_gfxstream_apex_supported = 6;
+
+  // Whether the guest has a separate apex for the Lavapipe Vulkan driver.
+  bool vulkan_lavapipe_apex_supported = 7;
+
+  // Whether the guest has a separate apex for the Swiftshader Vulkan driver.
+  bool vulkan_swiftshader_apex_supported = 8;
 }
 
 message Audio {
@@ -88,7 +97,7 @@ message Audio {
       bool mute_control_enabled = 1;
       Volume volume_control = 2;
     }
-    
+
     message Stream {
       uint32 id = 1;
       ChannelLayout channel_layout = 2;

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/streamer.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/streamer.cpp
@@ -151,7 +151,7 @@ class StreamerSockets : public virtual SetupFeature {
   // SetupFeature
   std::string Name() const override { return "StreamerSockets"; }
   bool Enabled() const override {
-    bool is_accelerated = instance_.gpu_mode() != GpuMode::GuestSwiftshader;
+    bool is_accelerated = !IsGuestRenderingMode(instance_.gpu_mode());
     return !(VmManagerIsQemu(config_) && is_accelerated);
   }
 

--- a/base/cvd/cuttlefish/host/frontend/webrtc/main.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/main.cpp
@@ -472,7 +472,9 @@ int CuttlefishMain() {
                             std::to_string(instance.memory_mb()) + " mb");
 
   std::string user_friendly_gpu_mode;
-  if (instance.gpu_mode() == GpuMode::GuestSwiftshader) {
+  if (instance.gpu_mode() == GpuMode::GuestLavapipe) {
+    user_friendly_gpu_mode = "Lavapipe (Guest GPU Rendering)";
+  } else if (instance.gpu_mode() == GpuMode::GuestSwiftshader) {
     user_friendly_gpu_mode = "SwiftShader (Guest CPU Rendering)";
   } else if (instance.gpu_mode() == GpuMode::DrmVirgl) {
     user_friendly_gpu_mode =

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
@@ -524,6 +524,10 @@ class CuttlefishConfig {
     bool enable_gpu_external_blob() const;
     bool enable_gpu_system_blob() const;
 
+    bool has_vulkan_gfxstream_apex() const;
+    bool has_vulkan_lavapipe_apex() const;
+    bool has_vulkan_swiftshader_apex() const;
+
     std::string hwcomposer() const;
 
     bool restart_subprocesses() const;
@@ -756,6 +760,10 @@ class CuttlefishConfig {
     void set_enable_gpu_vhost_user(const bool enable_gpu_vhost_user);
     void set_enable_gpu_external_blob(const bool enable_gpu_external_blob);
     void set_enable_gpu_system_blob(const bool enable_gpu_system_blob);
+
+    void set_has_vulkan_gfxstream_apex(const bool has_apex);
+    void set_has_vulkan_lavapipe_apex(const bool has_apex);
+    void set_has_vulkan_swiftshader_apex(const bool has_apex);
 
     void set_hwcomposer(const std::string&);
 

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
@@ -874,6 +874,34 @@ bool CuttlefishConfig::InstanceSpecific::enable_gpu_system_blob() const {
   return (*Dictionary())[kEnableGpuSystemBlob].asBool();
 }
 
+static constexpr char kHasVulkanGfxstreamApex[] = "has_vulkan_gfxstream_apex";
+void CuttlefishConfig::MutableInstanceSpecific::set_has_vulkan_gfxstream_apex(
+    const bool has_apex) {
+  (*Dictionary())[kHasVulkanGfxstreamApex] = has_apex;
+}
+bool CuttlefishConfig::InstanceSpecific::has_vulkan_gfxstream_apex() const {
+  return (*Dictionary())[kHasVulkanGfxstreamApex].asBool();
+}
+
+static constexpr char kHasVulkanLavapipeApex[] = "has_vulkan_lavapipe_apex";
+void CuttlefishConfig::MutableInstanceSpecific::set_has_vulkan_lavapipe_apex(
+    const bool has_apex) {
+  (*Dictionary())[kHasVulkanLavapipeApex] = has_apex;
+}
+bool CuttlefishConfig::InstanceSpecific::has_vulkan_lavapipe_apex() const {
+  return (*Dictionary())[kHasVulkanLavapipeApex].asBool();
+}
+
+static constexpr char kHasVulkanSwiftshaderApex[] =
+    "has_vulkan_swiftshader_apex";
+void CuttlefishConfig::MutableInstanceSpecific::set_has_vulkan_swiftshader_apex(
+    const bool has_apex) {
+  (*Dictionary())[kHasVulkanSwiftshaderApex] = has_apex;
+}
+bool CuttlefishConfig::InstanceSpecific::has_vulkan_swiftshader_apex() const {
+  return (*Dictionary())[kHasVulkanSwiftshaderApex].asBool();
+}
+
 static constexpr char kEnableAudio[] = "enable_audio";
 void CuttlefishConfig::MutableInstanceSpecific::set_enable_audio(bool enable) {
   (*Dictionary())[kEnableAudio] = enable;

--- a/base/cvd/cuttlefish/host/libs/config/gpu_mode.cc
+++ b/base/cvd/cuttlefish/host/libs/config/gpu_mode.cc
@@ -40,6 +40,8 @@ Result<GpuMode> GpuModeFromString(std::string_view mode) {
     return GpuMode::GfxstreamGuestAngleHostSwiftshader;
   } else if (mode == kGpuModeGfxstreamGuestAngleHostLavapipe) {
     return GpuMode::GfxstreamGuestAngleHostLavapipe;
+  } else if (mode == kGpuModeGuestLavapipe) {
+    return GpuMode::GuestLavapipe;
   } else if (mode == kGpuModeGuestSwiftshader) {
     return GpuMode::GuestSwiftshader;
   } else if (mode == kGpuModeNone) {
@@ -73,6 +75,9 @@ std::string_view format_as(GpuMode mode) {
     case GpuMode::GfxstreamGuestAngleHostSwiftshader:
       return kGpuModeGfxstreamGuestAngleHostSwiftshader;
       break;
+    case GpuMode::GuestLavapipe:
+      return kGpuModeGuestLavapipe;
+      break;
     case GpuMode::GuestSwiftshader:
       return kGpuModeGuestSwiftshader;
       break;
@@ -91,6 +96,10 @@ bool IsGfxstreamGuestAngleMode(GpuMode mode) {
   return mode == GpuMode::GfxstreamGuestAngle ||
          mode == GpuMode::GfxstreamGuestAngleHostLavapipe ||
          mode == GpuMode::GfxstreamGuestAngleHostSwiftshader;
+}
+
+bool IsGuestRenderingMode(GpuMode mode) {
+  return mode == GpuMode::GuestLavapipe || mode == GpuMode::GuestSwiftshader;
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/config/gpu_mode.h
+++ b/base/cvd/cuttlefish/host/libs/config/gpu_mode.h
@@ -31,6 +31,7 @@ enum class GpuMode {
   GfxstreamGuestAngle,
   GfxstreamGuestAngleHostLavapipe,
   GfxstreamGuestAngleHostSwiftshader,
+  GuestLavapipe,
   GuestSwiftshader,
   None,
 };
@@ -45,6 +46,7 @@ inline constexpr std::string_view kGpuModeGfxstreamGuestAngleHostLavapipe =
     "gfxstream_guest_angle_host_lavapipe";
 inline constexpr std::string_view kGpuModeGfxstreamGuestAngleHostSwiftshader =
     "gfxstream_guest_angle_host_swiftshader";
+inline constexpr std::string_view kGpuModeGuestLavapipe = "guest_lavapipe";
 inline constexpr std::string_view kGpuModeGuestSwiftshader =
     "guest_swiftshader";
 inline constexpr std::string_view kGpuModeNone = "none";
@@ -73,6 +75,9 @@ void AbslStringify(Sink& sink, GpuMode mode) {
     case GpuMode::GfxstreamGuestAngleHostSwiftshader:
       sink.Append(kGpuModeGfxstreamGuestAngleHostSwiftshader);
       break;
+    case GpuMode::GuestLavapipe:
+      sink.Append(kGpuModeGuestLavapipe);
+      break;
     case GpuMode::GuestSwiftshader:
       sink.Append(kGpuModeGuestSwiftshader);
       break;
@@ -88,5 +93,7 @@ std::string_view format_as(GpuMode mode);  // For libfmt
 
 bool IsGfxstreamMode(GpuMode mode);
 bool IsGfxstreamGuestAngleMode(GpuMode mode);
+
+bool IsGuestRenderingMode(GpuMode mode);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/metrics/metrics_conversion.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/metrics_conversion.cc
@@ -120,6 +120,9 @@ CuttlefishFlags_GpuMode ConvertGpuMode(GpuMode mode) {
     case GpuMode::GuestSwiftshader:
       return CuttlefishFlags_GpuMode::
           CuttlefishFlags_GpuMode_CUTTLEFISH_FLAGS_GPU_MODE_GUEST_SWIFTSHADER;
+    case GpuMode::GuestLavapipe:
+      return CuttlefishFlags_GpuMode::
+          CuttlefishFlags_GpuMode_CUTTLEFISH_FLAGS_GPU_MODE_GUEST_LAVAPIPE;
     case GpuMode::None:
       return CuttlefishFlags_GpuMode::
           CuttlefishFlags_GpuMode_CUTTLEFISH_FLAGS_GPU_MODE_NONE;

--- a/base/cvd/cuttlefish/host/libs/screen_connector/screen_connector.h
+++ b/base/cvd/cuttlefish/host/libs/screen_connector/screen_connector.h
@@ -71,6 +71,7 @@ class ScreenConnector : public ScreenConnectorFrameRenderer {
         GpuMode::GfxstreamGuestAngle,
         GpuMode::GfxstreamGuestAngleHostSwiftshader,
         GpuMode::GfxstreamGuestAngleHostLavapipe,
+        GpuMode::GuestLavapipe,
         GpuMode::GuestSwiftshader,
     };
     if (!Contains(valid_gpu_modes, instance.gpu_mode())) {

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
@@ -78,7 +78,18 @@ CrosvmManager::ConfigureGraphics(
 
   std::unordered_map<std::string, std::string> bootconfig_args;
 
-  if (instance.gpu_mode() == GpuMode::GuestSwiftshader) {
+  if (instance.gpu_mode() == GpuMode::GuestLavapipe) {
+    bootconfig_args = {
+        {"androidboot.cpuvulkan.version", std::to_string(VK_API_VERSION_1_4)},
+        {"androidboot.hardware.gralloc", "minigbm"},
+        {"androidboot.hardware.hwcomposer", instance.hwcomposer()},
+        {"androidboot.hardware.hwcomposer.mode", "client"},
+        {"androidboot.hardware.hwcomposer.display_finder_mode", "drm"},
+        {"androidboot.hardware.egl", "angle"},
+        {"androidboot.hardware.vulkan", "lvp"},
+        {"androidboot.opengles.version", "196609"},  // OpenGL ES 3.1
+    };
+  } else if (instance.gpu_mode() == GpuMode::GuestSwiftshader) {
     bootconfig_args = {
         {"androidboot.cpuvulkan.version", std::to_string(VK_API_VERSION_1_3)},
         {"androidboot.hardware.gralloc", "minigbm"},
@@ -326,7 +337,7 @@ Result<VhostUserDeviceCommands> BuildVhostUserGpu(
   gpu_device_cmd.Cmd().AddParameter("gpu");
 
   const GpuMode gpu_mode = instance.gpu_mode();
-  CF_EXPECT(IsGfxstreamMode(gpu_mode) || gpu_mode == GpuMode::GuestSwiftshader,
+  CF_EXPECT(IsGfxstreamMode(gpu_mode) || IsGuestRenderingMode(gpu_mode),
             "GPU mode " << GpuModeString(gpu_mode)
                         << " not yet supported with vhost user gpu.");
 
@@ -336,7 +347,7 @@ Result<VhostUserDeviceCommands> BuildVhostUserGpu(
   // Why does this need JSON instead of just following the normal flags style...
   Json::Value gpu_params_json;
   gpu_params_json["pci-address"] = gpu_pci_address;
-  if (gpu_mode == GpuMode::GuestSwiftshader) {
+  if (IsGuestRenderingMode(gpu_mode)) {
     gpu_params_json["backend"] = "2D";
   } else if (gpu_mode == GpuMode::Gfxstream) {
     gpu_params_json["context-types"] = "gfxstream-gles:gfxstream-vulkan";
@@ -482,7 +493,7 @@ Result<void> ConfigureGpu(const CuttlefishConfig& config, Command* crosvm_cmd) {
     crosvm_cmd->AddParameter("--wayland-sock=", instance.frames_socket_path());
   }
 
-  if (gpu_mode == GpuMode::GuestSwiftshader) {
+  if (IsGuestRenderingMode(gpu_mode)) {
     crosvm_cmd->AddParameter("--gpu=", gpu_displays_string, "backend=2D",
                              gpu_common_string);
   } else if (gpu_mode == GpuMode::DrmVirgl) {

--- a/base/cvd/cuttlefish/host/libs/vm_manager/gem5_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/gem5_manager.cpp
@@ -244,8 +244,20 @@ Gem5Manager::ConfigureGraphics(
 
   std::unordered_map<std::string, std::string> bootconfig_args;
 
-  if (instance.gpu_mode() == GpuMode::GuestSwiftshader) {
-    LOG(INFO) << "We are in SwiftShader mode";
+  if (instance.gpu_mode() == GpuMode::GuestLavapipe) {
+    VLOG(0) << "We are in Lavapipe mode";
+    bootconfig_args = {
+        {"androidboot.cpuvulkan.version", std::to_string(VK_API_VERSION_1_1)},
+        {"androidboot.hardware.gralloc", "minigbm"},
+        {"androidboot.hardware.hwcomposer", "ranchu"},
+        {"androidboot.hardware.hwcomposer.mode", "noop"},
+        {"androidboot.hardware.hwcomposer.display_finder_mode", "gem5"},
+        {"androidboot.hardware.egl", "angle"},
+        {"androidboot.hardware.vulkan", "lvp"},
+        {"androidboot.opengles.version", "196609"},  // OpenGL ES 3.1
+    };
+  } else if (instance.gpu_mode() == GpuMode::GuestSwiftshader) {
+    VLOG(0) << "We are in SwiftShader mode";
     bootconfig_args = {
         {"androidboot.cpuvulkan.version", std::to_string(VK_API_VERSION_1_1)},
         {"androidboot.hardware.gralloc", "minigbm"},

--- a/base/cvd/cuttlefish/host/libs/vm_manager/qemu_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/qemu_manager.cpp
@@ -127,7 +127,18 @@ QemuManager::ConfigureGraphics(
 
   std::unordered_map<std::string, std::string> bootconfig_args;
   const GpuMode gpu_mode = instance.gpu_mode();
-  if (gpu_mode == GpuMode::GuestSwiftshader) {
+  if (gpu_mode == GpuMode::GuestLavapipe) {
+    bootconfig_args = {
+        {"androidboot.cpuvulkan.version", std::to_string(VK_API_VERSION_1_4)},
+        {"androidboot.hardware.gralloc", "minigbm"},
+        {"androidboot.hardware.hwcomposer", instance.hwcomposer()},
+        {"androidboot.hardware.hwcomposer.mode", "client"},
+        {"androidboot.hardware.egl", "angle"},
+        {"androidboot.hardware.vulkan", "lvp"},
+        // OpenGL ES 3.1
+        {"androidboot.opengles.version", "196609"},
+    };
+  } else if (gpu_mode == GpuMode::GuestSwiftshader) {
     bootconfig_args = {
         {"androidboot.cpuvulkan.version", std::to_string(VK_API_VERSION_1_2)},
         {"androidboot.hardware.gralloc", "minigbm"},
@@ -446,8 +457,7 @@ Result<std::vector<MonitorCommand>> QemuManager::StartCommands(
 
     qemu_cmd.AddParameter("-vnc");
     qemu_cmd.AddParameter("127.0.0.1:", instance.qemu_vnc_server_port());
-  } else if (gpu_mode == GpuMode::GuestSwiftshader ||
-             IsGfxstreamMode(gpu_mode)) {
+  } else if (IsGuestRenderingMode(gpu_mode) || IsGfxstreamMode(gpu_mode)) {
     qemu_cmd.AddParameter("-vnc");
     qemu_cmd.AddParameter("127.0.0.1:", instance.qemu_vnc_server_port());
   } else {

--- a/base/cvd/external_proto/cf_flags.proto
+++ b/base/cvd/external_proto/cf_flags.proto
@@ -82,7 +82,7 @@ message CuttlefishFlags {
 
   string extra_kernel_cmdline = 9;
 
-  // Next index: 10
+  // Next index: 11
   enum GpuMode {
     CUTTLEFISH_FLAGS_GPU_MODE_UNSPECIFIED = 0;
     CUTTLEFISH_FLAGS_GPU_MODE_AUTO = 1;
@@ -94,6 +94,7 @@ message CuttlefishFlags {
     CUTTLEFISH_FLAGS_GPU_MODE_GUEST_GFXSTREAM_GUEST_ANGLE_HOST_LAVAPIPE = 7;
     CUTTLEFISH_FLAGS_GPU_MODE_GUEST_VIRGL_RENDERER = 8;
     CUTTLEFISH_FLAGS_GPU_MODE_NONE = 9;
+    CUTTLEFISH_FLAGS_GPU_MODE_GUEST_LAVAPIPE = 10;
   }
 
   // The graphics backend that the user asked for through flags.


### PR DESCRIPTION
Based on @valentineburley arsp/4898478.

This introduces a couple of new guest config values to determine if
various vulkan apexes are supported in order to work around the fact
that Cuttlefish at HEAD currently has both gfxstream and swiftshader
in a single apex (aosp/2818460). After this change is released, the
lavapipe vulkan apex can be introduced and the pre-existing gfxstream
plus swiftshader apex can be split.

Bug: b/530070181
Bug: b/536966381

```
Test: bazel run //cuttlefish/package:cvd -- create \
      (on main with pre-existing vulkan apex)

Test: bazel run //cuttlefish/package:cvd -- create \
      --gpu_mode=guest_swiftshader
      (on main with pre-existing vulkan apex)

Test: bazel run //cuttlefish/package:cvd -- create \
      --gpu_mode=gfxstream_guest_angle
      (on main with pre-existing vulkan apex)

Test: bazel run //cuttlefish/package:cvd -- create \
      --gpu_mode=gfxstream_guest_angle
      (on main with separated vulkan apexes from ag/41081278)

Test: bazel run //cuttlefish/package:cvd -- create \
      (on main with separated vulkan apexes from ag/41081278)

Test: bazel run //cuttlefish/package:cvd -- create \
      --gpu_mode=guest_lavapipe
      (on main with separated vulkan apexes from ag/41081278)

Test: bazel run //cuttlefish/package:cvd -- create \
      --config_file=spec.json
       (where spec.json specifies older udc image)
```