### PR TITLE
Fix build warnings in vhost_user_media

### DIFF
--- a/base/cvd/cuttlefish/host/commands/vhost_user_media/emulated_camera_mplane/src/device.rs
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_media/emulated_camera_mplane/src/device.rs
@@ -994,7 +994,7 @@ where
 
         // Ensure all requested controls belong to the selected class.
         if let CtrlWhich::Class(class_id) = which {
-            for (idx, ctrl) in ctrl_array.iter().enumerate() {
+            for (_idx, ctrl) in ctrl_array.iter().enumerate() {
                 if v4l2_ctrl_id2which(ctrl.id) != class_id {
                     ctrls.error_idx = ctrls.count;
                     return Err(libc::EINVAL);
@@ -1003,7 +1003,7 @@ where
         }
 
         // Process controls. Class controls are write-only headers and must fail on read.
-        for (idx, ctrl) in ctrl_array.iter_mut().enumerate() {
+        for (_idx, ctrl) in ctrl_array.iter_mut().enumerate() {
             match ctrl.id {
                 bindings::V4L2_CID_USER_CLASS | bindings::V4L2_CID_CAMERA_CLASS => {
                     ctrls.error_idx = ctrls.count;
@@ -1114,7 +1114,7 @@ where
 
         // Ensure all requested controls belong to the selected class.
         if let CtrlWhich::Class(class_id) = which {
-            for (idx, ctrl) in ctrl_array.iter().enumerate() {
+            for (_idx, ctrl) in ctrl_array.iter().enumerate() {
                 if v4l2_ctrl_id2which(ctrl.id) != class_id {
                     ctrls.error_idx = ctrls.count;
                     return Err(libc::EINVAL);
@@ -1123,7 +1123,7 @@ where
         }
 
         // Apply control values. Class controls are read-only headers and must fail on write/try.
-        for (idx, ctrl) in ctrl_array.iter_mut().enumerate() {
+        for (_idx, ctrl) in ctrl_array.iter_mut().enumerate() {
             match ctrl.id {
                 bindings::V4L2_CID_USER_CLASS | bindings::V4L2_CID_CAMERA_CLASS => {
                     ctrls.error_idx = ctrls.count;


### PR DESCRIPTION
```
warning: unused variable: `idx`
   --> cuttlefish/host/commands/vhost_user_media/emulated_camera_mplane/src/device.rs:997:18
    |
997 |             for (idx, ctrl) in ctrl_array.iter().enumerate() {
    |                  ^^^ help: if this is intentional, prefix it with an underscore: `_idx`
    |
    = note: `#[warn(unused_variables)]` on by default

warning: unused variable: `idx`
    --> cuttlefish/host/commands/vhost_user_media/emulated_camera_mplane/src/device.rs:1006:14
     |
1006 |         for (idx, ctrl) in ctrl_array.iter_mut().enumerate() {
     |              ^^^ help: if this is intentional, prefix it with an underscore: `_idx`

warning: unused variable: `idx`
    --> cuttlefish/host/commands/vhost_user_media/emulated_camera_mplane/src/device.rs:1117:18
     |
1117 |             for (idx, ctrl) in ctrl_array.iter().enumerate() {
     |                  ^^^ help: if this is intentional, prefix it with an underscore: `_idx`

warning: unused variable: `idx`
    --> cuttlefish/host/commands/vhost_user_media/emulated_camera_mplane/src/device.rs:1126:14
     |
1126 |         for (idx, ctrl) in ctrl_array.iter_mut().enumerate() {
     |              ^^^ help: if this is intentional, prefix it with an underscore: `_idx`

warning: 4 warnings emitted
```

Bug: b/541272143