### PR TITLE
Create a "monitor source" interface

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/BUILD.bazel
@@ -29,37 +29,40 @@ cf_cc_library(
     name = "display",
     srcs = ["display.cc"],
     hdrs = ["display.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
-        ":kernel",
-        ":launcher",
-        ":log_tee",
-        ":logcat",
-        ":truncate",
         "//cuttlefish/ansi_codes:should_color",
-        "//cuttlefish/common/libs/utils:environment",
         "//cuttlefish/common/libs/utils:tee_logging",
-        "//cuttlefish/host/commands/cvd/cli:format_byte_size",
-        "//cuttlefish/host/libs/log_names",
-        "//cuttlefish/io",
-        "//cuttlefish/io:read_exact",
-        "//cuttlefish/result",
+        "//cuttlefish/host/commands/cvd/cli/commands/monitor:monitor_source",
+        "//cuttlefish/host/commands/cvd/cli/commands/monitor:truncate",
+        "//libbase",
         "@abseil-cpp//absl/log:check",
         "@abseil-cpp//absl/strings",
-        "@abseil-cpp//absl/strings:cord",
     ],
 )
 
 cf_cc_test(
     name = "display_test",
     srcs = ["display_test.cc"],
-    depend_on_what_you_use_enabled = False,
     deps = [
-        ":display",
-        "//cuttlefish/io",
-        "//cuttlefish/io:in_memory",
-        "//cuttlefish/result:result_matchers",
+        "//cuttlefish/host/commands/cvd/cli/commands/monitor:display",
+        "//cuttlefish/host/commands/cvd/cli/commands/monitor:monitor_source",
         "@abseil-cpp//absl/strings",
+    ],
+)
+
+cf_cc_library(
+    name = "file_monitor_source",
+    srcs = ["file_monitor_source.cc"],
+    hdrs = ["file_monitor_source.h"],
+    deps = [
+        "//cuttlefish/host/commands/cvd/cli:format_byte_size",
+        "//cuttlefish/host/commands/cvd/cli/commands/monitor:monitor_source",
+        "//cuttlefish/io",
+        "//cuttlefish/io:read_exact",
+        "//cuttlefish/result:expect",
+        "//cuttlefish/result:result_type",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/strings:cord",
     ],
 )
 
@@ -69,7 +72,8 @@ cf_cc_library(
     hdrs = ["kernel.h"],
     deps = [
         "//cuttlefish/ansi_codes",
-        "//cuttlefish/result",
+        "//cuttlefish/result:expect",
+        "//cuttlefish/result:result_type",
         "@abseil-cpp//absl/strings",
     ],
 )
@@ -156,14 +160,26 @@ cf_cc_library(
         "//cuttlefish/files:file_exists",
         "//cuttlefish/host/commands/cvd/cli:utils",
         "//cuttlefish/host/commands/cvd/cli/commands/monitor:display",
+        "//cuttlefish/host/commands/cvd/cli/commands/monitor:file_monitor_source",
+        "//cuttlefish/host/commands/cvd/cli/commands/monitor:kernel",
+        "//cuttlefish/host/commands/cvd/cli/commands/monitor:launcher",
+        "//cuttlefish/host/commands/cvd/cli/commands/monitor:log_tee",
+        "//cuttlefish/host/commands/cvd/cli/commands/monitor:logcat",
+        "//cuttlefish/host/commands/cvd/cli/commands/monitor:monitor_source",
         "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/libs/log_names",
-        "//cuttlefish/io:in_memory",
+        "//cuttlefish/io",
         "//cuttlefish/io:shared_fd",
         "//cuttlefish/result",
         "@abseil-cpp//absl/cleanup",
         "@abseil-cpp//absl/strings",
     ],
