### PR TITLE
Explicitly reset the cursor in the monitor view

### DIFF
--- a/base/cvd/cuttlefish/ansi_codes/ansi_codes.h
+++ b/base/cvd/cuttlefish/ansi_codes/ansi_codes.h
@@ -21,6 +21,7 @@
 
 namespace cuttlefish {
 
+inline constexpr std::string_view kAnsiCursorTopLeft = "\033[;H";
 inline constexpr std::string_view kAnsiBoldBlue = "\033[1;34m";
 inline constexpr std::string_view kAnsiBoldCyan = "\033[1;36m";
 inline constexpr std::string_view kAnsiClearScreen = "\033[2J";

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/monitor.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/monitor.cc
@@ -172,7 +172,7 @@ Result<void> MonitorLogs(const LocalInstance& instance, SharedFD stop_eventfd) {
     display.DrawFile(SharedFdIo(logcat_fd), kLogNameLogcat, logcat_lines);
 
     const auto [output, total_lines_drawn] = display.Finalize();
-    std::cout << kAnsiClearScreen << output << std::flush;
+    std::cout << kAnsiClearScreen << kAnsiCursorTopLeft << output << std::flush;
 
     // Enforce a maximum framerate (max 20 FPS / min 50ms between draws)
     // so we don't saturate SSH bandwidth or CPU during heavy, continuous


### PR DESCRIPTION
The initial "alternate screen buffer" implementation only reset the screen without resetting the terminal position. I believe where the cursor ends up after clearing the screen is implementation dependent, so explicitly put it at the top left before rendering more content.

Bug: b/527974149