### PR TITLE
base: cvd: cuttlefish: Fix name resolution collision for Flag return type in FlagValue

### DIFF
--- a/base/cvd/cuttlefish/host/libs/web/cas/cas_flags.h
+++ b/base/cvd/cuttlefish/host/libs/web/cas/cas_flags.h
@@ -40,7 +40,9 @@ class FlagValue {
  private:
   friend struct CasDownloaderFlags;
 
-  Flag Flag(const std::string& name) { return GflagsCompatFlag(name, value_); }
+  cuttlefish::Flag Flag(const std::string& name) {
+    return GflagsCompatFlag(name, value_);
+  }
 
   std::optional<T> value_;
   T default_value_;


### PR DESCRIPTION
Qualify the return type `Flag` with `cuttlefish::Flag` in `FlagValue::Flag()` to prevent the compiler from interpreting the return type as the member function name itself during name lookup.