### PR TITLE
Move StackTrace[Error,Entry] formatting into the .cc file

### DIFF
--- a/base/cvd/cuttlefish/host/libs/metrics/device_metrics_orchestration.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/device_metrics_orchestration.cc
@@ -121,21 +121,21 @@ void GatherVmInstantiationMetrics(const LocalInstanceGroup& instance_group) {
       instance_group, DeviceEventType::DeviceInstantiation);
   if (!metrics_input_result.has_value()) {
     VLOG(0) << fmt::format("Failed to initialize metrics.  Error: {}",
-                           metrics_input_result.error());
+                           metrics_input_result.error().FormatForEnv());
     return;
   }
   Result<void> metrics_setup_result =
       SetUpMetrics(metrics_input_result->base_input.metrics_directory);
   if (!metrics_setup_result.has_value()) {
     VLOG(0) << fmt::format("Failed to initialize metrics.  Error: {}",
-                           metrics_setup_result.error());
+                           metrics_setup_result.error().FormatForEnv());
     return;
   }
   Result<void> run_metrics_result = RunMetrics(*metrics_input_result);
   if (!run_metrics_result.has_value()) {
     VLOG(0) << fmt::format(
         "Failed during metrics gathering and (possible) outputting.  Error: {}",
-        run_metrics_result.error());
+        run_metrics_result.error().FormatForEnv());
     return;
   }
 }
@@ -145,14 +145,14 @@ void GatherVmStartMetrics(const LocalInstanceGroup& instance_group) {
       GetDeviceMetricsInput(instance_group, DeviceEventType::DeviceBootStart);
   if (!metrics_input_result.has_value()) {
     VLOG(0) << fmt::format("Failed to initialize metrics.  Error: {}",
-                           metrics_input_result.error());
+                           metrics_input_result.error().FormatForEnv());
     return;
   }
   Result<void> run_metrics_result = RunMetrics(*metrics_input_result);
   if (!run_metrics_result.has_value()) {
     VLOG(0) << fmt::format(
         "Failed during metrics gathering and (possible) outputting.  Error: {}",
-        run_metrics_result.error());
+        run_metrics_result.error().FormatForEnv());
     return;
   }
 }
@@ -162,14 +162,14 @@ void GatherVmBootCompleteMetrics(const LocalInstanceGroup& instance_group) {
       instance_group, DeviceEventType::DeviceBootComplete);
   if (!metrics_input_result.has_value()) {
     VLOG(0) << fmt::format("Failed to initialize metrics.  Error: {}",
-                           metrics_input_result.error());
+                           metrics_input_result.error().FormatForEnv());
     return;
   }
   Result<void> run_metrics_result = RunMetrics(*metrics_input_result);
   if (!run_metrics_result.has_value()) {
     VLOG(0) << fmt::format(
         "Failed during metrics gathering and (possible) outputting.  Error: {}",
-        run_metrics_result.error());
+        run_metrics_result.error().FormatForEnv());
     return;
   }
 }
@@ -179,14 +179,14 @@ void GatherVmBootFailedMetrics(const LocalInstanceGroup& instance_group) {
       GetDeviceMetricsInput(instance_group, DeviceEventType::DeviceBootFailed);
   if (!metrics_input_result.has_value()) {
     VLOG(0) << fmt::format("Failed to initialize metrics.  Error: {}",
-                           metrics_input_result.error());
+                           metrics_input_result.error().FormatForEnv());
     return;
   }
   Result<void> run_metrics_result = RunMetrics(*metrics_input_result);
   if (!run_metrics_result.has_value()) {
     VLOG(0) << fmt::format(
         "Failed during metrics gathering and (possible) outputting.  Error: {}",
-        run_metrics_result.error());
+        run_metrics_result.error().FormatForEnv());
     return;
   }
 }
@@ -196,14 +196,14 @@ void GatherVmStopMetrics(const LocalInstanceGroup& instance_group) {
       GetDeviceMetricsInput(instance_group, DeviceEventType::DeviceStop);
   if (!metrics_input_result.has_value()) {
     VLOG(0) << fmt::format("Failed to initialize metrics.  Error: {}",
-                           metrics_input_result.error());
+                           metrics_input_result.error().FormatForEnv());
     return;
   }
   Result<void> run_metrics_result = RunMetrics(*metrics_input_result);
   if (!run_metrics_result.has_value()) {
     VLOG(0) << fmt::format(
         "Failed during metrics gathering and (possible) outputting.  Error: {}",
-        run_metrics_result.error());
+        run_metrics_result.error().FormatForEnv());
     return;
   }
 }

