### PR TITLE
emulated_camera_mplane: Add QVGA resolution support

### DIFF
--- a/base/cvd/cuttlefish/host/commands/vhost_user_media/emulated_camera_mplane/src/device.rs
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_media/emulated_camera_mplane/src/device.rs
@@ -514,7 +514,8 @@ const WIDTH: u32 = 640;
 const HEIGHT: u32 = 480;
 const FRAME_RATE: u32 = 30;
 
-const SUPPORTED_SIZES: [(u32, u32); 2] = [
+const SUPPORTED_SIZES: [(u32, u32); 3] = [
+    (320, 240),
     (640, 480),
     (1280, 720),
 ];


### PR DESCRIPTION
Add QVGA (320x240) to SUPPORTED_SIZES as this is required by Android Camera2 CTS test testAvailableStreamConfigs.

Bug: b/534454250
Test: atest CtsCameraTestCases:android.hardware.camera2.cts. ExtendedCameraCharacteristicsTest#testAvailableStreamConfigs