### PR TITLE
Create a UniqueFd counterpart to SharedFD

### DIFF
--- a/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
@@ -55,7 +55,7 @@ cf_cc_library(
     }),
     deps = [
         "//cuttlefish/common/libs/fs:file_instance",
-        "//cuttlefish/common/libs/utils:environment",
+        "//cuttlefish/common/libs/fs:unique_fd",
         "//cuttlefish/posix:strerror",
         "//cuttlefish/result",
         "@abseil-cpp//absl/log",

--- a/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
@@ -88,3 +88,19 @@ cf_cc_library(
         "//cuttlefish/common/libs/fs",
     ],
 )
+
+cf_cc_library(
+    name = "unique_fd",
+    srcs = ["unique_fd.cc"],
+    hdrs = ["unique_fd.h"],
+    include_cleaner_enabled = False,
+    deps = [
+        "//cuttlefish/common/libs/fs:file_instance",
+        "//cuttlefish/common/libs/utils:environment",
+        "//cuttlefish/posix:strerror",
+        "//cuttlefish/result",
+        "@abseil-cpp//absl/log",
+        "@abseil-cpp//absl/log:check",
+        "@fmt",
+    ],
+)

--- a/base/cvd/cuttlefish/common/libs/fs/file_instance.cc
+++ b/base/cvd/cuttlefish/common/libs/fs/file_instance.cc
@@ -282,8 +282,8 @@ void FileInstance::Set(fd_set* dest, int* max_index) const {
   FD_SET(fd_, dest);
 }
 