--- a/base/cvd/cuttlefish/host/libs/metrics/fetch_metrics_orchestration.cc
+++ b/base/cvd/cuttlefish/host/libs/metrics/fetch_metrics_orchestration.cc
@@ -85,7 +85,7 @@ void GatherFetchStartMetrics(const FetchFlags& fetch_flags) {
       SetUpMetrics(metrics_input.metrics_directory);
   if (!metrics_setup_result.has_value()) {
     VLOG(0) << fmt::format("Failed to initialize metrics.  Error: {}",
-                           metrics_setup_result.error());
+                           metrics_setup_result.error().FormatForEnv());
     return;
   }
 
@@ -93,7 +93,7 @@ void GatherFetchStartMetrics(const FetchFlags& fetch_flags) {
   if (!run_metrics_result.has_value()) {
     VLOG(0) << fmt::format(
         "Failed during metrics gathering and (possible) outputting.  Error: {}",
-        run_metrics_result.error());
+        run_metrics_result.error().FormatForEnv());
     return;
   }
 }
@@ -105,7 +105,7 @@ void GatherFetchCompleteMetrics(const std::string& target_directory,
   if (!run_metrics_result.has_value()) {
     VLOG(0) << fmt::format(
         "Failed during metrics gathering and (possible) outputting.  Error: {}",
-        run_metrics_result.error());
+        run_metrics_result.error().FormatForEnv());
     return;
   }
 }
@@ -116,7 +116,7 @@ void GatherFetchFailedMetrics(const std::string& target_directory) {
   if (!run_metrics_result.has_value()) {
     VLOG(0) << fmt::format(
         "Failed during metrics gathering and (possible) outputting.  Error: {}",
-        run_metrics_result.error());
+        run_metrics_result.error().FormatForEnv());
     return;
   }
 }

--- a/base/cvd/cuttlefish/result/error_type.cc
+++ b/base/cvd/cuttlefish/result/error_type.cc
@@ -26,8 +26,293 @@
 
 #include "absl/strings/str_cat.h"
 #include "fmt/base.h"
+#include "fmt/core.h"
+#include "fmt/format.h"
 
 #include "cuttlefish/ansi_codes/ansi_codes.h"
