### PR TITLE
Use env variable to use GCE metadata.

### DIFF
--- a/container/image/guest/run_services.sh
+++ b/container/image/guest/run_services.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [[ "${USE_GCE_METADATA}" == "true" ]]; then
+  echo "build_api_credentials_use_gce_metadata=true" \
+    >> /etc/default/cuttlefish-host_orchestrator
+fi
+
 service nginx start
 service cuttlefish-host-resources start
 service cuttlefish-operator start


### PR DESCRIPTION
In order to configure the container to use GCE metadata for the build API, either the entrypoint needs to be messed around with or that a bind-mount override of the host orchestrator default file needs to be used. Both are ugly. Instead, change the entrypoint behavior to do this if we set an environment variable.

We could do this via flags, but this seems simpler.