### PR TITLE
gigabyte-ampere-cuttlefish-installer: wait for the vm to finish booting

### DIFF
--- a/.github/workflows/gigabyte-ampere-cuttlefish-installer.yaml
+++ b/.github/workflows/gigabyte-ampere-cuttlefish-installer.yaml
@@ -56,7 +56,7 @@ jobs:
         nvidia_gpu: ["true", "false"]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     - name: Check preseed after install script
       uses: ./.github/actions/gigabyte-ampere-cuttlefish-installer-check-preseed-after-install-script
       with:
@@ -72,11 +72,11 @@ jobs:
       image: debian@sha256:13f29b6806e531c3ff3b565bb6eed73f2132506c8c9d41bb996065ca20fb27f2 # debian:trixie-20260223 (amd64)
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     - name: Build iso installer
       uses: ./.github/actions/build-gigabyte-ampere-cuttlefish-installer
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: gigabyte-ampere-cuttlefish-installer-artifacts
         path: gigabyte-ampere-cuttlefish-installer/preseed-mini.iso.xz
@@ -93,9 +93,9 @@ jobs:
       TEST_DISK_SIZE: "10G"
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: gigabyte-ampere-cuttlefish-installer-artifacts
     - name: Prepare test environment
@@ -137,9 +137,9 @@ jobs:
         working-directory: ./gigabyte-ampere-cuttlefish-installer
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: gigabyte-ampere-cuttlefish-installer-artifacts
     - name: Prepare test environment
@@ -185,9 +185,9 @@ jobs:
         working-directory: ./gigabyte-ampere-cuttlefish-installer
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: gigabyte-ampere-cuttlefish-installer-artifacts
     - name: Prepare test environment
@@ -233,9 +233,9 @@ jobs:
         working-directory: ./gigabyte-ampere-cuttlefish-installer
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: gigabyte-ampere-cuttlefish-installer-artifacts
     - name: Prepare test environment
@@ -281,9 +281,9 @@ jobs:
         working-directory: ./gigabyte-ampere-cuttlefish-installer
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: gigabyte-ampere-cuttlefish-installer-artifacts
     - name: Prepare test environment
@@ -361,9 +361,9 @@ jobs:
         working-directory: ./gigabyte-ampere-cuttlefish-installer
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: gigabyte-ampere-cuttlefish-installer-artifacts
     - name: Prepare test environment

--- a/.github/workflows/gigabyte-ampere-cuttlefish-installer.yaml
+++ b/.github/workflows/gigabyte-ampere-cuttlefish-installer.yaml
@@ -301,6 +301,9 @@ jobs:
       run: |
         screen -d -m -L -Logfile console_001.log ./installer-iso-run-qemu.sh
         while ! egrep "[^[:space:]]+[[:space:]]login:" console_001.log; do sleep 30; done
+        # The login prompt appears before the system is usable, so wait for the
+        # boot to complete. "degraded" means booted with some unit failed.
+        until sshpass -p cuttlefish ssh -o "StrictHostKeyChecking no" -o "UserKnownHostsFile /dev/null" -o "ConnectTimeout 60" -p 33322 vsoc-01@localhost 'systemctl is-system-running | grep -qE "running|degraded"'; do sleep 30; done
         cp -f console_001.log console_001_p1.log
         CONSOLELINES=$(cat console_001_p1.log | wc -l)
         cat console_001_p1.log
@@ -381,6 +384,9 @@ jobs:
       run: |
         screen -d -m -L -Logfile console_001.log ./installer-iso-run-qemu.sh
         while ! egrep "[^[:space:]]+[[:space:]]login:" console_001.log; do sleep 30; done
+        # The login prompt appears before the system is usable, so wait for the
+        # boot to complete. "degraded" means booted with some unit failed.
+        until sshpass -p cuttlefish ssh -o "StrictHostKeyChecking no" -o "UserKnownHostsFile /dev/null" -o "ConnectTimeout 60" -p 33322 vsoc-01@localhost 'systemctl is-system-running | grep -qE "running|degraded"'; do sleep 30; done
         cp -f console_001.log console_001_p1.log
         CONSOLELINES=$(cat console_001_p1.log | wc -l)
         cat console_001_p1.log


### PR DESCRIPTION
The qemu test jobs treat the serial console login prompt as "vm is ready" and ssh into the guest right away. The prompt only means getty started: the guest is still booting, so the ssh handshake gets reset (kex_exchange_identification: read: Connection reset by peer) and, once that is past, dns is not up yet for the first command needing it.

The console is polled every 30s, so the ssh always lands at the same point after boot and whether it works is luck. Four of twelve job instances across six recent runs failed this way, on both jobs and regardless of which kernel the installer had put on the vm.

Wait until systemd reports the boot finished before using the vm.

Bug: 537008147