### PR TITLE
Fix run_cvd abort on graceful guest VM shutdown

### DIFF
--- a/base/cvd/cuttlefish/host/libs/process_monitor/process_monitor.cc
+++ b/base/cvd/cuttlefish/host/libs/process_monitor/process_monitor.cc
@@ -453,6 +453,7 @@ Result<void> ProcessMonitor::MonitorRoutine() {
   CF_EXPECT(MonitorLoop(running, properties_mutex_,
                         properties_.restart_subprocesses_,
                         properties_.entries_));
+  running.store(false);
   if (child_sock_->IsOpen()) {
     child_sock_->Shutdown(SHUT_RDWR);
   }


### PR DESCRIPTION
When a guest VM shuts down cleanly, crosvm exits and MonitorLoop() finishes. However, child_sock_->Shutdown() was called before setting running to false. This caused ReadMonitorSocketLoop() to treat socket closure as an error, making ProcessMonitor exit with status 1 and causing run_cvd to abort(). The leftover stale sockets caused cvd fleet to report Unreachable and cvd restart to fail with "Connection refused".

Fix this by setting running.store(false) right after MonitorLoop() finishes, so ReadMonitorSocketLoop() recognizes socket closure as intentional and returns OK.

Test: verified monitor process exits cleanly with code 0 on guest shutdown.                                                                                                                                 
                                                                                                                                                                                                                                                 
BUG=b/538490772                                                                                                                                                                                                                              
BUG=b/534717429                                                           