### PR TITLE
Add an optional A/B pvmfw partition to the OS composite disk

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/android_composite_disk_config.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/android_composite_disk_config.cc
@@ -52,6 +52,7 @@ constexpr struct {
   std::string_view init_boot = "init_boot";
   std::string_view metadata = "metadata";
   std::string_view misc = "misc";
+  std::string_view pvmfw = "pvmfw";
   std::string_view super = "super";
   std::string_view userdata = "userdata";
   std::string_view vbmeta = "vbmeta";
@@ -85,6 +86,7 @@ Result<std::vector<ImagePartition>> AndroidCompositeDiskConfig(
   const std::set<std::string_view> ab_partitions = {
       kPartitions.boot,
       kPartitions.init_boot,
+      kPartitions.pvmfw,
       kPartitions.vbmeta,
       kPartitions.vbmeta_system,
       kPartitions.vbmeta_system_dlkm,

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/super_image_mixer.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/super_image_mixer.cc
@@ -49,14 +49,23 @@ namespace {
 constexpr char kMiscInfoPath[] = "META/misc_info.txt";
 constexpr char kDynamicPartitionsPath[] = "META/dynamic_partitions_info.txt";
 constexpr std::array kVendorTargetImages = {
-    "IMAGES/boot.img",          "IMAGES/dtbo.img",
-    "IMAGES/init_boot.img",     "IMAGES/odm.img",
-    "IMAGES/odm_dlkm.img",      "IMAGES/recovery.img",
-    "IMAGES/system_dlkm.img",   "IMAGES/userdata.img",
-    "IMAGES/vbmeta.img",        "IMAGES/vbmeta_system_dlkm.img",
-    "IMAGES/vbmeta_vendor.img", "IMAGES/vbmeta_vendor_dlkm.img",
-    "IMAGES/vendor.img",        "IMAGES/vendor_boot.img",
-    "IMAGES/vendor_dlkm.img",   "IMAGES/vendor_kernel_boot.img",
+    "IMAGES/boot.img",
+    "IMAGES/dtbo.img",
+    "IMAGES/init_boot.img",
+    "IMAGES/odm.img",
+    "IMAGES/odm_dlkm.img",
+    "IMAGES/pvmfw.img",
+    "IMAGES/recovery.img",
+    "IMAGES/system_dlkm.img",
+    "IMAGES/userdata.img",
+    "IMAGES/vbmeta.img",
+    "IMAGES/vbmeta_system_dlkm.img",
+    "IMAGES/vbmeta_vendor.img",
+    "IMAGES/vbmeta_vendor_dlkm.img",
+    "IMAGES/vendor.img",
+    "IMAGES/vendor_boot.img",
+    "IMAGES/vendor_dlkm.img",
+    "IMAGES/vendor_kernel_boot.img",
 };
 constexpr std::array kVendorTargetBuildProps = {
     "ODM/build.prop",


### PR DESCRIPTION
The image comes from the Android build when available. Targets that don't build protected VM firmware are unaffected.

Bug: 536088107