### PR TITLE
Disable bugreport_tests from podcvd E2E test

### DIFF
--- a/e2etests/cvd/bugreport_tests/BUILD.bazel
+++ b/e2etests/cvd/bugreport_tests/BUILD.bazel
@@ -25,7 +25,6 @@ go_test(
         "exclusive",
         "external",
         "no-sandbox",
-        "podcvd",
     ],
 )
 


### PR DESCRIPTION
As podcvd bugreport case is flaky and the expected underlying cause is limited computing resources of GitHub runner, this PR suggests to disable testing `bugreport_tests` from podcvd E2E tests until moving the test from GitHub runner into Kokoro.

Context: b/527644057