### PR TITLE
gigabyte-ampere-cuttlefish-installer: utils: download-ci-cf.sh: use JSON API

### DIFF
--- a/gigabyte-ampere-cuttlefish-installer/utils/download-ci-cf.sh
+++ b/gigabyte-ampere-cuttlefish-installer/utils/download-ci-cf.sh
@@ -6,9 +6,23 @@ set -o errexit
 
 URL=https://ci.android.com/builds/latest/branches/aosp-android-latest-release/targets/aosp_cf_arm64_only_phone-userdebug/view/BUILD_INFO
 RURL=$(curl -Ls -o /dev/null -w %{url_effective} ${URL})
-echo $RURL
+echo "RURL = ${RURL}"
 
-FILENAME=$(wget -nv -O - ${RURL%/view/BUILD_INFO}/ | grep aosp_cf_arm64_only_phone-img- | sed 's/.*\(aosp_cf_arm64_only_phone-img-[0-9]*[.]zip\).*/\1/g')
+BUILD_ID=$(echo "${RURL}" | sed -n 's/.*\/builds\/submitted\/\([^\/]*\)\/.*/\1/p')
+echo "BUILD_ID = ${BUILD_ID}"
+
+if [[ -z "${BUILD_ID}" ]]; then
+    echo "Error: BUILD_ID empty."
+    exit 1
+fi
+
+FILENAME="aosp_cf_arm64_only_phone-img-${BUILD_ID}.zip"
+echo "FILENAME = ${FILENAME}"
+
+if [[ -z "${FILENAME}" ]]; then
+    echo "Error: FILENAME empty."
+    exit 1
+fi
 
 wget -nv -c ${RURL%/view/BUILD_INFO}/raw/${FILENAME}
 wget -nv -c ${RURL%/view/BUILD_INFO}/raw/cvd-host_package.tar.gz


### PR DESCRIPTION
The previous way to download the artifacts doesn't work. We fix it by using the latest JSON API. And also make the script more verbose on error.