### PR TITLE
Proxy --acpi-table, --device-tree-overlay, and --file-backed-mapping to crosvm run

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
@@ -386,6 +386,20 @@ DEFINE_vec(
 DEFINE_vec(use_pmem, "true",
            "Make this flag false to disable pmem with crosvm");
 
+DEFINE_vec(crosvm_acpi_table, "",
+           "Passed directly to crosvm as --acpi-table. "
+           "Path to user provided ACPI table");
+
+DEFINE_vec(crosvm_device_tree_overlay, "",
+           "Passed directly to crosvm as --device-tree-overlay. "
+           "Path to user provided device tree overlay");
+
+DEFINE_vec(crosvm_file_backed_mapping, "",
+           "Passed directly to crosvm as --file-backed-mapping. "
+           "Map the given file into guest memory at the specified address. "
+           "Parameters (addr, size, path are required): "
+           "addr=NUM,size=NUM,path=PATH,offset=NUM,rw,sync,align,ram");
+
 DEFINE_vec(enable_wifi, fmt::format("{}", CF_DEFAULTS_ENABLE_WIFI),
            "Enables the guest WIFI. Mainly for Minidroid");
 

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
@@ -391,6 +391,24 @@ DEFINE_vec(
 DEFINE_vec(use_pmem, "true",
            "Make this flag false to disable pmem with crosvm");
 
+DEFINE_vec(crosvm_acpi_table, "",
+           "Passed directly to crosvm as --acpi-table. "
+           "Path to user provided ACPI table");
+
+DEFINE_vec(crosvm_device_tree_overlay, "",
+           "Passed directly to crosvm as --device-tree-overlay. "
+           "Path to user provided device tree overlay");
+
+DEFINE_vec(crosvm_file_backed_mapping, "",
+           "Passed directly to crosvm as --file-backed-mapping. "
+           "Map the given file into guest memory at the specified address. "
+           "Parameters (addr, size, path are required): "
+           "addr=NUM,size=NUM,path=PATH,offset=NUM,rw,sync,align,ram");
+
+DEFINE_vec(crosvm_file_backed_mapping_base64, "",
+           "This is base64 encoded version of crosvm_file_backed_mapping. "
+           "Used for multi device clusters.");
+
 DEFINE_vec(enable_wifi, fmt::format("{}", CF_DEFAULTS_ENABLE_WIFI),
            "Enables the guest WIFI. Mainly for Minidroid");
 

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.h
@@ -186,6 +186,10 @@ DECLARE_vec(crosvm_v4l2_proxy);
 
 DECLARE_vec(use_pmem);
 
+DECLARE_vec(crosvm_acpi_table);
+DECLARE_vec(crosvm_device_tree_overlay);
+DECLARE_vec(crosvm_file_backed_mapping);
+
 DECLARE_vec(enable_wifi);
 
 DECLARE_vec(device_external_network);

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.h
@@ -188,6 +188,11 @@ DECLARE_vec(crosvm_v4l2_proxy);
 
 DECLARE_vec(use_pmem);
 
+DECLARE_vec(crosvm_acpi_table);
+DECLARE_vec(crosvm_device_tree_overlay);
+DECLARE_vec(crosvm_file_backed_mapping);
+DECLARE_vec(crosvm_file_backed_mapping_base64);
+
 DECLARE_vec(enable_wifi);
 
 DECLARE_vec(device_external_network);

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -618,6 +618,12 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
   std::vector<bool> smt_vec = CF_EXPECT(GET_FLAG_BOOL_VALUE(smt));
   std::vector<std::string> crosvm_binary_vec =
       CF_EXPECT(GET_FLAG_STR_VALUE(crosvm_binary));
+  std::vector<std::string> crosvm_acpi_table_vec =
+      CF_EXPECT(GET_FLAG_STR_VALUE(crosvm_acpi_table));
+  std::vector<std::string> crosvm_device_tree_overlay_vec =
+      CF_EXPECT(GET_FLAG_STR_VALUE(crosvm_device_tree_overlay));
+  std::vector<std::string> crosvm_file_backed_mapping_vec =
+      CF_EXPECT(GET_FLAG_STR_VALUE(crosvm_file_backed_mapping));
   std::vector<std::string> seccomp_policy_dir_vec =
       CF_EXPECT(GET_FLAG_STR_VALUE(seccomp_policy_dir));
   std::vector<std::string> qemu_binary_dir_vec =
@@ -843,6 +849,11 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
     }
 
     instance.set_crosvm_binary(crosvm_binary_vec[instance_index]);
+    instance.set_crosvm_acpi_table(crosvm_acpi_table_vec[instance_index]);
+    instance.set_crosvm_device_tree_overlay(
+        crosvm_device_tree_overlay_vec[instance_index]);
+    instance.set_crosvm_file_backed_mapping(
+        crosvm_file_backed_mapping_vec[instance_index]);
     instance.set_seccomp_policy_dir(seccomp_policy_dir_vec[instance_index]);
     instance.set_qemu_binary_dir(qemu_binary_dir_vec[instance_index]);
 

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -622,6 +622,14 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
   std::vector<bool> smt_vec = CF_EXPECT(GET_FLAG_BOOL_VALUE(smt));
   std::vector<std::string> crosvm_binary_vec =
       CF_EXPECT(GET_FLAG_STR_VALUE(crosvm_binary));
+  std::vector<std::string> crosvm_acpi_table_vec =
+      CF_EXPECT(GET_FLAG_STR_VALUE(crosvm_acpi_table));
+  std::vector<std::string> crosvm_device_tree_overlay_vec =
+      CF_EXPECT(GET_FLAG_STR_VALUE(crosvm_device_tree_overlay));
+  std::vector<std::string> crosvm_file_backed_mapping_vec =
+      CF_EXPECT(GET_FLAG_STR_VALUE(crosvm_file_backed_mapping));
+  std::vector<std::string> crosvm_file_backed_mapping_base64_vec =
+      CF_EXPECT(GET_FLAG_STR_VALUE(crosvm_file_backed_mapping_base64));
   std::vector<std::string> seccomp_policy_dir_vec =
       CF_EXPECT(GET_FLAG_STR_VALUE(seccomp_policy_dir));
   std::vector<std::string> qemu_binary_dir_vec =
@@ -847,6 +855,18 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
     }
 
     instance.set_crosvm_binary(crosvm_binary_vec[instance_index]);
