### PR TITLE
Migrate from ReadAll to ReadToString

### DIFF
--- a/base/cvd/cuttlefish/common/libs/fs/shared_buf.cc
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_buf.cc
@@ -16,7 +16,6 @@
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -24,12 +23,6 @@
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 
 namespace cuttlefish {
-
-namespace {
-
-const size_t BUFF_SIZE = 1 << 14;
-
-}  // namespace
 
 ssize_t WriteAll(SharedFD fd, const char* buf, size_t size) {
   size_t total_written = 0;
@@ -63,23 +56,6 @@ ssize_t ReadExact(SharedFD fd, char* buf, size_t size) {
     total_read += *read_res;
   } while (total_read < size);
   return total_read;
-}
-
-ssize_t ReadAll(SharedFD fd, std::string* buf) {
-  char buff[BUFF_SIZE];
-  std::stringstream ss;
-  Result<uint64_t> read_res;
-  while ((read_res = fd->Read(buff, BUFF_SIZE - 1)).value_or(0) > 0) {
-    // this is necessary to avoid problems with having a '\0' in the middle of
-    // the buffer
-    ss << std::string(buff, *read_res);
-  }
-  if (!read_res.has_value()) {
-    errno = fd->GetErrno();
-    return -1;
-  }
-  *buf = ss.str();
-  return buf->size();
 }
 
 ssize_t ReadExact(SharedFD fd, std::string* buf) {

--- a/base/cvd/cuttlefish/common/libs/fs/shared_buf.h
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_buf.h
@@ -17,23 +17,11 @@
 
 #include <string>
 #include <string_view>
-#include <thread>
 #include <vector>
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 
 namespace cuttlefish {
-
-/**
- * Reads from fd until it is closed or errors, storing all data in buf.
- *
- * On a successful read, returns the number of bytes read.
- *
- * If a read error is encountered, returns -1. buf will contain any data read
- * up until that point and errno will be set.
- *
- */
-ssize_t ReadAll(SharedFD fd, std::string* buf);
 
 /**
  * Reads from fd until reading buf->size() bytes or errors.

--- a/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
@@ -120,6 +120,7 @@ cf_cc_library(
         "//cuttlefish/files:file_device_id",
         "//cuttlefish/files:file_exists",
         "//cuttlefish/files:link_or_copy",
+        "//cuttlefish/io:string",
         "//cuttlefish/posix:realpath",
         "//cuttlefish/posix:rename",
         "//cuttlefish/posix:strerror",
@@ -221,6 +222,7 @@ cf_cc_library(
     hdrs = ["json.h"],
     deps = [
         "//cuttlefish/common/libs/fs",
+        "//cuttlefish/io:string",
         "//cuttlefish/result",
         "@jsoncpp",
     ],
@@ -366,6 +368,8 @@ cf_cc_test(
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:unix_sockets",
+        "//cuttlefish/io:string",
+        "//cuttlefish/result",
         "//cuttlefish/result:result_matchers",
         "@abseil-cpp//absl/log:check",
     ],

--- a/base/cvd/cuttlefish/common/libs/utils/files.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/files.cpp
@@ -58,6 +58,7 @@
 #include "cuttlefish/files/file_device_id.h"
 #include "cuttlefish/files/file_exists.h"
 #include "cuttlefish/files/link_or_copy.h"
+#include "cuttlefish/io/string.h"
 #include "cuttlefish/posix/realpath.h"
 #include "cuttlefish/posix/rename.h"
 #include "cuttlefish/posix/strerror.h"
@@ -303,11 +304,7 @@ Result<std::string> ReadFileContents(const std::string& filepath) {
   auto file = SharedFD::Open(filepath, O_RDONLY);
   CF_EXPECTF(file->IsOpen(), "Failed to open file \"{}\".  Error: {}\n",
              filepath, file->StrError());
-  std::string file_content;
-  auto size = ReadAll(file, &file_content);
-  CF_EXPECTF(size >= 0, "Failed to read file contents.  Error: {}\n",
-             file->StrError());
-  return file_content;
+  return CF_EXPECT(ReadToString(*file));
 }
 Result<void> WriteNewFile(const std::string& filepath, std::string_view content,
                           mode_t mode) {

--- a/base/cvd/cuttlefish/common/libs/utils/json.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/json.cpp
@@ -25,8 +25,8 @@
 #include "json/reader.h"
 #include "json/value.h"
 
-#include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/io/string.h"
 #include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
@@ -44,10 +44,7 @@ Result<Json::Value> ParseJson(std::string_view input) {
 
 Result<Json::Value> LoadFromFile(SharedFD json_fd) {
   CF_EXPECT(json_fd->IsOpen(), "json_fd is not open.");
-  std::string json_contents;
-  // on success, this must return a positive integer
-  CF_EXPECT_GE(ReadAll(json_fd, &json_contents), 0,
-               "ReadAll() failed and returned 0 or -1");
+  const std::string json_contents = CF_EXPECT(ReadToString(*json_fd));
   Json::Value json_value = CF_EXPECTF(
       ParseJson(json_contents), "Failed to parse json: \n{}", json_contents);
   return json_value;

--- a/base/cvd/cuttlefish/common/libs/utils/unix_sockets_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/unix_sockets_test.cpp
@@ -29,6 +29,8 @@
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/io/string.h"
+#include "cuttlefish/result/result.h"
 #include "cuttlefish/result/result_matchers.h"
 
 namespace cuttlefish {
@@ -41,9 +43,9 @@ SharedFD CreateMemFDWithData(const std::string& data) {
 }
 
 std::string ReadAllFDData(SharedFD fd) {
-  std::string data;
-  CHECK(ReadAll(fd, &data) > 0) << fd->StrError();
-  return data;
+  Result<std::string> data = ReadToString(*fd);
+  EXPECT_THAT(data, IsOk());
+  return *data;
 }
 
 TEST(UnixSocketMessage, ExtractFileDescriptors) {

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -83,6 +83,7 @@ cf_cc_binary(
         "//cuttlefish/host/libs/feature",
         "//cuttlefish/host/libs/feature:inject",
         "//cuttlefish/host/libs/log_names",
+        "//cuttlefish/io:string",
         "//cuttlefish/posix:symlink",
         "//cuttlefish/pretty:vector",
         "//cuttlefish/result",

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd.cc
@@ -101,6 +101,7 @@
 #include "cuttlefish/host/libs/feature/feature.h"
 #include "cuttlefish/host/libs/feature/inject.h"
 #include "cuttlefish/host/libs/log_names/log_names.h"
+#include "cuttlefish/io/string.h"
 #include "cuttlefish/posix/symlink.h"
 #include "cuttlefish/pretty/vector.h"
 #include "cuttlefish/result/result.h"
@@ -571,13 +572,11 @@ Result<void> CheckNoTTY() {
 }
 
 Result<std::vector<std::string>> ReadInputFiles() {
-  std::string input_files_str;
   auto input_fd = SharedFD::Dup(0);
   CF_EXPECTF(input_fd->IsOpen(), "Failed to dup stdin: {}",
              input_fd->StrError());
-  auto bytes_read = ReadAll(input_fd, &input_files_str);
-  CF_EXPECT(bytes_read >= 0, "Failed to read input files. Error was \""
-                                 << input_fd->StrError() << "\"");
+  const std::string input_files_str =
+      CF_EXPECT(ReadToString(*input_fd), "Failed to read input files");
   return absl::StrSplit(input_files_str, "\n");
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/BUILD.bazel
@@ -385,6 +385,7 @@ cf_cc_library(
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/log_names",
         "//cuttlefish/host/libs/metrics:device_metrics_orchestration",
+        "//cuttlefish/io:string",
         "//cuttlefish/posix:symlink",
         "//cuttlefish/process:command",
         "//cuttlefish/result",

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -45,7 +45,6 @@
 #include "fmt/core.h"
 #include "fmt/format.h"
 
-#include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/contains.h"
 #include "cuttlefish/common/libs/utils/files.h"
@@ -76,6 +75,7 @@
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 #include "cuttlefish/host/libs/log_names/log_names.h"
 #include "cuttlefish/host/libs/metrics/device_metrics_orchestration.h"
+#include "cuttlefish/io/string.h"
 #include "cuttlefish/posix/symlink.h"
 #include "cuttlefish/process/command.h"
 #include "cuttlefish/result/result.h"
@@ -493,9 +493,7 @@ Result<void> CvdStartCommandHandler::Handle(const CommandRequest& request) {
         monitor_thread.join();
       }
       memfd->LSeek(0, SEEK_SET);
-      std::string full_output;
-      ReadAll(memfd, &full_output);
-      std::cout << full_output << std::flush;
+      std::cout << ReadToString(*memfd).value_or("") << std::flush;
     }
     return launch_res;
   }

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/BUILD.bazel
@@ -39,6 +39,7 @@ cf_cc_library(
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/utils:signals",
         "//cuttlefish/host/commands/cvd/instances:cvd_persistent_data",
+        "//cuttlefish/io:string",
         "//cuttlefish/result",
         "@abseil-cpp//absl/log:check",
     ],

--- a/base/cvd/cuttlefish/host/commands/cvd/instances/data_viewer.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/instances/data_viewer.cpp
@@ -22,6 +22,7 @@
 #include "absl/log/check.h"
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
+#include "cuttlefish/io/string.h"
 
 namespace cuttlefish {
 
@@ -36,10 +37,8 @@ Result<SharedFD> DataViewer::LockBackingFile(int op) const {
 }
 
 Result<cvd::PersistentData> DataViewer::LoadData(SharedFD fd) const {
-  std::string str;
-  auto read_size = ReadAll(fd, &str);
-  CF_EXPECTF(read_size >= 0, "Failed to read from backing file: {}",
-             fd->StrError());
+  const std::string str =
+      CF_EXPECT(ReadToString(*fd), "Failed to read from backing file");
   cvd::PersistentData data;
   data.ParseFromString(str);
   return std::move(data);

--- a/base/cvd/cuttlefish/host/commands/run_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/BUILD.bazel
@@ -153,6 +153,7 @@ cf_cc_library(
         "//cuttlefish/host/libs/feature:inject",
         "//cuttlefish/host/libs/process_monitor",
         "//cuttlefish/host/libs/vm_manager",
+        "//cuttlefish/io:string",
         "//cuttlefish/posix:strerror",
         "//cuttlefish/process:command",
         "//cuttlefish/process:execute",

--- a/base/cvd/cuttlefish/host/commands/run_cvd/server_loop_impl_snapshot.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/server_loop_impl_snapshot.cpp
@@ -27,7 +27,6 @@
 #include "android-base/file.h"
 #include "json/value.h"
 
-#include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/contains.h"
 #include "cuttlefish/common/libs/utils/json.h"
@@ -41,6 +40,7 @@
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 #include "cuttlefish/host/libs/config/vmm_mode.h"
 #include "cuttlefish/host/libs/process_monitor/process_monitor.h"
+#include "cuttlefish/io/string.h"
 #include "cuttlefish/process/command.h"
 #include "cuttlefish/process/execute.h"
 #include "cuttlefish/process/subprocess_options.h"
@@ -270,9 +270,8 @@ Result<void> ServerLoopImpl::TakeGuestSnapshot(VmmMode vm_manager,
   CF_EXPECTF(FileExists(json_path), "{} must exist but does not.", json_path);
   SharedFD json_fd = SharedFD::Open(json_path, O_RDONLY);
   CF_EXPECTF(json_fd->IsOpen(), "Failed to open {}", json_path);
-  std::string json_contents;
-  CF_EXPECT_GE(ReadAll(json_fd, &json_contents), 0,
-               std::string("Failed to read from ") + json_path);
+  const std::string json_contents =
+      CF_EXPECTF(ReadToString(*json_fd), "Failed to read from '{}'", json_path);
   Json::Value meta_json = CF_EXPECTF(
       ParseJson(json_contents), "Failed to parse json: \n{}", json_contents);
   CF_EXPECTF(VmManagerIsCrosvm(vm_manager),

--- a/base/cvd/cuttlefish/io/BUILD.bazel
+++ b/base/cvd/cuttlefish/io/BUILD.bazel
@@ -234,6 +234,7 @@ cf_cc_library(
         "//cuttlefish/io",
         "//cuttlefish/io:disjoint_range_set",
         "//cuttlefish/io:serialize_disjoint_range_set",
+        "//cuttlefish/io:string",
         "//cuttlefish/result",
         "@abseil-cpp//absl/log",
     ],

--- a/base/cvd/cuttlefish/io/lazily_loaded_file.cc
+++ b/base/cvd/cuttlefish/io/lazily_loaded_file.cc
@@ -36,6 +36,7 @@
 #include "cuttlefish/io/disjoint_range_set.h"
 #include "cuttlefish/io/io.h"
 #include "cuttlefish/io/serialize_disjoint_range_set.h"
+#include "cuttlefish/io/string.h"
 #include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
@@ -119,8 +120,7 @@ Result<void> LazilyLoadedFile::Impl::ReadMetadata() {
   CF_EXPECTF(metadata_fd->IsOpen(), "Failed to open {}: {}", MetadataFile(),
              metadata_fd->StrError());
 
-  std::string data;
-  CF_EXPECT_GE(ReadAll(metadata_fd, &data), 0, metadata_fd->StrError());
+  const std::string data = CF_EXPECT(ReadToString(*metadata_fd));
 
   Result<DisjointRangeSet> parsed_res = DeserializeDisjointRangeSet(data);
   if (parsed_res.has_value()) {

--- a/base/cvd/cuttlefish/process/BUILD.bazel
+++ b/base/cvd/cuttlefish/process/BUILD.bazel
@@ -53,6 +53,7 @@ cf_cc_library(
     hdrs = ["managed_stdio.h"],
     deps = [
         "//cuttlefish/common/libs/fs",
+        "//cuttlefish/io:string",
         "//cuttlefish/process:command",
         "//cuttlefish/process:subprocess",
         "//cuttlefish/process:subprocess_options",

--- a/base/cvd/cuttlefish/process/managed_stdio.cc
+++ b/base/cvd/cuttlefish/process/managed_stdio.cc
@@ -16,8 +16,6 @@
 
 #include "cuttlefish/process/managed_stdio.h"
 
-#include <cerrno>
-#include <cstring>
 #include <string>
 #include <thread>
 #include <utility>
@@ -27,6 +25,7 @@
 
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/io/string.h"
 #include "cuttlefish/process/command.h"
 #include "cuttlefish/process/subprocess.h"
 #include "cuttlefish/process/subprocess_options.h"
@@ -94,9 +93,11 @@ int RunWithManagedStdio(Command cmd_tmp, const std::string* stdin_str,
       return -1;
     }
     cmd.RedirectStdIO(Command::StdIoChannel::kStdOut, pipe_write);
-    stdout_thread = std::thread([pipe_read, stdout_str, &io_error]() {
-      int read = ReadAll(pipe_read, stdout_str);
-      if (read < 0) {
+    stdout_thread = std::thread([pipe_read, stdout_str, &io_error]() mutable {
+      Result<std::string> read_str = ReadToString(*pipe_read);
+      if (read_str.has_value()) {
+        *stdout_str = *read_str;
+      } else {
         io_error = true;
         LOG(ERROR) << "Error in reading stdout from process";
       }
@@ -110,9 +111,11 @@ int RunWithManagedStdio(Command cmd_tmp, const std::string* stdin_str,
       return -1;
     }
     cmd.RedirectStdIO(Command::StdIoChannel::kStdErr, pipe_write);
-    stderr_thread = std::thread([pipe_read, stderr_str, &io_error]() {
-      int read = ReadAll(pipe_read, stderr_str);
-      if (read < 0) {
+    stderr_thread = std::thread([pipe_read, &stderr_str, &io_error]() mutable {
+      Result<std::string> read_str = ReadToString(*pipe_read);
+      if (read_str.has_value()) {
+        *stderr_str = *read_str;
+      } else {
         io_error = true;
         LOG(ERROR) << "Error in reading stderr from process";
       }


### PR DESCRIPTION
Uses a Result type instead of a pointer, and operates on a pure virtual Reader rather than a SharedFD.

Bug: b/545794593