### PR TITLE
Fix tests in frontend operator webui

### DIFF
--- a/frontend/src/operator/webui/src/app/app.component.spec.ts
+++ b/frontend/src/operator/webui/src/app/app.component.spec.ts
@@ -1,31 +1,66 @@
-import {TestBed} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {provideHttpClient} from '@angular/common/http';
+import {provideHttpClientTesting} from '@angular/common/http/testing';
+import {provideRouter} from '@angular/router';
+import {MatButtonModule} from '@angular/material/button';
+import {MatIconModule} from '@angular/material/icon';
+import {MatSidenavModule} from '@angular/material/sidenav';
+import {MatSlideToggleModule} from '@angular/material/slide-toggle';
+import {MatToolbarModule} from '@angular/material/toolbar';
+import {KtdGridModule} from '@katoid/angular-grid-layout';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+
 import {AppComponent} from './app.component';
+import {DevicePaneComponent} from './device-pane/device-pane.component';
+import {ViewPaneComponent} from './view-pane/view-pane.component';
+import {SafeDeviceUrlPipe} from './safe-device-url.pipe';
+import {BUILD_VERSION} from '../environments/version';
 
 describe('AppComponent', () => {
+  let fixture: ComponentFixture<AppComponent>;
+  let app: AppComponent;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [AppComponent],
+      declarations: [
+        AppComponent,
+        DevicePaneComponent,
+        ViewPaneComponent,
+        SafeDeviceUrlPipe,
+      ],
+      imports: [
+        MatButtonModule,
+        MatIconModule,
+        MatSidenavModule,
+        MatSlideToggleModule,
+        MatToolbarModule,
+        KtdGridModule,
+        NoopAnimationsModule,
+      ],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+      ],
     }).compileComponents();
+
+    fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    app = fixture.componentInstance;
   });
 
   it('should create the app', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });
 
-  it("should have as title 'webui'", () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('webui');
+  it('should set version to BUILD_VERSION', () => {
+    expect(app.version).toEqual(BUILD_VERSION);
   });
 
   it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('.content span')?.textContent).toContain(
-      'webui app is running!'
-    );
+    expect(
+      compiled.querySelector('.cloud-android-title')?.textContent,
+    ).toContain('Cloud Android');
   });
 });

--- a/frontend/src/operator/webui/src/app/device-pane/device-pane.component.spec.ts
+++ b/frontend/src/operator/webui/src/app/device-pane/device-pane.component.spec.ts
@@ -1,4 +1,11 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {provideHttpClient} from '@angular/common/http';
+import {provideHttpClientTesting} from '@angular/common/http/testing';
+import {provideRouter} from '@angular/router';
+import {MatButtonModule} from '@angular/material/button';
+import {MatIconModule} from '@angular/material/icon';
+import {MatSlideToggleModule} from '@angular/material/slide-toggle';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 import {DevicePaneComponent} from './device-pane.component';
 
@@ -9,6 +16,17 @@ describe('DevicePaneComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [DevicePaneComponent],
+      imports: [
+        MatButtonModule,
+        MatIconModule,
+        MatSlideToggleModule,
+        NoopAnimationsModule,
+      ],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(DevicePaneComponent);

--- a/frontend/src/operator/webui/src/app/device.service.spec.ts
+++ b/frontend/src/operator/webui/src/app/device.service.spec.ts
@@ -1,4 +1,6 @@
 import {TestBed} from '@angular/core/testing';
+import {provideHttpClient} from '@angular/common/http';
+import {provideHttpClientTesting} from '@angular/common/http/testing';
 
 import {DeviceService} from './device.service';
 
@@ -6,7 +8,9 @@ describe('DeviceService', () => {
   let service: DeviceService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
     service = TestBed.inject(DeviceService);
   });
 

--- a/frontend/src/operator/webui/src/app/displays.service.spec.ts
+++ b/frontend/src/operator/webui/src/app/displays.service.spec.ts
@@ -1,4 +1,6 @@
 import {TestBed} from '@angular/core/testing';
+import {provideHttpClient} from '@angular/common/http';
+import {provideHttpClientTesting} from '@angular/common/http/testing';
 
 import {DisplaysService} from './displays.service';
 
@@ -6,7 +8,9 @@ describe('DisplaysService', () => {
   let service: DisplaysService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
     service = TestBed.inject(DisplaysService);
   });
 

--- a/frontend/src/operator/webui/src/app/view-pane/view-pane.component.html
+++ b/frontend/src/operator/webui/src/app/view-pane/view-pane.component.html
@@ -5,11 +5,11 @@
     rowHeight="1"
     scrollSpeed="4"
     [cols]="cols"
-    [layout]="(resultLayout | async)!"
+    [layout]="(resultLayout | async) ?? []"
     [scrollableParent]="document"
     (layoutUpdated)="layoutUpdated$.next($event)"
     >
-    @for (display of resultLayout | async; track trackById($index, display)) {
+    @for (display of (resultLayout | async) ?? []; track display.id) {
       <ktd-grid-item
         class="device-viewer"
         dragStartThreshold="0"

--- a/frontend/src/operator/webui/src/app/view-pane/view-pane.component.spec.ts
+++ b/frontend/src/operator/webui/src/app/view-pane/view-pane.component.spec.ts
@@ -1,6 +1,10 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {provideHttpClient} from '@angular/common/http';
+import {provideHttpClientTesting} from '@angular/common/http/testing';
+import {KtdGridModule} from '@katoid/angular-grid-layout';
 
 import {ViewPaneComponent} from './view-pane.component';
+import {SafeDeviceUrlPipe} from '../safe-device-url.pipe';
 
 describe('ViewPaneComponent', () => {
   let component: ViewPaneComponent;
@@ -8,7 +12,9 @@ describe('ViewPaneComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ViewPaneComponent],
+      declarations: [ViewPaneComponent, SafeDeviceUrlPipe],
+      imports: [KtdGridModule],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ViewPaneComponent);

--- a/frontend/src/operator/webui/src/app/view-pane/view-pane.component.ts
+++ b/frontend/src/operator/webui/src/app/view-pane/view-pane.component.ts
@@ -13,7 +13,6 @@ import {
   KtdGridComponent,
   KtdGridLayout,
   KtdGridLayoutItem,
-  ktdTrackById,
 } from '@katoid/angular-grid-layout';
 import {DisplayInfo} from '../../../../intercept/js/server_connector'
 
@@ -61,8 +60,6 @@ export class ViewPaneComponent implements OnInit, OnDestroy, AfterViewInit {
   cols = 0;
 
   layoutUpdated$ = new BehaviorSubject<KtdGridLayout>([]);
-
-  trackById = ktdTrackById;
 
   private readonly minPanelWidth = 330;
   private readonly minPanelHeight = 100;


### PR DESCRIPTION
Unit tests fail to compile and run currently for multiple reasons. This change makes `npm run test` pass in frontend/src/operator/webui.