### PR TITLE
base: cvd: cuttlefish: add missing <string> header in FlagBase

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/flag_base.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags/flag_base.h
@@ -18,6 +18,7 @@
 
 #include <stddef.h>
 
+#include <string>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
FlagBase uses std::string for explicit template instantiation, but <string> is not explicitly included. Add <string> to prevent compilation errors when this header is included standalone in other translation units.