+)
+
+cf_cc_library(
+    name = "monitor_source",
+    srcs = ["monitor_source.cc"],
+    hdrs = ["monitor_source.h"],
 )
 
 cf_cc_library(

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/display.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/display.cc
@@ -17,10 +17,8 @@
 #include "cuttlefish/host/commands/cvd/cli/commands/monitor/display.h"
 
 #include <stddef.h>
+#include <stdio.h>
 
-#include <algorithm>
-#include <cstddef>
-#include <cstdio>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -28,109 +26,34 @@
 #include <vector>
 
 #include "absl/log/check.h"
-#include "absl/strings/cord.h"
-#include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_replace.h"
-#include "absl/strings/str_split.h"
+#include "android-base/file.h"
 
 #include "cuttlefish/ansi_codes/should_color.h"
 #include "cuttlefish/common/libs/utils/tee_logging.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/monitor/kernel.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/monitor/launcher.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/monitor/log_tee.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/monitor/logcat.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/monitor_source.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/monitor/truncate.h"
-#include "cuttlefish/host/commands/cvd/cli/format_byte_size.h"
-#include "cuttlefish/host/libs/log_names/log_names.h"
-#include "cuttlefish/io/io.h"
-#include "cuttlefish/io/read_exact.h"
-#include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
-
-namespace {
-
-struct FileData {
-  std::vector<std::string> last_lines;
-  size_t total_size = 0;
-};
-
-Result<FileData> GetLastNLines(ReaderSeeker& rs, size_t n) {
-  FileData ret;
-  ret.total_size = CF_EXPECT(rs.SeekEnd(0));
-
-  absl::Cord accumulated_data;
-  size_t offset = ret.total_size;
-  size_t newline_count = 0;
-
-  while (offset > 0 && newline_count < n + 1) {
-    static constexpr size_t kChunkSize = 4096;
-    size_t to_read = std::min(kChunkSize, offset);
-    offset -= to_read;
-    CF_EXPECT(rs.SeekSet(offset));
-
-    std::string chunk(to_read, '\0');
-    CF_EXPECT(ReadExact(rs, chunk.data(), to_read));
-
-    newline_count += std::count(chunk.begin(), chunk.end(), '\n');
-    accumulated_data.Prepend(std::move(chunk));
-  }
-
-  ret.last_lines = absl::StrSplit(std::string(accumulated_data), '\n');
-
-  // Handle trailing newline
-  if (!ret.last_lines.empty() && ret.last_lines.back().empty()) {
-    ret.last_lines.pop_back();
-  }
-
-  size_t start_idx = ret.last_lines.size() > n ? ret.last_lines.size() - n : 0;
-  ret.last_lines.erase(ret.last_lines.begin(),
-                       ret.last_lines.begin() + start_idx);
-
-  return ret;
-}
-
-}  // namespace
 
 LogMonitorDisplay::LogMonitorDisplay(size_t width)
     : width_(width), total_lines_drawn_(0), colorize_(ShouldColorStdout()) {}
 
-void LogMonitorDisplay::DrawFile(ReaderSeeker& rs, const std::string& title,
-                                 size_t max_lines) {
-  if (max_lines == 0) {
-    return;
-  }
-  std::string title_with_size = title;
-  std::vector<std::string> lines;
-  Result<FileData> file_data = GetLastNLines(rs, max_lines);
-  if (file_data.ok()) {
-    lines = file_data->last_lines;
-    absl::StrAppend(&title_with_size, " (",
-                    FormatByteSize(file_data->total_size), ")");
-  } else {
-    lines.push_back(absl::StrCat("Failed to read ", title, ":"));
-    std::string error_str = file_data.error().FormatForEnv(/*color=*/false);
-    for (const auto& el : absl::StrSplit(error_str, '\n')) {
-      if (!el.empty()) {
-        lines.push_back(std::string(el));
-      }
-    }
-  }
-
-  if (lines.size() > max_lines) {
-    lines.resize(max_lines);
-  }
-  while (lines.size() < max_lines) {
-    lines.push_back("");
-  }
-
-  DrawBorderedText(lines, title_with_size);
+void LogMonitorDisplay::DrawReport(MonitorSource* source, size_t lines) {
+  MonitorOutput output = source ? source->Report(lines, width_ - 2)
+                                : MonitorOutput("No data", {"No data"});
+  DrawReport(std::move(output), lines);
 }
 
-void LogMonitorDisplay::DrawFile(ReaderSeeker&& rs, const std::string& title,
-                                 size_t max_lines) {
-  DrawFile(rs, title, max_lines);
+void LogMonitorDisplay::DrawReport(MonitorOutput output, size_t lines) {
+  if (output.lines.size() > lines) {
+    size_t to_erase = output.lines.size() - lines;
+    output.lines.erase(output.lines.begin(), output.lines.begin() + to_erase);
+  } else {
+    output.lines.resize(lines, "");
+  }
+  DrawBorderedText(output);
 }
 
 LogMonitorDisplayResult LogMonitorDisplay::Finalize() {
@@ -143,14 +66,14 @@ LogMonitorDisplayResult LogMonitorDisplay::Finalize() {
   };
 }
 
-void LogMonitorDisplay::DrawBorderedText(const std::vector<std::string>& lines,
-                                         const std::string& title) {
+void LogMonitorDisplay::DrawBorderedText(const MonitorOutput& output) {
+  const std::string title = android::base::Basename(output.title);
   std::string top_border = absl::StrCat("+--", title, " ");
   CHECK_GE(width_, 2);
   top_border.resize(width_ - 1, '-');
   ss_ << top_border << "+\n";
 
-  for (const std::string& raw_line : lines) {
+  for (const std::string& raw_line : output.lines) {
     std::string sanitized_holder;
     std::string_view line = raw_line;
     if (line.find_first_of("\t\r\n") != std::string_view::npos) {
@@ -159,56 +82,12 @@ void LogMonitorDisplay::DrawBorderedText(const std::vector<std::string>& lines,
                           &sanitized_holder);
       line = sanitized_holder;
     }
-
-    const bool cf_log = absl::StrContains(title, kLogNameAssembleCvd) ||
-                        absl::StrContains(title, kLogNameLauncher);
-    if (cf_log && line.find("log_tee(") == 0) {
-      const size_t bracket = line.find(']');
-      if (bracket != std::string_view::npos) {
-        line.remove_prefix(bracket + 1);
-        const size_t first_non_space = line.find_first_not_of(" \t");
-        if (first_non_space != std::string_view::npos) {
-          line.remove_prefix(first_non_space);
-        } else {
-          line = "";
-        }
-      }
-
-      if (Result<LogTeeLine> parsed = ParseLogTeeLine(line); parsed.ok()) {
-        FormatAndDrawLine(FormatLogTeeLine(*parsed));
-        continue;
-      }
-    }
-
-    if (absl::StrContains(title, kLogNameLogcat)) {
-      if (Result<LogcatLine> parsed = ParseLogcatLine(line); parsed.ok()) {
-        FormatAndDrawLine(FormatLogcatLine(*parsed));
-        continue;
-      }
-    }
-
-    if (absl::StrContains(title, kLogNameKernel)) {
-      if (Result<KernelLine> parsed = ParseKernelLine(line); parsed.ok()) {
-        FormatAndDrawLine(FormatKernelLine(*parsed));
-        continue;
-      }
-    }
-
-    if (absl::StrContains(title, kLogNameLauncher)) {
-      if (Result<LauncherLine> parsed = ParseLauncherLine(line); parsed.ok()) {
-        FormatAndDrawLine(FormatLauncherLine(*parsed));
-        continue;
-      }
-    }
-
-    std::string fallback_line(line);
-    fallback_line.resize(width_ - 2, ' ');
-    ss_ << "|" << fallback_line << "|\n";
+    FormatAndDrawLine(line);
   }
-  total_lines_drawn_ += 1 + lines.size();
+  total_lines_drawn_ += 1 + output.lines.size();
 }
 
-void LogMonitorDisplay::FormatAndDrawLine(const std::string& formatted) {
+void LogMonitorDisplay::FormatAndDrawLine(std::string_view formatted) {
   auto [final_line, visible_len] = TruncateColoredString(formatted, width_ - 2);
   if (visible_len < width_ - 2) {
     absl::StrAppend(&final_line, std::string(width_ - 2 - visible_len, ' '));

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/display.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/display.h
@@ -16,12 +16,12 @@
 
 #pragma once
 
-#include <cstddef>
+#include <stddef.h>
+
 #include <sstream>
 #include <string>
-#include <vector>
 
-#include "cuttlefish/io/io.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/monitor_source.h"
 
 namespace cuttlefish {
 
@@ -44,9 +44,9 @@ struct LogMonitorDisplayResult {
  * Example usage:
  * @code
  *   LogMonitorDisplay display(80); // 80 columns wide
- *   display.DrawFile(launcher_fd, "launcher.log");
- *   display.DrawFile(kernel_fd, "kernel.log");
- *   auto result = display.Finalize();
+ *   display.DrawReport(launcher_source, 20);
+ *   display.DrawReport(kernel_source, 40);
+ *   LogMonitorDisplayResult result = display.Finalize();
  *   std::cout << result.output << std::flush;
  * @endcode
  */
@@ -57,14 +57,9 @@ class LogMonitorDisplay {
    */
   LogMonitorDisplay(size_t width);
 
-  /**
-   * Reads the recent content of the given file descriptor and draws it
-   * within a bordered box titled with the provided name.
-   * If the file cannot be read, an error box is drawn instead.
-   */
-  void DrawFile(ReaderSeeker&, const std::string& title, size_t max_lines = 10);
-  void DrawFile(ReaderSeeker&&, const std::string& title,
-                size_t max_lines = 10);
+  /* Draw the output of a single monitor source. */
+  void DrawReport(MonitorSource*, size_t lines);
+  void DrawReport(MonitorOutput, size_t lines);
 
   /**
    * Appends the final bottom border to the display and returns the
@@ -76,15 +71,14 @@ class LogMonitorDisplay {
   /**
    * Helper to draw a list of text lines inside a bordered box with a title.
    */
-  void DrawBorderedText(const std::vector<std::string>& lines,
-                        const std::string& title);
+  void DrawBorderedText(const MonitorOutput&);
 
   /**
    * Formats a single line of text: parses it for specific log types (like
    * logcat, kernel), applies color formatting, truncates to fit the display
    * width, pads with spaces, and adds borders.
    */
-  void FormatAndDrawLine(const std::string& formatted);
+  void FormatAndDrawLine(std::string_view formatted);
 
   size_t width_;
   std::stringstream ss_;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/display_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/display_test.cc
@@ -16,104 +16,96 @@
 
 #include "cuttlefish/host/commands/cvd/cli/commands/monitor/display.h"
 
-#include <cstddef>
-#include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
-#include "absl/strings/match.h"
-#include "absl/strings/str_cat.h"
+#include "absl/strings/str_split.h"
 #include "gtest/gtest.h"
 
-#include "cuttlefish/io/in_memory.h"
-#include "cuttlefish/io/io.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/monitor_source.h"
 
 namespace cuttlefish {
+namespace {
 
-TEST(LogMonitorDisplayTest, DrawFileValid) {
-  std::unique_ptr<ReaderWriterSeeker> rs = InMemoryIo("line1\nline2\nline3\n");
-  ASSERT_TRUE(rs.get());
+TEST(LogMonitorDisplayTest, LineCountMatches) {
+  MonitorOutput monitor_output("test1.log", {"line1", "line2", "line3"});
 
-  LogMonitorDisplay display(40);
-  display.DrawFile(*rs, "test.log");
+  LogMonitorDisplay display(20);
+  display.DrawReport(std::move(monitor_output), 3);
 
-  std::string output = display.Finalize().output;
-  EXPECT_TRUE(absl::StrContains(output, "+--test.log "));
-  EXPECT_TRUE(
-      absl::StrContains(output, "|line1                                 |"));
-  EXPECT_TRUE(
-      absl::StrContains(output, "|line2                                 |"));
-  EXPECT_TRUE(
-      absl::StrContains(output, "|line3                                 |"));
-  EXPECT_TRUE(
-      absl::StrContains(output, "+--------------------------------------+"));
+  const LogMonitorDisplayResult result = display.Finalize();
+  ASSERT_EQ(result.total_lines_drawn, 5);
+
+  const std::vector<std::string> lines = absl::StrSplit(result.output, '\n');
+  ASSERT_EQ(lines.size(), 6);
+
+  EXPECT_EQ(lines[0], "+--test1.log ------+");
+  EXPECT_EQ(lines[1], "|line1             |");
+  EXPECT_EQ(lines[2], "|line2             |");
+  EXPECT_EQ(lines[3], "|line3             |");
+  EXPECT_EQ(lines[4], "+------------------+");
+  EXPECT_EQ(lines[5], "");
 }
 
-TEST(LogMonitorDisplayTest, TotalLinesDrawn) {
-  std::unique_ptr<ReaderWriterSeeker> rs = InMemoryIo("line1\n");
-  ASSERT_TRUE(rs.get());
+TEST(LogMonitorDisplayTest, TooFewLines) {
+  MonitorOutput monitor_output("test2.log", {"line1"});
 
-  LogMonitorDisplay display(40);
+  LogMonitorDisplay display(20);
+  display.DrawReport(std::move(monitor_output), 3);
 
-  display.DrawFile(*rs, "test.log");
-  int total_lines_drawn = display.Finalize().total_lines_drawn;
-  // 10 lines of content + 1 top border + 1 bottom border
-  EXPECT_EQ(total_lines_drawn, 12);
+  const LogMonitorDisplayResult result = display.Finalize();
+  ASSERT_EQ(result.total_lines_drawn, 5);
+
+  const std::vector<std::string> lines = absl::StrSplit(result.output, '\n');
+  ASSERT_EQ(lines.size(), 6);
+
+  EXPECT_EQ(lines[0], "+--test2.log ------+");
+  EXPECT_EQ(lines[1], "|line1             |");
+  EXPECT_EQ(lines[2], "|                  |");
+  EXPECT_EQ(lines[3], "|                  |");
+  EXPECT_EQ(lines[4], "+------------------+");
+  EXPECT_EQ(lines[5], "");
 }
 
-TEST(LogMonitorDisplayTest, DrawFileLastNLinesOrder) {
-  std::string data;
-  for (int i = 1; i <= 12; ++i) {
-    data += absl::StrCat("line", i, "\n");
-  }
-  std::unique_ptr<ReaderWriterSeeker> rs = InMemoryIo(data);
-  ASSERT_TRUE(rs.get());
+TEST(LogMonitorDisplayTest, TooManyLines) {
+  MonitorOutput monitor_output("test3.log",
+                               {"line1", "line2", "line3", "line4"});
 
-  LogMonitorDisplay display(40);
-  display.DrawFile(*rs, "test.log");
+  LogMonitorDisplay display(20);
+  display.DrawReport(monitor_output, 2);
 
-  std::string output = display.Finalize().output;
+  const LogMonitorDisplayResult result = display.Finalize();
+  ASSERT_EQ(result.total_lines_drawn, 4);
 
-  // Should contain line3 to line12
-  for (int i = 3; i <= 12; ++i) {
-    EXPECT_TRUE(absl::StrContains(output, absl::StrCat("|line", i)));
-  }
-  // Should NOT contain line1 or line2
-  EXPECT_FALSE(absl::StrContains(output, "|line1 "));
-  EXPECT_FALSE(absl::StrContains(output, "|line2 "));
+  const std::vector<std::string> lines = absl::StrSplit(result.output, '\n');
+  ASSERT_EQ(lines.size(), 5);
 
-  // Check order
-  size_t last_pos = 0;
-  for (int i = 3; i <= 12; ++i) {
-    size_t pos = output.find(absl::StrCat("|line", i));
-    ASSERT_NE(pos, std::string::npos);
-    EXPECT_GT(pos, last_pos);
-    last_pos = pos;
-  }
+  EXPECT_EQ(lines[0], "+--test3.log ------+");
+  EXPECT_EQ(lines[1], "|line3             |");
+  EXPECT_EQ(lines[2], "|line4             |");
+  EXPECT_EQ(lines[3], "+------------------+");
+  EXPECT_EQ(lines[4], "");
 }
 
-TEST(LogMonitorDisplayTest, DrawFileLinesAcrossChunks) {
-  std::string data;
-  for (int i = 1; i <= 10; ++i) {
-    std::string line = absl::StrCat("Line ", i, ": ");
-    int fill_len = 500 - line.length() - 1;
-    line += std::string(fill_len, 'A' + i);
-    line += "\n";
-    data += line;
-  }
-  ASSERT_EQ(data.size(), 5000);
+TEST(LogMonitorDisplayTest, LinesTooLong) {
+  MonitorOutput monitor_output("test4.log", {"line1AAAAAAAAAAAAAAAAAAAAAAAAA"});
 
-  std::unique_ptr<ReaderWriterSeeker> rs = InMemoryIo(data);
-  ASSERT_TRUE(rs.get());
+  LogMonitorDisplay display(20);
+  display.DrawReport(monitor_output, 2);
 
-  LogMonitorDisplay display(80);
-  display.DrawFile(*rs, "test.log");
+  const LogMonitorDisplayResult result = display.Finalize();
+  ASSERT_EQ(result.total_lines_drawn, 4);
 
-  std::string output = display.Finalize().output;
+  const std::vector<std::string> lines = absl::StrSplit(result.output, '\n');
+  ASSERT_EQ(lines.size(), 5);
 
-  // Verify all lines are present
-  for (int i = 1; i <= 10; ++i) {
-    EXPECT_TRUE(absl::StrContains(output, absl::StrCat("Line ", i, ": ")));
-  }
+  EXPECT_EQ(lines[0], "+--test4.log ------+");
+  EXPECT_EQ(lines[1], "|line1AAAAAAAAAAAAA|");
+  EXPECT_EQ(lines[2], "|                  |");
+  EXPECT_EQ(lines[3], "+------------------+");
+  EXPECT_EQ(lines[4], "");
 }
 
+}  // namespace
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/file_monitor_source.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/file_monitor_source.cc
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/file_monitor_source.h"
+
+#include <stddef.h>
+
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "absl/strings/cord.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_split.h"
+
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/monitor_source.h"
+#include "cuttlefish/host/commands/cvd/cli/format_byte_size.h"
+#include "cuttlefish/io/io.h"
+#include "cuttlefish/io/read_exact.h"
+#include "cuttlefish/result/expect.h"
+#include "cuttlefish/result/result_type.h"
+
+namespace cuttlefish {
+namespace {
+
+struct FileData {
+  std::vector<std::string> last_lines;
+  size_t total_size = 0;
+};
+
+Result<FileData> GetLastNLines(ReaderSeeker& rs, size_t n) {
+  FileData ret;
+  ret.total_size = CF_EXPECT(rs.SeekEnd(0));
+
+  absl::Cord accumulated_data;
+  size_t offset = ret.total_size;
+  size_t newline_count = 0;
+
+  while (offset > 0 && newline_count < n + 1) {
+    static constexpr size_t kChunkSize = 4096;
+    size_t to_read = std::min(kChunkSize, offset);
+    offset -= to_read;
+    CF_EXPECT(rs.SeekSet(offset));
+
+    std::string chunk(to_read, '\0');
+    CF_EXPECT(ReadExact(rs, chunk.data(), to_read));
+
+    newline_count += std::count(chunk.begin(), chunk.end(), '\n');
+    accumulated_data.Prepend(std::move(chunk));
+  }
+
+  ret.last_lines = absl::StrSplit(std::string(accumulated_data), '\n');
+
+  // Handle trailing newline
+  if (!ret.last_lines.empty() && ret.last_lines.back().empty()) {
+    ret.last_lines.pop_back();
+  }
+
+  size_t start_idx = ret.last_lines.size() > n ? ret.last_lines.size() - n : 0;
+  ret.last_lines.erase(ret.last_lines.begin(),
+                       ret.last_lines.begin() + start_idx);
+
+  return ret;
+}
+
+}  // namespace
+
+FileMonitorSource::FileMonitorSource(
+    std::string name, std::unique_ptr<ReaderSeeker> file_io,
+    std::function<Result<std::string>(std::string_view)> colorize_line)
+    : name_(std::move(name)),
+      file_io_(std::move(file_io)),
+      colorize_line_(std::move(colorize_line)) {}
+
+MonitorOutput FileMonitorSource::Report(size_t rows, size_t) {
+  Result<FileData> file_data = GetLastNLines(*file_io_, rows);
+  if (!file_data.ok()) {
+    return MonitorOutput(
+        absl::StrCat(name_, " (error)"),
+        absl::StrSplit(file_data.error().FormatForEnv(true), '\n'));
+  }
+  for (std::string& line : file_data->last_lines) {
+    line = colorize_line_(line).value_or(line);
+  }
+  std::string size = FormatByteSize(file_data->total_size);
+  return MonitorOutput(absl::StrCat(name_, " (", size, ")"),
+                       file_data->last_lines);
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/file_monitor_source.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/file_monitor_source.h
@@ -16,25 +16,31 @@
 
 #pragma once
 
+#include <stddef.h>
+
+#include <functional>
+#include <memory>
 #include <string>
 #include <string_view>
 
-#include "cuttlefish/result/result.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/monitor_source.h"
+#include "cuttlefish/io/io.h"
+#include "cuttlefish/result/result_type.h"
 
 namespace cuttlefish {
 
-struct LogcatLine {
-  std::string_view date;
-  std::string_view time;
-  std::string_view uid;
-  std::string_view pid;
-  char verbosity;
-  std::string_view tag;
-  std::string_view message;
-};
+class FileMonitorSource : public MonitorSource {
+ public:
+  FileMonitorSource(
+      std::string name, std::unique_ptr<ReaderSeeker> file_io,
+      std::function<Result<std::string>(std::string_view)> colorize_line);
 
-Result<LogcatLine> ParseLogcatLine(std::string_view line);
-std::string FormatLogcatLine(const LogcatLine& line);
-Result<std::string> ColorLogcatLine(std::string_view line);
+  MonitorOutput Report(size_t rows, size_t columns) override;
+
+ private:
+  std::string name_;
+  std::unique_ptr<ReaderSeeker> file_io_;
+  std::function<Result<std::string>(std::string_view)> colorize_line_;
+};
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/kernel.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/kernel.cc
@@ -23,7 +23,8 @@
 #include "absl/strings/str_cat.h"
 
 #include "cuttlefish/ansi_codes/ansi_codes.h"
-#include "cuttlefish/result/result.h"
+#include "cuttlefish/result/expect.h"
+#include "cuttlefish/result/result_type.h"
 
 namespace cuttlefish {
 
@@ -72,6 +73,10 @@ Result<KernelLine> ParseKernelLine(std::string_view line) {
 std::string FormatKernelLine(const KernelLine& line) {
   return absl::StrCat(kAnsiGreen, line.timestamp, kAnsiYellow, line.prefix,
                       kAnsiReset, line.message);
+}
+
+Result<std::string> ColorKernelLine(std::string_view line) {
+  return FormatKernelLine(CF_EXPECT(ParseKernelLine(line)));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/kernel.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/kernel.h
@@ -16,11 +16,10 @@
 
 #pragma once
 
-#include <cstddef>
 #include <string>
 #include <string_view>
 
-#include "cuttlefish/result/result.h"
+#include "cuttlefish/result/result_type.h"
 
 namespace cuttlefish {
 
@@ -29,7 +28,9 @@ struct KernelLine {
   std::string_view prefix;
   std::string_view message;
 };
+
 Result<KernelLine> ParseKernelLine(std::string_view line);
 std::string FormatKernelLine(const KernelLine& line);
+Result<std::string> ColorKernelLine(std::string_view line);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/launcher.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/launcher.cc
@@ -82,4 +82,8 @@ std::string FormatLauncherLine(const LauncherLine& line) {
                       line.proc_name, ": ", kAnsiReset, line.message);
 }
 
+Result<std::string> ColorLauncherLine(std::string_view line) {
+  return FormatLauncherLine(CF_EXPECT(ParseLauncherLine(line)));
+}
+
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/launcher.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/launcher.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <cstddef>
 #include <string>
 #include <string_view>
 
@@ -34,7 +33,9 @@ struct LauncherLine {
   std::string_view file_line;
   std::string_view message;
 };
+
 Result<LauncherLine> ParseLauncherLine(std::string_view line);
 std::string FormatLauncherLine(const LauncherLine& line);
+Result<std::string> ColorLauncherLine(std::string_view line);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/log_tee.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/log_tee.cc
@@ -82,4 +82,8 @@ std::string FormatLogTeeLine(const LogTeeLine& line) {
                       line.message);
 }
 
+Result<std::string> ColorLogTeeLine(std::string_view line) {
+  return FormatLogTeeLine(CF_EXPECT(ParseLogTeeLine(line)));
+}
+
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/log_tee.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/log_tee.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <cstddef>
 #include <string>
 #include <string_view>
 
@@ -30,7 +29,9 @@ struct LogTeeLine {
   std::string_view subsystem;
   std::string_view message;
 };
+
 Result<LogTeeLine> ParseLogTeeLine(std::string_view line);
 std::string FormatLogTeeLine(const LogTeeLine& line);
+Result<std::string> ColorLogTeeLine(std::string_view line);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/logcat.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/logcat.cc
@@ -71,4 +71,8 @@ std::string FormatLogcatLine(const LogcatLine& line) {
                       kAnsiYellow, line.tag, kAnsiReset, " ", line.message);
 }
 
+Result<std::string> ColorLogcatLine(std::string_view line) {
+  return FormatLogcatLine(CF_EXPECT(ParseLogcatLine(line)));
+}
+
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/monitor.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/monitor.cc
@@ -29,7 +29,9 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "absl/cleanup/cleanup.h"
@@ -39,26 +41,105 @@
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/files/file_exists.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/monitor/display.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/file_monitor_source.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/kernel.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/launcher.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/log_tee.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/logcat.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/monitor_source.h"
 #include "cuttlefish/host/commands/cvd/cli/utils.h"
 #include "cuttlefish/host/commands/cvd/instances/local_instance.h"
 #include "cuttlefish/host/libs/log_names/log_names.h"
-#include "cuttlefish/io/in_memory.h"
+#include "cuttlefish/io/io.h"
 #include "cuttlefish/io/shared_fd.h"
 #include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
 namespace {
 
-void UpdateFileAndWatch(const SharedFD& inotify_fd, const std::string& path,
-                        SharedFD& fd, int& watch) {
-  if (!fd->IsOpen()) {
-    if (FileExists(path)) {
-      fd = SharedFD::Open(path, O_RDONLY);
+Result<std::string> ColorLauncherOrLogTee(std::string_view line) {
+  if (line.find("log_tee(") != 0) {
+    return CF_EXPECT(ColorLauncherLine(line));
+  }
+  const size_t bracket = line.find(']');
+  if (bracket != std::string_view::npos) {
+    line.remove_prefix(bracket + 1);
+    const size_t first_non_space = line.find_first_not_of(" \t");
+    if (first_non_space != std::string_view::npos) {
+      line.remove_prefix(first_non_space);
+    } else {
+      line = "";
     }
   }
-  if (fd->IsOpen() && watch == -1) {
-    watch = inotify_fd->InotifyAddWatch(path, IN_DELETE_SELF | IN_MODIFY);
+  return CF_EXPECT(ColorLogTeeLine(line));
+}
+
+// TODO(schuffelen): integrate inotify watches into MonitorSource
+
+std::unique_ptr<MonitorSource> LauncherLogMonitorSource(
+    const LocalInstance& instance, SharedFD inotify_fd, int& watch) {
+  if (watch != -1) {
+    inotify_fd->InotifyRmWatch(watch);
+    watch = -1;
   }
+  const std::string launcher =
+      absl::StrCat(instance.InstanceDirectory(), "/logs/", kLogNameLauncher);
+  const std::string assemble =
+      absl::StrCat(instance.AssemblyDirectory(), "/", kLogNameAssembleCvd);
+  const std::string path = FileExists(launcher) ? launcher : assemble;
+  if (!FileExists(path)) {
+    return {};
+  }
+  SharedFD fd = SharedFD::Open(path, O_RDONLY);
+  if (!fd->IsOpen() || fd->LSeek(0, SEEK_END) <= 0) {
+    return {};
+  }
+  watch = inotify_fd->InotifyAddWatch(path, IN_DELETE_SELF | IN_MODIFY);
+  std::unique_ptr<ReaderSeeker> io = std::make_unique<SharedFdIo>(fd);
+  return std::make_unique<FileMonitorSource>(path, std::move(io),
+                                             ColorLauncherOrLogTee);
+}
+
+std::unique_ptr<MonitorSource> KernelLogMonitorSource(
+    const LocalInstance& instance, SharedFD inotify_fd, int& watch) {
+  if (watch != -1) {
+    inotify_fd->InotifyRmWatch(watch);
+    watch = -1;
+  }
+  const std::string path =
+      absl::StrCat(instance.InstanceDirectory(), "/logs/", kLogNameKernel);
+  if (!FileExists(path)) {
+    return {};
+  }
+  SharedFD fd = SharedFD::Open(path, O_RDONLY);
+  if (!fd->IsOpen() || fd->LSeek(0, SEEK_END) <= 0) {
+    return {};
+  }
+  watch = inotify_fd->InotifyAddWatch(path, IN_DELETE_SELF | IN_MODIFY);
+  std::unique_ptr<ReaderSeeker> io = std::make_unique<SharedFdIo>(fd);
+  return std::make_unique<FileMonitorSource>(path, std::move(io),
+                                             ColorKernelLine);
+}
+
+std::unique_ptr<MonitorSource> LogcatMonitorSource(
+    const LocalInstance& instance, SharedFD inotify_fd, int& watch) {
+  if (watch != -1) {
+    inotify_fd->InotifyRmWatch(watch);
+    watch = -1;
+  }
+  const std::string path =
+      absl::StrCat(instance.InstanceDirectory(), "/logs/", kLogNameLogcat);
+  if (!FileExists(path)) {
+    return {};
+  }
+  SharedFD fd = SharedFD::Open(path, O_RDONLY);
+  if (!fd->IsOpen() || fd->LSeek(0, SEEK_END) <= 0) {
+    return {};
+  }
+  watch = inotify_fd->InotifyAddWatch(path, IN_DELETE_SELF | IN_MODIFY);
+  std::unique_ptr<ReaderSeeker> io = std::make_unique<SharedFdIo>(fd);
+  return std::make_unique<FileMonitorSource>(path, std::move(io),
+                                             ColorLogcatLine);
 }
 
 }  // namespace
@@ -66,19 +147,9 @@ void UpdateFileAndWatch(const SharedFD& inotify_fd, const std::string& path,
 Result<void> MonitorLogs(const LocalInstance& instance, SharedFD stop_eventfd) {
   CF_EXPECT(isatty(0), "The monitor command requires an interactive terminal.");
 
-  const std::string kernel_log =
-      absl::StrCat(instance.InstanceDirectory(), "/logs/", kLogNameKernel);
-  const std::string launcher_log =
-      absl::StrCat(instance.InstanceDirectory(), "/logs/", kLogNameLauncher);
-  const std::string logcat =
-      absl::StrCat(instance.InstanceDirectory(), "/logs/", kLogNameLogcat);
-  const std::string assemble_log =
-      absl::StrCat(instance.AssemblyDirectory(), "/", kLogNameAssembleCvd);
-  bool using_assemble_log = true;
-
-  SharedFD kernel_fd;
-  SharedFD launcher_fd;
-  SharedFD logcat_fd;
+  std::unique_ptr<MonitorSource> kernel_monitor_source;
+  std::unique_ptr<MonitorSource> launcher_monitor_source;
+  std::unique_ptr<MonitorSource> logcat_monitor_source;
 
   const SharedFD inotify_fd = SharedFD::InotifyFd();
   CF_EXPECT(inotify_fd->IsOpen(), "Failed to create inotify fd");
@@ -88,8 +159,7 @@ Result<void> MonitorLogs(const LocalInstance& instance, SharedFD stop_eventfd) {
 
   const std::string logs_dir =
       absl::StrCat(instance.InstanceDirectory(), "/logs");
-  const int dir_watch =
-      inotify_fd->InotifyAddWatch(logs_dir, IN_CREATE | IN_DELETE);
+  inotify_fd->InotifyAddWatch(logs_dir, IN_CREATE | IN_DELETE);
 
   int kernel_watch = -1;
   int launcher_watch = -1;
@@ -105,71 +175,49 @@ Result<void> MonitorLogs(const LocalInstance& instance, SharedFD stop_eventfd) {
   };
 
   while (true) {
-    if (using_assemble_log) {
-      if (FileExists(launcher_log)) {
-        if (launcher_watch != -1) {
-          inotify_fd->InotifyRmWatch(launcher_watch);
-          launcher_watch = -1;
-        }
-        launcher_fd = SharedFD::Open(launcher_log, O_RDONLY);
-        if (launcher_fd->IsOpen()) {
-          launcher_watch = inotify_fd->InotifyAddWatch(
-              launcher_log, IN_DELETE_SELF | IN_MODIFY);
-          using_assemble_log = false;
-        }
-      } else if (!launcher_fd->IsOpen()) {
-        if (FileExists(assemble_log)) {
-          launcher_fd = SharedFD::Open(assemble_log, O_RDONLY);
-          if (launcher_fd->IsOpen()) {
-            if (launcher_watch == -1) {
-              launcher_watch = inotify_fd->InotifyAddWatch(
-                  assemble_log, IN_DELETE_SELF | IN_MODIFY);
-            }
-          }
-        }
+    if (!kernel_monitor_source.get()) {
+      kernel_monitor_source =
+          KernelLogMonitorSource(instance, inotify_fd, kernel_watch);
+    }
+    if (!logcat_monitor_source.get()) {
+      logcat_monitor_source =
+          LogcatMonitorSource(instance, inotify_fd, logcat_watch);
+    }
+    if (!launcher_monitor_source.get()) {
+      launcher_monitor_source =
+          LauncherLogMonitorSource(instance, inotify_fd, launcher_watch);
+    }
+
+    TerminalSize term_size =
+        GetTerminalSize().value_or(TerminalSize{.rows = 35, .columns = 80});
+    term_size.rows -= 3;
+    term_size.columns -= 1;
+    LogMonitorDisplay display(term_size.columns);
+
+    bool missing_source = false;
+    const std::vector<MonitorSource*> sources = {
+        launcher_monitor_source.get(),
+        kernel_monitor_source.get(),
+        logcat_monitor_source.get(),
+    };
+
+    for (size_t i = 0; i < sources.size(); i++) {
+      MonitorSource* source = sources[i];
+      if (source == nullptr) {
+        missing_source = true;
       }
-    } else {
-      UpdateFileAndWatch(inotify_fd, launcher_log, launcher_fd, launcher_watch);
+      size_t lines = (term_size.rows / 3) - 1;
+      while (i + 1 < sources.size() && sources[i + 1] == nullptr) {
+        lines += (term_size.rows / 3) - 1;
+        i++;
+        missing_source = true;
+      }
+      display.DrawReport(source, lines);
     }
 
-    UpdateFileAndWatch(inotify_fd, kernel_log, kernel_fd, kernel_watch);
-    UpdateFileAndWatch(inotify_fd, logcat, logcat_fd, logcat_watch);
-
-    const Result<TerminalSize> term_size_result = GetTerminalSize();
-    int width = 79;  // Default fallback width (80 - 1)
-    int height = 30;
-    if (term_size_result.ok()) {
-      width = term_size_result->columns - 1;
-      height = term_size_result->rows - 5;
+    if (missing_source) {
+      launcher_monitor_source.reset();  // will cut over to launcher.log soon
     }
-    LogMonitorDisplay display(width);
-
-    bool logcat_ready = false;
-    if (logcat_fd->IsOpen() && logcat_fd->LSeek(0, SEEK_END) > 0) {
-      logcat_ready = true;
-    }
-
-    const std::string launcher_name =
-        using_assemble_log ? kLogNameAssembleCvd : kLogNameLauncher;
-    size_t launcher_lines = height;
-    size_t kernel_lines = 0;
-    size_t logcat_lines = 0;
-    if (kernel_fd->IsOpen()) {
-      launcher_lines = height / 3 - 1;
-      kernel_lines = height - launcher_lines - 1;
-    }
-    if (logcat_ready) {
-      kernel_lines = height / 3 - 1;
-      logcat_lines = height - launcher_lines - kernel_lines - 2;
-    }
-    if (!FileExists(assemble_log)) {
-      display.DrawFile(*InMemoryIo("Waiting for assemble_cvd.log creation"),
-                       launcher_name, launcher_lines);
-    } else {
-      display.DrawFile(SharedFdIo(launcher_fd), launcher_name, launcher_lines);
-    }
-    display.DrawFile(SharedFdIo(kernel_fd), kLogNameKernel, kernel_lines);
-    display.DrawFile(SharedFdIo(logcat_fd), kLogNameLogcat, logcat_lines);
 
     const auto [output, total_lines_drawn] = display.Finalize();
     std::cout << kAnsiClearScreen << kAnsiCursorTopLeft << output << std::flush;
@@ -197,13 +245,7 @@ Result<void> MonitorLogs(const LocalInstance& instance, SharedFD stop_eventfd) {
 
     // Block until file changes occur. If any watch failed or is missing, use
     // a fallback timeout to awake and retry.
-    int timeout_ms = -1;
-    if (dir_watch == -1 || kernel_watch == -1 || launcher_watch == -1 ||
-        logcat_watch == -1 || !logcat_ready || using_assemble_log) {
-      timeout_ms = 200;
-    }
-
-    int poll_res = SharedFD::Poll(poll_fds, timeout_ms);
+    int poll_res = SharedFD::Poll(poll_fds, missing_source ? 200 : -1);
 
     if (stop_eventfd->IsOpen() && (poll_fds[1].revents & POLLIN)) {
       // Stop requested via eventfd
@@ -223,22 +265,21 @@ Result<void> MonitorLogs(const LocalInstance& instance, SharedFD stop_eventfd) {
         while (ptr < buf + read_res) {
           inotify_event* event = reinterpret_cast<inotify_event*>(ptr);
           if (event->mask & (IN_DELETE | IN_DELETE_SELF | IN_IGNORED)) {
-            using_assemble_log = true;
             if (launcher_watch != -1) {
               inotify_fd->InotifyRmWatch(launcher_watch);
               launcher_watch = -1;
             }
-            launcher_fd = SharedFD();
+            launcher_monitor_source.reset();
             if (kernel_watch != -1) {
               inotify_fd->InotifyRmWatch(kernel_watch);
               kernel_watch = -1;
             }
-            kernel_fd = SharedFD();
+            kernel_monitor_source.reset();
             if (logcat_watch != -1) {
               inotify_fd->InotifyRmWatch(logcat_watch);
               logcat_watch = -1;
             }
-            logcat_fd = SharedFD();
+            logcat_monitor_source.reset();
           }
           ptr += sizeof(inotify_event) + event->len;
         }

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/monitor_source.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/monitor_source.cc
@@ -14,27 +14,19 @@
  * limitations under the License.
  */
 
-#pragma once
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/monitor_source.h"
 
 #include <string>
-#include <string_view>
-
-#include "cuttlefish/result/result.h"
+#include <utility>
+#include <vector>
 
 namespace cuttlefish {
 
-struct LogcatLine {
-  std::string_view date;
-  std::string_view time;
-  std::string_view uid;
-  std::string_view pid;
-  char verbosity;
-  std::string_view tag;
-  std::string_view message;
-};
+MonitorOutput::MonitorOutput() = default;
 
-Result<LogcatLine> ParseLogcatLine(std::string_view line);
-std::string FormatLogcatLine(const LogcatLine& line);
-Result<std::string> ColorLogcatLine(std::string_view line);
+MonitorOutput::MonitorOutput(std::string title, std::vector<std::string> lines)
+    : title(std::move(title)), lines(std::move(lines)) {}
+
+MonitorSource::~MonitorSource() = default;
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/monitor_source.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/monitor_source.h
@@ -16,25 +16,31 @@
 
 #pragma once
 
-#include <string>
-#include <string_view>
+#include <stddef.h>
 
-#include "cuttlefish/result/result.h"
+#include <string>
+#include <vector>
 
 namespace cuttlefish {
 
-struct LogcatLine {
-  std::string_view date;
-  std::string_view time;
-  std::string_view uid;
-  std::string_view pid;
-  char verbosity;
-  std::string_view tag;
-  std::string_view message;
+struct MonitorOutput {
+  MonitorOutput();
+  MonitorOutput(std::string title, std::vector<std::string> lines);
+
+  std::string title;
+  std::vector<std::string> lines;
 };
 
-Result<LogcatLine> ParseLogcatLine(std::string_view line);
-std::string FormatLogcatLine(const LogcatLine& line);
-Result<std::string> ColorLogcatLine(std::string_view line);
+class MonitorSource {
+ public:
+  virtual ~MonitorSource();
+  /**
+   * Pulls new information from the data source if there is any and returns the
+   * text that should be shown in the monitor window.
+   *
+   * `rows` and `columns` are hints for the output. May output more or less.
+   */
+  virtual MonitorOutput Report(size_t rows, size_t columns) = 0;
+};
 
 }  // namespace cuttlefish


### PR DESCRIPTION
This is intended to decouple the "read from a file" logic from the dashboard rendering logic. Coloring the output is now also handled by the monitor source.

What remains outstanding is integrating the "needs to update" mechanism into the monitor source logic.

There are two future plans that I intend to support with this refactoring:

- `MonitorSource`s become stateful, and process the entire log file rather than skipping to the end. This will enable state tracking like "has the device booted yet."
- Data sources that are not files.

Bug: b/537428390
