### PR TITLE
Don't run DWYU when layering_check is disabled

### DIFF
--- a/base/cvd/cuttlefish/bazel/rules.bzl
+++ b/base/cvd/cuttlefish/bazel/rules.bzl
@@ -52,13 +52,14 @@ cf_build_test = macro(
     implementation = _cf_build_test_implementation,
 )
 
-def _cf_cc_binary_implementation(name, clang_format_enabled, clang_tidy_enabled, copts, depend_on_what_you_use_enabled, linkopts, **kwargs):
+def _cf_cc_binary_implementation(name, clang_format_enabled, clang_tidy_enabled, copts, depend_on_what_you_use_enabled, features, linkopts, **kwargs):
     if not clang_tidy_enabled and not kwargs["deprecation"]:
         kwargs["deprecation"] = "Not covered by clang-tidy"
     cc_binary(
         name = name,
         copts = (copts or []) + COPTS,
         linkopts = (linkopts or []) + LINKOPTS,
+        features = features,
         **kwargs
     )
     if clang_format_enabled:
@@ -76,7 +77,7 @@ def _cf_cc_binary_implementation(name, clang_format_enabled, clang_tidy_enabled,
             tags = ["clang_tidy", "clang-tidy"],
             visibility = ["//visibility:private"],
         )
-    if depend_on_what_you_use_enabled:
+    if depend_on_what_you_use_enabled and not "-layering_check" in features:
         dwyu_rule(
             name = name + "_depend_on_what_you_use",
             deps = [":" + name],
@@ -90,17 +91,19 @@ cf_cc_binary = macro(
         "clang_tidy_enabled": attr.bool(configurable = False, default = True, doc = "Decide if a corresponding clang_tidy_test target is generated"),
         "copts": attr.string_list(configurable = False, default = []),
         "depend_on_what_you_use_enabled": attr.bool(configurable = False, default = True, doc = "Decide if a corresponding depend-on-what-you-use target is generated"),
+        "features": attr.string_list(configurable = False, default = []),
         "linkopts": attr.string_list(configurable = False, default = []),
     },
     implementation = _cf_cc_binary_implementation,
 )
 
-def _cf_cc_library_implementation(name, clang_format_enabled, clang_tidy_enabled, copts, depend_on_what_you_use_enabled, **kwargs):
+def _cf_cc_library_implementation(name, clang_format_enabled, clang_tidy_enabled, copts, depend_on_what_you_use_enabled, features, **kwargs):
     if not clang_tidy_enabled and not kwargs["deprecation"]:
         kwargs["deprecation"] = "Not covered by clang-tidy"
     cc_library(
         name = name,
         copts = (copts or []) + COPTS,
+        features = features,
         **kwargs
     )
     if clang_format_enabled:
@@ -118,7 +121,7 @@ def _cf_cc_library_implementation(name, clang_format_enabled, clang_tidy_enabled
             tags = ["clang_tidy", "clang-tidy"],
             visibility = ["//visibility:private"],
         )
-    if depend_on_what_you_use_enabled:
+    if depend_on_what_you_use_enabled and not "-layering_check" in features:
         dwyu_rule(
             name = name + "_depend_on_what_you_use",
             deps = [":" + name],
@@ -132,11 +135,12 @@ cf_cc_library = macro(
         "clang_tidy_enabled": attr.bool(configurable = False, default = True, doc = "Decide if a corresponding clang_tidy_test target is generated"),
         "copts": attr.string_list(configurable = False, default = []),
         "depend_on_what_you_use_enabled": attr.bool(configurable = False, default = True, doc = "Decide if a corresponding depend-on-what-you-use target is generated"),
+        "features": attr.string_list(configurable = False, default = []),
     },
     implementation = _cf_cc_library_implementation,
 )
 
-def _cf_cc_test_implementation(name, clang_format_enabled, clang_tidy_enabled, copts, depend_on_what_you_use_enabled, deps, **kwargs):
+def _cf_cc_test_implementation(name, clang_format_enabled, clang_tidy_enabled, copts, depend_on_what_you_use_enabled, deps, features, **kwargs):
     if not clang_tidy_enabled and not kwargs["deprecation"]:
         kwargs["deprecation"] = "Not covered by clang-tidy"
     cc_test(
@@ -146,6 +150,7 @@ def _cf_cc_test_implementation(name, clang_format_enabled, clang_tidy_enabled, c
             "@googletest//:gtest",
             "@googletest//:gtest_main",
         ],
+        features = features,
         **kwargs
     )
     if clang_format_enabled:
@@ -163,7 +168,7 @@ def _cf_cc_test_implementation(name, clang_format_enabled, clang_tidy_enabled, c
             tags = ["clang_tidy", "clang-tidy"],
             visibility = ["//visibility:private"],
         )
