### PR TITLE
Fix file already exist error while running substitute in Docker

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/BUILD.bazel
@@ -325,6 +325,7 @@ cf_cc_library(
         "//libbase",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/strings",
+        "@fmt",
         "@protobuf",
     ],
 )

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/substitute.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/substitute.cc
@@ -17,7 +17,9 @@
 
 #include <unistd.h>
 
+#include <cerrno>
 #include <optional>
+#include <random>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -26,6 +28,7 @@
 #include "absl/strings/match.h"
 #include "absl/strings/strip.h"
 #include "android-base/file.h"
+#include "fmt/format.h"
 #include "google/protobuf/text_format.h"
 
 #include "cuttlefish/common/libs/utils/environment.h"
@@ -63,10 +66,27 @@ Result<void> Substitute(const std::string& target,
 
   CF_EXPECT(EnsureDirectoryExists(android::base::Dirname(full_link_name)));
 
-  int unlink_res = unlink(full_link_name.c_str());
-  CF_EXPECTF(unlink_res == 0 || errno == ENOENT, "{}", StrError(errno));
+  std::random_device rd;
+  std::string tmp_link_name;
+  constexpr int kMaxRetries = 10;
+  for (int attempt = 0; attempt < kMaxRetries; ++attempt) {
+    tmp_link_name = fmt::format("{}.tmp_{}_{}", full_link_name, getpid(), rd());
+    auto symlink_res = Symlink(target, tmp_link_name);
+    if (symlink_res.has_value()) {
+      break;
+    }
+    if (errno == EEXIST && attempt + 1 < kMaxRetries) {
+      continue;
+    }
+    return symlink_res;
+  }
 
-  CF_EXPECT(Symlink(target, full_link_name));
+  if (rename(tmp_link_name.c_str(), full_link_name.c_str()) != 0) {
+    const int err = errno;
+    unlink(tmp_link_name.c_str());
+    return CF_ERRF("Failed to rename symlink: {}", StrError(err));
+  }
+
   return {};
 }
 


### PR DESCRIPTION
In the OverlayFS, even if unlink() is succeeded, looks like there is a delay between unlink call and the file is actually disappears.

Change to use rename call which ensures atomic operation for substitution.