### PR TITLE
UI: Better icon for unlock screen button

### DIFF
--- a/base/cvd/cuttlefish/host/frontend/webrtc/html_client/client.html
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/html_client/client.html
@@ -21,6 +21,7 @@
         <link rel="stylesheet" type="text/css" href="custom.css" >
         <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined">
         <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols">
         <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Google+Symbols">
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
     </head>
@@ -40,7 +41,7 @@
             </button>
             <button id='back_btn' title='Back' disabled='true' class='material-icons'>arrow_back</button>
             <button id='home_btn' title='Home' disabled='true' class='material-icons'>home</button>
-            <button id='menu_btn' title='Menu' disabled='true' class='material-icons'>menu</button>
+            <button id='menu_btn' title='Unlock screen' disabled='true' class='material-symbols'>lock_open_right</button>
             <button id='gamepad_btn' title='Gamepad' disabled='true' style="display:none" class='material-icons'>gamepad</button>
             <button id='mouse_btn' title='Mouse' disabled='true' style="display:none" class='material-icons'>mouse</button>
             <button id='keyboard-modal-button' title='keyboard console' class='material-icons'>keyboard</button>


### PR DESCRIPTION
Uses the [lock open
right](https://fonts.google.com/icons?icon.query=unlock&icon.size=24&icon.color=%23e3e3e3&selected=Material+Symbols+Outlined:lock_open_right:FILL@0;wght@400;GRAD@0;opsz@24) material symbol instead of the menu one.