### PR TITLE
FileInstance implements ReaderWriterSeeker

### DIFF
--- a/base/cvd/cuttlefish/common/libs/fs/file_instance.cc
+++ b/base/cvd/cuttlefish/common/libs/fs/file_instance.cc
@@ -122,12 +122,12 @@ bool FileInstance::CopyFrom(FileInstance& in, size_t length,
     do {
       // No need to use poll for writes: even if the source closes, the data
       // needs to be delivered to the other side.
-      auto res = Write(buffer.data(), *num_read);
-      if (res <= 0) {
+      Result<uint64_t> res = Write(buffer.data(), *num_read);
+      if (res.value_or(0) == 0) {
         // The caller will have to log an appropriate message.
         return false;
       }
-      written += res;
+      written += *res;
     } while (written < *num_read);
   }
   return true;
@@ -499,26 +499,36 @@ ScopedMMap FileInstance::MMap(void* addr, size_t length, int prot, int flags,
   return ScopedMMap(ptr, length);
 }
 
-ssize_t FileInstance::Truncate(off_t length) {
+Result<void> FileInstance::Truncate(uint64_t length) {
   LocalErrno record_errno(errno_);
 
-  return TEMP_FAILURE_RETRY(ftruncate(fd_, length));
+  ssize_t res = TEMP_FAILURE_RETRY(ftruncate(fd_, length));
+  CF_EXPECT_GE(res, 0, ::cuttlefish::StrError(errno));
+
+  return {};
 }
 
-ssize_t FileInstance::Write(const void* buf, size_t count) {
+Result<uint64_t> FileInstance::Write(const void* buf, size_t count) {
   if (count == 0 && !IsRegular()) {
     return 0;
   }
 
   LocalErrno record_errno(errno_);
 
-  return TEMP_FAILURE_RETRY(write(fd_, buf, count));
+  ssize_t res = TEMP_FAILURE_RETRY(write(fd_, buf, count));
+  CF_EXPECT_GE(res, 0);
+
+  return static_cast<uint64_t>(res);
 }
 
-ssize_t FileInstance::PWrite(const void* buf, size_t count, size_t offset) {
+Result<uint64_t> FileInstance::PWrite(const void* buf, size_t count,
+                                      size_t offset) {
   LocalErrno record_errno(errno_);
 
-  return TEMP_FAILURE_RETRY(pwrite(fd_, buf, count, offset));
+  ssize_t res = TEMP_FAILURE_RETRY(pwrite(fd_, buf, count, offset));
+  CF_EXPECT_GE(res, 0);
+
+  return static_cast<uint64_t>(res);
 }
 
 #ifdef __linux__

--- a/base/cvd/cuttlefish/common/libs/fs/file_instance.h
+++ b/base/cvd/cuttlefish/common/libs/fs/file_instance.h
@@ -85,7 +85,7 @@ namespace cuttlefish {
  * escaping file descriptors. At this point SharedFD is the only class
  * that has access. We may eventually have ScopedFD and WeakFD.
  */
-class FileInstance : public ReaderSeeker {
+class FileInstance : public ReaderWriterSeeker {
   // Give SharedFD access to the aliasing constructor.
   friend class SharedFD;
   friend class UniqueFd;
@@ -183,7 +183,7 @@ class FileInstance : public ReaderSeeker {
   int SetTerminalRaw();
   std::string StrError() const;
   ScopedMMap MMap(void* addr, size_t length, int prot, int flags, off_t offset);
-  ssize_t Truncate(off_t length);
+  Result<void> Truncate(uint64_t length) override;
   /*
    * If the file is a regular file and the count is 0, Write() may detect
    * error(s) by calling write(fd, buf, 0) declared in <unistd.h>. If detected,
@@ -192,8 +192,9 @@ class FileInstance : public ReaderSeeker {
    * will do nothing and just return 0.
    *
    */
-  ssize_t Write(const void* buf, size_t count);
-  ssize_t PWrite(const void* buf, size_t count, size_t offset);
+  Result<uint64_t> Write(const void* buf, uint64_t count) override;
+  Result<uint64_t> PWrite(const void* buf, uint64_t count,
+                          uint64_t offset) override;
 #ifdef __linux__
   int EventfdWrite(eventfd_t value);
 #endif

--- a/base/cvd/cuttlefish/common/libs/fs/shared_buf.cc
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_buf.cc
@@ -33,17 +33,17 @@ const size_t BUFF_SIZE = 1 << 14;
 
 ssize_t WriteAll(SharedFD fd, const char* buf, size_t size) {
   size_t total_written = 0;
-  ssize_t written = 0;
+  Result<uint64_t> write_res;
   do {
-    written = fd->Write((void*)&(buf[total_written]), size - total_written);
-    if (written <= 0) {
-      if (written < 0) {
-        errno = fd->GetErrno();
-        return written;
-      }
+    write_res = fd->Write((void*)&(buf[total_written]), size - total_written);
+    if (!write_res.has_value()) {
+      errno = fd->GetErrno();
+      return -1;
+    }
+    if (*write_res == 0) {
       return total_written;
     }
-    total_written += written;
+    total_written += *write_res;
   } while (total_written < size);
   return total_written;
 }

--- a/base/cvd/cuttlefish/files/copy.cc
+++ b/base/cvd/cuttlefish/files/copy.cc
@@ -44,7 +44,7 @@ bool Copy(const std::string& from, const std::string& to) {
                << "\": " << fd_from->StrError();
     return false;
   }
-  if (fd_to->Truncate(farthest_seek) < 0) {
+  if (!fd_to->Truncate(farthest_seek).has_value()) {
     LOG(ERROR) << "Failed to truncate " << to << ": " << fd_to->StrError();
   }
   off_t offset = 0;

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/generate_persistent_bootconfig.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/disk/generate_persistent_bootconfig.cpp
@@ -103,7 +103,7 @@ Result<std::optional<BootConfigPartition>> BootConfigPartition::CreateIfNeeded(
   VLOG(0) << "Bootconfig parameters from vendor boot image and config are "
           << ReadFile(bootconfig_path);
 
-  CF_EXPECT(bootconfig_fd->Truncate(bootconfig.size()) == 0,
+  CF_EXPECT(bootconfig_fd->Truncate(bootconfig.size()),
             "`truncate --size=" << bootconfig.size() << " bytes "
                                 << bootconfig_path
                                 << "` failed:" << bootconfig_fd->StrError());
@@ -111,7 +111,7 @@ Result<std::optional<BootConfigPartition>> BootConfigPartition::CreateIfNeeded(
   if (VmManagerIsGem5(config)) {
     const off_t bootconfig_size_bytes_gem5 =
         AlignToPowerOf2(bytesWritten, PARTITION_SIZE_SHIFT);
-    CF_EXPECT(bootconfig_fd->Truncate(bootconfig_size_bytes_gem5) == 0);
+    CF_EXPECT(bootconfig_fd->Truncate(bootconfig_size_bytes_gem5));
     bootconfig_fd->Close();
   } else {
     bootconfig_fd->Close();

--- a/base/cvd/cuttlefish/host/commands/console_forwarder/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/console_forwarder/BUILD.bazel
@@ -17,6 +17,7 @@ cf_cc_binary(
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:logging",
         "//cuttlefish/posix:strerror",
+        "//cuttlefish/result",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/log:check",
         "@gflags",

--- a/base/cvd/cuttlefish/host/commands/console_forwarder/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/console_forwarder/main.cpp
@@ -42,6 +42,7 @@
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 #include "cuttlefish/host/libs/config/logging.h"
 #include "cuttlefish/posix/strerror.h"
+#include "cuttlefish/result/result.h"
 
 DEFINE_int32(console_in_fd, -1,
              "File descriptor for the console's input channel");
@@ -131,12 +132,12 @@ class ConsoleForwarder {
         // Write all bytes to the file descriptor. Writes may block, so the
         // mutex lock should NOT be held while writing to avoid blocking the
         // other thread.
-        ssize_t bytes_written = 0;
+        Result<uint64_t> bytes_written = 0;
         ssize_t bytes_to_write = buf_ptr->size();
         while (bytes_to_write > 0) {
           bytes_written =
-              fd->Write(buf_ptr->data() + bytes_written, bytes_to_write);
-          if (bytes_written < 0) {
+              fd->Write(buf_ptr->data() + *bytes_written, bytes_to_write);
+          if (!bytes_written.has_value()) {
             // It is expected for writes to the PTY to fail if nothing is
             // connected
             if (fd->GetErrno() != EAGAIN) {
@@ -148,7 +149,7 @@ class ConsoleForwarder {
             // disconnected, on serial console failure this process will abort).
             break;
           }
-          bytes_to_write -= bytes_written;
+          bytes_to_write -= *bytes_written;
         }
       }
       {

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/data_viewer.h
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/data_viewer.h
@@ -82,8 +82,7 @@ class DataViewer {
     sigfillset(&all_signals);
     SignalMasker blocker(all_signals);
     // Overwrite the file contents, don't append
-    CF_EXPECTF(fd->Truncate(0) >= 0, "Failed to truncate fd: {}",
-               fd->StrError());
+    CF_EXPECTF(fd->Truncate(0), "Failed to truncate fd: {}", fd->StrError());
     CF_EXPECTF(fd->LSeek(0, SEEK_SET) >= 0, "Failed to seek to 0: {}",
                fd->StrError());
     CF_EXPECT(StoreData(fd, std::move(data)));

--- a/base/cvd/cuttlefish/host/commands/kernel_log_monitor/kernel_log_server.cc
+++ b/base/cvd/cuttlefish/host/commands/kernel_log_monitor/kernel_log_server.cc
@@ -131,7 +131,7 @@ bool KernelLogServer::HandleIncomingMessage() {
     return false;
   }
   // Write the log to a file
-  if (log_fd_->Write(buf, *ret) < 0) {
+  if (!log_fd_->Write(buf, *ret).has_value()) {
     LOG(ERROR) << "Could not write kernel log to file: " << log_fd_->StrError();
     return false;
   }

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/channel_monitor.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/channel_monitor.cpp
@@ -60,7 +60,8 @@ ClientId ChannelMonitor::SetRemoteClient(SharedFD client, bool is_accepted) {
 
   // Trigger monitor loop
   if (write_pipe_->IsOpen()) {
-    write_pipe_->Write("OK", sizeof("OK"));
+    // TODO(schuffelen): Handle unused result
+    Result<uint64_t> unused = write_pipe_->Write("OK", sizeof("OK"));
   } else {
     LOG(ERROR) << "Pipe created fail, can't trigger monitor loop";
   }
@@ -170,7 +171,8 @@ void ChannelMonitor::CloseRemoteConnection(ClientId client) {
 
       // Trigger monitor loop
       if (write_pipe_->IsOpen()) {
-        write_pipe_->Write("OK", sizeof("OK"));
+        // TODO(schuffelen): Handle unused result
+        Result<uint64_t> unused = write_pipe_->Write("OK", sizeof("OK"));
         VLOG(0) << "asking to remove clients";
       } else {
         LOG(ERROR) << "Pipe created fail, can't trigger monitor loop";
@@ -183,7 +185,8 @@ void ChannelMonitor::CloseRemoteConnection(ClientId client) {
 
 ChannelMonitor::~ChannelMonitor() {
   if (write_pipe_->IsOpen()) {
-    write_pipe_->Write("KO", sizeof("KO"));
+    // TODO(schuffelen): Handle unused result
+    Result<uint64_t> unused = write_pipe_->Write("KO", sizeof("KO"));
   }
 
   if (monitor_thread_.joinable()) {

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/sms_service.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/sms_service.cpp
@@ -261,8 +261,9 @@ void SmsService::SendSmsToRemote(std::string remote_port, PDUParser& sms_pdu) {
 
   std::string command = "AT+REMOTESMS=" + pdu + "\r";
   std::string token = "REM0";
-  remote_client->Write(token.data(), token.size());
-  remote_client->Write(command.data(), command.size());
+  // TODO(schuffelen): handle result values
+  Result<uint64_t> unused = remote_client->Write(token.data(), token.size());
+  unused = remote_client->Write(command.data(), command.size());
 }
 
 /* process AT+CMGS PDU */

--- a/base/cvd/cuttlefish/host/commands/run_cvd/boot_state_machine.cc
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/boot_state_machine.cc
@@ -700,7 +700,8 @@ class CvdBootStateMachine : public SetupFeature, public KernelLogPipeConsumer {
   bool BootFailed() const { return state_ & kGuestBootFailed; }
 
   void SendExitCode(RunnerExitCodes exit_code, SharedFD fd) {
-    fd->Write(&exit_code, sizeof(exit_code));
+    // TODO(schuffelen): Handle unused result
+    (void)fd->Write(&exit_code, sizeof(exit_code));
     // The foreground process will exit after receiving the exit code, if we try
     // to write again we'll get a SIGPIPE
     fd->Close();

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/modem.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/modem.cpp
@@ -43,7 +43,7 @@ static StopperResult StopModemSimulator(int id) {
     return StopperResult::kFailure;
   }
   std::string msg("STOP");
-  if (monitor_sock->Write(msg.data(), msg.size()) < 0) {
+  if (!monitor_sock->Write(msg.data(), msg.size()).has_value()) {
     monitor_sock->Close();
     LOG(ERROR) << "Failed to send 'STOP' to modem simulator";
     return StopperResult::kFailure;

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/ti50_emulator.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/ti50_emulator.cpp
@@ -134,7 +134,8 @@ class Ti50Emulator : public vm_manager::VmmDependencyCommand {
     if (!cl->IsOpen()) {
       return CF_ERR("Failed to connect to gpioPltRst");
     }
-    CF_EXPECT_EQ(cl->Write("1", 1), 1);
+    uint64_t written = CF_EXPECT(cl->Write("1", 1));
+    CF_EXPECT_EQ(written, 1);
 
     LOG(INFO) << "ti50 emulator: reset GPIO!";
     return {};

--- a/base/cvd/cuttlefish/host/commands/run_cvd/server_loop_impl.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/server_loop_impl.cpp
@@ -233,12 +233,14 @@ void ServerLoopImpl::HandleActionWithNoData(const LauncherAction action,
       auto stop = process_monitor.StopMonitoredProcesses();
       if (stop.has_value()) {
         auto response = LauncherResponse::kSuccess;
-        client->Write(&response, sizeof(response));
+        // TODO(schuffelen): Handle unused result
+        (void)client->Write(&response, sizeof(response));
         std::exit(0);
       } else {
         LOG(ERROR) << "Failed to stop subprocesses:\n" << stop.error();
         auto response = LauncherResponse::kError;
-        client->Write(&response, sizeof(response));
+        // TODO(schuffelen): Handle unused result
+        (void)client->Write(&response, sizeof(response));
       }
       break;
     }
@@ -246,11 +248,13 @@ void ServerLoopImpl::HandleActionWithNoData(const LauncherAction action,
       auto stop = process_monitor.StopMonitoredProcesses();
       if (stop.has_value()) {
         auto response = LauncherResponse::kSuccess;
-        client->Write(&response, sizeof(response));
+        // TODO(schuffelen): Handle unused result
+        (void)client->Write(&response, sizeof(response));
         std::exit(RunnerExitCodes::kVirtualDeviceBootFailed);
       } else {
         auto response = LauncherResponse::kError;
-        client->Write(&response, sizeof(response));
+        // TODO(schuffelen): Handle unused result
+        (void)client->Write(&response, sizeof(response));
         LOG(ERROR) << "Failed to stop subprocesses:\n" << stop.error();
       }
       break;
@@ -258,7 +262,8 @@ void ServerLoopImpl::HandleActionWithNoData(const LauncherAction action,
     case LauncherAction::kStatus: {
       // TODO(schuffelen): Return more information on a side channel
       auto response = LauncherResponse::kSuccess;
-      client->Write(&response, sizeof(response));
+      // TODO(schuffelen): Handle unused result
+      (void)client->Write(&response, sizeof(response));
       break;
     }
     case LauncherAction::kPowerwash: {
@@ -268,7 +273,8 @@ void ServerLoopImpl::HandleActionWithNoData(const LauncherAction action,
       if (std::find(disks.begin(), disks.end(), overlay) == disks.end()) {
         LOG(ERROR) << "Powerwash unsupported with --use_overlay=false";
         auto response = LauncherResponse::kError;
-        client->Write(&response, sizeof(response));
+        // TODO(schuffelen): Handle unused result
+        (void)client->Write(&response, sizeof(response));
         break;
       }
 
@@ -276,22 +282,26 @@ void ServerLoopImpl::HandleActionWithNoData(const LauncherAction action,
       if (!stop.has_value()) {
         LOG(ERROR) << "Stopping processes failed:\n" << stop.error();
         auto response = LauncherResponse::kError;
-        client->Write(&response, sizeof(response));
+        // TODO(schuffelen): Handle unused result
+        (void)client->Write(&response, sizeof(response));
         break;
       }
       if (!PowerwashFiles()) {
         LOG(ERROR) << "Powerwashing files failed.";
         auto response = LauncherResponse::kError;
-        client->Write(&response, sizeof(response));
+        // TODO(schuffelen): Handle unused result
+        (void)client->Write(&response, sizeof(response));
         break;
       }
       auto response = LauncherResponse::kSuccess;
-      client->Write(&response, sizeof(response));
+      // TODO(schuffelen): Handle unused result
+      (void)client->Write(&response, sizeof(response));
 
       RestartRunCvd(client->UNMANAGED_Dup());
       // RestartRunCvd should not return, so something went wrong.
       response = LauncherResponse::kError;
-      client->Write(&response, sizeof(response));
+      // TODO(schuffelen): Handle unused result
+      (void)client->Write(&response, sizeof(response));
       LOG(FATAL) << "run_cvd in a bad state";
       break;
     }
@@ -300,17 +310,20 @@ void ServerLoopImpl::HandleActionWithNoData(const LauncherAction action,
       if (!stop.has_value()) {
         LOG(ERROR) << "Stopping processes failed:\n" << stop.error();
         auto response = LauncherResponse::kError;
-        client->Write(&response, sizeof(response));
+        // TODO(schuffelen): Handle unused result
+        (void)client->Write(&response, sizeof(response));
         break;
       }
       DeleteFifos();
 
       auto response = LauncherResponse::kSuccess;
-      client->Write(&response, sizeof(response));
+      // TODO(schuffelen): Handle unused result
+      (void)client->Write(&response, sizeof(response));
       RestartRunCvd(client->UNMANAGED_Dup());
       // RestartRunCvd should not return, so something went wrong.
       response = LauncherResponse::kError;
-      client->Write(&response, sizeof(response));
+      // TODO(schuffelen): Handle unused result
+      (void)client->Write(&response, sizeof(response));
       LOG(FATAL) << "run_cvd in a bad state";
       break;
     }
@@ -318,7 +331,8 @@ void ServerLoopImpl::HandleActionWithNoData(const LauncherAction action,
       LOG(ERROR) << "Unrecognized launcher action: "
                  << static_cast<char>(action);
       auto response = LauncherResponse::kError;
-      client->Write(&response, sizeof(response));
+      // TODO(schuffelen): Handle unused result
+      (void)client->Write(&response, sizeof(response));
       break;
   }
 }

--- a/base/cvd/cuttlefish/host/commands/secure_env/suspend_resume_handler.cpp
+++ b/base/cvd/cuttlefish/host/commands/secure_env/suspend_resume_handler.cpp
@@ -24,16 +24,18 @@ namespace {
 
 Result<void> WriteSuspendRequest(const SharedFD& socket) {
   const SnapshotSocketMessage suspend_request = SnapshotSocketMessage::kSuspend;
-  CF_EXPECT_EQ(sizeof(suspend_request),
-               socket->Write(&suspend_request, sizeof(suspend_request)),
+  uint64_t written =
+      CF_EXPECT(socket->Write(&suspend_request, sizeof(suspend_request)));
+  CF_EXPECT_EQ(sizeof(suspend_request), written,
                "socket write failed: " << socket->StrError());
   return {};
 }
 
 Result<void> ReadSuspendAck(const SharedFD& socket) {
   SnapshotSocketMessage ack_response;
-  CF_EXPECT_EQ(sizeof(ack_response),
-               socket->Read(&ack_response, sizeof(ack_response)).value_or(0),
+  uint64_t data_read =
+      CF_EXPECT(socket->Read(&ack_response, sizeof(ack_response)).value_or(0));
+  CF_EXPECT_EQ(sizeof(ack_response), data_read,
                "socket read failed: " << socket->StrError());
   CF_EXPECT_EQ(SnapshotSocketMessage::kSuspendAck, ack_response);
   return {};
@@ -41,8 +43,9 @@ Result<void> ReadSuspendAck(const SharedFD& socket) {
 
 Result<void> WriteResumeRequest(const SharedFD& socket) {
   const SnapshotSocketMessage resume_request = SnapshotSocketMessage::kResume;
-  CF_EXPECT_EQ(sizeof(resume_request),
-               socket->Write(&resume_request, sizeof(resume_request)),
+  uint64_t written =
+      CF_EXPECT(socket->Write(&resume_request, sizeof(resume_request)));
+  CF_EXPECT_EQ(sizeof(resume_request), written,
                "socket write failed: " << socket->StrError());
   return {};
 }
@@ -100,8 +103,8 @@ Result<void> SnapshotCommandHandler::SuspendResumeHandler() {
       CF_EXPECT(ReadSuspendAck(snapshot_sockets_.weaver));
       // Write response to run_cvd.
       auto response = LauncherResponse::kSuccess;
-      const auto n_written =
-          channel_to_run_cvd_->Write(&response, sizeof(response));
+      const uint64_t n_written =
+          CF_EXPECT(channel_to_run_cvd_->Write(&response, sizeof(response)));
       CF_EXPECT_EQ(sizeof(response), n_written);
       return {};
     };
@@ -115,8 +118,8 @@ Result<void> SnapshotCommandHandler::SuspendResumeHandler() {
       CF_EXPECT(WriteResumeRequest(snapshot_sockets_.weaver));
       // Write response to run_cvd.
       auto response = LauncherResponse::kSuccess;
-      const auto n_written =
-          channel_to_run_cvd_->Write(&response, sizeof(response));
+      const uint64_t n_written =
+          CF_EXPECT(channel_to_run_cvd_->Write(&response, sizeof(response)));
       CF_EXPECT_EQ(sizeof(response), n_written);
       return {};
     };

--- a/base/cvd/cuttlefish/host/commands/secure_env/worker_thread_loop_body.cpp
+++ b/base/cvd/cuttlefish/host/commands/secure_env/worker_thread_loop_body.cpp
@@ -61,8 +61,9 @@ Result<void> WorkerInnerLoop(std::function<bool()> process_callback,
       // Send the ACK response.
       const SnapshotSocketMessage ack_response =
           SnapshotSocketMessage::kSuspendAck;
-      CF_EXPECT_EQ(sizeof(ack_response),
-                   snapshot_socket->Write(&ack_response, sizeof(ack_response)),
+      uint64_t written = CF_EXPECT(
+          snapshot_socket->Write(&ack_response, sizeof(ack_response)));
+      CF_EXPECT_EQ(sizeof(ack_response), written,
                    "socket write failed: " << snapshot_socket->StrError());
       // Block until resumed.
       SnapshotSocketMessage resume_request;

--- a/base/cvd/cuttlefish/host/frontend/webrtc/adb_handler.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/adb_handler.cpp
@@ -77,7 +77,8 @@ AdbHandler::AdbHandler(
 AdbHandler::~AdbHandler() {
     // Send a message to the looper to shut down.
     uint64_t v = 1;
-    shutdown_->Write(&v, sizeof(v));
+    // TODO(schuffelen): Handle unused result
+    (void)shutdown_->Write(&v, sizeof(v));
     // Shut down the socket as well.  Not srictly necessary.
     adb_socket_->Shutdown(SHUT_RDWR);
     read_thread_.join();
@@ -113,12 +114,12 @@ void AdbHandler::ReadLoop() {
 void AdbHandler::handleMessage(const uint8_t *msg, size_t len) {
   size_t sent = 0;
   while (sent < len) {
-    auto this_sent = adb_socket_->Write(&msg[sent], len - sent);
-    if (this_sent < 0) {
+    Result<uint64_t> this_sent = adb_socket_->Write(&msg[sent], len - sent);
+    if (!this_sent.has_value()) {
       LOG(ERROR) << "Error writing to adb socket: " << adb_socket_->StrError();
       return;
     }
-    sent += this_sent;
+    sent += *this_sent;
   }
 }
 

--- a/base/cvd/cuttlefish/host/frontend/webrtc/bluetooth_handler.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/bluetooth_handler.cpp
@@ -39,7 +39,8 @@ BluetoothHandler::BluetoothHandler(
 BluetoothHandler::~BluetoothHandler() {
   // Send a message to the looper to shut down.
   uint64_t v = 1;
-  shutdown_->Write(&v, sizeof(v));
+  // TODO(schuffelen): Handle unused result
+  (void)shutdown_->Write(&v, sizeof(v));
   // Shut down the socket as well.  Not strictly necessary.
   rootcanal_socket_->Shutdown(SHUT_RDWR);
   read_thread_.join();
@@ -75,12 +76,13 @@ void BluetoothHandler::ReadLoop() {
 void BluetoothHandler::handleMessage(const uint8_t *msg, size_t len) {
   size_t sent = 0;
   while (sent < len) {
-    auto this_sent = rootcanal_socket_->Write(&msg[sent], len - sent);
-    if (this_sent < 0) {
+    Result<uint64_t> this_sent =
+        rootcanal_socket_->Write(&msg[sent], len - sent);
+    if (!this_sent.has_value()) {
       PLOG(ERROR) << "Error writing to rootcanal socket.";
       return;
     }
-    sent += this_sent;
+    sent += *this_sent;
   }
 }
 

--- a/base/cvd/cuttlefish/host/libs/audio_connector/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/audio_connector/BUILD.bazel
@@ -22,6 +22,7 @@ cf_cc_library(
         "//cuttlefish/common/libs/fs:scoped_mmap",
         "//cuttlefish/common/libs/fs:unique_fd",
         "//cuttlefish/common/libs/utils:cf_endian",
+        "//cuttlefish/result",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/log:check",
     ],

--- a/base/cvd/cuttlefish/host/libs/audio_connector/server.cpp
+++ b/base/cvd/cuttlefish/host/libs/audio_connector/server.cpp
@@ -36,6 +36,7 @@
 #include "cuttlefish/host/libs/audio_connector/buffers.h"
 #include "cuttlefish/host/libs/audio_connector/commands.h"
 #include "cuttlefish/host/libs/audio_connector/shm_layout.h"
+#include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
 
@@ -49,8 +50,8 @@ ScopedMMap AllocateShm(size_t size, const std::string& name, SharedFD* shm_fd) {
     return ScopedMMap();
   }
 
-  auto truncate_ret = (*shm_fd)->Truncate(size);
-  if (truncate_ret != 0) {
+  Result<void> truncate_ret = (*shm_fd)->Truncate(size);
+  if (!truncate_ret.has_value()) {
     LOG(FATAL) << "Unable to resize " << name << " to " << size
                << " bytes: " << (*shm_fd)->StrError();
     return ScopedMMap();

--- a/base/cvd/cuttlefish/host/libs/avb/avb.cpp
+++ b/base/cvd/cuttlefish/host/libs/avb/avb.cpp
@@ -142,7 +142,7 @@ Result<void> EnforceVbMetaSize(const std::string& path) {
     auto vbmeta_fd = SharedFD::Open(path, O_RDWR);
     CF_EXPECTF(vbmeta_fd->IsOpen(), "Unable to open {} with error {}", path,
                vbmeta_fd->StrError());
-    CF_EXPECTF(vbmeta_fd->Truncate(kVbMetaMaxSize) == 0,
+    CF_EXPECTF(vbmeta_fd->Truncate(kVbMetaMaxSize),
                "Truncating {} failed with error {}", path,
                vbmeta_fd->StrError());
     CF_EXPECTF(vbmeta_fd->Fsync() == 0, "fsync on {} failed with error {}",

--- a/base/cvd/cuttlefish/host/libs/config/data_image.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/data_image.cpp
@@ -80,7 +80,7 @@ Result<void> ResizeImage(const std::string& data_image, int data_image_mb,
   off_t raw_target = static_cast<off_t>(data_image_mb) << 20;
   auto fd = SharedFD::Open(data_image, O_RDWR);
   CF_EXPECTF(fd->IsOpen(), "Can't open '{}': '{}'", data_image, fd->StrError());
-  CF_EXPECTF(fd->Truncate(raw_target) == 0, "`truncate --size={}M {} fail: {}",
+  CF_EXPECTF(fd->Truncate(raw_target), "`truncate --size={}M {} fail: {}",
              data_image_mb, data_image, fd->StrError());
   CF_EXPECT(ForceFsckImage(data_image, instance));
   std::string resize_path;
@@ -164,7 +164,7 @@ Result<void> CreateBlankEmptyImage(std::string_view image, int num_mb) {
   SharedFD fd =
       SharedFD::Open(std::string(image), O_CREAT | O_TRUNC | O_RDWR, 0666);
   CF_EXPECTF(fd->IsOpen(), "Failed to open '{}': '{}'", image, fd->StrError());
-  CF_EXPECTF(fd->Truncate(image_size_bytes) == 0,
+  CF_EXPECTF(fd->Truncate(image_size_bytes),
              "`truncate --size={}M '{}'` failed: {}", num_mb, image,
              fd->StrError());
   return {};

--- a/base/cvd/cuttlefish/host/libs/config/esp/make_fat_image.cc
+++ b/base/cvd/cuttlefish/host/libs/config/esp/make_fat_image.cc
@@ -37,7 +37,7 @@ Result<void> MakeFatImage(const std::string& data_image, int data_image_mb,
 
   if (FileExists(MkfsFat())) {
     auto fd = SharedFD::Open(data_image, O_CREAT | O_TRUNC | O_RDWR, 0666);
-    CF_EXPECTF(fd->Truncate(image_size_bytes) == 0,
+    CF_EXPECTF(fd->Truncate(image_size_bytes),
                "`truncate --size={}M '{}'` failed: {}", data_image_mb,
                data_image, fd->StrError());
 

--- a/base/cvd/cuttlefish/host/libs/screen_connector/ring_buffer_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/screen_connector/ring_buffer_manager.cpp
@@ -51,7 +51,8 @@ Result<std::unique_ptr<DisplayRingBuffer>> DisplayRingBuffer::Create(
 
   CF_EXPECTF(sfd->IsOpen(), "Display buffer create failed {}", sfd->StrError());
 
-  sfd->Truncate(size);
+  // TODO(schuffelen): Handle unused result
+  Result<void> unused = sfd->Truncate(size);
 
   ScopedMMap smm = sfd->MMap(NULL, size, PROT_WRITE, MAP_SHARED, 0);
   addr = smm.get();

--- a/base/cvd/cuttlefish/host/libs/vm_manager/qemu_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/qemu_manager.cpp
@@ -76,12 +76,12 @@ StopperResult Stop() {
   char msg[] = "{\"execute\":\"qmp_capabilities\"}{\"execute\":\"quit\"}";
   ssize_t len = sizeof(msg) - 1;
   while (len > 0) {
-    int tmp = monitor_sock->Write(msg, len);
-    if (tmp < 0) {
+    Result<uint64_t> tmp = monitor_sock->Write(msg, len);
+    if (!tmp.has_value()) {
       LOG(ERROR) << "Error writing to socket: " << monitor_sock->StrError();
       return StopperResult::kFailure;
     }
-    len -= tmp;
+    len -= *tmp;
   }
   // Log the reply
   char buff[1000];

--- a/base/cvd/cuttlefish/io/shared_fd.cc
+++ b/base/cvd/cuttlefish/io/shared_fd.cc
@@ -39,9 +39,7 @@ Result<uint64_t> SharedFdIo::Read(void* buf, uint64_t count) {
 }
 
 Result<uint64_t> SharedFdIo::Write(const void* buf, uint64_t count) {
-  int64_t data_written = fd_->Write(buf, count);
-  CF_EXPECT_GE(data_written, 0, fd_->StrError());
-  return data_written;
+  return CF_EXPECT(fd_->Write(buf, count));
 }
 
 Result<uint64_t> SharedFdIo::SeekSet(uint64_t offset) {
@@ -68,13 +66,11 @@ Result<uint64_t> SharedFdIo::PRead(void* buf, uint64_t count,
 
 Result<uint64_t> SharedFdIo::PWrite(const void* buf, uint64_t count,
                                     uint64_t offset) {
-  int64_t data_written = fd_->PWrite(buf, count, offset);
-  CF_EXPECT_GE(data_written, 0, fd_->StrError());
-  return data_written;
+  return CF_EXPECT(fd_->PWrite(buf, count, offset));
 }
 
 Result<void> SharedFdIo::Truncate(uint64_t size) {
-  CF_EXPECT_EQ(fd_->Truncate(size), 0);
+  CF_EXPECT(fd_->Truncate(size));
   return {};
 }
 


### PR DESCRIPTION
This allows passing `*shared_fd` or `*unique_fd` instances to functions accepting Reader, Writer, ReaderSeeker, etc.

Write, PWrite, and Truncate were changed to return Result instances.

Bug: b/540553865