### PR TITLE
base: cvd: cuttlefish: Fix name resolution collision for Build return type in FetchBuildContext

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_context.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_context.cc
@@ -180,7 +180,7 @@ FetchBuildContext::FetchBuildContext(FetchContext& fetch_context,
       file_source_(file_source),
       trace_(trace) {}
 
-const Build& FetchBuildContext::Build() const { return build_; }
+const cuttlefish::Build& FetchBuildContext::Build() const { return build_; }
 
 std::string FetchBuildContext::GetBuildZipName(const std::string& name) const {
   std::string product =

--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_context.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_context.h
@@ -77,7 +77,7 @@ class FetchArtifact {
  */
 class FetchBuildContext {
  public:
-  const Build& Build() const;
+  const cuttlefish::Build& Build() const;
   std::string GetBuildZipName(const std::string&) const;
   // The specific filepath the user requested for a particular build. Ignored
   // for some builds.


### PR DESCRIPTION
Qualify the return type Build with cuttlefish::Build in FetchBuildContext::Build() to prevent the compiler from interpreting the return type as the member function name itself during name lookup.