### PR TITLE
cvd: Update --media flag format to [type]:[key=value]

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/flags_parser_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/flags_parser_test.cc
@@ -379,7 +379,7 @@ TEST(FlagsParserTest, ParseMediaSplaneSingleInstance) {
   auto serialized_data = LaunchCvdParserTester(json_configs);
   ASSERT_THAT(serialized_data, IsOk());
   EXPECT_TRUE(
-      FindConfig(*serialized_data, "--media=type=v4l2_emulated_camera_splane"))
+      FindConfig(*serialized_data, "--media=v4l2_emulated_camera_splane"))
       << "media flag is missing or wrongly formatted";
 }
 
@@ -412,7 +412,7 @@ TEST(FlagsParserTest, ParseMediaSplaneTwoDevices) {
   auto serialized_data = LaunchCvdParserTester(json_configs);
   ASSERT_THAT(serialized_data, IsOk());
   EXPECT_EQ(std::count(serialized_data->begin(), serialized_data->end(),
-                       "--media=type=v4l2_emulated_camera_splane"),
+                       "--media=v4l2_emulated_camera_splane"),
             2);
 }
 
@@ -443,7 +443,7 @@ TEST(FlagsParserTest, ParseMediaMplane) {
 
   ASSERT_THAT(serialized_data, IsOk());
   EXPECT_TRUE(
-      FindConfig(*serialized_data, "--media=type=v4l2_emulated_camera_mplane"))
+      FindConfig(*serialized_data, "--media=v4l2_emulated_camera_mplane"))
       << "media flag is missing or wrongly formatted";
 }
 
