### PR TITLE
baseimage: enable socket-activated SSH (ssh.socket)

### DIFF
--- a/tools/baseimage/pkg/gce/scripts/create_base_image_main.sh
+++ b/tools/baseimage/pkg/gce/scripts/create_base_image_main.sh
@@ -41,6 +41,11 @@ sudo chroot /mnt/image /usr/bin/apt upgrade -y
 # in /tmp by default.
 sudo chroot /mnt/image /usr/bin/systemctl mask tmp.mount
 
+# Enable socket-activated SSH so port 22 is available early during boot
+# without waiting for guest-agent and other multi-user services to finish.
+sudo chroot /mnt/image /usr/bin/systemctl disable ssh.service
+sudo chroot /mnt/image /usr/bin/systemctl enable ssh.socket
+
 # Avoid automatic updates during tests.
 # https://manpages.debian.org/trixie/unattended-upgrades/unattended-upgrade.8.en.html
 sudo chroot /mnt/image /usr/bin/apt purge -y unattended-upgrades


### PR DESCRIPTION
On Debian 13 (Trixie), OpenSSH uses ssh.service by default, which is ordered after google-guest-agent-manager.service and delays port 22 availability until ~33s into boot.

Switch to ssh.socket (socket activation) to bind port 22 early in sockets.target (~3s into boot), restoring immediate SSH readiness and matching Debian 12 behavior.

Bug: b/506998054
Assisted-By: Antigravity:Gemini-Next