### PR TITLE
Temporary add no-op build script for presubmit_podcvd configuration

### DIFF
--- a/.kokoro/no_op.sh
+++ b/.kokoro/no_op.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Temporary no-op script for presubmit_podcvd
+exit 0

--- a/.kokoro/presubmit_podcvd.cfg
+++ b/.kokoro/presubmit_podcvd.cfg
@@ -1,0 +1,1 @@
+build_file: "android-cuttlefish/.kokoro/no_op.sh"


### PR DESCRIPTION
As a temporary workaround for presubmit_podcvd error.