+
+namespace cuttlefish {
+namespace {
+
+enum class FormatSpecifier : char {
+  /** Prefix multi-line output with an arrow. */
+  kArrow = 'a',
+  /** Use colors in all other output specifiers. */
+  kColor = 'c',
+  /** The function name without namespace or arguments. */
+  kFunction = 'f',
+  /** The CF_EXPECT(exp) expression. */
+  kLongExpression = 'E',
+  /** The source file path relative to ANDROID_BUILD_TOP and line number. */
+  kLongLocation = 'L',
+  /** The user-friendly string provided to CF_EXPECT. */
+  kMessage = 'm',
+  /** Prefix output with the stack frame index. */
+  kNumbers = 'n',
+  /** The function signature with fully-qualified types. */
+  kPrettyFunction = 'F',
+  /** The short location and short filename. */
+  kShort = 's',
+  /** The `exp` inside `CF_EXPECT(exp)` */
+  kShortExpression = 'e',
+  /** The source file basename and line number. */
+  kShortLocation = 'l',
+};
+static constexpr auto kVerbose = {
+    FormatSpecifier::kArrow,
+    FormatSpecifier::kColor,
+    FormatSpecifier::kNumbers,
+    FormatSpecifier::kShort,
+};
+static constexpr auto kVeryVerbose = {
+    FormatSpecifier::kArrow,          FormatSpecifier::kColor,
+    FormatSpecifier::kNumbers,        FormatSpecifier::kLongLocation,
+    FormatSpecifier::kPrettyFunction, FormatSpecifier::kLongExpression,
+    FormatSpecifier::kMessage,
+};
+
+/*
+ * Print a single stack trace entry out of a list of format specifiers.
+ * Some format specifiers [a,c,n] cause changes that affect all lines, while
+ * the rest amount to printing a single line in the output. This code is
+ * reused by formatting code for both rendering individual stack trace
+ * entries, and rendering an entire stack trace with multiple entries.
+ */
+fmt::format_context::iterator FormatEntry(
+    fmt::format_context& ctx, const StackTraceEntry& entry,
+    const std::vector<FormatSpecifier>& specifiers, std::optional<int> index) {
+  auto out = ctx.out();
+  std::vector<FormatSpecifier> filtered_specs;
+  bool arrow = false;
+  bool color = false;
+  bool numbers = false;
+  for (auto spec : specifiers) {
+    switch (spec) {
+      case FormatSpecifier::kArrow:
+        arrow = true;
+        continue;
+      case FormatSpecifier::kColor:
+        color = true;
+        continue;
+      case FormatSpecifier::kLongExpression:
+      case FormatSpecifier::kShortExpression:
+        if (entry.Expression().empty()) {
+          continue;
+        }
+        break;
+      case FormatSpecifier::kMessage:
+        if (!entry.HasMessage()) {
+          continue;
+        }
+        break;
+      case FormatSpecifier::kNumbers:
+        numbers = true;
+        continue;
+      default:  // fall through
+        break;
+    }
+    filtered_specs.emplace_back(spec);
+  }
+  if (filtered_specs.empty()) {
+    filtered_specs.push_back(FormatSpecifier::kShort);
+  }
+  for (size_t i = 0; i < filtered_specs.size(); i++) {
+    if (index.has_value() && numbers) {
+      if (color) {
+        out = fmt::format_to(out, "{}. ", *index);
+      } else {
+        out = fmt::format_to(out, "{}. ", *index);
+      }
+    }
+    if (numbers) {
+      if (arrow && (int)i < ((int)filtered_specs.size()) - 2) {
+        out = fmt::format_to(out, "|  ");
+      } else if (arrow && i == filtered_specs.size() - 2) {
+        out = fmt::format_to(out, "v  ");
+      }
+    } else {
+      if (arrow && (int)i < ((int)filtered_specs.size()) - 2) {
+        out = fmt::format_to(out, " | ");
+      } else if (arrow && i == filtered_specs.size() - 2) {
+        out = fmt::format_to(out, " v ");
+      }
+    }
+    switch (filtered_specs[i]) {
+      case FormatSpecifier::kFunction:
+        out = fmt::format_to(out, "{}", entry.Function());
+        break;
+      case FormatSpecifier::kLongExpression:
+        out = fmt::format_to(out, "CF_EXPECT({})", entry.Expression());
+        break;
+      case FormatSpecifier::kLongLocation:
+        if (color) {
+          out = fmt::format_to(out, "{}:{}", entry.File(), entry.Line());
+        } else {
+          out = fmt::format_to(out, "{}:{}", entry.File(), entry.Line());
+        }
+        break;
+      case FormatSpecifier::kMessage:
+        if (color) {
+          out = fmt::format_to(out, "{}{}{}", kAnsiRed, entry.Message(),
+                               kAnsiReset);
+        } else {
+          out = fmt::format_to(out, "{}", entry.Message());
+        }
+        break;
+      case FormatSpecifier::kPrettyFunction:
+        out = fmt::format_to(out, "{}", entry.PrettyFunction());
+        break;
+      case FormatSpecifier::kShort: {
+        auto last_slash = entry.File().rfind("/");
+        auto short_file = entry.File().substr(
+            last_slash == std::string::npos ? 0 : last_slash + 1);
+        std::string last;
+        if (entry.HasMessage()) {
+          last = color ? absl::StrCat(kAnsiRed, entry.Message(), kAnsiReset)
+                       : entry.Message();
+        }
+        if (color) {
+          out = fmt::format_to(out, "{}:{} | {} | {}", short_file, entry.Line(),
+                               entry.Function(), last);
+        } else {
+          out = fmt::format_to(out, "{}:{} | {} | {}", short_file, entry.Line(),
+                               entry.Function(), last);
+        }
+        break;
+      }
+      case FormatSpecifier::kShortExpression:
+        out = fmt::format_to(out, "{}", entry.Expression());
+        break;
+      case FormatSpecifier::kShortLocation: {
+        auto last_slash = entry.File().rfind("/");
+        auto short_file = entry.File().substr(
+            last_slash == std::string::npos ? 0 : last_slash + 1);
+        if (color) {
+          out = fmt::format_to(out, "{}:{}", short_file, entry.Line());
+        } else {
+          out = fmt::format_to(out, "{}:{}", short_file, entry.Line());
+        }
+        break;
+      }
+      default:
+        fmt::format_to(out, "unknown specifier");
+    }
+    if (i < filtered_specs.size() - 1) {
+      out = fmt::format_to(out, "\n");
+    }
+  }
+  return out;
+}
+
+}  // namespace
+}  // namespace cuttlefish
+
+/**
+ * Specialized formatting for StackTraceEntry based on user-provided specifiers.
+ *
+ * A StackTraceEntry can be formatted with {:specifiers} in a `fmt::format`
+ * string, where `specifiers` is an ordered list of characters deciding on the
+ * format. `v` provides "verbose" output and `V` provides "very verbose" output.
+ * See `StackTraceEntry::FormatSpecifiers` for more fine-grained specifiers.
+ */
+template <>
+struct fmt::formatter<cuttlefish::StackTraceEntry> {
+ public:
+  constexpr auto parse(format_parse_context& ctx)
+      -> format_parse_context::iterator {
+    auto it = ctx.begin();
+    while (it != ctx.end() && *it != '}') {
+      if (*it == 'v') {
+        for (const auto& specifier : cuttlefish::kVerbose) {
+          fmt_specs_.push_back(specifier);
+        }
+      } else if (*it == 'V') {
+        for (const auto& specifier : cuttlefish::kVeryVerbose) {
+          fmt_specs_.push_back(specifier);
+        }
+      } else {
+        fmt_specs_.push_back(static_cast<cuttlefish::FormatSpecifier>(*it));
+      }
+      it++;
+    }
+    return it;
+  }
+
+  auto format(const cuttlefish::StackTraceEntry& entry,
+              format_context& ctx) const -> format_context::iterator {
+    return FormatEntry(ctx, entry, fmt_specs_, std::nullopt);
+  }
+
+ private:
+  std::vector<cuttlefish::FormatSpecifier> fmt_specs_;
+};
+
+/**
+ * Specialized formatting for a collection of StackTraceEntry elements.
+ *
+ * Can be formatted by a `fmt::format` string as {:specifiers}. See
+ * `fmt::formatter<cuttlefish::StackTraceEntry>` for the format specifiers of
+ * individual entries. By default the specifier list is passed down to all
+ * indivudal entries, with the following additional rules. The `^` specifier
+ * will change the ordering from inner-to-outer instead of outer-to-inner, and
+ * using the `/` specifier like `<abc>/<xyz>` will apply <xyz> only to the
+ * innermost stack entry, and <abc> to all other stack entries.
+ */
+template <>
+struct fmt::formatter<cuttlefish::StackTraceError> {
+ public:
+  constexpr auto parse(format_parse_context& ctx)
+      -> format_parse_context::iterator {
+    auto it = ctx.begin();
+    while (it != ctx.end() && *it != '}') {
+      if (*it == 'v') {
+        for (const auto& spec : cuttlefish::kVerbose) {
+          (has_inner_fmt_spec_ ? inner_fmt_specs_ : fmt_specs_).push_back(spec);
+        }
+      } else if (*it == 'V') {
+        for (const auto& spec : cuttlefish::kVeryVerbose) {
+          (has_inner_fmt_spec_ ? inner_fmt_specs_ : fmt_specs_).push_back(spec);
+        }
+      } else if (*it == '/') {
+        has_inner_fmt_spec_ = true;
+      } else if (*it == '^') {
+        inner_to_outer_ = true;
+      } else {
+        (has_inner_fmt_spec_ ? inner_fmt_specs_ : fmt_specs_)
+            .push_back(static_cast<cuttlefish::FormatSpecifier>(*it));
+      }
+      it++;
+    }
+    return it;
+  }
+
+  format_context::iterator format(const cuttlefish::StackTraceError& error,
+                                  format_context& ctx) const {
+    auto out = ctx.out();
+    auto& stack = error.Stack();
+    int begin = inner_to_outer_ ? 0 : stack.size() - 1;
+    int end = inner_to_outer_ ? stack.size() : -1;
+    int step = inner_to_outer_ ? 1 : -1;
+    for (int i = begin; i != end; i += step) {
+      auto& specs =
+          has_inner_fmt_spec_ && i == 0 ? inner_fmt_specs_ : fmt_specs_;
+      out = FormatEntry(ctx, stack[i], specs, i);
+      if (i != end - step) {
+        out = fmt::format_to(out, "\n");
+      }
+    }
+    return out;
+  }
+
+ private:
+  using StackTraceEntry = cuttlefish::StackTraceEntry;
+  using StackTraceError = cuttlefish::StackTraceError;
+
+  bool inner_to_outer_ = false;
+  bool has_inner_fmt_spec_ = false;
+  std::vector<cuttlefish::FormatSpecifier> fmt_specs_;
+  std::vector<cuttlefish::FormatSpecifier> inner_fmt_specs_;
+};
 
 namespace cuttlefish {
 
@@ -67,138 +352,38 @@ StackTraceEntry& StackTraceEntry::operator=(const StackTraceEntry& other) {
 }
 
 bool StackTraceEntry::HasMessage() const { return !message_.str().empty(); }
+const std::string& StackTraceEntry::Expression() const { return expression_; }
+const std::string& StackTraceEntry::File() const { return file_; }
+const std::string& StackTraceEntry::Function() const { return function_; }
+const std::string& StackTraceEntry::PrettyFunction() const {
+  return pretty_function_;
+}
+size_t StackTraceEntry::Line() const { return line_; }
+std::string StackTraceEntry::Message() const { return message_.str(); }
 
-/*
- * Print a single stack trace entry out of a list of format specifiers.
- * Some format specifiers [a,c,n] cause changes that affect all lines, while
- * the rest amount to printing a single line in the output. This code is
- * reused by formatting code for both rendering individual stack trace
- * entries, and rendering an entire stack trace with multiple entries.
- */
-fmt::format_context::iterator StackTraceEntry::format(
-    fmt::format_context& ctx, const std::vector<FormatSpecifier>& specifiers,
-    std::optional<int> index) const {
-  auto out = ctx.out();
-  std::vector<FormatSpecifier> filtered_specs;
-  bool arrow = false;
-  bool color = false;
-  bool numbers = false;
-  for (auto spec : specifiers) {
-    switch (spec) {
-      case FormatSpecifier::kArrow:
-        arrow = true;
-        continue;
-      case FormatSpecifier::kColor:
-        color = true;
-        continue;
-      case FormatSpecifier::kLongExpression:
-      case FormatSpecifier::kShortExpression:
-        if (expression_.empty()) {
-          continue;
-        }
-        break;
-      case FormatSpecifier::kMessage:
-        if (!HasMessage()) {
-          continue;
-        }
-        break;
-      case FormatSpecifier::kNumbers:
-        numbers = true;
-        continue;
-      default:  // fall through
-        break;
-    }
-    filtered_specs.emplace_back(spec);
-  }
-  if (filtered_specs.empty()) {
-    filtered_specs.push_back(FormatSpecifier::kShort);
-  }
-  for (size_t i = 0; i < filtered_specs.size(); i++) {
-    if (index.has_value() && numbers) {
-      if (color) {
-        out = fmt::format_to(out, "{}. ", *index);
-      } else {
-        out = fmt::format_to(out, "{}. ", *index);
-      }
-    }
-    if (numbers) {
-      if (arrow && (int)i < ((int)filtered_specs.size()) - 2) {
-        out = fmt::format_to(out, "|  ");
-      } else if (arrow && i == filtered_specs.size() - 2) {
-        out = fmt::format_to(out, "v  ");
-      }
-    } else {
-      if (arrow && (int)i < ((int)filtered_specs.size()) - 2) {
-        out = fmt::format_to(out, " | ");
-      } else if (arrow && i == filtered_specs.size() - 2) {
-        out = fmt::format_to(out, " v ");
-      }
-    }
-    switch (filtered_specs[i]) {
-      case FormatSpecifier::kFunction:
-        out = fmt::format_to(out, "{}", function_);
-        break;
-      case FormatSpecifier::kLongExpression:
-        out = fmt::format_to(out, "CF_EXPECT({})", expression_);
-        break;
-      case FormatSpecifier::kLongLocation:
-        if (color) {
-          out = fmt::format_to(out, "{}:{}", file_, line_);
-        } else {
-          out = fmt::format_to(out, "{}:{}", file_, line_);
-        }
-        break;
-      case FormatSpecifier::kMessage:
-        if (color) {
-          out = fmt::format_to(out, "{}{}{}", kAnsiRed, message_.str(),
-                               kAnsiReset);
-        } else {
-          out = fmt::format_to(out, "{}", message_.str());
-        }
-        break;
-      case FormatSpecifier::kPrettyFunction:
-        out = fmt::format_to(out, "{}", pretty_function_);
-        break;
-      case FormatSpecifier::kShort: {
-        auto last_slash = file_.rfind("/");
-        auto short_file =
-            file_.substr(last_slash == std::string::npos ? 0 : last_slash + 1);
-        std::string last;
-        if (HasMessage()) {
-          last = color ? absl::StrCat(kAnsiRed, message_.str(), kAnsiReset)
-                       : message_.str();
-        }
-        if (color) {
-          out = fmt::format_to(out, "{}:{} | {} | {}", short_file, line_,
-                               function_, last);
-        } else {
-          out = fmt::format_to(out, "{}:{} | {} | {}", short_file, line_,
-                               function_, last);
-        }
-        break;
-      }
-      case FormatSpecifier::kShortExpression:
-        out = fmt::format_to(out, "{}", expression_);
-        break;
-      case FormatSpecifier::kShortLocation: {
-        auto last_slash = file_.rfind("/");
-        auto short_file =
-            file_.substr(last_slash == std::string::npos ? 0 : last_slash + 1);
-        if (color) {
-          out = fmt::format_to(out, "{}:{}", short_file, line_);
-        } else {
-          out = fmt::format_to(out, "{}:{}", short_file, line_);
-        }
-        break;
-      }
-      default:
-        fmt::format_to(out, "unknown specifier");
-    }
-    if (i < filtered_specs.size() - 1) {
-      out = fmt::format_to(out, "\n");
-    }
-  }
-  return out;
+StackTraceError& StackTraceError::PushEntry(StackTraceEntry entry) & {
+  stack_.emplace_back(std::move(entry));
+  return *this;
+}
+
+StackTraceError StackTraceError::PushEntry(StackTraceEntry entry) && {
+  return std::move(this->PushEntry(entry));
+}
+
+const std::vector<StackTraceEntry>& StackTraceError::Stack() const {
+  return stack_;
+}
+
+std::string StackTraceError::Message() const {
+  return fmt::format(fmt::runtime("{:m}"), *this);
+}
+
+std::string StackTraceError::Trace() const {
+  return fmt::format(fmt::runtime("{:v}"), *this);
+}
+
+std::string StackTraceError::FormatForEnv(bool color) const {
+  return fmt::format(fmt::runtime(ResultErrorFormat(color)), *this);
 }
 
 std::string ResultErrorFormat(bool color) {
@@ -217,21 +402,3 @@ std::ostream& operator<<(std::ostream& out, const StackTraceError& error) {
 }
 
 }  // namespace cuttlefish
-
-fmt::format_context::iterator
-fmt::formatter<cuttlefish::StackTraceError>::format(
-    const cuttlefish::StackTraceError& error, format_context& ctx) const {
-  auto out = ctx.out();
-  auto& stack = error.Stack();
-  int begin = inner_to_outer_ ? 0 : stack.size() - 1;
-  int end = inner_to_outer_ ? stack.size() : -1;
-  int step = inner_to_outer_ ? 1 : -1;
-  for (int i = begin; i != end; i += step) {
-    auto& specs = has_inner_fmt_spec_ && i == 0 ? inner_fmt_specs_ : fmt_specs_;
-    out = stack[i].format(ctx, specs, i);
-    if (i != end - step) {
-      out = fmt::format_to(out, "\n");
-    }
-  }
-  return out;
-}

--- a/base/cvd/cuttlefish/result/error_type.h
+++ b/base/cvd/cuttlefish/result/error_type.h
@@ -17,15 +17,13 @@
 
 #include <unistd.h>
 
-#include <optional>
 #include <ostream>
 #include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "fmt/core.h"       // IWYU pragma: export
-#include "tl/expected.hpp"  // IWYU pragma: export
+#include "tl/expected.hpp"
 
 #include "cuttlefish/ansi_codes/should_color.h"
 
@@ -35,43 +33,6 @@ class StackTraceError;
 
 class StackTraceEntry {
  public:
-  enum class FormatSpecifier : char {
-    /** Prefix multi-line output with an arrow. */
-    kArrow = 'a',
-    /** Use colors in all other output specifiers. */
-    kColor = 'c',
-    /** The function name without namespace or arguments. */
-    kFunction = 'f',
-    /** The CF_EXPECT(exp) expression. */
-    kLongExpression = 'E',
-    /** The source file path relative to ANDROID_BUILD_TOP and line number. */
-    kLongLocation = 'L',
-    /** The user-friendly string provided to CF_EXPECT. */
-    kMessage = 'm',
-    /** Prefix output with the stack frame index. */
-    kNumbers = 'n',
-    /** The function signature with fully-qualified types. */
-    kPrettyFunction = 'F',
-    /** The short location and short filename. */
-    kShort = 's',
-    /** The `exp` inside `CF_EXPECT(exp)` */
-    kShortExpression = 'e',
-    /** The source file basename and line number. */
-    kShortLocation = 'l',
-  };
-  static constexpr auto kVerbose = {
-      FormatSpecifier::kArrow,
-      FormatSpecifier::kColor,
-      FormatSpecifier::kNumbers,
-      FormatSpecifier::kShort,
-  };
-  static constexpr auto kVeryVerbose = {
-      FormatSpecifier::kArrow,          FormatSpecifier::kColor,
-      FormatSpecifier::kNumbers,        FormatSpecifier::kLongLocation,
-      FormatSpecifier::kPrettyFunction, FormatSpecifier::kLongExpression,
-      FormatSpecifier::kMessage,
-  };
-
   StackTraceEntry(std::string file, size_t line, std::string pretty_function,
                   std::string function);
 
@@ -100,17 +61,12 @@ class StackTraceEntry {
   operator tl::expected<T, StackTraceError>() &&;
 
   bool HasMessage() const;
-
-  /*
-   * Print a single stack trace entry out of a list of format specifiers.
-   * Some format specifiers [a,c,n] cause changes that affect all lines, while
-   * the rest amount to printing a single line in the output. This code is
-   * reused by formatting code for both rendering individual stack trace
-   * entries, and rendering an entire stack trace with multiple entries.
-   */
-  fmt::format_context::iterator format(
-      fmt::format_context& ctx, const std::vector<FormatSpecifier>& specifiers,
-      std::optional<int> index) const;
+  const std::string& Expression() const;
+  const std::string& File() const;
+  const std::string& Function() const;
+  const std::string& PrettyFunction() const;
+  size_t Line() const;
+  std::string Message() const;
 
  private:
   std::string file_;
@@ -126,73 +82,17 @@ std::string ResultErrorFormat(bool color);
 #define CF_STACK_TRACE_ENTRY(expression) \
   StackTraceEntry(__FILE__, __LINE__, __PRETTY_FUNCTION__, __func__, expression)
 
-}  // namespace cuttlefish
-
-/**
- * Specialized formatting for StackTraceEntry based on user-provided specifiers.
- *
- * A StackTraceEntry can be formatted with {:specifiers} in a `fmt::format`
- * string, where `specifiers` is an ordered list of characters deciding on the
- * format. `v` provides "verbose" output and `V` provides "very verbose" output.
- * See `StackTraceEntry::FormatSpecifiers` for more fine-grained specifiers.
- */
-template <>
-struct fmt::formatter<cuttlefish::StackTraceEntry> {
- public:
-  constexpr auto parse(format_parse_context& ctx)
-      -> format_parse_context::iterator {
-    auto it = ctx.begin();
-    while (it != ctx.end() && *it != '}') {
-      if (*it == 'v') {
-        for (const auto& specifier : cuttlefish::StackTraceEntry::kVerbose) {
-          fmt_specs_.push_back(specifier);
-        }
-      } else if (*it == 'V') {
-        for (const auto& specifier :
-             cuttlefish::StackTraceEntry::kVeryVerbose) {
-          fmt_specs_.push_back(specifier);
-        }
-      } else {
-        fmt_specs_.push_back(
-            static_cast<cuttlefish::StackTraceEntry::FormatSpecifier>(*it));
-      }
-      it++;
-    }
-    return it;
-  }
-
-  auto format(const cuttlefish::StackTraceEntry& entry,
-              format_context& ctx) const -> format_context::iterator {
-    return entry.format(ctx, fmt_specs_, std::nullopt);
-  }
-
- private:
-  std::vector<cuttlefish::StackTraceEntry::FormatSpecifier> fmt_specs_;
-};
-
-namespace cuttlefish {
-
 class StackTraceError {
  public:
-  StackTraceError& PushEntry(StackTraceEntry entry) & {
-    stack_.emplace_back(std::move(entry));
-    return *this;
-  }
-  StackTraceError PushEntry(StackTraceEntry entry) && {
-    stack_.emplace_back(std::move(entry));
-    return std::move(*this);
-  }
-  const std::vector<StackTraceEntry>& Stack() const { return stack_; }
+  StackTraceError& PushEntry(StackTraceEntry entry) &;
+  StackTraceError PushEntry(StackTraceEntry entry) &&;
+  const std::vector<StackTraceEntry>& Stack() const;
 
-  std::string Message() const {
-    return fmt::format(fmt::runtime("{:m}"), *this);
-  }
+  std::string Message() const;
 
-  std::string Trace() const { return fmt::format(fmt::runtime("{:v}"), *this); }
+  std::string Trace() const;
 
-  std::string FormatForEnv(bool color = ShouldColorStdout()) const {
-    return fmt::format(fmt::runtime(ResultErrorFormat(color)), *this);
-  }
+  std::string FormatForEnv(bool color = ShouldColorStdout()) const;
 
   template <typename T>
   operator tl::expected<T, StackTraceError>() && {
@@ -215,55 +115,3 @@ inline StackTraceEntry::operator tl::expected<T, StackTraceError>() && {
 std::ostream& operator<<(std::ostream&, const StackTraceError&);
 
 }  // namespace cuttlefish
-
-/**
- * Specialized formatting for a collection of StackTraceEntry elements.
- *
- * Can be formatted by a `fmt::format` string as {:specifiers}. See
- * `fmt::formatter<cuttlefish::StackTraceEntry>` for the format specifiers of
- * individual entries. By default the specifier list is passed down to all
- * indivudal entries, with the following additional rules. The `^` specifier
- * will change the ordering from inner-to-outer instead of outer-to-inner, and
- * using the `/` specifier like `<abc>/<xyz>` will apply <xyz> only to the
- * innermost stack entry, and <abc> to all other stack entries.
- */
-template <>
-struct fmt::formatter<cuttlefish::StackTraceError> {
- public:
-  constexpr auto parse(format_parse_context& ctx)
-      -> format_parse_context::iterator {
-    auto it = ctx.begin();
-    while (it != ctx.end() && *it != '}') {
-      if (*it == 'v') {
-        for (const auto& spec : StackTraceEntry::kVerbose) {
-          (has_inner_fmt_spec_ ? inner_fmt_specs_ : fmt_specs_).push_back(spec);
-        }
-      } else if (*it == 'V') {
-        for (const auto& spec : StackTraceEntry::kVeryVerbose) {
-          (has_inner_fmt_spec_ ? inner_fmt_specs_ : fmt_specs_).push_back(spec);
-        }
-      } else if (*it == '/') {
-        has_inner_fmt_spec_ = true;
-      } else if (*it == '^') {
-        inner_to_outer_ = true;
-      } else {
-        (has_inner_fmt_spec_ ? inner_fmt_specs_ : fmt_specs_)
-            .push_back(static_cast<StackTraceEntry::FormatSpecifier>(*it));
-      }
-      it++;
-    }
-    return it;
-  }
-
-  format_context::iterator format(const cuttlefish::StackTraceError& error,
-                                  format_context& ctx) const;
-
- private:
-  using StackTraceEntry = cuttlefish::StackTraceEntry;
-  using StackTraceError = cuttlefish::StackTraceError;
-
-  bool inner_to_outer_ = false;
-  bool has_inner_fmt_spec_ = false;
-  std::vector<StackTraceEntry::FormatSpecifier> fmt_specs_;
-  std::vector<StackTraceEntry::FormatSpecifier> inner_fmt_specs_;
-};


### PR DESCRIPTION
This removes one source of transitively including libfmt headers everywhere. It has the downside of making the error type not formattable by libfmt in other source files, but there were few uses of that in the codebase.

Bug: b/538740351