### PR TITLE
cuttlefish: delete more virgl

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
@@ -56,6 +56,11 @@ DEFINE_vec(serial_number, CF_DEFAULTS_SERIAL_NUMBER,
            "Serial number to use for the device");
 DEFINE_vec(use_random_serial, fmt::format("{}", CF_DEFAULTS_USE_RANDOM_SERIAL),
            "Whether to use random serial for the device.");
+DEFINE_vec(gpu_mode, CF_DEFAULTS_GPU_MODE,
+           "What gpu configuration to use, one of {auto, custom, "
+           "gfxstream, gfxstream_guest_angle, "
+           "gfxstream_guest_angle_host_swiftshader, "
+           "gfxstream_guest_angle_host_lavapipe, guest_swiftshader}");
 DEFINE_vec(gpu_vhost_user_mode,
            fmt::format("{}", CF_DEFAULTS_GPU_VHOST_USER_MODE),
            "Whether or not to run the Virtio GPU worker in a separate"

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -1134,17 +1134,8 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
     }
 
     instance.set_hwcomposer(hwcomposer_vec[instance_index]);
-    if (!hwcomposer_vec[instance_index].empty()) {
-      if (hwcomposer_vec[instance_index] == kHwComposerRanchu) {
-        CF_EXPECT(gpu_mode != GpuMode::DrmVirgl,
-                  "ranchu hwcomposer not supported with --gpu_mode=drm_virgl");
-      }
-    }
-
     if (hwcomposer_vec[instance_index] == kHwComposerAuto) {
-      if (gpu_mode == GpuMode::DrmVirgl) {
-        instance.set_hwcomposer(kHwComposerDrm);
-      } else if (gpu_mode == GpuMode::None) {
+      if (gpu_mode == kGpuModeNone) {
         instance.set_hwcomposer(kHwComposerNone);
       } else {
         instance.set_hwcomposer(kHwComposerRanchu);

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -1181,17 +1181,8 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
     }
 
     instance.set_hwcomposer(hwcomposer_vec[instance_index]);
-    if (!hwcomposer_vec[instance_index].empty()) {
-      if (hwcomposer_vec[instance_index] == kHwComposerRanchu) {
-        CF_EXPECT(gpu_mode != GpuMode::DrmVirgl,
-                  "ranchu hwcomposer not supported with --gpu_mode=drm_virgl");
-      }
-    }
-
     if (hwcomposer_vec[instance_index] == kHwComposerAuto) {
-      if (gpu_mode == GpuMode::DrmVirgl) {
-        instance.set_hwcomposer(kHwComposerDrm);
-      } else if (gpu_mode == GpuMode::None) {
+      if (gpu_mode == kGpuModeNone) {
         instance.set_hwcomposer(kHwComposerNone);
       } else {
         instance.set_hwcomposer(kHwComposerRanchu);

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/gpu_mode.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/gpu_mode.cc
@@ -30,8 +30,8 @@
 
 DEFINE_string(
     gpu_mode, CF_DEFAULTS_GPU_MODE,
-    "What gpu configuration to use.  One of {auto, custom, drm_virgl, "
-    "gfxstream, gfxstream_guest_angle, gfxstream_guest_angle_host_lavapipe, "
+    "What gpu configuration to use.  One of {auto, custom, gfxstream "
+    "gfxstream_guest_angle, gfxstream_guest_angle_host_lavapipe, "
     "gfxstream_guest_angle_host_swiftshader, guest_swiftshader, none}");
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/graphics_flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/graphics_flags.cc
@@ -498,10 +498,6 @@ std::vector<GpuMode> GetGpuModeCandidates(const GuestConfig& guest_config) {
              "Assuming the historically accepted modes.";
 
   std::vector<GpuMode> gpu_mode_candidates;
-  if (guest_config.prefer_drm_virgl_when_supported) {
-    gpu_mode_candidates.push_back(GpuMode::DrmVirgl);
-  }
-
   if (EnableHostRenderingByDefault()) {
     gpu_mode_candidates.push_back(GpuMode::GfxstreamGuestAngle);
     gpu_mode_candidates.push_back(GpuMode::Gfxstream);
@@ -521,7 +517,6 @@ std::vector<GpuMode> GetGpuModeCandidates(const GuestConfig& guest_config) {
       gpu_mode_candidates.push_back(GpuMode::GuestLavapipe);
     }
   }
-
   gpu_mode_candidates.push_back(GpuMode::None);
 
   return gpu_mode_candidates;
@@ -921,7 +916,7 @@ Result<GpuMode> ConfigureGpuSettings(
   (void)guest_config;
   CF_EXPECT(gpu_mode_arg == GpuMode::Auto ||
             gpu_mode_arg == GpuMode::GuestSwiftshader ||
-            gpu_mode_arg == GpuMode::DrmVirgl || gpu_mode_arg == GpuMode::None);
+            gpu_mode_arg == GpuMode::None);
   if (gpu_mode_arg == GpuMode::Auto) {
     gpu_mode_arg = GpuMode::GuestSwiftshader;
   }

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/graphics_flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/graphics_flags.cc
@@ -506,10 +506,6 @@ std::vector<GpuMode> GetGpuModeCandidates(const GuestConfig& guest_config) {
              "Assuming the historically accepted modes.";
 
   std::vector<GpuMode> gpu_mode_candidates;
-  if (guest_config.prefer_drm_virgl_when_supported) {
-    gpu_mode_candidates.push_back(GpuMode::DrmVirgl);
-  }
-
   if (EnableHostRenderingByDefault()) {
     gpu_mode_candidates.push_back(GpuMode::GfxstreamGuestAngle);
     gpu_mode_candidates.push_back(GpuMode::Gfxstream);
@@ -529,7 +525,6 @@ std::vector<GpuMode> GetGpuModeCandidates(const GuestConfig& guest_config) {
       gpu_mode_candidates.push_back(GpuMode::GuestLavapipe);
     }
   }
-
   gpu_mode_candidates.push_back(GpuMode::None);
 
   return gpu_mode_candidates;
@@ -929,7 +924,7 @@ Result<GpuMode> ConfigureGpuSettings(
   (void)guest_config;
   CF_EXPECT(gpu_mode_arg == GpuMode::Auto ||
             gpu_mode_arg == GpuMode::GuestSwiftshader ||
-            gpu_mode_arg == GpuMode::DrmVirgl || gpu_mode_arg == GpuMode::None);
+            gpu_mode_arg == GpuMode::None);
   if (gpu_mode_arg == GpuMode::Auto) {
     gpu_mode_arg = GpuMode::GuestSwiftshader;
   }

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/guest_config.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/guest_config.cc
@@ -126,10 +126,6 @@ Result<void> ParseGuestConfigTextProto(const std::string& guest_config_path,
     guest_config.supports_bgra_framebuffers =
         graphics_config.bgra_framebuffers_supported();
   }
-  if (graphics_config.has_prefer_drm_virgl_when_supported()) {
-    guest_config.prefer_drm_virgl_when_supported =
-        graphics_config.prefer_drm_virgl_when_supported();
-  }
   const auto& gpu_mode_map = GetGpuModeMap();
   for (int i = 0; i < graphics_config.gpu_mode_candidates_size(); i++) {
     config::GpuMode candidate = graphics_config.gpu_mode_candidates(i);
@@ -267,10 +263,6 @@ Result<void> ParseGuestConfigTxt(const std::string& guest_config_path,
       MapHasValue(info, "supports_bgra_framebuffers", "true");
 
   guest_config.vhost_user_vsock = MapHasValue(info, "vhost_user_vsock", "true");
-
-  guest_config.prefer_drm_virgl_when_supported =
-      MapHasValue(info, "prefer_drm_virgl_when_supported", "true");
-
   guest_config.ti50_emulator = MapGetResult(info, "ti50_emulator").value_or("");
 
   if (const Result<std::string> res =
@@ -323,8 +315,6 @@ PrettyStruct Pretty(const GuestConfig& config, PrettyAdlPlaceholder) {
               config.gfxstream_gl_program_binary_link_status_supported)
       .Member("vhost_user_vsock", config.vhost_user_vsock)
       .Member("supports_bgra_framebuffers", config.supports_bgra_framebuffers)
-      .Member("prefer_drm_virgl_when_supported",
-              config.prefer_drm_virgl_when_supported)
       .Member("mouse_supported", config.mouse_supported)
       .Member("gamepad_supported", config.gamepad_supported)
       .Member("ti50_emulator", config.ti50_emulator)

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/guest_config.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/guest_config.cc
@@ -119,10 +119,6 @@ Result<void> ParseGuestConfigTextProto(const std::string& guest_config_path,
     guest_config.supports_bgra_framebuffers =
         graphics_config.bgra_framebuffers_supported();
   }
-  if (graphics_config.has_prefer_drm_virgl_when_supported()) {
-    guest_config.prefer_drm_virgl_when_supported =
-        graphics_config.prefer_drm_virgl_when_supported();
-  }
   const auto& gpu_mode_map = GetGpuModeMap();
   for (int i = 0; i < graphics_config.gpu_mode_candidates_size(); i++) {
     config::GpuMode candidate = graphics_config.gpu_mode_candidates(i);
@@ -260,10 +256,6 @@ Result<void> ParseGuestConfigTxt(const std::string& guest_config_path,
       MapHasValue(info, "supports_bgra_framebuffers", "true");
 
   guest_config.vhost_user_vsock = MapHasValue(info, "vhost_user_vsock", "true");
-
-  guest_config.prefer_drm_virgl_when_supported =
-      MapHasValue(info, "prefer_drm_virgl_when_supported", "true");
-
   guest_config.ti50_emulator = MapGetResult(info, "ti50_emulator").value_or("");
 
   if (const Result<std::string> res =
@@ -316,8 +308,6 @@ PrettyStruct Pretty(const GuestConfig& config, PrettyAdlPlaceholder) {
               config.gfxstream_gl_program_binary_link_status_supported)
       .Member("vhost_user_vsock", config.vhost_user_vsock)
       .Member("supports_bgra_framebuffers", config.supports_bgra_framebuffers)
-      .Member("prefer_drm_virgl_when_supported",
-              config.prefer_drm_virgl_when_supported)
       .Member("mouse_supported", config.mouse_supported)
       .Member("gamepad_supported", config.gamepad_supported)
       .Member("ti50_emulator", config.ti50_emulator)

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/guest_config.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/guest_config.h
@@ -43,7 +43,6 @@ struct GuestConfig {
   bool guest_lavapipe_supported = false;
   bool vhost_user_vsock = false;
   bool supports_bgra_framebuffers = false;
-  bool prefer_drm_virgl_when_supported = false;
   bool mouse_supported = false;
   bool gamepad_supported = false;
   std::string ti50_emulator;

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/proto/guest_config.proto
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/proto/guest_config.proto
@@ -22,13 +22,12 @@ enum GpuMode {
   GPU_MODE_UNKNOWN = 0;
   GPU_MODE_AUTO = 1;
   GPU_MODE_CUSTOM = 2;
-  GPU_MODE_DRM_VIRGL = 3;
-  GPU_MODE_GFXSTREAM = 4;
-  GPU_MODE_GFXSTREAM_GUEST_ANGLE = 5;
-  GPU_MODE_GFXSTREAM_GUEST_ANGLE_HOST_LAVAPIPE = 6;
-  GPU_MODE_GFXSTREAM_GUEST_ANGLE_HOST_SWIFTSHADER = 7;
-  GPU_MODE_GUEST_SWIFTSHADER = 8;
-  GPU_MODE_NONE = 9;
+  GPU_MODE_GFXSTREAM = 3;
+  GPU_MODE_GFXSTREAM_GUEST_ANGLE = 4;
+  GPU_MODE_GFXSTREAM_GUEST_ANGLE_HOST_LAVAPIPE = 5;
+  GPU_MODE_GFXSTREAM_GUEST_ANGLE_HOST_SWIFTSHADER = 6;
+  GPU_MODE_GUEST_SWIFTSHADER = 7;
+  GPU_MODE_NONE = 8;
 }
 
 message Graphics {
@@ -41,10 +40,6 @@ message Graphics {
 
   // Whether the guest UI can use the BGRA pixel format for its framebuffers.
   bool bgra_framebuffers_supported = 3;
-
-  // If true, the system will prefer using the drm_virgl display mode when
-  // available.
-  bool prefer_drm_virgl_when_supported = 4;
 
   // The list of gpu modes supported by the guest in order of preference.
   repeated GpuMode gpu_mode_candidates = 5;

--- a/base/cvd/cuttlefish/host/frontend/webrtc/doc/graphics.dot
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/doc/graphics.dot
@@ -5,7 +5,7 @@ digraph {
     browser [label = "Browser"]
     vnc_client [label = "VNC Client"]
   }
-  host_renderer [label = < <font color="blue">gfxstream</font> / virglrenderer >]
+  host_renderer [label = < <font color="blue">gfxstream</font>>]
   run_cvd
   wayland_socket [label = "internal/frames.sock", shape = "rectangle"]
   webrtc [label = < <b>webrtc</b> >, penwidth = 2]

--- a/base/cvd/cuttlefish/host/frontend/webrtc/doc/graphics.svg
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/doc/graphics.svg
@@ -32,7 +32,6 @@
 <ellipse fill="none" stroke="black" cx="167" cy="-377" rx="104.78" ry="18"/>
 <text text-anchor="start" x="94.5" y="-374.3" font-family="Times,serif" font-size="14.00"> </text>
 <text text-anchor="start" x="98.5" y="-374.3" font-family="Times,serif" font-size="14.00" fill="blue">gfxstream</text>
-<text text-anchor="start" x="153.5" y="-374.3" font-family="Times,serif" font-size="14.00"> / virglrenderer </text>
 </g>
 <!-- vmm -->
 <g id="node7" class="node">

--- a/base/cvd/cuttlefish/host/frontend/webrtc/main.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/main.cpp
@@ -477,9 +477,6 @@ int CuttlefishMain() {
     user_friendly_gpu_mode = "Lavapipe (Guest GPU Rendering)";
   } else if (instance.gpu_mode() == GpuMode::GuestSwiftshader) {
     user_friendly_gpu_mode = "SwiftShader (Guest CPU Rendering)";
-  } else if (instance.gpu_mode() == GpuMode::DrmVirgl) {
-    user_friendly_gpu_mode =
-        "VirglRenderer (Accelerated Rendering using Host OpenGL)";
   } else if (instance.gpu_mode() == GpuMode::Gfxstream) {
     user_friendly_gpu_mode =
         "Gfxstream (Accelerated Rendering using Host OpenGL and Vulkan)";

--- a/base/cvd/cuttlefish/host/frontend/webrtc/main.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/main.cpp
@@ -544,9 +544,6 @@ int CuttlefishMain() {
     user_friendly_gpu_mode = "Lavapipe (Guest GPU Rendering)";
   } else if (instance.gpu_mode() == GpuMode::GuestSwiftshader) {
     user_friendly_gpu_mode = "SwiftShader (Guest CPU Rendering)";
-  } else if (instance.gpu_mode() == GpuMode::DrmVirgl) {
-    user_friendly_gpu_mode =
-        "VirglRenderer (Accelerated Rendering using Host OpenGL)";
   } else if (instance.gpu_mode() == GpuMode::Gfxstream) {
     user_friendly_gpu_mode =
         "Gfxstream (Accelerated Rendering using Host OpenGL and Vulkan)";

--- a/base/cvd/cuttlefish/host/libs/config/gpu_mode.h
+++ b/base/cvd/cuttlefish/host/libs/config/gpu_mode.h
@@ -38,7 +38,6 @@ enum class GpuMode {
 
 inline constexpr std::string_view kGpuModeAuto = "auto";
 inline constexpr std::string_view kGpuModeCustom = "custom";
-inline constexpr std::string_view kGpuModeDrmVirgl = "drm_virgl";
 inline constexpr std::string_view kGpuModeGfxstream = "gfxstream";
 inline constexpr std::string_view kGpuModeGfxstreamGuestAngle =
     "gfxstream_guest_angle";

--- a/base/cvd/cuttlefish/host/libs/screen_connector/screen_connector.h
+++ b/base/cvd/cuttlefish/host/libs/screen_connector/screen_connector.h
@@ -66,7 +66,6 @@ class ScreenConnector : public ScreenConnectorFrameRenderer {
     auto instance = config->ForDefaultInstance();
     std::unordered_set<GpuMode> valid_gpu_modes{
         GpuMode::Custom,
-        GpuMode::DrmVirgl,
         GpuMode::Gfxstream,
         GpuMode::GfxstreamGuestAngle,
         GpuMode::GfxstreamGuestAngleHostSwiftshader,

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
@@ -112,19 +112,6 @@ CrosvmManager::ConfigureGraphics(
         {"androidboot.hardware.vulkan", "pastel"},
         {"androidboot.opengles.version", "196609"},  // OpenGL ES 3.1
     };
-  } else if (instance.gpu_mode() == GpuMode::DrmVirgl) {
-    bootconfig_args = {
-        {"androidboot.cpuvulkan.version", "0"},
-        {"androidboot.hardware.gralloc", "minigbm"},
-        {"androidboot.hardware.hwcomposer", "ranchu"},
-        {"androidboot.hardware.hwcomposer.mode", "client"},
-        {"androidboot.hardware.hwcomposer.display_finder_mode", "drm"},
-        {"androidboot.hardware.hwcomposer.display_framebuffer_format",
-         instance.guest_uses_bgra_framebuffers() ? "bgra" : "rgba"},
-        {"androidboot.hardware.egl", "mesa"},
-        // No "hardware" Vulkan support, yet
-        {"androidboot.opengles.version", "196608"},  // OpenGL ES 3.0
-    };
   } else if (IsGfxstreamMode(instance.gpu_mode())) {
     const std::string gles_impl =
         IsGfxstreamGuestAngleMode(instance.gpu_mode()) ? "angle" : "emulation";
@@ -539,10 +526,6 @@ Result<void> ConfigureGpu(const CuttlefishConfig& config, Command* crosvm_cmd) {
   if (IsGuestRenderingMode(gpu_mode)) {
     crosvm_cmd->AddParameter("--gpu=", gpu_displays_string, "backend=2D",
                              gpu_common_string);
-  } else if (gpu_mode == GpuMode::DrmVirgl) {
-    crosvm_cmd->AddParameter("--gpu=", gpu_displays_string,
-                             "backend=virglrenderer,context-types=virgl2",
-                             gpu_common_3d_string);
   } else if (gpu_mode == GpuMode::Gfxstream) {
     crosvm_cmd->AddParameter(
         "--gpu=", gpu_displays_string,

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
@@ -102,19 +102,6 @@ CrosvmManager::ConfigureGraphics(
         {"androidboot.hardware.vulkan", "pastel"},
         {"androidboot.opengles.version", "196609"},  // OpenGL ES 3.1
     };
-  } else if (instance.gpu_mode() == GpuMode::DrmVirgl) {
-    bootconfig_args = {
-        {"androidboot.cpuvulkan.version", "0"},
-        {"androidboot.hardware.gralloc", "minigbm"},
-        {"androidboot.hardware.hwcomposer", "ranchu"},
-        {"androidboot.hardware.hwcomposer.mode", "client"},
-        {"androidboot.hardware.hwcomposer.display_finder_mode", "drm"},
-        {"androidboot.hardware.hwcomposer.display_framebuffer_format",
-         instance.guest_uses_bgra_framebuffers() ? "bgra" : "rgba"},
-        {"androidboot.hardware.egl", "mesa"},
-        // No "hardware" Vulkan support, yet
-        {"androidboot.opengles.version", "196608"},  // OpenGL ES 3.0
-    };
   } else if (IsGfxstreamMode(instance.gpu_mode())) {
     const std::string gles_impl =
         IsGfxstreamGuestAngleMode(instance.gpu_mode()) ? "angle" : "emulation";
@@ -497,10 +484,6 @@ Result<void> ConfigureGpu(const CuttlefishConfig& config, Command* crosvm_cmd) {
   if (IsGuestRenderingMode(gpu_mode)) {
     crosvm_cmd->AddParameter("--gpu=", gpu_displays_string, "backend=2D",
                              gpu_common_string);
-  } else if (gpu_mode == GpuMode::DrmVirgl) {
-    crosvm_cmd->AddParameter("--gpu=", gpu_displays_string,
-                             "backend=virglrenderer,context-types=virgl2",
-                             gpu_common_3d_string);
   } else if (gpu_mode == GpuMode::Gfxstream) {
     crosvm_cmd->AddParameter(
         "--gpu=", gpu_displays_string,

--- a/base/cvd/cuttlefish/host/libs/vm_manager/qemu_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/qemu_manager.cpp
@@ -476,8 +476,6 @@ Result<std::vector<MonitorCommand>> QemuManager::StartCommands(
     std::string gpu_device;
     if (gpu_mode == GpuMode::GuestSwiftshader || qemu_version.first < 6) {
       gpu_device = "virtio-gpu-pci";
-    } else if (gpu_mode == GpuMode::DrmVirgl) {
-      gpu_device = "virtio-gpu-gl-pci";
     } else if (gpu_mode == GpuMode::Gfxstream) {
       gpu_device =
           "virtio-gpu-rutabaga,x-gfxstream-gles=on,gfxstream-vulkan=on,"


### PR DESCRIPTION
Many people upstream call virgl "notoriously broken" and the urge to delete it upstream is growing irresitable.

"VirGL is no longer considered maintained any more. Unless someone
 steps up to maintain it in the long run, the code is likely to star
 bit-rotting and might eventually be removed. We recommend users
 start moving over to other solutions sooner rather than later"

https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/41240 https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/41259 https://lists.freedesktop.org/archives/mesa-announce/2026-May/000849.html

The Android GPU virtualization teams already did their part [1], deleting virgl from AOSP in 2024.

There's some dead code around here host side, so let's delete that to leave no room for mis-interpretations.

Cuttlefish users are advised to continue investing into gfxstream Vulkan.

[1] https://www.youtube.com/watch?v=81M62lI4mhc