### PR TITLE
gigabyte-ampere-cuttlefish-installer: stop preinstalling kernels in the preseed check environment

### DIFF
--- a/.github/actions/gigabyte-ampere-cuttlefish-installer-check-preseed-after-install-script/action.yaml
+++ b/.github/actions/gigabyte-ampere-cuttlefish-installer-check-preseed-after-install-script/action.yaml
@@ -23,7 +23,6 @@ runs:
       apt-get install -y lsb-release
       apt-get install -y pciutils
       apt-get install -y apt-show-versions
-      apt-get install -y linux-image-arm64 linux-headers-arm64
   - name: Setup base and non-free repository
     shell: bash
     run: |


### PR DESCRIPTION
The check container installed linux-image-arm64 and linux-headers-arm64 from the live trixie/trixie-security archives. Real installer targets never have trixie headers, and their presence makes DKMS build the NVIDIA driver against whatever kernel trixie-security shipped that day.

Bug: 537008147