### PR TITLE
Remove depend_on_what_you_use_enabled = False from run_cvd/launch

### DIFF
--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
@@ -1,18 +1,18 @@
-load("//cuttlefish/bazel:rules.bzl", "cf_cc_library")
+load("//cuttlefish/bazel:rules.bzl", "cf_build_test", "cf_cc_library")
 
 package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
+cf_build_test(name = "launch_build_test")
+
 cf_cc_library(
     name = "auto_cmd",
     hdrs = ["auto_cmd.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:type_name",
         "//cuttlefish/host/libs/feature",
         "//cuttlefish/result",
-        "//libbase",
         "@fruit",
     ],
 )
@@ -116,13 +116,11 @@ cf_cc_library(
     name = "cvdalloc",
     srcs = ["cvdalloc.cpp"],
     hdrs = ["cvdalloc.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//allocd:alloc_utils",
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/host/commands/cvdalloc:privilege",
         "//cuttlefish/host/commands/cvdalloc:sem",
-        "//cuttlefish/host/libs/command_util",
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:known_paths",
         "//cuttlefish/host/libs/feature",
@@ -131,7 +129,6 @@ cf_cc_library(
         "//cuttlefish/process:command",
         "//cuttlefish/process:subprocess",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/log",
         "@fruit",
     ],
@@ -178,7 +175,6 @@ cf_cc_library(
     name = "input_connections_provider",
     srcs = ["input_connections_provider.cc"],
     hdrs = ["input_connections_provider.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",
@@ -186,7 +182,6 @@ cf_cc_library(
         "//cuttlefish/host/commands/run_cvd/launch:log_tee_creator",
         "//cuttlefish/host/libs/config:config_instance_derived",
         "//cuttlefish/host/libs/config:cuttlefish_config",
-        "//cuttlefish/host/libs/config:guest_os",
         "//cuttlefish/host/libs/config:known_paths",
         "//cuttlefish/host/libs/feature",
         "//cuttlefish/process:command",
@@ -201,19 +196,15 @@ cf_cc_library(
     name = "kernel_log_monitor",
     srcs = ["kernel_log_monitor.cpp"],
     hdrs = ["kernel_log_monitor.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
-        "//cuttlefish/host/commands/run_cvd:reporting",
         "//cuttlefish/host/libs/config:config_instance_derived",
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:known_paths",
-        "//cuttlefish/host/libs/config:logging",
         "//cuttlefish/host/libs/feature",
         "//cuttlefish/host/libs/feature:inject",
         "//cuttlefish/posix:strerror",
         "//cuttlefish/process:command",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/log:check",
         "@fruit",
     ],
@@ -252,7 +243,6 @@ cf_cc_library(
     name = "mcu",
     srcs = ["mcu.cpp"],
     hdrs = ["mcu.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:wait_for_file",
@@ -263,7 +253,6 @@ cf_cc_library(
         "//cuttlefish/host/libs/vm_manager",
         "//cuttlefish/process:command",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/strings",
         "@fruit",
         "@jsoncpp",
@@ -274,7 +263,6 @@ cf_cc_library(
     name = "modem",
     srcs = ["modem.cpp"],
     hdrs = ["modem.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/host/libs/config:cuttlefish_config",
@@ -283,7 +271,6 @@ cf_cc_library(
         "//cuttlefish/process:command",
         "//cuttlefish/process:subprocess",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/log",
     ],
 )
@@ -326,7 +313,6 @@ cf_cc_library(
     name = "open_wrt",
     srcs = ["open_wrt.cpp"],
     hdrs = ["open_wrt.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:in_sandbox",
         "//cuttlefish/common/libs/utils:json",
@@ -341,7 +327,6 @@ cf_cc_library(
         "//cuttlefish/host/libs/log_names",
         "//cuttlefish/host/libs/vm_manager",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/log",
         "@fruit",
     ],
@@ -410,9 +395,7 @@ cf_cc_library(
     name = "secure_env",
     srcs = ["secure_env.cpp"],
     hdrs = ["secure_env.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
-        "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/commands/run_cvd/launch:snapshot_control_files",
         "//cuttlefish/host/libs/config:cuttlefish_config",
@@ -468,7 +451,6 @@ cf_cc_library(
     name = "streamer",
     srcs = ["streamer.cpp"],
     hdrs = ["streamer.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",
@@ -476,22 +458,18 @@ cf_cc_library(
         "//cuttlefish/host/commands/run_cvd/launch:enable_multitouch",
         "//cuttlefish/host/commands/run_cvd/launch:input_connections_provider",
         "//cuttlefish/host/commands/run_cvd/launch:sensors_socket_pair",
-        "//cuttlefish/host/commands/run_cvd/launch:vhost_user_media_devices",
         "//cuttlefish/host/commands/run_cvd/launch:webrtc_controller",
         "//cuttlefish/host/libs/config:config_utils",
         "//cuttlefish/host/libs/config:custom_actions",
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:gpu_mode",
-        "//cuttlefish/host/libs/config:guest_os",
         "//cuttlefish/host/libs/config:known_paths",
         "//cuttlefish/host/libs/feature",
         "//cuttlefish/posix:strerror",
         "//cuttlefish/process:command",
         "//cuttlefish/process:subprocess",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/log",
-        "@fmt",
         "@fruit",
     ],
 )
@@ -500,7 +478,6 @@ cf_cc_library(
     name = "ti50_emulator",
     srcs = ["ti50_emulator.cpp"],
     hdrs = ["ti50_emulator.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:socket2socket_proxy",
@@ -511,10 +488,8 @@ cf_cc_library(
         "//cuttlefish/host/libs/vm_manager",
         "//cuttlefish/process:command",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/log",
         "@fruit",
-        "@jsoncpp",
     ],
 )
 
@@ -522,7 +497,6 @@ cf_cc_library(
     name = "tombstone_receiver",
     srcs = ["tombstone_receiver.cpp"],
     hdrs = ["tombstone_receiver.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:files",
@@ -532,7 +506,6 @@ cf_cc_library(
         "//cuttlefish/posix:strerror",
         "//cuttlefish/process:command",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/log",
     ],
 )
@@ -571,7 +544,6 @@ cf_cc_library(
     name = "vhost_device_vsock",
     srcs = ["vhost_device_vsock.cpp"],
     hdrs = ["vhost_device_vsock.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/utils:environment",
         "//cuttlefish/common/libs/utils:wait_for_unix_socket",
@@ -583,7 +555,6 @@ cf_cc_library(
         "//cuttlefish/host/libs/vm_manager",
         "//cuttlefish/process:command",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/log",
         "@fmt",
         "@fruit",
@@ -594,21 +565,14 @@ cf_cc_library(
     name = "vhost_user_media_devices",
     srcs = ["vhost_user_media_devices.cpp"],
     hdrs = ["vhost_user_media_devices.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
-        "//cuttlefish/common/libs/utils:files",
-        "//cuttlefish/host/commands/run_cvd/launch:enable_multitouch",
         "//cuttlefish/host/commands/run_cvd/launch:log_tee_creator",
         "//cuttlefish/host/libs/config:cuttlefish_config",
-        "//cuttlefish/host/libs/config:guest_os",
         "//cuttlefish/host/libs/config:known_paths",
         "//cuttlefish/host/libs/feature",
         "//cuttlefish/process:command",
         "//cuttlefish/result",
-        "//libbase",
-        "@abseil-cpp//absl/log",
-        "@fmt",
         "@fruit",
     ],
 )
@@ -617,14 +581,12 @@ cf_cc_library(
     name = "webrtc_controller",
     srcs = ["webrtc_controller.cpp"],
     hdrs = ["webrtc_controller.h"],
-    depend_on_what_you_use_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/host/frontend/webrtc:libcuttlefish_webrtc_command_channel",
         "//cuttlefish/host/frontend/webrtc:libcuttlefish_webrtc_commands_proto",
         "//cuttlefish/host/libs/feature",
         "//cuttlefish/result",
-        "//libbase",
         "@abseil-cpp//absl/log",
         "@fruit",
         "@googleapis//google/rpc:code_cc_proto",


### PR DESCRIPTION
Removed the attribute from all targets in run_cvd/launch/BUILD.bazel and cleaned up the unused dependencies reported by DWYU.

Assisted-by: Jetski:gemini-2.5-pro
Bug: b/532697459
Bug: b/534499070