### PR TITLE
Immediately address bazelbuild/bazel#30604.

### DIFF
--- a/tools/buildutils/installbazel.sh
+++ b/tools/buildutils/installbazel.sh
@@ -21,7 +21,7 @@ set -e
 function install_bazel_x86_64() {
   echo "Installing bazel"
   apt install apt-transport-https curl gnupg -y
-  curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor >bazel-archive-keyring.gpg
+  curl -fsSL https://releases.bazel.build/bazel-release.pub.gpg | gpg --dearmor >bazel-archive-keyring.gpg
   mv bazel-archive-keyring.gpg /usr/share/keyrings
   echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
   # bazel needs the zip command to gather test outputs but doesn't depend on it


### PR DESCRIPTION
We curl this URL, which is now broken. #2981 is considering using bazelisk, but the scripts and presubmits are broken now, so we should fix this now.