### PR TITLE
gigabyte-ampere-cuttlefish-installer: enable nested virtualization

### DIFF
--- a/.github/actions/gigabyte-ampere-cuttlefish-installer-check-preseed-after-install-script/action.yaml
+++ b/.github/actions/gigabyte-ampere-cuttlefish-installer-check-preseed-after-install-script/action.yaml
@@ -17,16 +17,17 @@ runs:
       apt-get update
       apt-get upgrade -y
       apt-get install -y sudo
+      apt-get install -y ca-certificates
       apt-get install -y initramfs-tools
       apt-get install -y grub-efi-arm64
       apt-get install -y lsb-release
       apt-get install -y pciutils
       apt-get install -y apt-show-versions
       apt-get install -y linux-image-arm64 linux-headers-arm64
-  - name: Setup non-free repository
+  - name: Setup base and non-free repository
     shell: bash
     run: |
-      echo "deb http://deb.debian.org/debian $(lsb_release -c -s) contrib non-free non-free-firmware" | tee /etc/apt/sources.list.d/debian-nonfree-1.list
+      echo "deb http://deb.debian.org/debian $(lsb_release -c -s) main contrib non-free non-free-firmware" | tee /etc/apt/sources.list
       apt -o Apt::Get::Assume-Yes=true -o APT::Color=0 -o DPkgPM::Progress-Fancy=0 update
   - name: Setup backports repository
     shell: bash
@@ -35,6 +36,12 @@ runs:
         echo "deb http://deb.debian.org/debian $(lsb_release -c -s)-backports main contrib non-free non-free-firmware" | tee /etc/apt/sources.list.d/debian-backports-1.list
         apt -o Apt::Get::Assume-Yes=true -o APT::Color=0 -o DPkgPM::Progress-Fancy=0 update
       fi
+  - name: Setup pinned snapshot source
+    working-directory: ./gigabyte-ampere-cuttlefish-installer
+    shell: bash
+    run: |
+      mkdir -p /root/debian-snapshot
+      cp -f preseed/debian-snapshot.list /root/debian-snapshot/
   - name: Check nVidia GPU emulation
     shell: bash
     run: echo "EMULATE_NVIDIA_GPU=${{ inputs.emulate-nvidia }}" >> $GITHUB_ENV

--- a/cloud-init-image-for-cuttlefish/user-data
+++ b/cloud-init-image-for-cuttlefish/user-data
@@ -22,6 +22,13 @@ growpart:
     - /dev/sda1
 
 write_files:
+  - path: /etc/apt/sources.list.d/debian-snapshot.list
+    permissions: '0644'
+    owner: root:root
+    content: |
+      # Frozen snapshot: pins the kernel and NVIDIA versions installed by
+      # after_install_1.sh; bump the timestamp and those versions together.
+      deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260315T022902Z/ trixie-backports main contrib non-free non-free-firmware
   - path: /root/after_install_1.sh
     permissions: '0755'
     owner: root:root
@@ -55,38 +62,34 @@ write_files:
 
       # Install kernel
       DEBIAN_DISTRIBUTION="$(lsb_release -c -s)"
-      #apt-get install -y '^linux-image-6.1.*aosp14-linaro.*' '^linux-headers-6.1.*aosp14-linaro.*'
-      has_backports=$(apt-cache policy | grep "${DEBIAN_DISTRIBUTION}-backports")
-      if [ x"$has_backports" != x"" ]; then
-        apt install -y -t "${DEBIAN_DISTRIBUTION}-backports" "linux-headers-${DEBIAN_ARCH}"
-        apt install -y -t "${DEBIAN_DISTRIBUTION}-backports" "linux-image-${DEBIAN_ARCH}"
-      fi
+      KERNEL_ABI="6.18.15+deb13-arm64"
+      KERNEL_DEB_VERSION="6.18.15-1~bpo13+1"
+      NVIDIA_DEB_VERSION="550.163.01-4~bpo13+1"
+      apt-get -o Acquire::Retries=5 update
+      apt-get install -y -o Acquire::Retries=5 \
+        "linux-image-${KERNEL_ABI}=${KERNEL_DEB_VERSION}" \
+        "linux-headers-${KERNEL_ABI}=${KERNEL_DEB_VERSION}" || exit 1
 
       # Install nVidia or AMD GPU driver
       nvidia_gpu=$(lspci | grep -i nvidia)
       amd_gpu=$(lspci | grep VGA | grep AMD)
       if [ x"$amd_gpu" != x"" ]; then
         # # Install amd firmware
