### PR TITLE
Integrate notifications into MonitorSource

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/BUILD.bazel
@@ -125,6 +125,28 @@ cf_cc_test(
 )
 
 cf_cc_library(
+    name = "log_sources",
+    srcs = ["log_sources.cc"],
+    hdrs = ["log_sources.h"],
+    deps = [
+        "//cuttlefish/common/libs/fs",
+        "//cuttlefish/files:file_exists",
+        "//cuttlefish/host/commands/cvd/cli/commands/monitor:file_monitor_source",
+        "//cuttlefish/host/commands/cvd/cli/commands/monitor:kernel",
+        "//cuttlefish/host/commands/cvd/cli/commands/monitor:launcher",
+        "//cuttlefish/host/commands/cvd/cli/commands/monitor:log_tee",
+        "//cuttlefish/host/commands/cvd/cli/commands/monitor:logcat",
+        "//cuttlefish/host/commands/cvd/cli/commands/monitor:monitor_source",
+        "//cuttlefish/host/commands/cvd/instances",
+        "//cuttlefish/host/libs/log_names",
+        "//cuttlefish/io",
+        "//cuttlefish/io:shared_fd",
+        "//cuttlefish/result",
+        "@abseil-cpp//absl/strings",
+    ],
+)
+
+cf_cc_library(
     name = "log_tee",
     srcs = ["log_tee.cc"],
     hdrs = ["log_tee.h"],
@@ -173,20 +195,12 @@ cf_cc_library(
     deps = [
         "//cuttlefish/ansi_codes",
         "//cuttlefish/common/libs/fs",
-        "//cuttlefish/files:file_exists",
         "//cuttlefish/host/commands/cvd/cli:utils",
         "//cuttlefish/host/commands/cvd/cli/commands/monitor:display",
         "//cuttlefish/host/commands/cvd/cli/commands/monitor:drain_inotify",
-        "//cuttlefish/host/commands/cvd/cli/commands/monitor:file_monitor_source",
-        "//cuttlefish/host/commands/cvd/cli/commands/monitor:kernel",
-        "//cuttlefish/host/commands/cvd/cli/commands/monitor:launcher",
-        "//cuttlefish/host/commands/cvd/cli/commands/monitor:log_tee",
-        "//cuttlefish/host/commands/cvd/cli/commands/monitor:logcat",
+        "//cuttlefish/host/commands/cvd/cli/commands/monitor:log_sources",
         "//cuttlefish/host/commands/cvd/cli/commands/monitor:monitor_source",
         "//cuttlefish/host/commands/cvd/instances",
-        "//cuttlefish/host/libs/log_names",
-        "//cuttlefish/io",
-        "//cuttlefish/io:shared_fd",
         "//cuttlefish/result",
         "@abseil-cpp//absl/cleanup",
         "@abseil-cpp//absl/strings",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/BUILD.bazel
@@ -51,16 +51,32 @@ cf_cc_test(
 )
 
 cf_cc_library(
+    name = "drain_inotify",
+    srcs = ["drain_inotify.cc"],
+    hdrs = ["drain_inotify.h"],
+    deps = [
+        "//cuttlefish/common/libs/fs",
+        "//cuttlefish/posix:strerror",
+        "//cuttlefish/result:expect",
+        "//cuttlefish/result:result_type",
+    ],
+)
+
+cf_cc_library(
     name = "file_monitor_source",
     srcs = ["file_monitor_source.cc"],
     hdrs = ["file_monitor_source.h"],
     deps = [
+        "//cuttlefish/common/libs/fs",
         "//cuttlefish/host/commands/cvd/cli:format_byte_size",
+        "//cuttlefish/host/commands/cvd/cli/commands/monitor:drain_inotify",
         "//cuttlefish/host/commands/cvd/cli/commands/monitor:monitor_source",
         "//cuttlefish/io",
         "//cuttlefish/io:read_exact",
         "//cuttlefish/result:expect",
         "//cuttlefish/result:result_type",
+        "//libbase",
+        "@abseil-cpp//absl/log:check",
         "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/strings:cord",
     ],
@@ -160,6 +176,7 @@ cf_cc_library(
         "//cuttlefish/files:file_exists",
         "//cuttlefish/host/commands/cvd/cli:utils",
         "//cuttlefish/host/commands/cvd/cli/commands/monitor:display",
+        "//cuttlefish/host/commands/cvd/cli/commands/monitor:drain_inotify",
         "//cuttlefish/host/commands/cvd/cli/commands/monitor:file_monitor_source",
         "//cuttlefish/host/commands/cvd/cli/commands/monitor:kernel",
         "//cuttlefish/host/commands/cvd/cli/commands/monitor:launcher",
@@ -180,6 +197,9 @@ cf_cc_library(
     name = "monitor_source",
     srcs = ["monitor_source.cc"],
     hdrs = ["monitor_source.h"],
+    deps = [
+        "//cuttlefish/common/libs/fs",
+    ],
 )
 
 cf_cc_library(

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/drain_inotify.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/drain_inotify.cc
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/drain_inotify.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <sys/inotify.h>
+#include <sys/types.h>
+
+#include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/posix/strerror.h"
+#include "cuttlefish/result/expect.h"
+#include "cuttlefish/result/result_type.h"
+
+namespace cuttlefish {
+
+/*
+ * Exhaustively drain all available events from the non-blocking descriptor to
+ * coalesce rapid file modifications.
+ *
+ * Returns a bit mask of the events unioned together.
+ */
+Result<uint32_t> DrainInotifyEvents(SharedFD inotify_fd) {
+  uint32_t events = 0;
+
+  char buf[4096] __attribute__((aligned(__alignof__(struct inotify_event))));
+  ssize_t read_res = 0;
+  while ((read_res = inotify_fd->Read(buf, sizeof(buf))) > 0) {
+    char* ptr = buf;
+    while (ptr < buf + read_res) {
+      inotify_event* event = reinterpret_cast<inotify_event*>(ptr);
+      events |= event->mask;
+      ptr += sizeof(inotify_event) + event->len;
+    }
+  }
+  CF_EXPECT(read_res != 0, "Unexpected End-of-File reading inotify descriptor");
+  const int err = inotify_fd->GetErrno();
+  CF_EXPECTF(err == EAGAIN || err == EWOULDBLOCK,
+             "Unexpected error reading inotify descriptor: {}", StrError(err));
+  return events;
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/drain_inotify.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/drain_inotify.h
@@ -16,36 +16,20 @@
 
 #pragma once
 
-#include <stddef.h>
-
-#include <functional>
-#include <memory>
-#include <string>
-#include <string_view>
+#include <stdint.h>
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/monitor/monitor_source.h"
-#include "cuttlefish/io/io.h"
 #include "cuttlefish/result/result_type.h"
 
 namespace cuttlefish {
 
-class FileMonitorSource : public MonitorSource {
- public:
-  FileMonitorSource(
-      std::string path, std::unique_ptr<ReaderSeeker> file_io,
-      std::function<Result<std::string>(std::string_view)> colorize_line);
-  ~FileMonitorSource() override;
-
-  MonitorOutput Report(size_t rows, size_t columns) override;
-
-  SharedFD ReadyFd() override;
-
- private:
-  std::string path_;
-  std::unique_ptr<ReaderSeeker> file_io_;
-  std::function<Result<std::string>(std::string_view)> colorize_line_;
-  SharedFD inotify_fd_;
-};
+/*
+ * Exhaustively drain all available events from the non-blocking inotify file
+ * descriptor to coalesce rapid file modifications. The file descriptor should
+ * be set to non-blocking.
+ *
+ * Returns a bit mask of the events unioned together.
+ */
+Result<uint32_t> DrainInotifyEvents(SharedFD inotify_fd);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/file_monitor_source.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/file_monitor_source.cc
@@ -16,7 +16,10 @@
 
 #include "cuttlefish/host/commands/cvd/cli/commands/monitor/file_monitor_source.h"
 
+#include <fcntl.h>
 #include <stddef.h>
+#include <stdint.h>
+#include <sys/inotify.h>
 
 #include <algorithm>
 #include <functional>
@@ -26,10 +29,14 @@
 #include <utility>
 #include <vector>
 
+#include "absl/log/check.h"
 #include "absl/strings/cord.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
+#include "android-base/file.h"
 
+#include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/drain_inotify.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/monitor/monitor_source.h"
 #include "cuttlefish/host/commands/cvd/cli/format_byte_size.h"
 #include "cuttlefish/io/io.h"
@@ -83,25 +90,37 @@ Result<FileData> GetLastNLines(ReaderSeeker& rs, size_t n) {
 }  // namespace
 
 FileMonitorSource::FileMonitorSource(
-    std::string name, std::unique_ptr<ReaderSeeker> file_io,
+    std::string path, std::unique_ptr<ReaderSeeker> file_io,
     std::function<Result<std::string>(std::string_view)> colorize_line)
-    : name_(std::move(name)),
+    : path_(std::move(path)),
       file_io_(std::move(file_io)),
-      colorize_line_(std::move(colorize_line)) {}
+      colorize_line_(std::move(colorize_line)) {
+  inotify_fd_ = SharedFD::InotifyFd();
+  CHECK(inotify_fd_->IsOpen()) << inotify_fd_->StrError();
+  CHECK_GE(inotify_fd_->InotifyAddWatch(path_, IN_DELETE_SELF | IN_MODIFY), 0);
+  const int flags = inotify_fd_->Fcntl(F_GETFL, 0);
+  CHECK_GE(inotify_fd_->Fcntl(F_SETFL, flags | O_NONBLOCK), 0);
+}
+
+FileMonitorSource::~FileMonitorSource() = default;
 
 MonitorOutput FileMonitorSource::Report(size_t rows, size_t) {
+  const std::string basename = android::base::Basename(path_);
   Result<FileData> file_data = GetLastNLines(*file_io_, rows);
   if (!file_data.ok()) {
     return MonitorOutput(
-        absl::StrCat(name_, " (error)"),
+        absl::StrCat(basename, " (error)"),
         absl::StrSplit(file_data.error().FormatForEnv(true), '\n'));
   }
   for (std::string& line : file_data->last_lines) {
     line = colorize_line_(line).value_or(line);
   }
   std::string size = FormatByteSize(file_data->total_size);
-  return MonitorOutput(absl::StrCat(name_, " (", size, ")"),
+  Result<uint32_t> unused = DrainInotifyEvents(inotify_fd_);
+  return MonitorOutput(absl::StrCat(basename, " (", size, ")"),
                        file_data->last_lines);
 }
+
+SharedFD FileMonitorSource::ReadyFd() { return inotify_fd_; }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/log_sources.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/log_sources.cc
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/log_sources.h"
+
+#include <fcntl.h>
+#include <stdio.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "absl/strings/str_cat.h"
+
+#include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/files/file_exists.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/file_monitor_source.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/kernel.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/launcher.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/log_tee.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/logcat.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/monitor_source.h"
+#include "cuttlefish/host/commands/cvd/instances/local_instance.h"
+#include "cuttlefish/host/libs/log_names/log_names.h"
+#include "cuttlefish/io/io.h"
+#include "cuttlefish/io/shared_fd.h"
+#include "cuttlefish/result/result.h"
+
+namespace cuttlefish {
+namespace {
+
+Result<std::string> ColorLauncherOrLogTee(std::string_view line) {
+  if (line.find("log_tee(") != 0) {
+    return CF_EXPECT(ColorLauncherLine(line));
+  }
+  const size_t bracket = line.find(']');
+  if (bracket != std::string_view::npos) {
+    line.remove_prefix(bracket + 1);
+    const size_t first_non_space = line.find_first_not_of(" \t");
+    if (first_non_space != std::string_view::npos) {
+      line.remove_prefix(first_non_space);
+    } else {
+      line = "";
+    }
+  }
+  return CF_EXPECT(ColorLogTeeLine(line));
+}
+
+}  // namespace
+
+std::unique_ptr<MonitorSource> LauncherLogMonitorSource(
+    const LocalInstance& instance) {
+  const std::string launcher =
+      absl::StrCat(instance.InstanceDirectory(), "/logs/", kLogNameLauncher);
+  const std::string assemble =
+      absl::StrCat(instance.AssemblyDirectory(), "/", kLogNameAssembleCvd);
+  const std::string path = FileExists(launcher) ? launcher : assemble;
+  if (!FileExists(path)) {
+    return {};
+  }
+  SharedFD fd = SharedFD::Open(path, O_RDONLY);
+  if (!fd->IsOpen() || fd->LSeek(0, SEEK_END) <= 0) {
+    return {};
+  }
+  std::unique_ptr<ReaderSeeker> io = std::make_unique<SharedFdIo>(fd);
+  return std::make_unique<FileMonitorSource>(path, std::move(io),
+                                             ColorLauncherOrLogTee);
+}
+
+std::unique_ptr<MonitorSource> KernelLogMonitorSource(
+    const LocalInstance& instance) {
+  const std::string path =
+      absl::StrCat(instance.InstanceDirectory(), "/logs/", kLogNameKernel);
+  if (!FileExists(path)) {
+    return {};
+  }
+  SharedFD fd = SharedFD::Open(path, O_RDONLY);
+  if (!fd->IsOpen() || fd->LSeek(0, SEEK_END) <= 0) {
+    return {};
+  }
+  std::unique_ptr<ReaderSeeker> io = std::make_unique<SharedFdIo>(fd);
+  return std::make_unique<FileMonitorSource>(path, std::move(io),
+                                             ColorKernelLine);
+}
+
+std::unique_ptr<MonitorSource> LogcatMonitorSource(
+    const LocalInstance& instance) {
+  const std::string path =
+      absl::StrCat(instance.InstanceDirectory(), "/logs/", kLogNameLogcat);
+  if (!FileExists(path)) {
+    return {};
+  }
+  SharedFD fd = SharedFD::Open(path, O_RDONLY);
+  if (!fd->IsOpen() || fd->LSeek(0, SEEK_END) <= 0) {
+    return {};
+  }
+  std::unique_ptr<ReaderSeeker> io = std::make_unique<SharedFdIo>(fd);
+  return std::make_unique<FileMonitorSource>(path, std::move(io),
+                                             ColorLogcatLine);
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/log_sources.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/log_sources.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/monitor_source.h"
+#include "cuttlefish/host/commands/cvd/instances/local_instance.h"
+
+namespace cuttlefish {
+
+std::unique_ptr<MonitorSource> LauncherLogMonitorSource(
+    const LocalInstance& instance);
+
+std::unique_ptr<MonitorSource> KernelLogMonitorSource(
+    const LocalInstance& instance);
+
+std::unique_ptr<MonitorSource> LogcatMonitorSource(
+    const LocalInstance& instance);
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/monitor.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/monitor.cc
@@ -16,13 +16,12 @@
 
 #include "cuttlefish/host/commands/cvd/cli/commands/monitor/monitor.h"
 
-#include <errno.h>
 #include <fcntl.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <sys/eventfd.h>
 #include <sys/inotify.h>
 #include <sys/poll.h>
-#include <sys/types.h>
 #include <unistd.h>
 
 #include <chrono>
@@ -41,6 +40,7 @@
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/files/file_exists.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/monitor/display.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/drain_inotify.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/monitor/file_monitor_source.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/monitor/kernel.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/monitor/launcher.h"
@@ -74,14 +74,8 @@ Result<std::string> ColorLauncherOrLogTee(std::string_view line) {
   return CF_EXPECT(ColorLogTeeLine(line));
 }
 
-// TODO(schuffelen): integrate inotify watches into MonitorSource
-
 std::unique_ptr<MonitorSource> LauncherLogMonitorSource(
-    const LocalInstance& instance, SharedFD inotify_fd, int& watch) {
-  if (watch != -1) {
-    inotify_fd->InotifyRmWatch(watch);
-    watch = -1;
-  }
+    const LocalInstance& instance) {
   const std::string launcher =
       absl::StrCat(instance.InstanceDirectory(), "/logs/", kLogNameLauncher);
   const std::string assemble =
@@ -94,18 +88,13 @@ std::unique_ptr<MonitorSource> LauncherLogMonitorSource(
   if (!fd->IsOpen() || fd->LSeek(0, SEEK_END) <= 0) {
     return {};
   }
-  watch = inotify_fd->InotifyAddWatch(path, IN_DELETE_SELF | IN_MODIFY);
   std::unique_ptr<ReaderSeeker> io = std::make_unique<SharedFdIo>(fd);
   return std::make_unique<FileMonitorSource>(path, std::move(io),
                                              ColorLauncherOrLogTee);
 }
 
 std::unique_ptr<MonitorSource> KernelLogMonitorSource(
-    const LocalInstance& instance, SharedFD inotify_fd, int& watch) {
-  if (watch != -1) {
-    inotify_fd->InotifyRmWatch(watch);
-    watch = -1;
-  }
+    const LocalInstance& instance) {
   const std::string path =
       absl::StrCat(instance.InstanceDirectory(), "/logs/", kLogNameKernel);
   if (!FileExists(path)) {
@@ -115,18 +104,13 @@ std::unique_ptr<MonitorSource> KernelLogMonitorSource(
   if (!fd->IsOpen() || fd->LSeek(0, SEEK_END) <= 0) {
     return {};
   }
-  watch = inotify_fd->InotifyAddWatch(path, IN_DELETE_SELF | IN_MODIFY);
   std::unique_ptr<ReaderSeeker> io = std::make_unique<SharedFdIo>(fd);
   return std::make_unique<FileMonitorSource>(path, std::move(io),
                                              ColorKernelLine);
 }
 
 std::unique_ptr<MonitorSource> LogcatMonitorSource(
-    const LocalInstance& instance, SharedFD inotify_fd, int& watch) {
-  if (watch != -1) {
-    inotify_fd->InotifyRmWatch(watch);
-    watch = -1;
-  }
+    const LocalInstance& instance) {
   const std::string path =
       absl::StrCat(instance.InstanceDirectory(), "/logs/", kLogNameLogcat);
   if (!FileExists(path)) {
@@ -136,7 +120,6 @@ std::unique_ptr<MonitorSource> LogcatMonitorSource(
   if (!fd->IsOpen() || fd->LSeek(0, SEEK_END) <= 0) {
     return {};
   }
-  watch = inotify_fd->InotifyAddWatch(path, IN_DELETE_SELF | IN_MODIFY);
   std::unique_ptr<ReaderSeeker> io = std::make_unique<SharedFdIo>(fd);
   return std::make_unique<FileMonitorSource>(path, std::move(io),
                                              ColorLogcatLine);
@@ -151,19 +134,16 @@ Result<void> MonitorLogs(const LocalInstance& instance, SharedFD stop_eventfd) {
   std::unique_ptr<MonitorSource> launcher_monitor_source;
   std::unique_ptr<MonitorSource> logcat_monitor_source;
 
-  const SharedFD inotify_fd = SharedFD::InotifyFd();
-  CF_EXPECT(inotify_fd->IsOpen(), "Failed to create inotify fd");
-  const int flags = inotify_fd->Fcntl(F_GETFL, 0);
-  CF_EXPECT(inotify_fd->Fcntl(F_SETFL, flags | O_NONBLOCK) != -1,
+  const SharedFD dir_inotify_fd = SharedFD::InotifyFd();
+  CF_EXPECT(dir_inotify_fd->IsOpen(), "Failed to create inotify fd");
+  const int flags = dir_inotify_fd->Fcntl(F_GETFL, 0);
+  CF_EXPECT(dir_inotify_fd->Fcntl(F_SETFL, flags | O_NONBLOCK) != -1,
             "Failed to set inotify fd to non-blocking");
 
   const std::string logs_dir =
       absl::StrCat(instance.InstanceDirectory(), "/logs");
-  inotify_fd->InotifyAddWatch(logs_dir, IN_CREATE | IN_DELETE);
+  dir_inotify_fd->InotifyAddWatch(logs_dir, IN_CREATE | IN_DELETE);
 
-  int kernel_watch = -1;
-  int launcher_watch = -1;
-  int logcat_watch = -1;
   std::chrono::steady_clock::time_point last_draw_time =
       std::chrono::steady_clock::time_point();
 
@@ -176,16 +156,13 @@ Result<void> MonitorLogs(const LocalInstance& instance, SharedFD stop_eventfd) {
 
   while (true) {
     if (!kernel_monitor_source.get()) {
-      kernel_monitor_source =
-          KernelLogMonitorSource(instance, inotify_fd, kernel_watch);
+      kernel_monitor_source = KernelLogMonitorSource(instance);
     }
     if (!logcat_monitor_source.get()) {
-      logcat_monitor_source =
-          LogcatMonitorSource(instance, inotify_fd, logcat_watch);
+      logcat_monitor_source = LogcatMonitorSource(instance);
     }
     if (!launcher_monitor_source.get()) {
-      launcher_monitor_source =
-          LauncherLogMonitorSource(instance, inotify_fd, launcher_watch);
+      launcher_monitor_source = LauncherLogMonitorSource(instance);
     }
 
     TerminalSize term_size =
@@ -215,10 +192,6 @@ Result<void> MonitorLogs(const LocalInstance& instance, SharedFD stop_eventfd) {
       display.DrawReport(source, lines);
     }
 
-    if (missing_source) {
-      launcher_monitor_source.reset();  // will cut over to launcher.log soon
-    }
-
     const auto [output, total_lines_drawn] = display.Finalize();
     std::cout << kAnsiClearScreen << kAnsiCursorTopLeft << output << std::flush;
 
@@ -236,16 +209,29 @@ Result<void> MonitorLogs(const LocalInstance& instance, SharedFD stop_eventfd) {
 
     // Setup poll_fds
     std::vector<PollSharedFd> poll_fds = {
-        PollSharedFd{.fd = inotify_fd, .events = POLLIN, .revents = 0},
+        PollSharedFd{.fd = dir_inotify_fd, .events = POLLIN, .revents = 0},
     };
     if (stop_eventfd->IsOpen()) {
       poll_fds.push_back(
           PollSharedFd{.fd = stop_eventfd, .events = POLLIN, .revents = 0});
     }
+    for (MonitorSource* source : sources) {
+      if (source == nullptr) {
+        continue;
+      }
+      SharedFD ready_fd = source->ReadyFd();
+      if (!ready_fd->IsOpen()) {
+        missing_source = true;
+        continue;
+      }
+      poll_fds.push_back(
+          PollSharedFd{.fd = ready_fd, .events = POLLIN, .revents = 0});
+    }
 
     // Block until file changes occur. If any watch failed or is missing, use
     // a fallback timeout to awake and retry.
     int poll_res = SharedFD::Poll(poll_fds, missing_source ? 200 : -1);
+    CF_EXPECT_GE(poll_res, 0);
 
     if (stop_eventfd->IsOpen() && (poll_fds[1].revents & POLLIN)) {
       // Stop requested via eventfd
@@ -254,42 +240,17 @@ Result<void> MonitorLogs(const LocalInstance& instance, SharedFD stop_eventfd) {
       return {};
     }
 
-    if (poll_res > 0 && (poll_fds[0].revents & POLLIN)) {
-      // Exhaustively drain all available events from the non-blocking
-      // descriptor to coalesce rapid file modifications.
-      char buf[4096]
-          __attribute__((aligned(__alignof__(struct inotify_event))));
-      ssize_t read_res = 0;
-      while ((read_res = inotify_fd->Read(buf, sizeof(buf))) > 0) {
-        char* ptr = buf;
-        while (ptr < buf + read_res) {
-          inotify_event* event = reinterpret_cast<inotify_event*>(ptr);
-          if (event->mask & (IN_DELETE | IN_DELETE_SELF | IN_IGNORED)) {
-            if (launcher_watch != -1) {
-              inotify_fd->InotifyRmWatch(launcher_watch);
-              launcher_watch = -1;
-            }
-            launcher_monitor_source.reset();
-            if (kernel_watch != -1) {
-              inotify_fd->InotifyRmWatch(kernel_watch);
-              kernel_watch = -1;
-            }
-            kernel_monitor_source.reset();
-            if (logcat_watch != -1) {
-              inotify_fd->InotifyRmWatch(logcat_watch);
-              logcat_watch = -1;
-            }
-            logcat_monitor_source.reset();
-          }
-          ptr += sizeof(inotify_event) + event->len;
-        }
+    if (poll_fds[0].revents & POLLIN) {
+      uint32_t events = DrainInotifyEvents(dir_inotify_fd).value_or(IN_DELETE);
+      if ((events & IN_DELETE) > 0) {
+        launcher_monitor_source.reset();
+        kernel_monitor_source.reset();
+        logcat_monitor_source.reset();
       }
-      CF_EXPECT(read_res != 0,
-                "Unexpected End-of-File reading inotify descriptor");
-      const int err = inotify_fd->GetErrno();
-      CF_EXPECTF(err == EAGAIN || err == EWOULDBLOCK,
-                 "Unexpected error reading inotify descriptor: {} ({})",
-                 inotify_fd->StrError(), err);
+    }
+
+    if (missing_source) {
+      launcher_monitor_source.reset();  // will cut over to launcher.log soon
     }
   }
   return {};

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/monitor.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/monitor.cc
@@ -30,7 +30,6 @@
 #include <string>
 #include <string_view>
 #include <thread>
-#include <utility>
 #include <vector>
 
 #include "absl/cleanup/cleanup.h"
@@ -38,94 +37,15 @@
 
 #include "cuttlefish/ansi_codes/ansi_codes.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"
-#include "cuttlefish/files/file_exists.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/monitor/display.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/monitor/drain_inotify.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/monitor/file_monitor_source.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/monitor/kernel.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/monitor/launcher.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/monitor/log_tee.h"
-#include "cuttlefish/host/commands/cvd/cli/commands/monitor/logcat.h"
+#include "cuttlefish/host/commands/cvd/cli/commands/monitor/log_sources.h"
 #include "cuttlefish/host/commands/cvd/cli/commands/monitor/monitor_source.h"
 #include "cuttlefish/host/commands/cvd/cli/utils.h"
 #include "cuttlefish/host/commands/cvd/instances/local_instance.h"
-#include "cuttlefish/host/libs/log_names/log_names.h"
-#include "cuttlefish/io/io.h"
-#include "cuttlefish/io/shared_fd.h"
 #include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
-namespace {
-
-Result<std::string> ColorLauncherOrLogTee(std::string_view line) {
-  if (line.find("log_tee(") != 0) {
-    return CF_EXPECT(ColorLauncherLine(line));
-  }
-  const size_t bracket = line.find(']');
-  if (bracket != std::string_view::npos) {
-    line.remove_prefix(bracket + 1);
-    const size_t first_non_space = line.find_first_not_of(" \t");
-    if (first_non_space != std::string_view::npos) {
-      line.remove_prefix(first_non_space);
-    } else {
-      line = "";
-    }
-  }
-  return CF_EXPECT(ColorLogTeeLine(line));
-}
-
-std::unique_ptr<MonitorSource> LauncherLogMonitorSource(
-    const LocalInstance& instance) {
-  const std::string launcher =
-      absl::StrCat(instance.InstanceDirectory(), "/logs/", kLogNameLauncher);
-  const std::string assemble =
-      absl::StrCat(instance.AssemblyDirectory(), "/", kLogNameAssembleCvd);
-  const std::string path = FileExists(launcher) ? launcher : assemble;
-  if (!FileExists(path)) {
-    return {};
-  }
-  SharedFD fd = SharedFD::Open(path, O_RDONLY);
-  if (!fd->IsOpen() || fd->LSeek(0, SEEK_END) <= 0) {
-    return {};
-  }
-  std::unique_ptr<ReaderSeeker> io = std::make_unique<SharedFdIo>(fd);
-  return std::make_unique<FileMonitorSource>(path, std::move(io),
-                                             ColorLauncherOrLogTee);
-}
-
-std::unique_ptr<MonitorSource> KernelLogMonitorSource(
-    const LocalInstance& instance) {
-  const std::string path =
-      absl::StrCat(instance.InstanceDirectory(), "/logs/", kLogNameKernel);
-  if (!FileExists(path)) {
-    return {};
-  }
-  SharedFD fd = SharedFD::Open(path, O_RDONLY);
-  if (!fd->IsOpen() || fd->LSeek(0, SEEK_END) <= 0) {
-    return {};
-  }
-  std::unique_ptr<ReaderSeeker> io = std::make_unique<SharedFdIo>(fd);
-  return std::make_unique<FileMonitorSource>(path, std::move(io),
-                                             ColorKernelLine);
-}
-
-std::unique_ptr<MonitorSource> LogcatMonitorSource(
-    const LocalInstance& instance) {
-  const std::string path =
-      absl::StrCat(instance.InstanceDirectory(), "/logs/", kLogNameLogcat);
-  if (!FileExists(path)) {
-    return {};
-  }
-  SharedFD fd = SharedFD::Open(path, O_RDONLY);
-  if (!fd->IsOpen() || fd->LSeek(0, SEEK_END) <= 0) {
-    return {};
-  }
-  std::unique_ptr<ReaderSeeker> io = std::make_unique<SharedFdIo>(fd);
-  return std::make_unique<FileMonitorSource>(path, std::move(io),
-                                             ColorLogcatLine);
-}
-
-}  // namespace
 
 Result<void> MonitorLogs(const LocalInstance& instance, SharedFD stop_eventfd) {
   CF_EXPECT(isatty(0), "The monitor command requires an interactive terminal.");

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/monitor_source.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/monitor_source.h
@@ -21,6 +21,8 @@
 #include <string>
 #include <vector>
 
+#include "cuttlefish/common/libs/fs/shared_fd.h"
+
 namespace cuttlefish {
 
 struct MonitorOutput {
@@ -41,6 +43,14 @@ class MonitorSource {
    * `rows` and `columns` are hints for the output. May output more or less.
    */
   virtual MonitorOutput Report(size_t rows, size_t columns) = 0;
+
+  /**
+   * When this file descriptor is ready for reading (as defined by `poll`), it
+   * is ready to report new data from `Report`.
+   *
+   * If the file descriptor is invalid, the source is always considered ready.
+   */
+  virtual SharedFD ReadyFd() = 0;
 };
 
 }  // namespace cuttlefish


### PR DESCRIPTION
This moves setting up inotify logic into FileMonitorSource and simplifies the monitor loop a bit. It also prepares for alternate MonitorSource implementations that are not based on files.

Bug: b/537428390