### PR TITLE
Fix silent delete failure from bashism

### DIFF
--- a/base/debian/cuttlefish-base.cuttlefish-host-resources.init
+++ b/base/debian/cuttlefish-base.cuttlefish-host-resources.init
@@ -175,7 +175,7 @@ manage_nft_rule() {
         delete)
             if [ -f "$handle_file" ]; then
                 # Find the handle file and use it to clean things up.
-                handle=$(< "$handle_file")
+                handle=$(cat "$handle_file")
                 nft delete rule "$family" "$table" "$chain" handle "$handle"
                 rm "$handle_file"
             else


### PR DESCRIPTION
The script's shebang is sh, so it's better to just use `cat`. Not actually a leak, since deleting the table cleans it up, but it _is_ still subtly wrong as-is.