### PR TITLE
More depend-on-what-you-use and cf_build_test enforcement

### DIFF
--- a/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
@@ -1,8 +1,10 @@
-load("//cuttlefish/bazel:rules.bzl", "cf_cc_library", "cf_cc_test")
+load("//cuttlefish/bazel:rules.bzl", "cf_build_test", "cf_cc_library", "cf_cc_test")
 
 package(
     default_visibility = ["//:android_cuttlefish"],
 )
+
+cf_build_test(name = "fs_build_test")
 
 cf_cc_library(
     name = "epoll",
@@ -45,13 +47,9 @@ cf_cc_library(
 
 cf_cc_test(
     name = "fs_test",
-    srcs = [
-        "shared_fd_test.cpp",
-    ],
-    depend_on_what_you_use_enabled = False,
+    srcs = ["shared_fd_test.cpp"],
     deps = [
-        ":fs",
-        "//libbase",
+        "//cuttlefish/common/libs/fs",
     ],
 )
 

--- a/base/cvd/cuttlefish/common/libs/key_equals_value/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/key_equals_value/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//cuttlefish/bazel:rules.bzl", "cf_cc_library", "cf_cc_test")
+load("//cuttlefish/bazel:rules.bzl", "cf_build_test", "cf_cc_library", "cf_cc_test")
 
 package(
     default_visibility = ["//:android_cuttlefish"],
@@ -6,14 +6,14 @@ package(
 
 exports_files([".clang-tidy"])
 
+cf_build_test(name = "key_equals_value_build_test")
+
 cf_cc_library(
     name = "key_equals_value",
     srcs = ["key_equals_value.cc"],
     hdrs = ["key_equals_value.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
-        "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/result",
         "@abseil-cpp//absl/strings",
     ],
@@ -22,10 +22,8 @@ cf_cc_library(
 cf_cc_test(
     name = "key_equals_value_test",
     srcs = ["key_equals_value_test.cc"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/key_equals_value",
-        "//cuttlefish/result",
         "//cuttlefish/result:result_matchers",
     ],
 )

--- a/base/cvd/cuttlefish/common/libs/security/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/security/BUILD.bazel
@@ -1,22 +1,17 @@
-load("//cuttlefish/bazel:rules.bzl", "cf_cc_library")
+load("//cuttlefish/bazel:rules.bzl", "cf_build_test", "cf_cc_library")
 
 package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
+cf_build_test(name = "security_build_test")
+
 cf_cc_library(
     name = "confui_sign",
-    srcs = [
-        "confui_sign.cpp",
-    ],
-    hdrs = [
-        "confui_sign.h",
-    ],
-    depend_on_what_you_use_enabled = False,
+    srcs = ["confui_sign.cpp"],
+    hdrs = ["confui_sign.h"],
     deps = [
         "//cuttlefish/common/libs/fs",
-        "//libbase",
-        "@abseil-cpp//absl/log",
     ],
 )
 

--- a/base/cvd/cuttlefish/common/libs/transport/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/transport/BUILD.bazel
@@ -1,10 +1,12 @@
-load("//cuttlefish/bazel:rules.bzl", "cf_cc_library")
+load("//cuttlefish/bazel:rules.bzl", "cf_build_test", "cf_cc_library")
 
 package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
 exports_files([".clang-tidy"])
+
+cf_build_test(name = "transport_build_test")
 
 cf_cc_library(
     name = "transport",
@@ -16,12 +18,10 @@ cf_cc_library(
         "channel.h",
         "channel_sharedfd.h",
     ],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/result:expect",
         "//cuttlefish/result:result_type",
-        "//libbase",
         "@abseil-cpp//absl/log",
     ],
 )

--- a/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
@@ -1,19 +1,19 @@
-load("//cuttlefish/bazel:rules.bzl", "cf_cc_library", "cf_cc_test")
+load("//cuttlefish/bazel:rules.bzl", "cf_build_test", "cf_cc_library", "cf_cc_test")
 
 package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
+cf_build_test(name = "utils_build_test")
+
 cf_cc_library(
     name = "archive",
     srcs = ["archive.cpp"],
     hdrs = ["archive.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/process:command",
         "//cuttlefish/process:managed_stdio",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/strings",
     ],
@@ -76,12 +76,10 @@ cf_cc_library(
     name = "disk_usage",
     srcs = ["disk_usage.cpp"],
     hdrs = ["disk_usage.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/process:command",
         "//cuttlefish/process:managed_stdio",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/strings",
     ],
 )
@@ -95,10 +93,6 @@ cf_cc_library(
     hdrs = [
         "environment.h",
         "known_paths.h",
-    ],
-    depend_on_what_you_use_enabled = False,
-    deps = [
-        "//libbase",
     ],
 )
 
@@ -115,14 +109,12 @@ cf_cc_library(
     name = "files",
     srcs = ["files.cpp"],
     hdrs = ["files.h"],
-    depend_on_what_you_use_enabled = False,
     target_compatible_with = [
         "@platforms//os:linux",  # SEEK_DATA
     ],
     deps = [
         ":environment",
         "//cuttlefish/common/libs/fs",
-        "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:in_sandbox",
         "//cuttlefish/common/libs/utils:users",
         "//cuttlefish/files:copy",
@@ -130,7 +122,6 @@ cf_cc_library(
         "//cuttlefish/files:file_exists",
         "//cuttlefish/posix:rename",
         "//cuttlefish/posix:strerror",
-        "//cuttlefish/posix:symlink",
         "//cuttlefish/result",
         "//libbase",
         "@abseil-cpp//absl/log",
@@ -188,9 +179,7 @@ cf_cc_library(
     name = "host_info",
     srcs = ["host_info.cpp"],
     hdrs = ["host_info.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
-        "//libbase",
         "@abseil-cpp//absl/base:no_destructor",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/log:check",
@@ -207,12 +196,10 @@ cf_cc_library(
     name = "inotify",
     srcs = ["inotify.cpp"],
     hdrs = ["inotify.h"],
-    depend_on_what_you_use_enabled = False,
     target_compatible_with = [
         "@platforms//os:linux",
     ],
     deps = [
-        "//libbase",
         "@abseil-cpp//absl/log",
     ],
 )
@@ -241,11 +228,7 @@ cf_cc_library(
     name = "network",
     srcs = ["network.cpp"],
     hdrs = ["network.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
-        "//libbase",
-        "@abseil-cpp//absl/log",
-        "@abseil-cpp//absl/strings",
         "@fmt",
     ],
 )
@@ -280,10 +263,8 @@ cf_cc_library(
     name = "semver",
     srcs = ["semver.cpp"],
     hdrs = ["semver.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/result",
-        "//cuttlefish/result:expect",
         "@abseil-cpp//absl/strings",
     ],
 )
@@ -291,11 +272,8 @@ cf_cc_library(
 cf_cc_test(
     name = "semver_test",
     srcs = ["semver_test.cpp"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:semver",
-        "//cuttlefish/result:result_matchers",
-        "//cuttlefish/result:result_type",
     ],
 )
 
@@ -303,9 +281,7 @@ cf_cc_library(
     name = "signals",
     srcs = ["signals.cpp"],
     hdrs = ["signals.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
-        "//libbase",
         "@abseil-cpp//absl/log:check",
     ],
 )
@@ -319,13 +295,11 @@ cf_cc_library(
     name = "socket2socket_proxy",
     srcs = ["socket2socket_proxy.cpp"],
     hdrs = ["socket2socket_proxy.h"],
-    depend_on_what_you_use_enabled = False,
     target_compatible_with = [
         "@platforms//os:linux",
     ],
     deps = [
         "//cuttlefish/common/libs/fs",
-        "//libbase",
         "@abseil-cpp//absl/log",
     ],
 )
@@ -334,10 +308,8 @@ cf_cc_library(
     name = "tee_logging",
     srcs = ["tee_logging.cpp"],
     hdrs = ["tee_logging.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
-        "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:environment",
         "//cuttlefish/process:proc_file_utils",
         "//cuttlefish/result",
@@ -375,11 +347,9 @@ cf_cc_library(
     name = "unix_sockets",
     srcs = ["unix_sockets.cpp"],
     hdrs = ["unix_sockets.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/log:check",
     ],
@@ -388,11 +358,9 @@ cf_cc_library(
 cf_cc_test(
     name = "unix_sockets_test",
     srcs = ["unix_sockets_test.cpp"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:unix_sockets",
-        "//cuttlefish/result",
         "//libbase",
         "@abseil-cpp//absl/log:check",
     ],
@@ -414,13 +382,11 @@ cf_cc_library(
     srcs = ["vsock_connection.cpp"],
     hdrs = ["vsock_connection.h"],
     clang_tidy_enabled = False,  # TODO: b/403278821 - fix warnings and re-enable after migration work
-    depend_on_what_you_use_enabled = False,
     target_compatible_with = [
         "@platforms//os:linux",
     ],
     deps = [
         "//cuttlefish/common/libs/fs",
-        "//libbase",
         "@abseil-cpp//absl/log",
         "@jsoncpp",
     ],

--- a/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
@@ -43,9 +43,6 @@ cf_cc_test(
 cf_cc_library(
     name = "cf_endian",
     hdrs = ["cf_endian.h"],
-    deps = [
-        "//libbase",
-    ],
 )
 
 cf_cc_library(

--- a/base/cvd/cuttlefish/common/libs/utils/cf_endian.h
+++ b/base/cvd/cuttlefish/common/libs/utils/cf_endian.h
@@ -15,9 +15,8 @@
 
 #pragma once
 
+#include <endian.h>
 #include <inttypes.h>
-
-#include "android-base/endian.h"
 
 // The utilities in android-base/endian.h still require the use of regular int
 // types to store values with any endianness, which requires the user to

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//cuttlefish/bazel:rules.bzl", "cf_cc_library")
+load("//cuttlefish/bazel:rules.bzl", "cf_build_test", "cf_cc_library")
 
 package(
     default_visibility = ["//:android_cuttlefish"],
@@ -14,18 +14,17 @@ exports_files([
     "load_configs.h",
 ])
 
+cf_build_test(name = "commands_build_test")
+
 cf_cc_library(
     name = "bugreport",
     srcs = ["bugreport.cpp"],
     hdrs = ["bugreport.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
-        "//cuttlefish/common/libs/utils:users",
         "//cuttlefish/files:file_exists",
         "//cuttlefish/flag_parser",
         "//cuttlefish/host/commands/cvd/cli:command_request",
-        "//cuttlefish/host/commands/cvd/cli:interruptible_terminal",
         "//cuttlefish/host/commands/cvd/cli:utils",
         "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
         "//cuttlefish/host/commands/cvd/cli/selector",
@@ -49,7 +48,6 @@ cf_cc_library(
     name = "cache",
     srcs = ["cache.cpp"],
     hdrs = ["cache.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/flag_parser",
         "//cuttlefish/host/commands/cvd/cache",
@@ -57,7 +55,6 @@ cf_cc_library(
         "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
         "//cuttlefish/host/commands/cvd/utils",
         "//cuttlefish/result",
-        "//libbase",
         "@fmt",
         "@jsoncpp",
     ],
@@ -67,12 +64,10 @@ cf_cc_library(
     name = "clear",
     srcs = ["clear.cpp"],
     hdrs = ["clear.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/flag_parser",
         "//cuttlefish/host/commands/cvd/cli:command_request",
         "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
-        "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/commands/cvd/instances:instance_manager",
         "//cuttlefish/result",
     ],
@@ -95,7 +90,6 @@ cf_cc_library(
     name = "display",
     srcs = ["display.cpp"],
     hdrs = ["display.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/flag_parser",
@@ -103,7 +97,6 @@ cf_cc_library(
         "//cuttlefish/host/commands/cvd/cli:utils",
         "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
         "//cuttlefish/host/commands/cvd/cli/selector",
-        "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/commands/cvd/instances:instance_manager",
         "//cuttlefish/host/commands/cvd/utils",
         "//cuttlefish/process:command",
@@ -116,22 +109,17 @@ cf_cc_library(
     name = "env",
     srcs = ["env.cpp"],
     hdrs = ["env.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
-        "//cuttlefish/flag_parser",
         "//cuttlefish/host/commands/cvd/cli:command_request",
         "//cuttlefish/host/commands/cvd/cli:utils",
         "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
         "//cuttlefish/host/commands/cvd/cli/selector",
-        "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/commands/cvd/instances:instance_manager",
         "//cuttlefish/host/commands/cvd/utils",
         "//cuttlefish/process:command",
         "//cuttlefish/process:managed_stdio",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/strings",
-        "@fmt",
     ],
 )
 
@@ -139,7 +127,6 @@ cf_cc_library(
     name = "fetch",
     srcs = ["fetch.cpp"],
     hdrs = ["fetch.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:tee_logging",
@@ -154,7 +141,6 @@ cf_cc_library(
         "//cuttlefish/host/commands/cvd/utils:common",
         "//cuttlefish/host/libs/metrics:fetch_metrics_orchestration",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/log",
         "@fmt",
     ],
@@ -164,15 +150,12 @@ cf_cc_library(
     name = "fleet",
     srcs = ["fleet.cpp"],
     hdrs = ["fleet.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/flag_parser",
         "//cuttlefish/host/commands/cvd/cli:command_request",
         "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
-        "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/commands/cvd/instances:instance_manager",
         "//cuttlefish/result",
-        "//libbase",
         "@jsoncpp",
     ],
 )
@@ -197,14 +180,12 @@ cf_cc_library(
     name = "host_tool_target",
     srcs = ["host_tool_target.cpp"],
     hdrs = ["host_tool_target.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/files:file_exists",
         "//cuttlefish/host/commands/cvd/utils",
         "//cuttlefish/process:command",
         "//cuttlefish/process:managed_stdio",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/strings",
         "@fmt",
     ],
@@ -227,7 +208,6 @@ cf_cc_library(
     name = "login",
     srcs = ["login.cpp"],
     hdrs = ["login.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:environment",
         "//cuttlefish/common/libs/utils:is_google_corp",
@@ -239,9 +219,6 @@ cf_cc_library(
         "//cuttlefish/host/libs/web/http_client:curl_global_init",
         "//cuttlefish/host/libs/web/http_client:curl_http_client",
         "//cuttlefish/result",
-        "//libbase",
-        "@abseil-cpp//absl/strings",
-        "@zlib",
     ],
 )
 
@@ -268,17 +245,13 @@ cf_cc_library(
     name = "power_btn",
     srcs = ["power_btn.cpp"],
     hdrs = ["power_btn.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/flag_parser",
         "//cuttlefish/host/commands/cvd/cli:command_request",
         "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
         "//cuttlefish/host/commands/cvd/cli/selector",
-        "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/commands/cvd/instances:instance_manager",
         "//cuttlefish/result",
-        "//libbase",
-        "@fmt",
     ],
 )
 
@@ -286,17 +259,13 @@ cf_cc_library(
     name = "powerwash",
     srcs = ["powerwash.cpp"],
     hdrs = ["powerwash.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/flag_parser",
         "//cuttlefish/host/commands/cvd/cli:command_request",
         "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
         "//cuttlefish/host/commands/cvd/cli/selector",
-        "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/commands/cvd/instances:instance_manager",
         "//cuttlefish/result",
-        "//libbase",
-        "@fmt",
     ],
 )
 
@@ -304,7 +273,6 @@ cf_cc_library(
     name = "remove",
     srcs = ["remove.cpp"],
     hdrs = ["remove.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/flag_parser",
         "//cuttlefish/host/commands/cvd/cli:command_request",
@@ -315,7 +283,6 @@ cf_cc_library(
         "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/commands/cvd/instances:instance_manager",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/log",
     ],
 )
@@ -324,18 +291,14 @@ cf_cc_library(
     name = "reset",
     srcs = ["reset.cpp"],
     hdrs = ["reset.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
-        "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/flag_parser",
         "//cuttlefish/host/commands/cvd/cli:command_request",
         "//cuttlefish/host/commands/cvd/cli:help_format",
         "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
-        "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/commands/cvd/instances:instance_manager",
         "//cuttlefish/host/commands/cvd/utils",
         "//cuttlefish/result",
-        "//libbase",
         "@fmt",
     ],
 )
@@ -344,17 +307,13 @@ cf_cc_library(
     name = "restart",
     srcs = ["restart.cpp"],
     hdrs = ["restart.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/flag_parser",
         "//cuttlefish/host/commands/cvd/cli:command_request",
         "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
         "//cuttlefish/host/commands/cvd/cli/selector",
-        "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/commands/cvd/instances:instance_manager",
         "//cuttlefish/result",
-        "//libbase",
-        "@fmt",
     ],
 )
 
@@ -362,7 +321,6 @@ cf_cc_library(
     name = "screen_recording",
     srcs = ["screen_recording.cpp"],
     hdrs = ["screen_recording.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/flag_parser",
         "//cuttlefish/host/commands/cvd/cli:command_request",
@@ -371,9 +329,7 @@ cf_cc_library(
         "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/commands/cvd/instances:instance_manager",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/log",
-        "@fmt",
         "@jsoncpp",
     ],
 )
@@ -403,7 +359,6 @@ cf_cc_library(
     name = "start",
     srcs = ["start.cpp"],
     hdrs = ["start.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:contains",
@@ -424,7 +379,6 @@ cf_cc_library(
         "//cuttlefish/host/commands/cvd/instances:cvd_persistent_data",
         "//cuttlefish/host/commands/cvd/instances:instance_manager",
         "//cuttlefish/host/commands/cvd/instances:stop",
-        "//cuttlefish/host/commands/cvd/instances/lock",
         "//cuttlefish/host/commands/cvd/utils",
         "//cuttlefish/host/libs/config:config_constants",
         "//cuttlefish/host/libs/config:cuttlefish_config",
@@ -432,9 +386,7 @@ cf_cc_library(
         "//cuttlefish/host/libs/metrics:device_metrics_orchestration",
         "//cuttlefish/posix:symlink",
         "//cuttlefish/process:command",
-        "//cuttlefish/process:managed_stdio",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/strings",
         "@fmt",
@@ -445,7 +397,6 @@ cf_cc_library(
     name = "status",
     srcs = ["status.cpp"],
     hdrs = ["status.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/flag_parser",
         "//cuttlefish/host/commands/cvd/cli:command_request",
@@ -456,9 +407,7 @@ cf_cc_library(
         "//cuttlefish/host/commands/cvd/instances:instance_manager",
         "//cuttlefish/host/libs/config:config_constants",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/strings",
-        "@fmt",
         "@jsoncpp",
     ],
 )
@@ -467,22 +416,17 @@ cf_cc_library(
     name = "stop",
     srcs = ["stop.cpp"],
     hdrs = ["stop.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/flag_parser",
         "//cuttlefish/host/commands/cvd/cli:command_request",
         "//cuttlefish/host/commands/cvd/cli:help_format",
         "//cuttlefish/host/commands/cvd/cli:utils",
         "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
-        "//cuttlefish/host/commands/cvd/cli/commands:host_tool_target",
         "//cuttlefish/host/commands/cvd/cli/selector",
         "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/commands/cvd/instances:instance_manager",
-        "//cuttlefish/host/commands/cvd/utils",
         "//cuttlefish/host/libs/metrics:device_metrics_orchestration",
         "//cuttlefish/result",
-        "//libbase",
-        "@abseil-cpp//absl/strings",
     ],
 )
 
@@ -490,13 +434,11 @@ cf_cc_library(
     name = "version",
     srcs = ["version.cpp"],
     hdrs = ["version.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:proto",
         "//cuttlefish/flag_parser",
         "//cuttlefish/host/commands/cvd/cli:command_request",
         "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
-        "//cuttlefish/host/commands/cvd/utils",
         "//cuttlefish/host/commands/cvd/version",
         "//cuttlefish/result",
         "@fmt",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/BUILD.bazel
@@ -1,27 +1,25 @@
-load("//cuttlefish/bazel:rules.bzl", "cf_cc_library", "cf_cc_test")
+load("//cuttlefish/bazel:rules.bzl", "cf_build_test", "cf_cc_library", "cf_cc_test")
 
 package(
-    default_visibility = ["//cuttlefish/host/commands/cvd/cli:__subpackages__"],
+    default_visibility = ["//:android_cuttlefish"],
 )
+
+cf_build_test(name = "monitor_build_test")
 
 cf_cc_library(
     name = "command_handler",
     srcs = ["command_handler.cc"],
     hdrs = ["command_handler.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/flag_parser",
         "//cuttlefish/host/commands/cvd/cli:command_request",
-        "//cuttlefish/host/commands/cvd/cli:utils",
         "//cuttlefish/host/commands/cvd/cli/commands:command_handler",
         "//cuttlefish/host/commands/cvd/cli/commands/monitor",
         "//cuttlefish/host/commands/cvd/cli/selector",
-        "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/commands/cvd/instances:instance_manager",
         "//cuttlefish/host/commands/cvd/utils:interrupt_listener",
         "//cuttlefish/result",
-        "//libbase",
     ],
 )
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/BUILD.bazel
@@ -1,11 +1,13 @@
 load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_proto_grpc_go//:defs.bzl", "go_proto_compile")
-load("//cuttlefish/bazel:rules.bzl", "cf_cc_library", "cf_cc_test")
+load("//cuttlefish/bazel:rules.bzl", "cf_build_test", "cf_cc_library", "cf_cc_test")
 
 package(
     default_visibility = ["//:android_cuttlefish"],
 )
+
+cf_build_test(name = "parser")
 
 cf_cc_library(
     name = "cf_configs_instances",
@@ -42,11 +44,9 @@ cf_cc_library(
     name = "cf_configs_common",
     srcs = ["cf_configs_common.cpp"],
     hdrs = ["cf_configs_common.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         ":load_config_cc_proto",
         "//cuttlefish/result",
-        "//libbase",
         "@fmt",
         "@jsoncpp",
         "@protobuf",
@@ -67,13 +67,11 @@ cf_cc_library(
     name = "fetch_config_parser",
     srcs = ["fetch_config_parser.cpp"],
     hdrs = ["fetch_config_parser.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/host/commands/cvd/cli/parser:cf_configs_common",
         "//cuttlefish/host/commands/cvd/cli/parser:load_config_cc_proto",
         "//cuttlefish/host/commands/cvd/fetch:fetch_cvd_parser",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/strings",
     ],
 )
@@ -94,14 +92,12 @@ cf_cc_library(
     name = "launch_cvd_parser",
     srcs = ["launch_cvd_parser.cpp"],
     hdrs = ["launch_cvd_parser.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/host/commands/cvd/cli/parser:cf_configs_common",
         "//cuttlefish/host/commands/cvd/cli/parser:cf_configs_instances",
         "//cuttlefish/host/commands/cvd/cli/parser:launch_cvd_templates",
         "//cuttlefish/host/commands/cvd/cli/parser:load_config_cc_proto",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/strings",
     ],
 )
@@ -182,11 +178,9 @@ cf_cc_library(
     testonly = True,
     srcs = ["test_common.cc"],
     hdrs = ["test_common.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/host/commands/cvd/cli/parser:cf_flags_validator",
         "//cuttlefish/host/commands/cvd/cli/parser:launch_cvd_parser",
-        "//cuttlefish/host/commands/cvd/cli/parser:load_configs_parser",
         "//cuttlefish/result",
         "@jsoncpp",
     ],

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/BUILD.bazel
@@ -1,16 +1,16 @@
-load("//cuttlefish/bazel:rules.bzl", "cf_cc_library", "cf_cc_test")
+load("//cuttlefish/bazel:rules.bzl", "cf_build_test", "cf_cc_library", "cf_cc_test")
 
 package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
+cf_build_test(name = "instance")
+
 cf_cc_test(
     name = "boot_configs_test",
     srcs = ["boot_configs_test.cc"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/host/commands/cvd/cli/parser:test_common",
-        "@jsoncpp",
     ],
 )
 
@@ -53,7 +53,6 @@ cf_cc_library(
     name = "cf_graphics_configs",
     srcs = ["cf_graphics_configs.cpp"],
     hdrs = ["cf_graphics_configs.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:base64",
         "//cuttlefish/host/commands/assemble_cvd:flags_defaults",
@@ -61,7 +60,6 @@ cf_cc_library(
         "//cuttlefish/host/commands/cvd/cli/parser:cf_configs_common",
         "//cuttlefish/host/commands/cvd/cli/parser:load_config_cc_proto",
         "//cuttlefish/result",
-        "//libbase",
         "@protobuf",
     ],
 )
@@ -103,15 +101,12 @@ cf_cc_library(
     name = "cf_vm_configs",
     srcs = ["cf_vm_configs.cpp"],
     hdrs = ["cf_vm_configs.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:flags_validator",
         "//cuttlefish/host/commands/assemble_cvd:flags_defaults",
         "//cuttlefish/host/commands/cvd/cli/parser:cf_configs_common",
         "//cuttlefish/host/commands/cvd/cli/parser:load_config_cc_proto",
         "//cuttlefish/result",
-        "//libbase",
-        "@fmt",
         "@protobuf//:json_util",
     ],
 )
@@ -119,17 +114,14 @@ cf_cc_library(
 cf_cc_test(
     name = "disk_configs_test",
     srcs = ["disk_configs_test.cc"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/host/commands/cvd/cli/parser:test_common",
-        "@jsoncpp",
     ],
 )
 
 cf_cc_test(
     name = "graphics_configs_test",
     srcs = ["graphics_configs_test.cc"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:base64",
         "//cuttlefish/common/libs/utils:json",
@@ -137,7 +129,6 @@ cf_cc_test(
         "//cuttlefish/host/commands/assemble_cvd:launch_cvd_cc_proto",
         "//cuttlefish/host/commands/cvd/cli/parser:test_common",
         "//cuttlefish/result:result_matchers",
-        "@jsoncpp",
         "@protobuf",
         "@protobuf//:differencer",
     ],
@@ -146,11 +137,9 @@ cf_cc_test(
 cf_cc_test(
     name = "vm_configs_test",
     srcs = ["vm_configs_test.cc"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:json",
         "//cuttlefish/host/commands/cvd/cli/parser:test_common",
         "//cuttlefish/result:result_matchers",
-        "@jsoncpp",
     ],
 )

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/selector/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/selector/BUILD.bazel
@@ -1,27 +1,23 @@
-load("//cuttlefish/bazel:rules.bzl", "cf_cc_library", "cf_cc_test")
+load("//cuttlefish/bazel:rules.bzl", "cf_build_test", "cf_cc_library", "cf_cc_test")
 
 package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
+cf_build_test(name = "selector_build_test")
+
 cf_cc_library(
     name = "creation_analyzer",
     srcs = ["creation_analyzer.cpp"],
     hdrs = ["creation_analyzer.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
-        "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:users",
         "//cuttlefish/host/commands/cvd/cli:utils",
         "//cuttlefish/host/commands/cvd/cli/selector:selector_common_parser",
-        "//cuttlefish/host/commands/cvd/instances",
-        "//cuttlefish/host/commands/cvd/instances:cvd_persistent_data",
         "//cuttlefish/host/commands/cvd/instances:instance_manager",
-        "//cuttlefish/host/commands/cvd/instances/lock",
         "//cuttlefish/host/commands/cvd/utils:common",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/strings",
     ],
@@ -51,12 +47,10 @@ cf_cc_library(
 cf_cc_test(
     name = "num_instances_parser_test",
     srcs = ["num_instances_parser_test.cpp"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         ":num_instances_parser",
         ":selector_common_parser",
         "//cuttlefish/flag_parser",
-        "//cuttlefish/result",
         "//cuttlefish/result:result_matchers",
     ],
 )
@@ -65,16 +59,13 @@ cf_cc_library(
     name = "selector",
     srcs = ["selector.cpp"],
     hdrs = ["selector.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/ansi_codes:terminal_colors",
-        "//cuttlefish/common/libs/utils:users",
         "//cuttlefish/host/commands/cvd/cli:command_request",
         "//cuttlefish/host/commands/cvd/cli:interruptible_terminal",
         "//cuttlefish/host/commands/cvd/instances",
         "//cuttlefish/host/commands/cvd/instances:instance_manager",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/strings",
     ],
 )
@@ -83,14 +74,12 @@ cf_cc_library(
     name = "selector_common_parser",
     srcs = ["selector_common_parser.cpp"],
     hdrs = ["selector_common_parser.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:contains",
         "//cuttlefish/flag_parser",
         "//cuttlefish/host/commands/cvd/cli/selector:selector_constants",
         "//cuttlefish/host/commands/cvd/instances:device_name",
         "//cuttlefish/result",
-        "//libbase",
     ],
 )
 

--- a/base/cvd/tools/lint/BUILD.bazel
+++ b/base/cvd/tools/lint/BUILD.bazel
@@ -1,4 +1,12 @@
 load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+load("@depend_on_what_you_use//dwyu/cc:defs.bzl", "MAP_DIRECT_DEPS", "dwyu_make_cc_info_mapping")
+
+dwyu_make_cc_info_mapping(
+    name = "map_external_deps",
+    mapping = {
+        "@protobuf": MAP_DIRECT_DEPS,
+    },
+)
 
 native_binary(
     name = "clang_tidy",

--- a/base/cvd/tools/lint/linters.bzl
+++ b/base/cvd/tools/lint/linters.bzl
@@ -20,6 +20,7 @@ clang_tidy_test = lint_test(aspect = clang_tidy)
 
 depend_on_what_you_use = dwyu_cc_aspect_factory(
     preprocessing_mode = "fast",
+    target_mapping = Label("@//tools/lint:map_external_deps")
 )
 
 def _dwyu_rule_impl(ctx):


### PR DESCRIPTION
- `cli/parser`
- `parser/instance`
- `cli/selector`
- `cli/commands`
- `commands/monitor`
- `libs/fs`
- `libs/key_equals_value`
- `libs/security`
- `libs/transport`
- `libs/utils`

Bug: b/534499070
Bug: b/532697459