### PR TITLE
[1.55][cherrypick] Skip TAP device validation for cvdalloc launches.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/run_cvd/validate.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/validate.cpp
@@ -37,7 +37,8 @@ namespace cuttlefish {
 static Result<void> TestTapDevices(
     const CuttlefishConfig::InstanceSpecific& instance) {
 #ifdef __linux__
-  if (InSandbox()) {
+  if (InSandbox()
+  || instance.use_cvdalloc()) { // cvdalloc owns its own resources. those resources can't be validated this way.
     return {};
   }
   auto wifi = instance.wifi_tap_name();


### PR DESCRIPTION
(Cherrypicks dxapd's change from #2720 onto 1.55.)