### PR TITLE
Add a "--host_substitution=only" mode

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/BUILD.bazel
@@ -214,6 +214,7 @@ cf_cc_library(
         "//cuttlefish/host/commands/cvd/fetch:fetch_tracer",
         "//cuttlefish/host/commands/cvd/fetch:host_package",
         "//cuttlefish/host/commands/cvd/fetch:host_tools_target",
+        "//cuttlefish/host/commands/cvd/fetch:symlink_host_package",
         "//cuttlefish/host/commands/cvd/fetch:target_directories",
         "//cuttlefish/host/commands/cvd/utils:common",
         "//cuttlefish/host/libs/config:fetcher_config",
@@ -326,6 +327,20 @@ cf_cc_library(
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/strings",
         "@protobuf",
+    ],
+)
+
+cf_cc_library(
+    name = "symlink_host_package",
+    srcs = ["symlink_host_package.cc"],
+    hdrs = ["symlink_host_package.h"],
+    deps = [
+        "//cuttlefish/common/libs/utils:files",
+        "//cuttlefish/posix:symlink",
+        "//cuttlefish/result:expect",
+        "//cuttlefish/result:result_type",
+        "//libbase",
+        "@abseil-cpp//absl/strings",
     ],
 )
 

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd.cc
@@ -42,6 +42,7 @@
 #include "cuttlefish/host/commands/cvd/fetch/fetch_tracer.h"
 #include "cuttlefish/host/commands/cvd/fetch/host_package.h"
 #include "cuttlefish/host/commands/cvd/fetch/host_tools_target.h"
+#include "cuttlefish/host/commands/cvd/fetch/symlink_host_package.h"
 #include "cuttlefish/host/commands/cvd/fetch/target_directories.h"
 #include "cuttlefish/host/commands/cvd/utils/common.h"
 #include "cuttlefish/host/libs/config/fetcher_config.h"
@@ -469,12 +470,19 @@ Result<FetchResult> Fetch(const FetchFlags& flags,
       downloaders.AndroidBuild(), host_target, fallback_host_build));
   prefetch_trace.CompletePhase("GetBuilds");
 
-  auto host_package_future = std::async(
-      std::launch::async, FetchHostPackage,
-      std::ref(downloaders.AndroidBuild()), std::cref(host_target_build),
-      std::cref(host_target.host_tools_directory),
-      std::cref(flags.keep_downloaded_archives),
-      std::cref(flags.host_substitutions), tracer.NewTrace("Host Package"));
+  std::future<Result<void>> host_package_future;
+  if (flags.host_substitutions == std::vector<std::string>{"only"}) {
+    host_package_future =
+        std::async(std::launch::async, SymlinkHostPackage,
+                   std::cref(host_target.host_tools_directory));
+  } else {
+    host_package_future = std::async(
+        std::launch::async, FetchHostPackage,
+        std::ref(downloaders.AndroidBuild()), std::cref(host_target_build),
+        std::cref(host_target.host_tools_directory),
+        std::cref(flags.keep_downloaded_archives),
+        std::cref(flags.host_substitutions), tracer.NewTrace("Host Package"));
+  }
   size_t count = 1;
   FetchResult fetch_result;
   for (const auto& target : targets) {

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/symlink_host_package.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/symlink_host_package.cc
@@ -1,0 +1,71 @@
+//
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cuttlefish/host/commands/cvd/fetch/symlink_host_package.h"
+
+#include <string>
+
+#include "absl/strings/str_cat.h"
+#include "absl/strings/strip.h"
+#include "android-base/file.h"
+
+#include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/posix/symlink.h"
+#include "cuttlefish/result/expect.h"
+#include "cuttlefish/result/result_type.h"
+
+namespace cuttlefish {
+namespace {
+
+/**
+ * cvd needs to be run from a path ending in cuttlefish-common/bin/cvd. This
+ * function validates that and returns the path to the cuttlefish-common
+ * directory.
+ */
+Result<std::string> GetCuttlefishCommonDir() {
+  std::string cvd_exe = android::base::GetExecutablePath();
+  CF_EXPECTF(cvd_exe.ends_with("cuttlefish-common/bin/cvd"),
+             "Can't perform substitutions when cvd is not under "
+             "cuttlefish-common/bin, it's currently at {}",
+             cvd_exe);
+  return cvd_exe.substr(0, cvd_exe.size() - std::string("/bin/cvd").size());
+}
+
+}  // namespace
+
+// TODO(schuffelen): deduplicate with substitute.cc
+Result<void> SymlinkHostPackage(const std::string& target_dir) {
+  const std::string common_dir = CF_EXPECT(GetCuttlefishCommonDir());
+  auto make_symlinks = [&common_dir,
+                        &target_dir](const std::string& path) -> Result<void> {
+    std::string_view local_path(path);
+    CF_EXPECTF(absl::ConsumePrefix(&local_path, common_dir),
+               "Unexpected prefix in : '{}'", local_path);
+
+    const std::string full_target_path =
+        absl::StrCat(target_dir, "/", local_path);
+
+    if (IsDirectory(path)) {
+      CF_EXPECT(EnsureDirectoryExists(full_target_path));
+    } else {
+      CF_EXPECT(Symlink(path, full_target_path));
+    }
+    return {};
+  };
+  CF_EXPECT(WalkDirectory(common_dir, make_symlinks));
+  return {};
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/symlink_host_package.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/symlink_host_package.h
@@ -1,0 +1,26 @@
+//
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include "cuttlefish/result/result_type.h"
+
+namespace cuttlefish {
+
+Result<void> SymlinkHostPackage(const std::string& target_dir);
+
+}  // namespace cuttlefish


### PR DESCRIPTION
This skips downloading `cvd-host_package.tar.gz` and only downloads the img-*.zip file. The files normally provided from `cvd-host_package.tar.gz` are instead loaded from `/usr/lib/cuttlefish-common` or the equivalent from the development directory.

It is not yet possible to boot a device from only these files.

Bug: b/540976680