### PR TITLE
WIP: Clear the output directory based on a placeholder file

### DIFF
--- a/base/cvd/cuttlefish/package/rules.bzl
+++ b/base/cvd/cuttlefish/package/rules.bzl
@@ -56,6 +56,15 @@ def _package_files_impl(ctx):
 
     path_to_declared_file = dict()
 
+    placeholder_clear_dir = ctx.actions.declare_file(ctx.attr.base_dir + ".placeholder")
+    full_base_dir = placeholder_clear_dir.dirname + "/" + ctx.attr.base_dir
+    ctx.actions.run_shell(
+        mnemonic = "ClearOutputDirectory",
+        command = "rm -r " + full_base_dir + " && touch " + placeholder_clear_dir.path,
+        inputs = [_file_from_label(src) for src in ctx.attr.package_file_to_src.values()],
+        outputs = [placeholder_clear_dir],
+    )
+
     for (dst, src) in ctx.attr.package_file_to_src.items():
         out_file = ctx.actions.declare_file(ctx.attr.base_dir + '/' + dst)
 
@@ -69,7 +78,7 @@ def _package_files_impl(ctx):
         ctx.actions.run_shell(
             mnemonic = "MakeOutputDir",
             outputs = [out_file],
-            inputs = [input_file],
+            inputs = [placeholder_clear_dir, input_file],
             command = "mkdir -p " + out_file.dirname + " && cp " + input_file.path + " " + out_file.path,
         )
 
@@ -90,7 +99,7 @@ def _package_files_impl(ctx):
         ctx.actions.run_shell(
             mnemonic = "MakeOutputDir",
             outputs = [dst_file],
-            inputs = [src_file],
+            inputs = [placeholder_clear_dir, src_file],
             command = "mkdir -p " + dst_file.dirname + " && ln -s " + relative_target + " " + dst_file.path,
         )
 


### PR DESCRIPTION
Requires `--spawn_strategy=local` otherwise produces:

```
ERROR: /mnt/build/standalone/android-cuttlefish/base/cvd/cuttlefish/package/BUILD.bazel:8:14: ClearOutputDirectory cuttlefish/package/cuttlefish-common.placeholder failed: (Exit 1): bash failed: error executing ClearOutputDirectory command (from target //cuttlefish/package:common) /bin/bash -c 'rm -r bazel-out/k8-fastbuild/bin/cuttlefish/package/cuttlefish-common && touch bazel-out/k8-fastbuild/bin/cuttlefish/package/cuttlefish-common.placeholder'

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
rm: cannot remove 'bazel-out/k8-fastbuild/bin/cuttlefish/package/cuttlefish-common': No such file or directory
Target //cuttlefish/package:common failed to build
```
