### PR TITLE
Hold kernel package during base image builds

### DIFF
--- a/tools/baseimage/pkg/gce/scripts/create_base_image_main.sh
+++ b/tools/baseimage/pkg/gce/scripts/create_base_image_main.sh
@@ -26,9 +26,12 @@ sudo apt-get upgrade -y
 # Avoids blocking "Default mirror not found" popup prompt when pbuilder is installed.
 echo "pbuilder        pbuilder/mirrorsite     string  https://deb.debian.org/debian" | sudo debconf-set-selections
 
-kmodver_begin=$(sudo chroot /mnt/image/ /usr/bin/dpkg -s linux-image-cloud-${arch} | grep ^Depends: | \
-  cut -d: -f2 | cut -d" " -f2 | sed 's/linux-image-//')
+kmodver_begin=$(sudo chroot /mnt/image/ /usr/bin/dpkg -l | grep '^ii' | \
+  awk '{print $2}' | grep '^linux-image-[0-9]' | head -n1 | sed 's/linux-image-//')
 echo "IMAGE STARTS WITH KERNEL: ${kmodver_begin}"
+
+# Make sure we don't update the kernel image or headers during this process
+sudo chroot /mnt/image /usr/bin/apt-mark hold linux-image-cloud-${arch} linux-headers-cloud-${arch}
 
 sudo chroot /mnt/image /usr/bin/apt update
 sudo chroot /mnt/image /usr/bin/apt upgrade -y

--- a/tools/baseimage/pkg/gce/scripts/install_cuttlefish_debs.sh
+++ b/tools/baseimage/pkg/gce/scripts/install_cuttlefish_debs.sh
@@ -25,9 +25,12 @@ arch=$(uname -m)
 [ "${arch}" = "x86_64" ] && arch=amd64
 [ "${arch}" = "aarch64" ] && arch=arm64
 
-kmodver_begin=$(sudo chroot /mnt/image/ /usr/bin/dpkg -s linux-image-cloud-${arch} | grep ^Depends: | \
-  cut -d: -f2 | cut -d" " -f2 | sed 's/linux-image-//')
+kmodver_begin=$(sudo chroot /mnt/image/ /usr/bin/dpkg -l | grep '^ii' | \
+  awk '{print $2}' | grep '^linux-image-[0-9]' | head -n1 | sed 's/linux-image-//')
 echo "IMAGE STARTS WITH KERNEL: ${kmodver_begin}"
+
+# Make sure we don't update the kernel image or headers during this process
+sudo chroot /mnt/image /usr/bin/apt-mark hold linux-image-cloud-${arch} linux-headers-cloud-${arch}
 
 sudo chroot /mnt/image /usr/bin/apt update
 sudo chroot /mnt/image /usr/bin/apt upgrade -y

--- a/tools/baseimage/pkg/gce/scripts/install_nvidia.sh
+++ b/tools/baseimage/pkg/gce/scripts/install_nvidia.sh
@@ -27,12 +27,9 @@ if [ ! -d /dev/fd ]; then
   ln -s /proc/self/fd /dev/fd
 fi
 
-# Using "Depends:" is more reliable than "Version:", because it works for
-# backported ("bpo") kernels as well. NOTE: "Package" can be used instead
-# if we don't install the metapackage ("linux-image-cloud-${arch}") but a
-# specific version in the future
-kmodver=$(dpkg -s linux-image-cloud-${arch} | grep ^Depends: | \
-          cut -d: -f2 | cut -d" " -f2 | sed 's/linux-image-//')
+# Query the installed concrete kernel package version on disk rather than the metapackage
+kmodver=$(dpkg -l | grep '^ii' | awk '{print $2}' | \
+          grep '^linux-image-[0-9]' | head -n1 | sed 's/linux-image-//')
 
 apt-get install -y wget
 


### PR DESCRIPTION
Needed so that base image updates are only done as needed.

Assisted-By: Antigravity:Gemini-Next
Bug: b/538688546