-        # if [ x"$has_backports" != x"" ]; then
-        #     apt-get install -y -t ${DEBIAN_DISTRIBUTION}-backports firmware-amd-graphics
-        # else
-        #     apt-get install -y firmware-amd-graphics
-        # fi
+        # apt-get install -y firmware-amd-graphics
         # sed -i 's/GRUB_CMDLINE_LINUX_DEFAULT=\"\(.*\)\"/GRUB_CMDLINE_LINUX_DEFAULT=\"\1 amdgpu.runpm=0 amdgpu.dc=0\"/' /etc/default/grub
         # dpkg-reconfigure -fnoninteractive "grub-efi-${DEBIAN_ARCH}"
         echo "AMD GPU detected — skipping GPU driver installation."
       elif [ x"$nvidia_gpu" != x"" ]; then
-        # Install nvidia driver
-        if [ x"$has_backports" != x"" ]; then
-          DEBIAN_FRONTEND=noninteractive apt-get install -y -t "${DEBIAN_DISTRIBUTION}-backports" -q --force-yes nvidia-kernel-dkms
-          DEBIAN_FRONTEND=noninteractive apt-get install -y -t "${DEBIAN_DISTRIBUTION}-backports" -q --force-yes nvidia-driver
-          DEBIAN_FRONTEND=noninteractive apt-get install -y -t "${DEBIAN_DISTRIBUTION}-backports" -q --force-yes firmware-misc-nonfree
-        else
-          DEBIAN_FRONTEND=noninteractive apt-get install -y -q --force-yes nvidia-open-kernel-dkms
-          DEBIAN_FRONTEND=noninteractive apt-get install -y -q --force-yes nvidia-driver
-          DEBIAN_FRONTEND=noninteractive apt-get install -y -q --force-yes firmware-misc-nonfree
-        fi
+        # Install nvidia driver, pinned to the version validated against the
+        # pinned kernel.
+        DEBIAN_FRONTEND=noninteractive apt-get install -y -q -o Acquire::Retries=5 \
+          -t "${DEBIAN_DISTRIBUTION}-backports" \
+          "nvidia-open-kernel-dkms=${NVIDIA_DEB_VERSION}" \
+          "nvidia-driver=${NVIDIA_DEB_VERSION}" || exit 1
+        DEBIAN_FRONTEND=noninteractive apt-get install -y -q firmware-misc-nonfree
+        apt-mark hold nvidia-open-kernel-dkms nvidia-driver
       fi
+      rm -f /etc/apt/sources.list.d/debian-snapshot.list
       # End of Install kernel
 
       # Install android cuttlefish packages

--- a/gigabyte-ampere-cuttlefish-installer/addpreseed.sh
+++ b/gigabyte-ampere-cuttlefish-installer/addpreseed.sh
@@ -11,6 +11,7 @@ new_iso=preseed-mini.iso
 
 PRESEEDFILE=$(realpath "${BASEDIR}"/preseed/preseed.cfg)
 AFTERINSTALLSCRIPT=$(realpath "${BASEDIR}"/preseed/after_install_1.sh)
+DEBIANSNAPSHOTLIST=$(realpath "${BASEDIR}"/preseed/debian-snapshot.list)
 
 part_img_ready=1
 if test "$auto_extract_efi" = 1; then
@@ -34,6 +35,7 @@ bsdtar -C ${new_files} -xf "$orig_iso"
 cd ${new_files}
 cp -f "${PRESEEDFILE}" preseed.cfg
 cp -f "${AFTERINSTALLSCRIPT}" after_install_1.sh
+cp -f "${DEBIANSNAPSHOTLIST}" debian-snapshot.list
 chmod a+rx after_install_1.sh
 
 # add preseed to console based installer
@@ -41,6 +43,7 @@ chmod ug+w initrd.gz
 gzip -d -f initrd.gz
 echo preseed.cfg | cpio -H newc -o -A -F initrd
 echo after_install_1.sh | cpio -H newc -o -A -F initrd