@@ -475,7 +475,7 @@ TEST(FlagsParserTest, ParseMediaV4l2Proxy) {
   auto serialized_data = LaunchCvdParserTester(json_configs);
 
   ASSERT_THAT(serialized_data, IsOk());
-  EXPECT_TRUE(FindConfig(*serialized_data, "--media=type=v4l2_proxy"))
+  EXPECT_TRUE(FindConfig(*serialized_data, "--media=v4l2_proxy"))
       << "media flag is missing or wrongly formatted";
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_media_configs.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/instance/cf_media_configs.cpp
@@ -41,16 +41,16 @@ Result<std::vector<std::string>> GenerateMediaFlags(
       for (const auto& device : instance.media().devices()) {
         std::string flag = "--media=";
         if (device.has_v4l2_emulated_camera_splane()) {
-          flag += "type=v4l2_emulated_camera_splane";
+          flag += "v4l2_emulated_camera_splane";
         } else if (device.has_v4l2_emulated_camera_mplane()) {
-          flag += "type=v4l2_emulated_camera_mplane";
+          flag += "v4l2_emulated_camera_mplane";
         } else if (device.has_v4l2_proxy()) {
           // TODO(b/520114678): Use device.v4l2_proxy.device_path when
           // supported.
-          flag += "type=v4l2_proxy";
+          flag += "v4l2_proxy";
         }
         if (device.has_lens_facing()) {
-          flag += ",lens_facing=" + device.lens_facing();
+          flag += ":lens_facing=" + device.lens_facing();
         }
         flags.push_back(flag);
       }

--- a/base/cvd/cuttlefish/host/libs/config/media.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/media.cpp
@@ -16,6 +16,7 @@
 
 #include "cuttlefish/host/libs/config/media.h"
 
+#include <cstddef>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -38,30 +39,30 @@ static constexpr char kMediaTypeV4l2Proxy[] = "v4l2_proxy";
 
 Result<std::optional<CuttlefishConfig::MediaConfig>> ParseMediaConfig(
     const std::string& flag) {
-  std::unordered_map<std::string, std::string> props;
-  if (!flag.empty()) {
-    const std::vector<std::string> pairs = absl::StrSplit(flag, ",");
-    for (const std::string& pair : pairs) {
-      const std::vector<std::string> keyvalue = absl::StrSplit(pair, "=");
-      CF_EXPECT_EQ(keyvalue.size(), 2,
-                   "Invalid media flag key-value: \"" << flag << "\"");
-      const std::string& prop_key = keyvalue[0];
-      const std::string& prop_val = keyvalue[1];
-      props[prop_key] = prop_val;
-    }
-  }
+  const std::vector<std::string> parts = absl::StrSplit(flag, ":");
+  CF_EXPECT(!parts.empty(), "Invalid media flag: \"" << flag << "\"");
 
-  auto type_it = props.find("type");
-  CF_EXPECT(type_it != props.end(), "Missing media type");
+  const std::string& type_str = parts[0];
   CuttlefishConfig::MediaType type{CuttlefishConfig::MediaType::kUnknown};
-  if (type_it->second == kMediaTypeV4l2EmulatedCameraSPlane) {
+  if (type_str == kMediaTypeV4l2EmulatedCameraSPlane) {
     type = CuttlefishConfig::MediaType::kV4l2EmulatedCameraSPlane;
-  } else if (type_it->second == kMediaTypeV4l2EmulatedCameraMPlane) {
+  } else if (type_str == kMediaTypeV4l2EmulatedCameraMPlane) {
     type = CuttlefishConfig::MediaType::kV4l2EmulatedCameraMPlane;
-  } else if (type_it->second == kMediaTypeV4l2Proxy) {
+  } else if (type_str == kMediaTypeV4l2Proxy) {
     type = CuttlefishConfig::MediaType::kV4l2Proxy;
   } else {
-    return CF_ERRF("Unknown media type value: \"{}\"", type_it->second);
+    return CF_ERRF("Unknown media type value: \"{}\"", type_str);
+  }
+
+  std::unordered_map<std::string, std::string> props;
+  for (size_t i = 1; i < parts.size(); ++i) {
+    const std::vector<std::string> keyvalue = absl::StrSplit(parts[i], "=");
+    CF_EXPECT_EQ(keyvalue.size(), 2,
+                 "Invalid media flag key-value: \"" << parts[i] << "\" in \""
+                                                    << flag << "\"");
+    const std::string& prop_key = keyvalue[0];
+    const std::string& prop_val = keyvalue[1];
+    props[prop_key] = prop_val;
   }
 
   std::string lens_facing = "";

--- a/base/cvd/cuttlefish/host/libs/config/media.h
+++ b/base/cvd/cuttlefish/host/libs/config/media.h
@@ -24,18 +24,18 @@ namespace cuttlefish {
 
 constexpr const char kMediaFlag[] = "media";
 constexpr const char kMediaHelp[] =
-    "Comma separated key=value pairs of media device properties. Supported "
-    "properties:\n"
-    " 'type': optional, defaults to 'v4l2_emulated_camera_splane', supported "
-    "values:\n"
+    "Colon separated media device properties: "
+    "\"[type]:[key1]=[val1]:[key2]=[val2]\". "
+    "Supported types:\n"
     "    'v4l2_emulated_camera_splane': emulated media capture device "
     "(single-plane)\n"
     "    'v4l2_emulated_camera_mplane': emulated media capture device "
     "(multi-plane)\n"
     "    'v4l2_proxy': proxy a host V4L2 device into the guest\n"
+    "Supported keys:\n"
     " 'lens_facing': optional, supported values: 'FRONT', 'BACK', 'EXTERNAL'\n"
     "Example usage:\n"
-    "  --media=type=v4l2_emulated_camera_splane,lens_facing=BACK\n";
+    "  --media=v4l2_emulated_camera_mplane:lens_facing=BACK\n";
 
 Result<std::optional<CuttlefishConfig::MediaConfig>> ParseMediaConfig(
     const std::string& flag);

--- a/e2etests/cvd/media_tests/cts/main_test.go
+++ b/e2etests/cvd/media_tests/cts/main_test.go
@@ -31,8 +31,8 @@ func TestEmulatedCamera(t *testing.T) {
 			},
 			Create: e2etests.CreateArgs{
 				Args: []string{
-					"--media=type=v4l2_emulated_camera_mplane,lens_facing=BACK",
-					"--media=type=v4l2_emulated_camera_mplane,lens_facing=FRONT",
+					"--media=v4l2_emulated_camera_mplane:lens_facing=BACK",
+					"--media=v4l2_emulated_camera_mplane:lens_facing=FRONT",
 				},
 			},
 		},

--- a/e2etests/cvd/media_tests/v4l2compliance/main_test.go
+++ b/e2etests/cvd/media_tests/v4l2compliance/main_test.go
@@ -53,7 +53,7 @@ func TestEmulatedCameraV4l2Compliance(t *testing.T) {
 
 			if _, err := c.CVDCreate(e2etests.CreateArgs{
 				Args: []string{
-					fmt.Sprintf("--media=type=%s", tc.mediaType),
+					fmt.Sprintf("--media=%s", tc.mediaType),
 				},
 			}); err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Modify --media flag parsing logic to support the new pattern: "--media=[type]:[key1]=[val1]:[key2]=[val2]"
e.g. "--media=v4l2_emulated_camera_mplane:lens_facing=BACK"

This clearly separates the primary media type from its optional properties using `:`.

Bug: b/541325033
Assisted-by: Jetski:Gemini 3.5 Flash