-/* static */ std::shared_ptr<FileInstance> FileInstance::ClosedInstance() {
-  return std::shared_ptr<FileInstance>(new FileInstance(-1, EBADF));
+/* static */ std::unique_ptr<FileInstance> FileInstance::ClosedInstance() {
+  return std::unique_ptr<FileInstance>(new FileInstance(-1, EBADF));
 }
 
 int FileInstance::Bind(const struct sockaddr* addr, socklen_t addrlen) {

--- a/base/cvd/cuttlefish/common/libs/fs/file_instance.h
+++ b/base/cvd/cuttlefish/common/libs/fs/file_instance.h
@@ -88,13 +88,14 @@ namespace cuttlefish {
 class FileInstance : public ReaderSeeker {
   // Give SharedFD access to the aliasing constructor.
   friend class SharedFD;
+  friend class UniqueFd;
   friend class Epoll;
 
  public:
   virtual ~FileInstance() { Close(); }
 
   // This can't be a singleton because our shared_ptr's aren't thread safe.
-  static std::shared_ptr<FileInstance> ClosedInstance();
+  static std::unique_ptr<FileInstance> ClosedInstance();
 
   int Bind(const struct sockaddr* addr, socklen_t addrlen);
   int Connect(const struct sockaddr* addr, socklen_t addrlen);

--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd.cpp
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd.cpp
@@ -42,7 +42,7 @@
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_select.h"
-#include "cuttlefish/common/libs/utils/known_paths.h"
+#include "cuttlefish/common/libs/fs/unique_fd.h"
 #include "cuttlefish/posix/strerror.h"
 #include "cuttlefish/result/result.h"
 
@@ -87,15 +87,6 @@ void CheckMarked(fd_set* in_out_mask, SharedFDSet* in_out_set) {
   }
 }
 
-int memfd_create_wrapper(const char* name, unsigned int flags) {
-#ifdef __linux__
-  return memfd_create(name, flags);
-#else
-  (void)flags;
-  return shm_open(name, O_RDWR);
-#endif
-}
-
 }  // namespace
 
 int Select(SharedFDSet* read_set, SharedFDSet* write_set,
@@ -131,9 +122,16 @@ SharedFD::SharedFD(SharedFD&& other) {
   other.value_.reset(new FileInstance(-1, EBADF));
 }
 
+SharedFD::SharedFD(UniqueFd other) { value_ = std::move(other.value_); }
+
 SharedFD& SharedFD::operator=(SharedFD&& other) {
   value_ = std::move(other.value_);
   other.value_.reset(new FileInstance(-1, EBADF));
+  return *this;
+}
+
+SharedFD& SharedFD::operator=(UniqueFd other) {
+  value_ = std::move(other.value_);
   return *this;
 }
 
@@ -155,48 +153,16 @@ int SharedFD::Poll(PollSharedFd* fds, size_t num_fds, int timeout) {
   return ret;
 }
 
-static void MakeAddress(const char* name, bool abstract,
-                        struct sockaddr_un* dest, socklen_t* len) {
-  memset(dest, 0, sizeof(*dest));
-  dest->sun_family = AF_UNIX;
-  // sun_path is NOT expected to be nul-terminated.
-  // See man 7 unix.
-  size_t namelen;
-  if (abstract) {
-    // ANDROID_SOCKET_NAMESPACE_ABSTRACT
-    namelen = strlen(name);
-    CHECK_LE(namelen, sizeof(dest->sun_path) - 1)
-        << "MakeAddress failed. Name=" << name << " is longer than allowed.";
-    dest->sun_path[0] = 0;
-    memcpy(dest->sun_path + 1, name, namelen);
-  } else {
-    // ANDROID_SOCKET_NAMESPACE_RESERVED
-    // ANDROID_SOCKET_NAMESPACE_FILESYSTEM
-    // TODO(pinghao): Distinguish between them?
-    namelen = strlen(name);
-    CHECK_LE(namelen, sizeof(dest->sun_path))
-        << "MakeAddress failed. Name=" << name << " is longer than allowed.";
-    strncpy(dest->sun_path, name, strlen(name));
-  }
-  *len = namelen + offsetof(struct sockaddr_un, sun_path) + 1;
-}
-
 SharedFD SharedFD::Accept(const FileInstance& listener, struct sockaddr* addr,
                           socklen_t* addrlen) {
-  return SharedFD(
-      std::shared_ptr<FileInstance>(listener.Accept(addr, addrlen)));
+  return UniqueFd::Accept(listener, addr, addrlen);
 }
 
 SharedFD SharedFD::Accept(const FileInstance& listener) {
-  return SharedFD::Accept(listener, NULL, NULL);
+  return UniqueFd::Accept(listener);
 }
 
-SharedFD SharedFD::Dup(int unmanaged_fd) {
-  int fd = fcntl(unmanaged_fd, F_DUPFD_CLOEXEC, 3);
-  int error_num = errno;
-  return SharedFD(
-      std::shared_ptr<FileInstance>(new FileInstance(fd, error_num)));
-}
+SharedFD SharedFD::Dup(int unmanaged_fd) { return UniqueFd::Dup(unmanaged_fd); }
 
 bool SharedFD::Pipe(SharedFD* fd0, SharedFD* fd1) {
   int fds[2];
@@ -215,22 +181,16 @@ bool SharedFD::Pipe(SharedFD* fd0, SharedFD* fd1) {
 
 #ifdef __linux__
 SharedFD SharedFD::Event(int initval, int flags) {
-  int fd = eventfd(initval, flags);
-  return std::shared_ptr<FileInstance>(new FileInstance(fd, errno));
+  return UniqueFd::Event(initval, flags);
 }
 
 SharedFD SharedFD::ShmOpen(const std::string& name, int oflag, int mode) {
-  errno = 0;
-  int fd = shm_open(name.c_str(), oflag, mode);
-  int error_num = errno;
-  return std::shared_ptr<FileInstance>(new FileInstance(fd, error_num));
+  return UniqueFd::ShmOpen(name, oflag, mode);
 }
 #endif
 
 SharedFD SharedFD::MemfdCreate(const std::string& name, unsigned int flags) {
-  int fd = memfd_create_wrapper(name.c_str(), flags);
-  int error_num = errno;
-  return std::shared_ptr<FileInstance>(new FileInstance(fd, error_num));
+  return UniqueFd::MemfdCreate(name, flags);
 }
 
 SharedFD SharedFD::MemfdCreateWithData(const std::string& name,
@@ -271,26 +231,17 @@ Result<std::pair<SharedFD, SharedFD>> SharedFD::SocketPair(int domain, int type,
 }
 
 SharedFD SharedFD::Open(const std::string& path, int flags, mode_t mode) {
-  return Open(path.c_str(), flags, mode);
+  return UniqueFd::Open(path, flags, mode);
 }
 
 SharedFD SharedFD::Open(const char* path, int flags, mode_t mode) {
-  int fd = TEMP_FAILURE_RETRY(open(path, flags, mode));
-  if (fd == -1) {
-    return SharedFD(std::shared_ptr<FileInstance>(new FileInstance(fd, errno)));
-  } else {
-    return SharedFD(std::shared_ptr<FileInstance>(new FileInstance(fd, 0)));
-  }
+  return UniqueFd::Open(path, flags, mode);
 }
 
-SharedFD SharedFD::InotifyFd(void) {
-  errno = 0;
-  int fd = TEMP_FAILURE_RETRY(inotify_init1(IN_CLOEXEC));
-  return SharedFD(std::shared_ptr<FileInstance>(new FileInstance(fd, errno)));
-}
+SharedFD SharedFD::InotifyFd(void) { return UniqueFd::InotifyFd(); }
 
 SharedFD SharedFD::Creat(const std::string& path, mode_t mode) {
-  return SharedFD::Open(path, O_CREAT | O_WRONLY | O_TRUNC, mode);
+  return UniqueFd::Creat(path, mode);
 }
 
 int SharedFD::Fchdir(SharedFD shared_fd) {
@@ -303,36 +254,15 @@ int SharedFD::Fchdir(SharedFD shared_fd) {
 }
 
 Result<SharedFD> SharedFD::Fifo(const std::string& path, mode_t mode) {
-  struct stat st{};
-  if (TEMP_FAILURE_RETRY(stat(path.c_str(), &st)) == 0) {
-    CF_EXPECTF(TEMP_FAILURE_RETRY(remove(path.c_str())) == 0,
-               "Failed to delete old file at '{}': '{}'", path,
-               ::cuttlefish::StrError(errno));
-  }
-
-  CF_EXPECTF(TEMP_FAILURE_RETRY(mkfifo(path.c_str(), mode)) == 0,
-             "Failed to mkfifo('{}', {:o})", path, mode);
-  auto ret = Open(path, O_RDWR);
-  CF_EXPECTF(ret->IsOpen(), "Failed to open '{}': '{}'", path, ret->StrError());
-  return ret;
+  return CF_EXPECT(UniqueFd::Fifo(path, mode));
 }
 
 SharedFD SharedFD::Socket(int domain, int socket_type, int protocol) {
-  int fd = TEMP_FAILURE_RETRY(socket(domain, socket_type, protocol));
-  if (fd == -1) {
-    return SharedFD(std::shared_ptr<FileInstance>(new FileInstance(fd, errno)));
-  } else {
-    return SharedFD(std::shared_ptr<FileInstance>(new FileInstance(fd, 0)));
-  }
+  return UniqueFd::Socket(domain, socket_type, protocol);
 }
 
 SharedFD SharedFD::Mkstemp(std::string* path) {
-  int fd = mkstemp(path->data());
-  if (fd == -1) {
-    return SharedFD(std::shared_ptr<FileInstance>(new FileInstance(fd, errno)));
-  } else {
-    return SharedFD(std::shared_ptr<FileInstance>(new FileInstance(fd, 0)));
-  }
+  return UniqueFd::Mkstemp(path);
 }
 
 Result<std::pair<SharedFD, std::string>> SharedFD::Mkostemp(
@@ -348,213 +278,47 @@ Result<std::pair<SharedFD, std::string>> SharedFD::Mkostemp(
                                                std::move(temp_path));
 }
 
-SharedFD SharedFD::ErrorFD(int error) {
-  return SharedFD(std::shared_ptr<FileInstance>(new FileInstance(-1, error)));
-}
+SharedFD SharedFD::ErrorFD(int error) { return UniqueFd::ErrorFD(error); }
 
 SharedFD SharedFD::SocketLocalClient(const std::string& name, bool abstract,
                                      int in_type) {
-  return SocketLocalClient(name, abstract, in_type, 0);
+  return UniqueFd::SocketLocalClient(name, abstract, in_type);
 }
 
 SharedFD SharedFD::SocketLocalClient(const std::string& name, bool abstract,
                                      int in_type, int timeout_seconds) {
-  struct sockaddr_un addr;
-  socklen_t addrlen;
-  MakeAddress(name.c_str(), abstract, &addr, &addrlen);
-  SharedFD rval = SharedFD::Socket(PF_UNIX, in_type, 0);
-  if (!rval->IsOpen()) {
-    return rval;
-  }
-  struct timeval timeout = {timeout_seconds, 0};
-  auto casted_addr = reinterpret_cast<sockaddr*>(&addr);
-  if (rval->ConnectWithTimeout(casted_addr, addrlen, &timeout) == -1) {
-    return SharedFD::ErrorFD(rval->GetErrno());
-  }
-  return rval;
+  return UniqueFd::SocketLocalClient(name, abstract, in_type, timeout_seconds);
 }
 
 SharedFD SharedFD::SocketLocalClient(int port, int type) {
-  sockaddr_in addr{};
-  addr.sin_family = AF_INET;
-  addr.sin_port = htons(port);
-  addr.sin_addr.s_addr = htonl(INADDR_ANY);
-  auto rval = SharedFD::Socket(AF_INET, type, 0);
-  if (!rval->IsOpen()) {
-    return rval;
-  }
-  if (rval->Connect(reinterpret_cast<const sockaddr*>(&addr), sizeof addr) <
-      0) {
-    return SharedFD::ErrorFD(rval->GetErrno());
-  }
-  return rval;
+  return UniqueFd::SocketLocalClient(port, type);
 }
 
 SharedFD SharedFD::SocketClient(const std::string& host, int port, int type,
                                 std::chrono::seconds timeout) {
-  sockaddr_in addr{};
-  addr.sin_family = AF_INET;
-  addr.sin_port = htons(port);
-  addr.sin_addr.s_addr = inet_addr(host.c_str());
-  auto rval = SharedFD::Socket(AF_INET, type, 0);
-  if (!rval->IsOpen()) {
-    return rval;
-  }
-  struct timeval timeout_timeval = {static_cast<time_t>(timeout.count()), 0};
-  if (rval->ConnectWithTimeout(reinterpret_cast<const sockaddr*>(&addr),
-                               sizeof addr, &timeout_timeval) < 0) {
-    return SharedFD::ErrorFD(rval->GetErrno());
-  }
-  return rval;
+  return UniqueFd::SocketClient(host, port, type, timeout);
 }
 
 SharedFD SharedFD::Socket6Client(const std::string& host,
                                  const std::string& interface, int port,
                                  int type, std::chrono::seconds timeout) {
-  sockaddr_in6 addr{};
-  addr.sin6_family = AF_INET6;
-  addr.sin6_port = htons(port);
-  inet_pton(AF_INET6, host.c_str(), &addr.sin6_addr);
-  auto rval = SharedFD::Socket(AF_INET6, type, 0);
-  if (!rval->IsOpen()) {
-    return rval;
-  }
-
-  if (!interface.empty()) {
-#ifdef __linux__
-    ifreq ifr{};
-    snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", interface.c_str());
-
-    if (rval->SetSockOpt(SOL_SOCKET, SO_BINDTODEVICE, &ifr, sizeof(ifr)) ==
-        -1) {
-      return SharedFD::ErrorFD(rval->GetErrno());
-    }
-#elif defined(__APPLE__)
-    int idx = if_nametoindex(interface.c_str());
-    if (rval->SetSockOpt(IPPROTO_IP, IP_BOUND_IF, &idx, sizeof(idx)) == -1) {
-      return SharedFD::ErrorFD(rval->GetErrno());
-    }
-#else
-#error "Unsupported operating system"
-#endif
-  }
-
-  struct timeval timeout_timeval = {static_cast<time_t>(timeout.count()), 0};
-  if (rval->ConnectWithTimeout(reinterpret_cast<const sockaddr*>(&addr),
-                               sizeof addr, &timeout_timeval) < 0) {
-    return SharedFD::ErrorFD(rval->GetErrno());
-  }
-  return rval;
+  return UniqueFd::Socket6Client(host, interface, port, type, timeout);
 }
 
 SharedFD SharedFD::SocketLocalServer(int port, int type) {
-  struct sockaddr_in addr;
-  memset(&addr, 0, sizeof(addr));
-  addr.sin_family = AF_INET;
-  addr.sin_port = htons(port);
-  addr.sin_addr.s_addr = htonl(INADDR_ANY);
-  SharedFD rval = SharedFD::Socket(AF_INET, type, 0);
-  if (!rval->IsOpen()) {
-    return rval;
-  }
-  int n = 1;
-  if (rval->SetSockOpt(SOL_SOCKET, SO_REUSEADDR, &n, sizeof(n)) == -1) {
-    LOG(ERROR) << "SetSockOpt failed " << rval->StrError();
-    return SharedFD::ErrorFD(rval->GetErrno());
-  }
-  if (rval->Bind(reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
-    LOG(ERROR) << "Bind failed " << rval->StrError();
-    return SharedFD::ErrorFD(rval->GetErrno());
-  }
-  if (type == SOCK_STREAM || type == SOCK_SEQPACKET) {
-    if (rval->Listen(4) < 0) {
-      LOG(ERROR) << "Listen failed " << rval->StrError();
-      return SharedFD::ErrorFD(rval->GetErrno());
-    }
-  }
-  return rval;
+  return UniqueFd::SocketLocalServer(port, type);
 }
 
 SharedFD SharedFD::SocketLocalServer(const std::string& name, bool abstract,
                                      int in_type, mode_t mode) {
-  // DO NOT UNLINK addr.sun_path. It does NOT have to be null-terminated.
-  // See man 7 unix for more details.
-  if (!abstract) {
-    (void)unlink(name.c_str());
-  }
-
-  struct sockaddr_un addr;
-  socklen_t addrlen;
-  MakeAddress(name.c_str(), abstract, &addr, &addrlen);
-  SharedFD rval = SharedFD::Socket(PF_UNIX, in_type, 0);
-  if (!rval->IsOpen()) {
-    return rval;
-  }
-
-  int n = 1;
-  if (rval->SetSockOpt(SOL_SOCKET, SO_REUSEADDR, &n, sizeof(n)) == -1) {
-    LOG(ERROR) << "SetSockOpt failed " << rval->StrError();
-    return SharedFD::ErrorFD(rval->GetErrno());
-  }
-  if (rval->Bind(reinterpret_cast<sockaddr*>(&addr), addrlen) == -1) {
-    LOG(ERROR) << "Bind failed; name=" << name << ": " << rval->StrError();
-    return SharedFD::ErrorFD(rval->GetErrno());
-  }
-
-  /* Only the bottom bits are really the socket type; there are flags too. */
-  constexpr int SOCK_TYPE_MASK = 0xf;
-  auto socket_type = in_type & SOCK_TYPE_MASK;
-
-  // Connection oriented sockets: start listening.
-  if (socket_type == SOCK_STREAM || socket_type == SOCK_SEQPACKET) {
-    // Follows the default from socket_local_server
-    if (rval->Listen(1) == -1) {
-      LOG(ERROR) << "Listen failed: " << rval->StrError();
-      return SharedFD::ErrorFD(rval->GetErrno());
-    }
-  }
-
-  if (!abstract) {
-    if (TEMP_FAILURE_RETRY(chmod(name.c_str(), mode)) == -1) {
-      LOG(ERROR) << "chmod failed: " << ::cuttlefish::StrError(errno);
-      // However, continue since we do have a listening socket
-    }
-  }
-  return rval;
+  return UniqueFd::SocketLocalServer(name, abstract, in_type, mode);
 }
 
 #ifdef __linux__
 SharedFD SharedFD::VsockServer(
     unsigned int port, int type,
     std::optional<int> vhost_user_vsock_listening_cid, unsigned int cid) {
-  if (vhost_user_vsock_listening_cid) {
-    return SharedFD::SocketLocalServer(
-        GetVhostUserVsockServerAddr(port, *vhost_user_vsock_listening_cid),
-        false /* abstract */, type, 0666 /* mode */);
-  }
-
-  auto vsock = SharedFD::Socket(AF_VSOCK, type, 0);
-  if (!vsock->IsOpen()) {
-    return vsock;
-  }
-  sockaddr_vm addr{};
-  addr.svm_family = AF_VSOCK;
-  addr.svm_port = port;
-  addr.svm_cid = cid;
-  auto casted_addr = reinterpret_cast<sockaddr*>(&addr);
-  if (vsock->Bind(casted_addr, sizeof(addr)) == -1) {
-    LOG(ERROR) << "Port " << port << " Bind failed (" << vsock->StrError()
-               << ")";
-    return SharedFD::ErrorFD(vsock->GetErrno());
-  }
-  if (type == SOCK_STREAM || type == SOCK_SEQPACKET) {
-    if (vsock->Listen(4) < 0) {
-      LOG(ERROR) << "Port" << port << " Listen failed (" << vsock->StrError()
-                 << ")";
-      return SharedFD::ErrorFD(vsock->GetErrno());
-    }
-  }
-  return vsock;
+  return UniqueFd::VsockServer(port, type, vhost_user_vsock_listening_cid, cid);
 }
 
 SharedFD SharedFD::VsockServer(
@@ -564,15 +328,12 @@ SharedFD SharedFD::VsockServer(
 
 std::string SharedFD::GetVhostUserVsockServerAddr(
     unsigned int port, int vhost_user_vsock_listening_cid) {
-  // TODO(b/277909042): better path than /tmp/vsock_{}/vm.vsock_{}
-  return fmt::format(
-      "{}_{}", GetVhostUserVsockClientAddr(vhost_user_vsock_listening_cid),
-      port);
+  return UniqueFd::GetVhostUserVsockServerAddr(port,
+                                               vhost_user_vsock_listening_cid);
 }
 
 std::string SharedFD::GetVhostUserVsockClientAddr(int cid) {
-  // TODO(b/277909042): better path than /tmp/vsock_{}/vm.vsock_{}
-  return fmt::format("{}/vsock_{}_{}/vm.vsock", TempDir(), cid, getuid());
+  return UniqueFd::GetVhostUserVsockClientAddr(cid);
 }
 
 SharedFD SharedFD::VsockClient(unsigned int cid, unsigned int port, int type,

--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd.h
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd.h
@@ -49,6 +49,7 @@
 #include <vector>
 
 #include "cuttlefish/common/libs/fs/file_instance.h"
+#include "cuttlefish/common/libs/fs/unique_fd.h"
 #include "cuttlefish/result/result.h"
 
 /**
@@ -130,8 +131,10 @@ class SharedFD {
   SharedFD(const std::shared_ptr<FileInstance>& in) : value_(in) {}
   SharedFD(SharedFD const&) = default;
   SharedFD(SharedFD&& other);
+  SharedFD(UniqueFd other);
   SharedFD& operator=(SharedFD const&) = default;
   SharedFD& operator=(SharedFD&& other);
+  SharedFD& operator=(UniqueFd other);
   // Reference the listener as a FileInstance to make this FD type agnostic.
   static SharedFD Accept(const FileInstance& listener, struct sockaddr* addr,
                          socklen_t* addrlen);

--- a/base/cvd/cuttlefish/common/libs/fs/unique_fd.cc
+++ b/base/cvd/cuttlefish/common/libs/fs/unique_fd.cc
@@ -1,0 +1,496 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "cuttlefish/common/libs/fs/unique_fd.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <sys/file.h>
+#include <sys/mman.h>
+#include <sys/sendfile.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "absl/log/check.h"
+#include "absl/log/log.h"
+#include "fmt/format.h"
+
+#include "cuttlefish/common/libs/utils/known_paths.h"
+#include "cuttlefish/posix/strerror.h"
+#include "cuttlefish/result/result.h"
+
+// #define ENABLE_GCE_SHARED_FD_LOGGING 1
+
+namespace cuttlefish {
+
+namespace {
+
+class LocalErrno {
+ public:
+  LocalErrno(int& local_errno) : local_errno_(local_errno), preserved_(errno) {
+    errno = 0;
+  }
+  ~LocalErrno() {
+    local_errno_ = errno;
+    errno = preserved_;
+  }
+
+ private:
+  int& local_errno_;
+  int preserved_;
+};
+
+int memfd_create_wrapper(const char* name, unsigned int flags) {
+#ifdef __linux__
+  return memfd_create(name, flags);
+#else
+  (void)flags;
+  return shm_open(name, O_RDWR);
+#endif
+}
+
+}  // namespace
+
+UniqueFd::UniqueFd(UniqueFd&& other) {
+  value_ = std::move(other.value_);
+  other.value_.reset(new FileInstance(-1, EBADF));
+}
+
+UniqueFd& UniqueFd::operator=(UniqueFd&& other) {
+  value_ = std::move(other.value_);
+  other.value_.reset(new FileInstance(-1, EBADF));
+  return *this;
+}
+
+static void MakeAddress(const char* name, bool abstract,
+                        struct sockaddr_un* dest, socklen_t* len) {
+  memset(dest, 0, sizeof(*dest));
+  dest->sun_family = AF_UNIX;
+  // sun_path is NOT expected to be nul-terminated.
+  // See man 7 unix.
+  size_t namelen;
+  if (abstract) {
+    // ANDROID_SOCKET_NAMESPACE_ABSTRACT
+    namelen = strlen(name);
+    CHECK_LE(namelen, sizeof(dest->sun_path) - 1)
+        << "MakeAddress failed. Name=" << name << " is longer than allowed.";
+    dest->sun_path[0] = 0;
+    memcpy(dest->sun_path + 1, name, namelen);
+  } else {
+    // ANDROID_SOCKET_NAMESPACE_RESERVED
+    // ANDROID_SOCKET_NAMESPACE_FILESYSTEM
+    // TODO(pinghao): Distinguish between them?
+    namelen = strlen(name);
+    CHECK_LE(namelen, sizeof(dest->sun_path))
+        << "MakeAddress failed. Name=" << name << " is longer than allowed.";
+    strncpy(dest->sun_path, name, strlen(name));
+  }
+  *len = namelen + offsetof(struct sockaddr_un, sun_path) + 1;
+}
+
+UniqueFd UniqueFd::Accept(const FileInstance& listener, struct sockaddr* addr,
+                          socklen_t* addrlen) {
+  return UniqueFd(
+      std::unique_ptr<FileInstance>(listener.Accept(addr, addrlen)));
+}
+
+UniqueFd UniqueFd::Accept(const FileInstance& listener) {
+  return UniqueFd::Accept(listener, NULL, NULL);
+}
+
+UniqueFd UniqueFd::Dup(int unmanaged_fd) {
+  int fd = fcntl(unmanaged_fd, F_DUPFD_CLOEXEC, 3);
+  int error_num = errno;
+  return UniqueFd(
+      std::unique_ptr<FileInstance>(new FileInstance(fd, error_num)));
+}
+
+bool UniqueFd::Pipe(UniqueFd* fd0, UniqueFd* fd1) {
+  int fds[2];
+#ifdef __linux__
+  int rval = pipe2(fds, O_CLOEXEC);
+#else
+  int rval = pipe(fds);
+#endif
+  if (rval != -1) {
+    (*fd0) = std::unique_ptr<FileInstance>(new FileInstance(fds[0], errno));
+    (*fd1) = std::unique_ptr<FileInstance>(new FileInstance(fds[1], errno));
+    return true;
+  }
+  return false;
+}
+
+#ifdef __linux__
+UniqueFd UniqueFd::Event(int initval, int flags) {
+  int fd = eventfd(initval, flags);
+  return std::unique_ptr<FileInstance>(new FileInstance(fd, errno));
+}
+
+UniqueFd UniqueFd::ShmOpen(const std::string& name, int oflag, int mode) {
+  errno = 0;
+  int fd = shm_open(name.c_str(), oflag, mode);
+  int error_num = errno;
+  return std::unique_ptr<FileInstance>(new FileInstance(fd, error_num));
+}
+#endif
+
+UniqueFd UniqueFd::MemfdCreate(const std::string& name, unsigned int flags) {
+  int fd = memfd_create_wrapper(name.c_str(), flags);
+  int error_num = errno;
+  return std::unique_ptr<FileInstance>(new FileInstance(fd, error_num));
+}
+
+bool UniqueFd::SocketPair(int domain, int type, int protocol, UniqueFd* fd0,
+                          UniqueFd* fd1) {
+  int fds[2];
+  int rval = socketpair(domain, type, protocol, fds);
+  if (rval != -1) {
+    (*fd0) = std::unique_ptr<FileInstance>(new FileInstance(fds[0], errno));
+    (*fd1) = std::unique_ptr<FileInstance>(new FileInstance(fds[1], errno));
+    return true;
+  }
+  return false;
+}
+
+Result<std::pair<UniqueFd, UniqueFd>> UniqueFd::SocketPair(int domain, int type,
+                                                           int protocol) {
+  UniqueFd a, b;
+  if (!UniqueFd::SocketPair(domain, type, protocol, &a, &b)) {
+    return CF_ERR("socketpair failed: " << ::cuttlefish::StrError(errno));
+  }
+  return std::make_pair(std::move(a), std::move(b));
+}
+
+UniqueFd UniqueFd::Open(const std::string& path, int flags, mode_t mode) {
+  return Open(path.c_str(), flags, mode);
+}
+
+UniqueFd UniqueFd::Open(const char* path, int flags, mode_t mode) {
+  int fd = TEMP_FAILURE_RETRY(open(path, flags, mode));
+  if (fd == -1) {
+    return UniqueFd(std::unique_ptr<FileInstance>(new FileInstance(fd, errno)));
+  } else {
+    return UniqueFd(std::unique_ptr<FileInstance>(new FileInstance(fd, 0)));
+  }
+}
+
+UniqueFd UniqueFd::InotifyFd(void) {
+  errno = 0;
+  int fd = TEMP_FAILURE_RETRY(inotify_init1(IN_CLOEXEC));
+  return UniqueFd(std::unique_ptr<FileInstance>(new FileInstance(fd, errno)));
+}
+
+UniqueFd UniqueFd::Creat(const std::string& path, mode_t mode) {
+  return UniqueFd::Open(path, O_CREAT | O_WRONLY | O_TRUNC, mode);
+}
+
+int UniqueFd::Fchdir(UniqueFd shared_fd) {
+  if (!shared_fd.value_) {
+    return -1;
+  }
+  LocalErrno record_errno(shared_fd->errno_);
+
+  return TEMP_FAILURE_RETRY(fchdir(shared_fd->fd_));
+}
+
+Result<UniqueFd> UniqueFd::Fifo(const std::string& path, mode_t mode) {
+  struct stat st{};
+  if (TEMP_FAILURE_RETRY(stat(path.c_str(), &st)) == 0) {
+    CF_EXPECTF(TEMP_FAILURE_RETRY(remove(path.c_str())) == 0,
+               "Failed to delete old file at '{}': '{}'", path,
+               ::cuttlefish::StrError(errno));
+  }
+
+  CF_EXPECTF(TEMP_FAILURE_RETRY(mkfifo(path.c_str(), mode)) == 0,
+             "Failed to mkfifo('{}', {:o})", path, mode);
+  auto ret = Open(path, O_RDWR);
+  CF_EXPECTF(ret->IsOpen(), "Failed to open '{}': '{}'", path, ret->StrError());
+  return ret;
+}
+
+UniqueFd UniqueFd::Socket(int domain, int socket_type, int protocol) {
+  int fd = TEMP_FAILURE_RETRY(socket(domain, socket_type, protocol));
+  if (fd == -1) {
+    return UniqueFd(std::unique_ptr<FileInstance>(new FileInstance(fd, errno)));
+  } else {
+    return UniqueFd(std::unique_ptr<FileInstance>(new FileInstance(fd, 0)));
+  }
+}
+
+UniqueFd UniqueFd::Mkstemp(std::string* path) {
+  int fd = mkstemp(path->data());
+  if (fd == -1) {
+    return UniqueFd(std::unique_ptr<FileInstance>(new FileInstance(fd, errno)));
+  } else {
+    return UniqueFd(std::unique_ptr<FileInstance>(new FileInstance(fd, 0)));
+  }
+}
+
+Result<std::pair<UniqueFd, std::string>> UniqueFd::Mkostemp(
+    const std::string_view path, const int flags) {
+  // mkostemp replaces the Xs with random selections to make a unique filename
+  auto temp_path = fmt::format("{}XXXXXX", path);
+  const int fd = mkostemp(temp_path.data(), flags);
+  CF_EXPECTF(fd != -1, "Error creating temporary file: {}",
+             ::cuttlefish::StrError(errno));
+  auto shared_fd =
+      UniqueFd(std::unique_ptr<FileInstance>(new FileInstance(fd, 0)));
+  return std::make_pair<UniqueFd, std::string>(std::move(shared_fd),
+                                               std::move(temp_path));
+}
+
+UniqueFd UniqueFd::ErrorFD(int error) {
+  return UniqueFd(std::unique_ptr<FileInstance>(new FileInstance(-1, error)));
+}
+
+UniqueFd UniqueFd::SocketLocalClient(const std::string& name, bool abstract,
+                                     int in_type) {
+  return SocketLocalClient(name, abstract, in_type, 0);
+}
+
+UniqueFd UniqueFd::SocketLocalClient(const std::string& name, bool abstract,
+                                     int in_type, int timeout_seconds) {
+  struct sockaddr_un addr;
+  socklen_t addrlen;
+  MakeAddress(name.c_str(), abstract, &addr, &addrlen);
+  UniqueFd rval = UniqueFd::Socket(PF_UNIX, in_type, 0);
+  if (!rval->IsOpen()) {
+    return rval;
+  }
+  struct timeval timeout = {timeout_seconds, 0};
+  auto casted_addr = reinterpret_cast<sockaddr*>(&addr);
+  if (rval->ConnectWithTimeout(casted_addr, addrlen, &timeout) == -1) {
+    return UniqueFd::ErrorFD(rval->GetErrno());
+  }
+  return rval;
+}
+
+UniqueFd UniqueFd::SocketLocalClient(int port, int type) {
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(port);
+  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  auto rval = UniqueFd::Socket(AF_INET, type, 0);
+  if (!rval->IsOpen()) {
+    return rval;
+  }
+  if (rval->Connect(reinterpret_cast<const sockaddr*>(&addr), sizeof addr) <
+      0) {
+    return UniqueFd::ErrorFD(rval->GetErrno());
+  }
+  return rval;
+}
+
+UniqueFd UniqueFd::SocketClient(const std::string& host, int port, int type,
+                                std::chrono::seconds timeout) {
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(port);
+  addr.sin_addr.s_addr = inet_addr(host.c_str());
+  auto rval = UniqueFd::Socket(AF_INET, type, 0);
+  if (!rval->IsOpen()) {
+    return rval;
+  }
+  struct timeval timeout_timeval = {static_cast<time_t>(timeout.count()), 0};
+  if (rval->ConnectWithTimeout(reinterpret_cast<const sockaddr*>(&addr),
+                               sizeof addr, &timeout_timeval) < 0) {
+    return UniqueFd::ErrorFD(rval->GetErrno());
+  }
+  return rval;
+}
+
+UniqueFd UniqueFd::Socket6Client(const std::string& host,
+                                 const std::string& interface, int port,
+                                 int type, std::chrono::seconds timeout) {
+  sockaddr_in6 addr{};
+  addr.sin6_family = AF_INET6;
+  addr.sin6_port = htons(port);
+  inet_pton(AF_INET6, host.c_str(), &addr.sin6_addr);
+  auto rval = UniqueFd::Socket(AF_INET6, type, 0);
+  if (!rval->IsOpen()) {
+    return rval;
+  }
+
+  if (!interface.empty()) {
+#ifdef __linux__
+    ifreq ifr{};
+    snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", interface.c_str());
+
+    if (rval->SetSockOpt(SOL_SOCKET, SO_BINDTODEVICE, &ifr, sizeof(ifr)) ==
+        -1) {
+      return UniqueFd::ErrorFD(rval->GetErrno());
+    }
+#elif defined(__APPLE__)
+    int idx = if_nametoindex(interface.c_str());
+    if (rval->SetSockOpt(IPPROTO_IP, IP_BOUND_IF, &idx, sizeof(idx)) == -1) {
+      return UniqueFd::ErrorFD(rval->GetErrno());
+    }
+#else
+#error "Unsupported operating system"
+#endif
+  }
+
+  struct timeval timeout_timeval = {static_cast<time_t>(timeout.count()), 0};
+  if (rval->ConnectWithTimeout(reinterpret_cast<const sockaddr*>(&addr),
+                               sizeof addr, &timeout_timeval) < 0) {
+    return UniqueFd::ErrorFD(rval->GetErrno());
+  }
+  return rval;
+}
+
+UniqueFd UniqueFd::SocketLocalServer(int port, int type) {
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(port);
+  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  UniqueFd rval = UniqueFd::Socket(AF_INET, type, 0);
+  if (!rval->IsOpen()) {
+    return rval;
+  }
+  int n = 1;
+  if (rval->SetSockOpt(SOL_SOCKET, SO_REUSEADDR, &n, sizeof(n)) == -1) {
+    LOG(ERROR) << "SetSockOpt failed " << rval->StrError();
+    return UniqueFd::ErrorFD(rval->GetErrno());
+  }
+  if (rval->Bind(reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+    LOG(ERROR) << "Bind failed " << rval->StrError();
+    return UniqueFd::ErrorFD(rval->GetErrno());
+  }
+  if (type == SOCK_STREAM || type == SOCK_SEQPACKET) {
+    if (rval->Listen(4) < 0) {
+      LOG(ERROR) << "Listen failed " << rval->StrError();
+      return UniqueFd::ErrorFD(rval->GetErrno());
+    }
+  }
+  return rval;
+}
+
+UniqueFd UniqueFd::SocketLocalServer(const std::string& name, bool abstract,
+                                     int in_type, mode_t mode) {
+  // DO NOT UNLINK addr.sun_path. It does NOT have to be null-terminated.
+  // See man 7 unix for more details.
+  if (!abstract) {
+    (void)unlink(name.c_str());
+  }
+
+  struct sockaddr_un addr;
+  socklen_t addrlen;
+  MakeAddress(name.c_str(), abstract, &addr, &addrlen);
+  UniqueFd rval = UniqueFd::Socket(PF_UNIX, in_type, 0);
+  if (!rval->IsOpen()) {
+    return rval;
+  }
+
+  int n = 1;
+  if (rval->SetSockOpt(SOL_SOCKET, SO_REUSEADDR, &n, sizeof(n)) == -1) {
+    LOG(ERROR) << "SetSockOpt failed " << rval->StrError();
+    return UniqueFd::ErrorFD(rval->GetErrno());
+  }
+  if (rval->Bind(reinterpret_cast<sockaddr*>(&addr), addrlen) == -1) {
+    LOG(ERROR) << "Bind failed; name=" << name << ": " << rval->StrError();
+    return UniqueFd::ErrorFD(rval->GetErrno());
+  }
+
+  /* Only the bottom bits are really the socket type; there are flags too. */
+  constexpr int SOCK_TYPE_MASK = 0xf;
+  auto socket_type = in_type & SOCK_TYPE_MASK;
+
+  // Connection oriented sockets: start listening.
+  if (socket_type == SOCK_STREAM || socket_type == SOCK_SEQPACKET) {
+    // Follows the default from socket_local_server
+    if (rval->Listen(1) == -1) {
+      LOG(ERROR) << "Listen failed: " << rval->StrError();
+      return UniqueFd::ErrorFD(rval->GetErrno());
+    }
+  }
+
+  if (!abstract) {
+    if (TEMP_FAILURE_RETRY(chmod(name.c_str(), mode)) == -1) {
+      LOG(ERROR) << "chmod failed: " << ::cuttlefish::StrError(errno);
+      // However, continue since we do have a listening socket
+    }
+  }
+  return rval;
+}
+
+#ifdef __linux__
+UniqueFd UniqueFd::VsockServer(
+    unsigned int port, int type,
+    std::optional<int> vhost_user_vsock_listening_cid, unsigned int cid) {
+  if (vhost_user_vsock_listening_cid) {
+    return UniqueFd::SocketLocalServer(
+        GetVhostUserVsockServerAddr(port, *vhost_user_vsock_listening_cid),
+        false /* abstract */, type, 0666 /* mode */);
+  }
+
+  auto vsock = UniqueFd::Socket(AF_VSOCK, type, 0);
+  if (!vsock->IsOpen()) {
+    return vsock;
+  }
+  sockaddr_vm addr{};
+  addr.svm_family = AF_VSOCK;
+  addr.svm_port = port;
+  addr.svm_cid = cid;
+  auto casted_addr = reinterpret_cast<sockaddr*>(&addr);
+  if (vsock->Bind(casted_addr, sizeof(addr)) == -1) {
+    LOG(ERROR) << "Port " << port << " Bind failed (" << vsock->StrError()
+               << ")";
+    return UniqueFd::ErrorFD(vsock->GetErrno());
+  }
+  if (type == SOCK_STREAM || type == SOCK_SEQPACKET) {
+    if (vsock->Listen(4) < 0) {
+      LOG(ERROR) << "Port" << port << " Listen failed (" << vsock->StrError()
+                 << ")";
+      return UniqueFd::ErrorFD(vsock->GetErrno());
+    }
+  }
+  return vsock;
+}
+
+UniqueFd UniqueFd::VsockServer(
+    int type, std::optional<int> vhost_user_vsock_listening_cid) {
+  return VsockServer(VMADDR_PORT_ANY, type, vhost_user_vsock_listening_cid);
+}
+
+std::string UniqueFd::GetVhostUserVsockServerAddr(
+    unsigned int port, int vhost_user_vsock_listening_cid) {
+  // TODO(b/277909042): better path than /tmp/vsock_{}/vm.vsock_{}
+  return fmt::format(
+      "{}_{}", GetVhostUserVsockClientAddr(vhost_user_vsock_listening_cid),
+      port);
+}
+
+std::string UniqueFd::GetVhostUserVsockClientAddr(int cid) {
+  // TODO(b/277909042): better path than /tmp/vsock_{}/vm.vsock_{}
+  return fmt::format("{}/vsock_{}_{}/vm.vsock", TempDir(), cid, getuid());
+}
+
+#endif
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/fs/unique_fd.h
+++ b/base/cvd/cuttlefish/common/libs/fs/unique_fd.h
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CUTTLEFISH_COMMON_COMMON_LIBS_FS_UNIQUE_FD_H_
+#define CUTTLEFISH_COMMON_COMMON_LIBS_FS_UNIQUE_FD_H_
+
+#include <fcntl.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/inotify.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <sys/un.h>
+#include <termios.h>
+#include <unistd.h>
+
+// Must be below sys/socket.h to support older libc
+#ifdef __linux__
+#include <linux/vm_sockets.h>
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
+#endif
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "cuttlefish/common/libs/fs/file_instance.h"
+#include "cuttlefish/result/result.h"
+
+/**
+ * Classes to to enable safe access to files.
+ * POSIX kernels have an unfortunate habit of recycling file descriptors.
+ * That can cause problems like http://b/26121457 in code that doesn't manage
+ * file lifetimes properly. These classes implement an alternate interface
+ * that has some advantages:
+ *
+ * o References to files are tightly controlled
+ * o Files are auto-closed if they go out of scope
+ * o Files are life-time aware. It is impossible to close the instance twice.
+ * o File descriptors are always initialized. By default the descriptor is
+ *   set to a closed instance.
+ *
+ * These classes are designed to mimic to POSIX interface as closely as
+ * possible. Specifically, they don't attempt to track the type of file
+ * descriptors and expose only the valid operations. This is by design, since
+ * it makes it easier to convert existing code to UniqueFds and avoids the
+ * possibility that new POSIX functionality will lead to large refactorings.
+ */
+namespace cuttlefish {
+
+struct PollSharedFd;
+class Epoll;
+class FileInstance;
+struct VhostUserVsockCid;
+struct VsockCid;
+
+/**
+ * Counted reference to a FileInstance.
+ *
+ * This is also the place where most new FileInstances are created. The creation
+ * methods correspond to the underlying POSIX calls.
+ *
+ * UniqueFds can be compared and stored in STL containers. The semantics are
+ * slightly different from POSIX file descriptors:
+ *
+ * o The value of the UniqueFd is the identity of its underlying FileInstance.
+ *
+ * o Each newly created UniqueFd has a unique, closed FileInstance:
+ *    UniqueFd a, b;
+ *    assert (a != b);
+ *    a = b;
+ *    assert(a == b);
+ *
+ * o FileInstances are never visibly recycled.
+ *
+ * o If the UniqueFd referring to a FileInstance goes out of scope the file is
+ *   closed and the FileInstance is recycled.
+ *
+ * Creation methods must ensure that no references to the new file descriptor
+ * escape. The underlying FileInstance should have the only reference to the
+ * file descriptor. Any method that needs to know the fd must be in either
+ * UniqueFd or FileInstance.
+ *
+ * UniqueFds always have an underlying FileInstance, so all of the method
+ * calls are safe in accordance with the null object pattern.
+ *
+ * Errors on system calls that create new FileInstances, such as Open, are
+ * reported with a new, closed FileInstance with the errno set.
+ */
+class UniqueFd {
+  // Give SharedFD access to the underlying unique_ptr.
+  friend class SharedFD;
+
+ public:
+  inline UniqueFd();
+  UniqueFd(std::unique_ptr<FileInstance> in) : value_(std::move(in)) {}
+  UniqueFd(UniqueFd&& other);
+  UniqueFd& operator=(UniqueFd&& other);
+  // Reference the listener as a FileInstance to make this FD type agnostic.
+  static UniqueFd Accept(const FileInstance& listener, struct sockaddr* addr,
+                         socklen_t* addrlen);
+  static UniqueFd Accept(const FileInstance& listener);
+  static UniqueFd Dup(int unmanaged_fd);
+  // All UniqueFds have the O_CLOEXEC flag after creation. To remove use the
+  // Fcntl or Dup functions.
+  static UniqueFd Open(const char* pathname, int flags, mode_t mode = 0);
+  static UniqueFd Open(const std::string& pathname, int flags, mode_t mode = 0);
+  static UniqueFd InotifyFd();
+  static UniqueFd Creat(const std::string& pathname, mode_t mode);
+  static int Fchdir(UniqueFd);
+  static Result<UniqueFd> Fifo(const std::string& pathname, mode_t mode);
+  static bool Pipe(UniqueFd* fd0, UniqueFd* fd1);
+#ifdef __linux__
+  static UniqueFd Event(int initval = 0, int flags = 0);
+  static UniqueFd ShmOpen(const std::string& name, int oflag, int mode);
+#endif
+  static UniqueFd MemfdCreate(const std::string& name, unsigned int flags = 0);
+  static UniqueFd Mkstemp(std::string* path);
+  static Result<std::pair<UniqueFd, std::string>> Mkostemp(
+      std::string_view path, int flags = O_CLOEXEC);
+  static int Poll(PollSharedFd* fds, size_t num_fds, int timeout);
+  static int Poll(std::vector<PollSharedFd>& fds, int timeout);
+  static bool SocketPair(int domain, int type, int protocol, UniqueFd* fd0,
+                         UniqueFd* fd1);
+  static Result<std::pair<UniqueFd, UniqueFd>> SocketPair(int domain, int type,
+                                                          int protocol);
+  static UniqueFd Socket(int domain, int socket_type, int protocol);
+  static UniqueFd SocketLocalClient(const std::string& name, bool is_abstract,
+                                    int in_type);
+  static UniqueFd SocketLocalClient(const std::string& name, bool is_abstract,
+                                    int in_type, int timeout_seconds);
+  static UniqueFd SocketLocalClient(int port, int type);
+  static UniqueFd SocketClient(
+      const std::string& host, int port, int type,
+      std::chrono::seconds timeout = std::chrono::seconds(0));
+  static UniqueFd Socket6Client(
+      const std::string& host, const std::string& interface, int port, int type,
+      std::chrono::seconds timeout = std::chrono::seconds(0));
+  static UniqueFd SocketLocalServer(const std::string& name, bool is_abstract,
+                                    int in_type, mode_t mode);
+  static UniqueFd SocketLocalServer(int port, int type);
+
+#ifdef __linux__
+  // For binding in vsock, svm_cid from `cid` param would be either
+  // VMADDR_CID_ANY, VMADDR_CID_LOCAL, VMADDR_CID_HOST or their own CID, and it
+  // is used for indicating connections which it accepts from.
+  //  * VMADDR_CID_ANY: accept from any
+  //  * VMADDR_CID_LOCAL: accept from local
+  //  * VMADDR_CID_HOST: accept from child vm
+  //  * their own CID: accept from parent vm
+  // With vhost-user-vsock, it is basically similar to VMADDR_CID_HOST, but for
+  // now it has limitations that it should bind to a specific socket file which
+  // is for a certain cid. So for vhost-user-vsock, we need to specify the
+  // expected client's cid. That's why vhost_user_vsock_listening_cid is
+  // necessary.
+  // TODO: combining them when vhost-user-vsock impl supports a kind of
+  // VMADDR_CID_HOST
+  static UniqueFd VsockServer(unsigned int port, int type,
+                              std::optional<int> vhost_user_vsock_listening_cid,
+                              unsigned int cid = VMADDR_CID_ANY);
+  static UniqueFd VsockServer(
+      int type, std::optional<int> vhost_user_vsock_listening_cid);
+  static std::string GetVhostUserVsockServerAddr(
+      unsigned int port, int vhost_user_vsock_listening_cid);
+  static std::string GetVhostUserVsockClientAddr(int cid);
+#endif
+
+  auto operator<=>(const UniqueFd&) const = default;
+
+  const std::unique_ptr<FileInstance>& operator->() const { return value_; }
+
+  const FileInstance& operator*() const { return *value_; }
+
+  FileInstance& operator*() { return *value_; }
+
+ private:
+  static UniqueFd ErrorFD(int error);
+
+  std::unique_ptr<FileInstance> value_;
+};
+
+UniqueFd::UniqueFd() : value_(FileInstance::ClosedInstance()) {}
+
+}  // namespace cuttlefish
+
+#endif  // CUTTLEFISH_COMMON_COMMON_LIBS_FS_UNIQUE_FD_H_


### PR DESCRIPTION
Sometimes the machinery of std::shared_ptr is not necessary, and the semantics of std::unique_ptr are simpler.

Bug: b/545278508