+echo debian-snapshot.list | cpio -H newc -o -A -F initrd
 gzip -9 initrd
 chmod a-w initrd.gz
 # add preseed to GTK based installer
@@ -50,11 +53,13 @@ chmod ug+w initrd.gz
 gzip -d -f initrd.gz
 cp -f ../preseed.cfg .
 cp -f ../after_install_1.sh .
+cp -f ../debian-snapshot.list .
 echo preseed.cfg | cpio -H newc -o -A -F initrd
 echo after_install_1.sh | cpio -H newc -o -A -F initrd
+echo debian-snapshot.list | cpio -H newc -o -A -F initrd
 gzip -9 initrd
 chmod a-w initrd.gz
-rm -f preseed.cfg after_install_1.sh
+rm -f preseed.cfg after_install_1.sh debian-snapshot.list
 cd ..
 chmod a-w gtk
 # modify Graphical installer to use tty1

--- a/gigabyte-ampere-cuttlefish-installer/preseed/after_install_1.sh
+++ b/gigabyte-ampere-cuttlefish-installer/preseed/after_install_1.sh
@@ -27,6 +27,12 @@ DEBIAN_DISTRIBUTION="$(lsb_release -c -s)"
 DEBIAN_SNAPSHOT_DIR="/root/debian-snapshot"
 #apt-get install -y '^linux-image-6.1.*aosp14-linaro.*' '^linux-headers-6.1.*aosp14-linaro.*'
 has_backports=$(apt-cache policy | grep "${DEBIAN_DISTRIBUTION}-backports")
+# Enable ARM64 nested virtualization (KVM NV2).
+#
+# Note that any VHE host honors the flag, FEAT_NV2 or not. Without FEAT_NV2 KVM
+# falls back to normal VHE operation. Without a GICv3-class vGIC the flag is
+# fatal - KVM initialization fails and /dev/kvm never appears.
+sed -i 's/GRUB_CMDLINE_LINUX_DEFAULT=\"\(.*\)\"/GRUB_CMDLINE_LINUX_DEFAULT=\"\1 kvm-arm.mode=nested\"/' /etc/default/grub
 if [ x"$has_backports" != x"" ]; then
     apt install -y -t "${DEBIAN_DISTRIBUTION}-backports" linux-headers-arm64
     apt install -y -t "${DEBIAN_DISTRIBUTION}-backports" linux-image-arm64
@@ -70,6 +76,13 @@ elif [ x"$nvidia_gpu" != x"" ]; then
     fi
 fi
 # End of Install kernel
+
+# Regenerate grub.cfg: the kernel postinst's update-grub hook only runs when a
+# kernel package is actually configured, so a no-op install above would leave
+# the nested-virt cmdline out of the boot menu.
+if [ -e /boot/grub/grub.cfg ]; then
+    update-grub || exit 1
+fi
 
 # Install android cuttlefish packages
 #DEPLOY_CHANNEL=

--- a/gigabyte-ampere-cuttlefish-installer/preseed/after_install_1.sh
+++ b/gigabyte-ampere-cuttlefish-installer/preseed/after_install_1.sh
@@ -20,23 +20,23 @@ adduser vsoc-01 kvm
 adduser vsoc-01 render
 adduser vsoc-01 video
 
-# Detect distribution
-DEBIAN_DISTRIBUTION="$(lsb_release -c -s)"
-DEBIAN_ARCH="$(dpkg --print-architecture)"
-
-apt -o Apt::Get::Assume-Yes=true -o APT::Color=0 -o DPkgPM::Progress-Fancy=0 \
-    update
+apt -o Apt::Get::Assume-Yes=true -o APT::Color=0 -o DPkgPM::Progress-Fancy=0 update
 
 # Install kernel
 DEBIAN_DISTRIBUTION="$(lsb_release -c -s)"
+DEBIAN_SNAPSHOT_DIR="/root/debian-snapshot"
 #apt-get install -y '^linux-image-6.1.*aosp14-linaro.*' '^linux-headers-6.1.*aosp14-linaro.*'
 has_backports=$(apt-cache policy | grep "${DEBIAN_DISTRIBUTION}-backports")
 if [ x"$has_backports" != x"" ]; then
     apt install -y -t "${DEBIAN_DISTRIBUTION}-backports" linux-headers-arm64
     apt install -y -t "${DEBIAN_DISTRIBUTION}-backports" linux-image-arm64
 else
