### PR TITLE
Ensure kernel requested gets applied

### DIFF
--- a/tools/baseimage/pkg/gce/scripts/install_kernel_main.sh
+++ b/tools/baseimage/pkg/gce/scripts/install_kernel_main.sh
@@ -34,7 +34,7 @@ version=$(sudo chroot /mnt/image/ /usr/bin/dpkg -s linux-image-cloud-${arch} | g
 echo "START VERSION: ${version}"
 
 sudo chroot /mnt/image /usr/bin/apt-get update
-sudo chroot /mnt/image /usr/bin/apt-get upgrade -y
+sudo chroot /mnt/image /usr/bin/apt-get dist-upgrade -y
 
 version=$(sudo chroot /mnt/image/ /usr/bin/dpkg -s linux-image-cloud-${arch} | grep ^Depends: | \
   cut -d: -f2 | cut -d" " -f2 )
@@ -50,6 +50,20 @@ if [ "${version}" != "${linux_image_deb}" ]; then
   echo "CREATE IMAGE FAILED!!!"
   echo "Expected ${linux_image_deb}, got: ${version}"
   exit 1
+fi
+
+# Remove old kernel packages, keeping only the target kernel and the
+# linux-image-cloud-${arch} meta-package.
+old_kernels=$(sudo chroot /mnt/image /usr/bin/dpkg -l | grep '^ii' | awk '{print $2}' | \
+  grep '^linux-image-' | grep -v "^${linux_image_deb}$" | grep -v "^linux-image-cloud-${arch}$" || true)
+if [ -n "${old_kernels}" ]; then
+  echo "Removing old kernel packages: ${old_kernels}"
+  sudo chroot /mnt/image /usr/bin/apt-get purge -y ${old_kernels}
+  # update-grub may fail in a chroot; the grub config will be rebuilt
+  # when the image boots, so this is non-fatal.
+  sudo chroot /mnt/image /bin/sh -c 'command -v update-grub >/dev/null && update-grub || true'
+else
+  echo "No old kernel packages to remove"
 fi
 
 # Skip unmounting:


### PR DESCRIPTION
Security kernels don't get installed unless dist-upgrade is run.

Also delete the old kernels so when the NVIDIA
drivers get installed, they don't install against
the older kernel.

Assisted-By: Antigravity:Gemini-Next
Bug: b/538688547