### PR TITLE
Implement ReaderSeeker on FileInstance

### DIFF
--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd.cpp
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd.cpp
@@ -967,10 +967,14 @@ Result<uint64_t> FileInstance::Read(void* buf, uint64_t count) {
   return static_cast<uint64_t>(res);
 }
 
-ssize_t FileInstance::PRead(void* buf, size_t count, size_t offset) {
-  LocalErrno record_errno(errno_);
+Result<uint64_t> FileInstance::PRead(void* buf, size_t count,
+                                     size_t offset) const {
+  LocalErrno record_errno(const_cast<int&>(errno_));
 
-  return TEMP_FAILURE_RETRY(pread(fd_, buf, count, offset));
+  ssize_t res = TEMP_FAILURE_RETRY(pread(fd_, buf, count, offset));
+  CF_EXPECT_GE(res, 0, ::cuttlefish::StrError(errno));
+
+  return static_cast<uint64_t>(res);
 }
 
 #ifdef __linux__
@@ -991,6 +995,24 @@ ssize_t FileInstance::SendMsg(const struct msghdr* msg, int flags) {
   LocalErrno record_errno(errno_);
 
   return TEMP_FAILURE_RETRY(sendmsg(fd_, msg, flags));
+}
+
+Result<uint64_t> FileInstance::SeekSet(uint64_t offset) {
+  off_t ret = LSeek(static_cast<off_t>(offset), SEEK_SET);
+  CF_EXPECT_GE(ret, 0, StrError());
+  return ret;
+}
+
+Result<uint64_t> FileInstance::SeekCur(int64_t offset) {
+  off_t ret = LSeek(static_cast<off_t>(offset), SEEK_CUR);
+  CF_EXPECT_GE(ret, 0, StrError());
+  return ret;
+}
+
+Result<uint64_t> FileInstance::SeekEnd(int64_t offset) {
+  off_t ret = LSeek(static_cast<off_t>(offset), SEEK_END);
+  CF_EXPECT_GE(ret, 0, StrError());
+  return ret;
 }
 
 int FileInstance::Shutdown(int how) {

--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd.h
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd.h
@@ -285,7 +285,7 @@ class ScopedMMap {
  * escaping file descriptors. At this point SharedFD is the only class
  * that has access. We may eventually have ScopedFD and WeakFD.
  */
-class FileInstance : public Reader {
+class FileInstance : public ReaderSeeker {
   // Give SharedFD access to the aliasing constructor.
   friend class SharedFD;
   friend class Epoll;
@@ -353,12 +353,17 @@ class FileInstance : public Reader {
   ssize_t Recv(void* buf, size_t len, int flags);
   ssize_t RecvMsg(struct msghdr* msg, int flags);
   Result<uint64_t> Read(void* buf, uint64_t count) override;
-  ssize_t PRead(void* buf, size_t count, size_t offset);
+  Result<uint64_t> PRead(void* buf, uint64_t count,
+                         uint64_t offset) const override;
 #ifdef __linux__
   int EventfdRead(eventfd_t* value);
 #endif
   ssize_t Send(const void* buf, size_t len, int flags);
   ssize_t SendMsg(const struct msghdr* msg, int flags);
+
+  Result<uint64_t> SeekSet(uint64_t) override;
+  Result<uint64_t> SeekCur(int64_t) override;
+  Result<uint64_t> SeekEnd(int64_t) override;
 
   template <typename... Args>
   ssize_t SendFileDescriptors(const void* buf, size_t len, Args&&... sent_fds) {

--- a/base/cvd/cuttlefish/io/shared_fd.cc
+++ b/base/cvd/cuttlefish/io/shared_fd.cc
@@ -63,9 +63,7 @@ Result<uint64_t> SharedFdIo::SeekEnd(int64_t offset) {
 
 Result<uint64_t> SharedFdIo::PRead(void* buf, uint64_t count,
                                    uint64_t offset) const {
-  int64_t data_read = fd_->PRead(buf, count, offset);
-  CF_EXPECT_GE(data_read, 0, fd_->StrError());
-  return data_read;
+  return CF_EXPECT(fd_->PRead(buf, count, offset));
 }
 
 Result<uint64_t> SharedFdIo::PWrite(const void* buf, uint64_t count,


### PR DESCRIPTION
`FileInstance::PRead` had no callers besides `SharedFdIo`. The `Seeker` methods are named differently so it doesn't conflict with `FileInstance::LSeek`.

Bug: b/540553865