-    apt install -y linux-headers-arm64
-    apt install -y linux-image-arm64
+    KERNEL_ABI="6.18.15+deb13-arm64"
+    KERNEL_DEB_VERSION="6.18.15-1~bpo13+1"
+    apt-get -o Dir::Etc::SourceParts="${DEBIAN_SNAPSHOT_DIR}" -o Acquire::Retries=5 update
+    apt-get install -y -o Dir::Etc::SourceParts="${DEBIAN_SNAPSHOT_DIR}" -o Acquire::Retries=5 \
+        "linux-image-${KERNEL_ABI}=${KERNEL_DEB_VERSION}" \
+        "linux-headers-${KERNEL_ABI}=${KERNEL_DEB_VERSION}" || exit 1
 fi
 
 # Install nVidia or AMD GPU driver
@@ -59,9 +59,14 @@ elif [ x"$nvidia_gpu" != x"" ]; then
         DEBIAN_FRONTEND=noninteractive apt-get install -y -t "${DEBIAN_DISTRIBUTION}-backports" -q --force-yes nvidia-driver
         DEBIAN_FRONTEND=noninteractive apt-get install -y -t "${DEBIAN_DISTRIBUTION}-backports" -q --force-yes firmware-misc-nonfree
     else
-        DEBIAN_FRONTEND=noninteractive apt-get install -y -q --force-yes nvidia-open-kernel-dkms
-        DEBIAN_FRONTEND=noninteractive apt-get install -y -q --force-yes nvidia-driver
-        DEBIAN_FRONTEND=noninteractive apt-get install -y -q --force-yes firmware-misc-nonfree
+        NVIDIA_DEB_VERSION="550.163.01-4~bpo13+1"
+        apt-get -o Dir::Etc::SourceParts="${DEBIAN_SNAPSHOT_DIR}" -o Acquire::Retries=5 update
+        DEBIAN_FRONTEND=noninteractive apt-get install -y -q -o Dir::Etc::SourceParts="${DEBIAN_SNAPSHOT_DIR}" \
+            -o Acquire::Retries=5 -t ${DEBIAN_DISTRIBUTION}-backports \
+            "nvidia-open-kernel-dkms=${NVIDIA_DEB_VERSION}" \
+            "nvidia-driver=${NVIDIA_DEB_VERSION}" || exit 1
+        DEBIAN_FRONTEND=noninteractive apt-get install -y -q firmware-misc-nonfree
+        apt-mark hold nvidia-open-kernel-dkms nvidia-driver
     fi
 fi
 # End of Install kernel

--- a/gigabyte-ampere-cuttlefish-installer/preseed/debian-snapshot.list
+++ b/gigabyte-ampere-cuttlefish-installer/preseed/debian-snapshot.list
@@ -1,0 +1,1 @@
+deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260315T022902Z/ trixie-backports main contrib non-free non-free-firmware

--- a/gigabyte-ampere-cuttlefish-installer/preseed/preseed.cfg
+++ b/gigabyte-ampere-cuttlefish-installer/preseed/preseed.cfg
@@ -201,7 +201,7 @@ d-i partman-auto/expert_recipe_linaro_lvm_nopv string         \
                       method{ efi } format{ }                 \
                       label { esp }                           \
               .                                               \
-              256 2048 4096 ext4                              \
+              512 2048 4096 ext4                              \
                       $primary{ }                             \
                       $bootable{ }                            \
                       method{ format }                        \
@@ -322,6 +322,8 @@ d-i grub-installer/update-nvram boolean false
 d-i finish-install/reboot_in_progress note
 
 d-i preseed/late_command string \
-  cp -f /after_install_1.sh /target/root; \
+  mkdir -p /target/root/debian-snapshot && \
+  cp -f /debian-snapshot.list /target/root/debian-snapshot/ && \
+  cp -f /after_install_1.sh /target/root && \
   in-target /bin/sh /root/after_install_1.sh;
 


### PR DESCRIPTION
* Pins 6.18 kernel and compatible Nvidia driver.
* Appends `kvm.mode=nested` into Kernel command line so server can be booted into `VHE+NV2` when possible.

Bug: 537008147