+    instance.set_crosvm_acpi_table(crosvm_acpi_table_vec[instance_index]);
+    instance.set_crosvm_device_tree_overlay(
+        crosvm_device_tree_overlay_vec[instance_index]);
+    instance.set_crosvm_file_backed_mapping(
+        crosvm_file_backed_mapping_vec[instance_index]);
+    if (!crosvm_file_backed_mapping_base64_vec[instance_index].empty()) {
+      std::vector<uint8_t> decoded_mapping = CF_EXPECT(
+          DecodeBase64(crosvm_file_backed_mapping_base64_vec[instance_index]));
+      std::string decoded_mapping_str(decoded_mapping.begin(),
+                                      decoded_mapping.end());
+      instance.set_crosvm_file_backed_mapping(decoded_mapping_str);
+    }
     instance.set_seccomp_policy_dir(seccomp_policy_dir_vec[instance_index]);
     instance.set_qemu_binary_dir(qemu_binary_dir_vec[instance_index]);
 

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
@@ -392,6 +392,9 @@ class CuttlefishConfig {
     bool crosvm_simple_media_device() const;
     std::string crosvm_v4l2_proxy() const;
     bool use_pmem() const;
+    std::string crosvm_acpi_table() const;
+    std::string crosvm_device_tree_overlay() const;
+    std::string crosvm_file_backed_mapping() const;
 
     // Wifi MAC address inside the guest
     int wifi_mac_prefix() const;
@@ -644,6 +647,9 @@ class CuttlefishConfig {
     void set_crosvm_simple_media_device(const bool simple_media_device);
     void set_crosvm_v4l2_proxy(const std::string v4l2_proxy);
     void set_use_pmem(const bool use_pmem);
+    void set_crosvm_acpi_table(const std::string acpi_table);
+    void set_crosvm_device_tree_overlay(const std::string device_tree_overlay);
+    void set_crosvm_file_backed_mapping(const std::string file_backed_mapping);
     // Wifi MAC address inside the guest
     void set_wifi_mac_prefix(const int wifi_mac_prefix);
     // Gnss grpc proxy server port inside the host

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
@@ -406,6 +406,9 @@ class CuttlefishConfig {
     std::string crosvm_v4l2_proxy() const;
     bool use_pmem() const;
     bool enable_pkvm() const;
+    std::string crosvm_acpi_table() const;
+    std::string crosvm_device_tree_overlay() const;
+    std::string crosvm_file_backed_mapping() const;
 
     // Wifi MAC address inside the guest
     int wifi_mac_prefix() const;
@@ -659,6 +662,9 @@ class CuttlefishConfig {
     void set_crosvm_v4l2_proxy(std::string v4l2_proxy);
     void set_use_pmem(bool use_pmem);
     void set_enable_pkvm(bool enable_pkvm);
+    void set_crosvm_acpi_table(const std::string& acpi_table);
+    void set_crosvm_device_tree_overlay(const std::string& device_tree_overlay);
+    void set_crosvm_file_backed_mapping(const std::string& file_backed_mapping);
     // Wifi MAC address inside the guest
     void set_wifi_mac_prefix(int wifi_mac_prefix);
     // Gnss grpc proxy server port inside the host

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
@@ -1901,6 +1901,35 @@ bool CuttlefishConfig::InstanceSpecific::use_pmem() const {
   return (*Dictionary())[kCrosvmUsePmem].asBool();
 }
 
+static constexpr char kCrosvmAcpiTable[] = "crosvm_acpi_table";
+void CuttlefishConfig::MutableInstanceSpecific::set_crosvm_acpi_table(
+    const std::string acpi_table) {
+  (*Dictionary())[kCrosvmAcpiTable] = acpi_table;
+}
+std::string CuttlefishConfig::InstanceSpecific::crosvm_acpi_table() const {
+  return (*Dictionary())[kCrosvmAcpiTable].asString();
+}
+
+static constexpr char kCrosvmDeviceTreeOverlay[] = "crosvm_device_tree_overlay";
+void CuttlefishConfig::MutableInstanceSpecific::set_crosvm_device_tree_overlay(
+    const std::string device_tree_overlay) {
+  (*Dictionary())[kCrosvmDeviceTreeOverlay] = device_tree_overlay;
+}
+std::string CuttlefishConfig::InstanceSpecific::crosvm_device_tree_overlay()
+    const {
+  return (*Dictionary())[kCrosvmDeviceTreeOverlay].asString();
+}
+
+static constexpr char kCrosvmFileBackedMapping[] = "crosvm_file_backed_mapping";
+void CuttlefishConfig::MutableInstanceSpecific::set_crosvm_file_backed_mapping(
+    const std::string file_backed_mapping) {
+  (*Dictionary())[kCrosvmFileBackedMapping] = file_backed_mapping;
+}
+std::string CuttlefishConfig::InstanceSpecific::crosvm_file_backed_mapping()
+    const {
+  return (*Dictionary())[kCrosvmFileBackedMapping].asString();
+}
+
 static constexpr char kEnableTapDevices[] = "enable_tap_devices";
 void CuttlefishConfig::MutableInstanceSpecific::set_enable_tap_devices(
     const bool enable_tap_devices) {

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
@@ -1910,6 +1910,35 @@ bool CuttlefishConfig::InstanceSpecific::enable_pkvm() const {
   return (*Dictionary())[kEnablePkvm].asBool();
 }
 
+static constexpr char kCrosvmAcpiTable[] = "crosvm_acpi_table";
+void CuttlefishConfig::MutableInstanceSpecific::set_crosvm_acpi_table(
+    const std::string& acpi_table) {
+  (*Dictionary())[kCrosvmAcpiTable] = acpi_table;
+}
+std::string CuttlefishConfig::InstanceSpecific::crosvm_acpi_table() const {
+  return (*Dictionary())[kCrosvmAcpiTable].asString();
+}
+
+static constexpr char kCrosvmDeviceTreeOverlay[] = "crosvm_device_tree_overlay";
+void CuttlefishConfig::MutableInstanceSpecific::set_crosvm_device_tree_overlay(
+    const std::string& device_tree_overlay) {
+  (*Dictionary())[kCrosvmDeviceTreeOverlay] = device_tree_overlay;
+}
+std::string CuttlefishConfig::InstanceSpecific::crosvm_device_tree_overlay()
+    const {
+  return (*Dictionary())[kCrosvmDeviceTreeOverlay].asString();
+}
+
+static constexpr char kCrosvmFileBackedMapping[] = "crosvm_file_backed_mapping";
+void CuttlefishConfig::MutableInstanceSpecific::set_crosvm_file_backed_mapping(
+    const std::string& file_backed_mapping) {
+  (*Dictionary())[kCrosvmFileBackedMapping] = file_backed_mapping;
+}
+std::string CuttlefishConfig::InstanceSpecific::crosvm_file_backed_mapping()
+    const {
+  return (*Dictionary())[kCrosvmFileBackedMapping].asString();
+}
+
 static constexpr char kEnableTapDevices[] = "enable_tap_devices";
 void CuttlefishConfig::MutableInstanceSpecific::set_enable_tap_devices(
     const bool enable_tap_devices) {

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
@@ -574,6 +574,19 @@ Result<std::vector<MonitorCommand>> CrosvmManager::StartCommands(
   crosvm_cmd.AddControlSocket(instance.CrosvmSocketPath(),
                               instance.crosvm_binary());
 
+  if (!instance.crosvm_acpi_table().empty()) {
+    crosvm_cmd.Cmd().AddParameter("--acpi-table=",
+                                  instance.crosvm_acpi_table());
+  }
+  if (!instance.crosvm_device_tree_overlay().empty()) {
+    crosvm_cmd.Cmd().AddParameter("--device-tree-overlay=",
+                                  instance.crosvm_device_tree_overlay());
+  }
+  if (!instance.crosvm_file_backed_mapping().empty()) {
+    crosvm_cmd.Cmd().AddParameter("--file-backed-mapping=",
+                                  instance.crosvm_file_backed_mapping());
+  }
+
   if (!config.kvm_path().empty()) {
     crosvm_cmd.AddKvmPath(config.kvm_path());
   }

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
@@ -616,6 +616,19 @@ Result<std::vector<MonitorCommand>> CrosvmManager::StartCommands(
   crosvm_cmd.AddControlSocket(instance.CrosvmSocketPath(),
                               instance.crosvm_binary());
 
+  if (!instance.crosvm_acpi_table().empty()) {
+    crosvm_cmd.Cmd().AddParameter("--acpi-table=",
+                                  instance.crosvm_acpi_table());
+  }
+  if (!instance.crosvm_device_tree_overlay().empty()) {
+    crosvm_cmd.Cmd().AddParameter("--device-tree-overlay=",
+                                  instance.crosvm_device_tree_overlay());
+  }
+  if (!instance.crosvm_file_backed_mapping().empty()) {
+    crosvm_cmd.Cmd().AddParameter("--file-backed-mapping=",
+                                  instance.crosvm_file_backed_mapping());
+  }
+
   if (!config.kvm_path().empty()) {
     crosvm_cmd.AddKvmPath(config.kvm_path());
   }


### PR DESCRIPTION
This CL Introduce new command line arguments and cuttlefish config properties to allow proxying user provided ACPI tables, device tree overlays, and file-backed mappings to `crosvm run` command.

Assisted-by: Antigravity:Gemini-Next
Bug: 510177847