### PR TITLE
assemble_cvd: Support quiescent boot for U-Boot

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_config.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_config.cc
@@ -77,7 +77,14 @@ void WritePausedEntrypoint(std::string_view entrypoint,
 
 void WriteAndroidEnvironment(
     std::ostream& env, const CuttlefishConfig::InstanceSpecific& instance) {
-  WritePausedEntrypoint("run bootcmd_android", instance, env);
+  const std::string entrypoint =
+      "bcb load virtio 0 misc; "
+      "if bcb test command = boot-quiescent; then "
+      "setenv bootargs \"$bootargs androidboot.quiescent=1\"; "
+      "bcb clear command; bcb store; "
+      "fi; "
+      "run bootcmd_android";
+  WritePausedEntrypoint(entrypoint, instance, env);
 
   if (!instance.boot_slot().empty()) {
     env << "android_slot_suffix=_" << instance.boot_slot() << '\0';


### PR DESCRIPTION
The prebuilt U-Boot bootloader in Cuttlefish TV lacks quiescent boot support because it does not read the 'boot-quiescent' command from the BCB partition.

Inject a check into the U-Boot environment script ('uenvcmd') during assemble_cvd. If 'boot-quiescent' is detected in BCB, append 'androidboot.quiescent=1' to kernel bootargs and clear the BCB command.

Bug: b/465288316