-    if depend_on_what_you_use_enabled:
+    if depend_on_what_you_use_enabled and not "-layering_check" in features:
         dwyu_rule(
             name = name + "_depend_on_what_you_use",
             deps = [":" + name],
@@ -178,6 +183,7 @@ cf_cc_test = macro(
         "copts": attr.string_list(configurable = False, default = []),
         "depend_on_what_you_use_enabled": attr.bool(configurable = False, default = True, doc = "Decide if a corresponding depend-on-what-you-use target is generated"),
         "deps": attr.label_list(configurable = False),
+        "features": attr.string_list(configurable = False, default = []),
     },
     implementation = _cf_cc_test_implementation,
 )

--- a/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
@@ -158,7 +158,6 @@ cf_cc_library(
     name = "gflags_xml_parser",
     srcs = ["gflags_xml_parser.cpp"],
     hdrs = ["gflags_xml_parser.h"],
-    depend_on_what_you_use_enabled = False,
     features = ["-layering_check"],
     deps = [
         "//cuttlefish/result",

--- a/base/cvd/cuttlefish/flag_parser/BUILD.bazel
+++ b/base/cvd/cuttlefish/flag_parser/BUILD.bazel
@@ -38,7 +38,6 @@ cf_cc_test(
 cf_cc_test(
     name = "gflags_compat_test",
     srcs = ["gflags_compat_test.cpp"],
-    depend_on_what_you_use_enabled = False,
     # `layering_check` conflicts with the combination of the clang prebuilt and
     # the cmake build rules used for @libxml2.
     features = ["-layering_check"],

--- a/base/cvd/cuttlefish/host/commands/start/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/start/BUILD.bazel
@@ -15,7 +15,6 @@ cf_cc_binary(
         "override_bool_arg.cpp",
         "override_bool_arg.h",
     ],
-    depend_on_what_you_use_enabled = False,
     # `layering_check` conflicts with the combination of the clang prebuilt and
     # the cmake build rules used for @libxml2.
     features = ["-layering_check"],

--- a/base/cvd/cuttlefish/host/libs/location/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/location/BUILD.bazel
@@ -17,7 +17,6 @@ cf_cc_library(
         "GpxParser.h",
         "KmlParser.h",
     ],
-    depend_on_what_you_use_enabled = False,
     # `layering_check` conflicts with the combination of the clang prebuilt and
     # the cmake build rules used for @libxml2.
     features = ["-layering_check"],

--- a/base/cvd/cuttlefish/host/libs/zip/libzip_cc/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/zip/libzip_cc/BUILD.bazel
@@ -10,7 +10,6 @@ cf_cc_library(
     name = "archive",
     srcs = ["archive.cc"],
     hdrs = ["archive.h"],
-    depend_on_what_you_use_enabled = False,
     features = ["-layering_check"],  # libzip
     linkopts = ["-llzma"],  # libzip
     linkstatic = True,  # libzip
@@ -33,7 +32,6 @@ cf_cc_library(
     name = "error",
     srcs = ["error.cc"],
     hdrs = ["error.h"],
-    depend_on_what_you_use_enabled = False,
     features = ["-layering_check"],  # libzip
     linkopts = ["-llzma"],  # libzip
     linkstatic = True,  # libzip
@@ -47,7 +45,6 @@ cf_cc_library(
 cf_cc_library(
     name = "managed",
     hdrs = ["managed.h"],
-    depend_on_what_you_use_enabled = False,
     features = ["-layering_check"],  # libzip
     linkopts = ["-llzma"],  # libzip
     linkstatic = True,  # libzip
@@ -59,7 +56,6 @@ cf_cc_library(
     name = "readable_source",
     srcs = ["readable_source.cc"],
     hdrs = ["readable_source.h"],
-    depend_on_what_you_use_enabled = False,
     features = ["-layering_check"],  # libzip
     linkopts = ["-llzma"],  # libzip
     linkstatic = True,  # libzip
@@ -79,7 +75,6 @@ cf_cc_library(
     name = "seekable_source",
     srcs = ["seekable_source.cc"],
     hdrs = ["seekable_source.h"],
-    depend_on_what_you_use_enabled = False,
     features = ["-layering_check"],  # libzip
     linkopts = ["-llzma"],  # libzip
     linkstatic = True,  # libzip
@@ -110,7 +105,6 @@ cf_cc_library(
     name = "writable_source",
     srcs = ["writable_source.cc"],
     hdrs = ["writable_source.h"],
-    depend_on_what_you_use_enabled = False,
     features = ["-layering_check"],  # libzip
     linkopts = ["-llzma"],  # libzip
     linkstatic = True,  # libzip


### PR DESCRIPTION
Both will fail in the same places, so avoid having to redundantly disable both layering_check and DWYU checks.

Bug: b/534499070