### PR TITLE
base: Support CrosVM auto-detection of MTE support

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
@@ -334,7 +334,9 @@ DEFINE_vec(use_sdcard, CF_DEFAULTS_USE_SDCARD ? "true" : "false",
 DEFINE_vec(protected_vm, fmt::format("{}", CF_DEFAULTS_PROTECTED_VM),
            "Boot in Protected VM mode");
 
-DEFINE_vec(mte, CF_DEFAULTS_MTE, "Enable MTE, one of {true, false}.");
+DEFINE_vec(mte, CF_DEFAULTS_MTE,
+           "Enable MTE, one of {true, false, auto}. Auto enables MTE only when "
+           "the host supports it.");
 
 DEFINE_vec(enable_pkvm, fmt::format("{}", CF_DEFAULTS_ENABLE_PKVM),
            "Provision the guest to run pKVM so it can host its own protected "

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd_flags.cpp
@@ -334,7 +334,7 @@ DEFINE_vec(use_sdcard, CF_DEFAULTS_USE_SDCARD ? "true" : "false",
 DEFINE_vec(protected_vm, fmt::format("{}", CF_DEFAULTS_PROTECTED_VM),
            "Boot in Protected VM mode");
 
-DEFINE_vec(mte, fmt::format("{}", CF_DEFAULTS_MTE), "Enable MTE");
+DEFINE_vec(mte, CF_DEFAULTS_MTE, "Enable MTE, one of {true, false}.");
 
 DEFINE_vec(enable_pkvm, fmt::format("{}", CF_DEFAULTS_ENABLE_PKVM),
            "Provision the guest to run pKVM so it can host its own protected "

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -99,6 +99,7 @@
 #include "cuttlefish/host/libs/config/gpu_mode.h"
 #include "cuttlefish/host/libs/config/host_tools_version.h"
 #include "cuttlefish/host/libs/config/instance_nums.h"
+#include "cuttlefish/host/libs/config/mte.h"
 #include "cuttlefish/host/libs/config/secure_hals.h"
 #include "cuttlefish/host/libs/config/vmm_mode.h"
 #include "cuttlefish/host/libs/vhal_proxy_server/vhal_proxy_server_eth_addr.h"
@@ -566,7 +567,7 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
       CF_EXPECT(GET_FLAG_BOOL_VALUE(record_screen));
   std::vector<std::string> gem5_debug_file_vec =
       CF_EXPECT(GET_FLAG_STR_VALUE(gem5_debug_file));
-  std::vector<bool> mte_vec = CF_EXPECT(GET_FLAG_BOOL_VALUE(mte));
+  std::vector<std::string> mte_vec = CF_EXPECT(GET_FLAG_STR_VALUE(mte));
   std::vector<bool> enable_kernel_log_vec =
       CF_EXPECT(GET_FLAG_BOOL_VALUE(enable_kernel_log));
   std::vector<bool> kgdb_vec = CF_EXPECT(GET_FLAG_BOOL_VALUE(kgdb));
@@ -839,7 +840,11 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
 
     instance.set_record_screen(record_screen_vec[instance_index]);
     instance.set_gem5_debug_file(gem5_debug_file_vec[instance_index]);
-    instance.set_mte(mte_vec[instance_index]);
+    instance.set_mte(CF_EXPECT(ParseMte(mte_vec[instance_index])));
+    if (instance.mte() != Mte::kOff) {
+      CF_EXPECT_EQ(guest_configs[instance_index].target_arch, Arch::Arm64,
+                   "--mte requires an arm64 guest");
+    }
     instance.set_enable_kernel_log(enable_kernel_log_vec[instance_index]);
     if (!boot_slot_vec[instance_index].empty()) {
       instance.set_boot_slot(boot_slot_vec[instance_index]);

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags_defaults.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags_defaults.h
@@ -99,7 +99,7 @@
   cuttlefish::ForCurrentInstance("CUTTLEFISHCVD")
 #define CF_DEFAULTS_SECURE_HALS CF_DEFAULTS_DYNAMIC_STRING
 #define CF_DEFAULTS_PROTECTED_VM false
-#define CF_DEFAULTS_MTE false
+#define CF_DEFAULTS_MTE "false"
 #define CF_DEFAULTS_ENABLE_PKVM false
 
 // Kernel default parameters

--- a/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/BUILD.bazel
@@ -131,6 +131,7 @@ cf_cc_library(
         "//cuttlefish/host/libs/config:gpu_mode",
         "//cuttlefish/host/libs/config:guest_hwui_renderer",
         "//cuttlefish/host/libs/config:guest_renderer_preload",
+        "//cuttlefish/host/libs/config:mte",
         "//cuttlefish/host/libs/config:secure_hals",
         "//cuttlefish/host/libs/config:vmm_mode",
         "//cuttlefish/host/libs/log_names",
@@ -321,6 +322,16 @@ cf_cc_library(
     name = "guest_renderer_preload",
     srcs = ["guest_renderer_preload.cc"],
     hdrs = ["guest_renderer_preload.h"],
+    deps = [
+        "//cuttlefish/result",
+        "@abseil-cpp//absl/strings",
+    ],
+)
+
+cf_cc_library(
+    name = "mte",
+    srcs = ["mte.cpp"],
+    hdrs = ["mte.h"],
     deps = [
         "//cuttlefish/result",
         "@abseil-cpp//absl/strings",

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
@@ -38,6 +38,7 @@
 #include "cuttlefish/host/libs/config/gpu_mode.h"
 #include "cuttlefish/host/libs/config/guest_hwui_renderer.h"
 #include "cuttlefish/host/libs/config/guest_renderer_preload.h"
+#include "cuttlefish/host/libs/config/mte.h"
 #include "cuttlefish/host/libs/config/secure_hals.h"
 #include "cuttlefish/host/libs/config/vmm_mode.h"
 #include "cuttlefish/result/result.h"
@@ -464,7 +465,7 @@ class CuttlefishConfig {
     std::vector<std::string> extra_bootconfig_args() const;
     bool record_screen() const;
     std::string gem5_debug_file() const;
-    bool mte() const;
+    Mte mte() const;
     std::string boot_slot() const;
     bool fail_fast() const;
     bool vhost_user_block() const;
@@ -701,7 +702,7 @@ class CuttlefishConfig {
     void set_extra_bootconfig_args(const std::string& extra_bootconfig_args);
     void set_record_screen(bool record_screen);
     void set_gem5_debug_file(const std::string& gem5_debug_file);
-    void set_mte(bool mte);
+    void set_mte(Mte mte);
     void set_boot_slot(const std::string& boot_slot);
     void set_grpc_socket_path(const std::string& socket_path);
     void set_fail_fast(bool fail_fast);

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
@@ -50,6 +50,7 @@
 #include "cuttlefish/host/libs/config/gpu_mode.h"
 #include "cuttlefish/host/libs/config/guest_hwui_renderer.h"
 #include "cuttlefish/host/libs/config/guest_renderer_preload.h"
+#include "cuttlefish/host/libs/config/mte.h"
 #include "cuttlefish/host/libs/log_names/log_names.h"
 #include "cuttlefish/result/result.h"
 
@@ -1025,11 +1026,11 @@ void CuttlefishConfig::MutableInstanceSpecific::set_gem5_debug_file(
 }
 
 static constexpr char kMte[] = "mte";
-void CuttlefishConfig::MutableInstanceSpecific::set_mte(bool mte) {
-  (*Dictionary())[kMte] = mte;
+void CuttlefishConfig::MutableInstanceSpecific::set_mte(Mte mte) {
+  (*Dictionary())[kMte] = static_cast<int>(mte);
 }
-bool CuttlefishConfig::InstanceSpecific::mte() const {
-  return (*Dictionary())[kMte].asBool();
+Mte CuttlefishConfig::InstanceSpecific::mte() const {
+  return static_cast<Mte>((*Dictionary())[kMte].asInt());
 }
 
 static constexpr char kEnableKernelLog[] = "enable_kernel_log";

--- a/base/cvd/cuttlefish/host/libs/config/mte.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/mte.cpp
@@ -18,6 +18,7 @@
 
 #include <string_view>
 
+#include "absl/strings/match.h"
 #include "absl/strings/numbers.h"
 
 #include "cuttlefish/result/result.h"
@@ -25,6 +26,9 @@
 namespace cuttlefish {
 
 Result<Mte> ParseMte(std::string_view str) {
+  if (absl::EqualsIgnoreCase(str, "auto")) {
+    return Mte::kAuto;
+  }
   bool bool_res;
   CF_EXPECTF(absl::SimpleAtob(str, &bool_res),
              "Failed to parse mte option \"{}\"", str);

--- a/base/cvd/cuttlefish/host/libs/config/mte.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/mte.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/host/libs/config/mte.h"
+
+#include <string_view>
+
+#include "absl/strings/numbers.h"
+
+#include "cuttlefish/result/result.h"
+
+namespace cuttlefish {
+
+Result<Mte> ParseMte(std::string_view str) {
+  bool bool_res;
+  CF_EXPECTF(absl::SimpleAtob(str, &bool_res),
+             "Failed to parse mte option \"{}\"", str);
+  return bool_res ? Mte::kOn : Mte::kOff;
+}
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/config/mte.h
+++ b/base/cvd/cuttlefish/host/libs/config/mte.h
@@ -24,6 +24,7 @@ namespace cuttlefish {
 enum class Mte {
   kOff,
   kOn,
+  kAuto,
 };
 
 Result<Mte> ParseMte(std::string_view);

--- a/base/cvd/cuttlefish/host/libs/config/mte.h
+++ b/base/cvd/cuttlefish/host/libs/config/mte.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string_view>
+
+#include "cuttlefish/result/result.h"
+
+namespace cuttlefish {
+
+enum class Mte {
+  kOff,
+  kOn,
+};
+
+Result<Mte> ParseMte(std::string_view);
+
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/vm_manager/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/BUILD.bazel
@@ -54,6 +54,7 @@ cf_cc_library(
         "//cuttlefish/host/libs/config:guest_hwui_renderer",
         "//cuttlefish/host/libs/config:guest_renderer_preload",
         "//cuttlefish/host/libs/config:known_paths",
+        "//cuttlefish/host/libs/config:mte",
         "//cuttlefish/host/libs/config:vmm_mode",
         "//cuttlefish/host/libs/feature",
         "//cuttlefish/host/libs/feature:inject",

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_builder.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_builder.cpp
@@ -93,7 +93,11 @@ Result<void> CrosvmBuilder::AddCpus(const Json::Value& vcpu_config_json) {
 }
 
 void CrosvmBuilder::AddCpus(size_t cpus) {
-  command_.AddParameter("--cpus=", cpus);
+  std::vector<std::string> cpus_params;
+  cpus_params.push_back(std::to_string(cpus));
+
+  command_.AddParameter("--cpus");
+  command_.AddJoinedParameter(cpus_params);
 }
 
 void CrosvmBuilder::AddHvcSink() {

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_builder.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_builder.cpp
@@ -23,6 +23,7 @@
 #include "cuttlefish/host/libs/command_util/snapshot_utils.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 #include "cuttlefish/host/libs/config/known_paths.h"
+#include "cuttlefish/host/libs/config/mte.h"
 #include "cuttlefish/host/libs/vm_manager/crosvm_cpu.h"
 #include "cuttlefish/process/command.h"
 
@@ -71,20 +72,22 @@ void CrosvmBuilder::AddControlSocket(const std::string& control_socket,
 }
 
 Result<void> CrosvmBuilder::AddCpus(size_t cpus,
-                                    const std::string& vcpu_config_path) {
+                                    const std::string& vcpu_config_path,
+                                    Mte mte) {
   if (!vcpu_config_path.empty()) {
     Json::Value vcpu_config_json = CF_EXPECT(LoadFromFile(vcpu_config_path));
 
-    CF_EXPECT(AddCpus(vcpu_config_json));
+    CF_EXPECT(AddCpus(vcpu_config_json, mte));
   } else {
-    AddCpus(cpus);
+    AddCpus(cpus, mte);
   }
   return {};
 }
 
-Result<void> CrosvmBuilder::AddCpus(const Json::Value& vcpu_config_json) {
+Result<void> CrosvmBuilder::AddCpus(const Json::Value& vcpu_config_json,
+                                    Mte mte) {
   std::vector<std::string> cpu_args =
-      CF_EXPECT(CrosvmCpuArguments(vcpu_config_json));
+      CF_EXPECT(CrosvmCpuArguments(vcpu_config_json, mte));
 
   for (const std::string& cpu_arg : cpu_args) {
     command_.AddParameter(cpu_arg);
@@ -92,9 +95,12 @@ Result<void> CrosvmBuilder::AddCpus(const Json::Value& vcpu_config_json) {
   return {};
 }
 
-void CrosvmBuilder::AddCpus(size_t cpus) {
+void CrosvmBuilder::AddCpus(size_t cpus, Mte mte) {
   std::vector<std::string> cpus_params;
   cpus_params.push_back(std::to_string(cpus));
+  if (mte == Mte::kAuto) {
+    cpus_params.push_back("mte=[auto]");
+  }
 
   command_.AddParameter("--cpus");
   command_.AddJoinedParameter(cpus_params);

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_builder.h
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_builder.h
@@ -20,6 +20,7 @@
 
 #include "json/value.h"
 
+#include "cuttlefish/host/libs/config/mte.h"
 #include "cuttlefish/host/libs/vm_manager/pci.h"
 #include "cuttlefish/process/command.h"
 #include "cuttlefish/result/result.h"
@@ -35,9 +36,10 @@ class CrosvmBuilder {
                              int exit_code);
   void AddControlSocket(const std::string&, const std::string&);
 
-  Result<void> AddCpus(size_t cpus, const std::string& vcpu_config_path);
-  Result<void> AddCpus(const Json::Value&);
-  void AddCpus(size_t cpus);
+  Result<void> AddCpus(size_t cpus, const std::string& vcpu_config_path,
+                       Mte mte = Mte::kOff);
+  Result<void> AddCpus(const Json::Value&, Mte mte = Mte::kOff);
+  void AddCpus(size_t cpus, Mte mte = Mte::kOff);
 
   void AddHvcSink();
   void AddHvcReadOnly(const std::string& output, bool console = false);

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_cpu.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_cpu.cpp
@@ -119,8 +119,12 @@ Result<std::vector<std::string>> CrosvmCpuArguments(
   cpu_arguments.emplace_back(std::move(cgroup_path_arg));
   cpu_arguments.emplace_back("--virt-cpufreq-upstream");
 
-  cpu_arguments.emplace_back(
-      fmt::format("--cpus={},freq-domains={}", cpus, freq_domain_arg));
+  std::vector<std::string> cpus_params;
+  cpus_params.push_back(std::to_string(cpus));
+  cpus_params.push_back(fmt::format("freq-domains={}", freq_domain_arg));
+
+  cpu_arguments.emplace_back("--cpus");
+  cpu_arguments.emplace_back(absl::StrJoin(cpus_params, ","));
 
   return cpu_arguments;
 }

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_cpu.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_cpu.cpp
@@ -48,7 +48,7 @@ std::string SerializeFreqDomains(
 }  // namespace
 
 Result<std::vector<std::string>> CrosvmCpuArguments(
-    const Json::Value& vcpu_config_json) {
+    const Json::Value& vcpu_config_json, Mte mte) {
   std::vector<std::string> cpu_arguments;
 
   std::map<int, std::vector<int>> freq_domains;
@@ -122,6 +122,9 @@ Result<std::vector<std::string>> CrosvmCpuArguments(
   std::vector<std::string> cpus_params;
   cpus_params.push_back(std::to_string(cpus));
   cpus_params.push_back(fmt::format("freq-domains={}", freq_domain_arg));
+  if (mte == Mte::kAuto) {
+    cpus_params.push_back("mte=[auto]");
+  }
 
   cpu_arguments.emplace_back("--cpus");
   cpu_arguments.emplace_back(absl::StrJoin(cpus_params, ","));

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_cpu.h
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_cpu.h
@@ -20,10 +20,11 @@
 
 #include "json/value.h"
 
+#include "cuttlefish/host/libs/config/mte.h"
 #include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
 
 Result<std::vector<std::string>> CrosvmCpuArguments(
-    const Json::Value& vcpu_config);
+    const Json::Value& vcpu_config, Mte mte = Mte::kOff);
 }

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
@@ -666,7 +666,8 @@ Result<std::vector<MonitorCommand>> CrosvmManager::StartCommands(
     crosvm_cmd.Cmd().AddParameter("--mte");
   }
 
-  CF_EXPECT(crosvm_cmd.AddCpus(instance.cpus(), instance.vcpu_config_path()));
+  CF_EXPECT(crosvm_cmd.AddCpus(instance.cpus(), instance.vcpu_config_path(),
+                               instance.mte()));
 
   auto disk_num = instance.virtual_disk_paths().size();
   CF_EXPECT(VmManager::kMaxDisks >= disk_num,

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
@@ -524,6 +524,16 @@ Result<void> ConfigureGpu(const CuttlefishConfig& config, Command* crosvm_cmd) {
   return {};
 }
 
+bool PmemEnabled(const CuttlefishConfig::InstanceSpecific& instance) {
+  // pmem is disabled for pkvm guests: the pmem backing files are mmap'd
+  // MAP_SHARED, and host writeback of storage-backed pages triggers
+  // mmu-notifiers that arm64 KVM currently handles by tearing down the
+  // guest's entire shadow stage-2 instead of a range-scoped invalidation
+  // (see the nested_mmu reverse-mapping TODO in arch/arm64/kvm/mmu.c),
+  // which makes the guest extremely slow.
+  return instance.use_pmem() && !instance.enable_pkvm() && !instance.mte();
+}
+
 Result<std::vector<MonitorCommand>> CrosvmManager::StartCommands(
     const CuttlefishConfig& config,
     std::vector<VmmDependencyCommand*>& dependencyCommands) {
@@ -642,16 +652,8 @@ Result<std::vector<MonitorCommand>> CrosvmManager::StartCommands(
   }
 
   if (instance.hwcomposer() != kHwComposerNone) {
-    // pmem is disabled for pkvm guests: the pmem backing files are mmap'd
-    // MAP_SHARED, and host writeback of storage-backed pages triggers
-    // mmu-notifiers that arm64 KVM currently handles by tearing down the
-    // guest's entire shadow stage-2 instead of a range-scoped invalidation
-    // (see the nested_mmu reverse-mapping TODO in arch/arm64/kvm/mmu.c),
-    // which makes the guest extremely slow.
-    const bool pmem_disabled =
-        instance.mte() || instance.enable_pkvm() || !instance.use_pmem();
     const std::string pmem_path = HwcomposerPmemPath(instance);
-    if (!pmem_disabled && FileExists(pmem_path)) {
+    if (PmemEnabled(instance) && FileExists(pmem_path)) {
       crosvm_cmd.Cmd().AddParameter("--pmem=path=", pmem_path);
     }
   }
@@ -736,14 +738,12 @@ Result<std::vector<MonitorCommand>> CrosvmManager::StartCommands(
   }
 #endif
 
-  const bool pmem_disabled =
-      instance.mte() || instance.enable_pkvm() || !instance.use_pmem();
   const std::string access_kregistry = AccessKregistryPath(instance);
-  if (!pmem_disabled && FileExists(access_kregistry)) {
+  if (PmemEnabled(instance) && FileExists(access_kregistry)) {
     crosvm_cmd.Cmd().AddParameter("--pmem=path=", access_kregistry);
   }
 
-  if (!pmem_disabled && FileExists(PstorePath(instance))) {
+  if (PmemEnabled(instance) && FileExists(PstorePath(instance))) {
     crosvm_cmd.Cmd().AddParameter("--pstore=path=", PstorePath(instance),
                                   ",size=", FileSize(PstorePath(instance)));
   }

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
@@ -51,6 +51,7 @@
 #include "cuttlefish/host/libs/config/guest_hwui_renderer.h"
 #include "cuttlefish/host/libs/config/guest_renderer_preload.h"
 #include "cuttlefish/host/libs/config/known_paths.h"
+#include "cuttlefish/host/libs/config/mte.h"
 #include "cuttlefish/host/libs/vm_manager/crosvm_builder.h"
 #include "cuttlefish/host/libs/vm_manager/qemu_manager.h"
 #include "cuttlefish/host/libs/vm_manager/vhost_user.h"
@@ -531,7 +532,8 @@ bool PmemEnabled(const CuttlefishConfig::InstanceSpecific& instance) {
   // guest's entire shadow stage-2 instead of a range-scoped invalidation
   // (see the nested_mmu reverse-mapping TODO in arch/arm64/kvm/mmu.c),
   // which makes the guest extremely slow.
-  return instance.use_pmem() && !instance.enable_pkvm() && !instance.mte();
+  return instance.use_pmem() && !instance.enable_pkvm() &&
+         instance.mte() != Mte::kOn;
 }
 
 Result<std::vector<MonitorCommand>> CrosvmManager::StartCommands(
@@ -660,7 +662,7 @@ Result<std::vector<MonitorCommand>> CrosvmManager::StartCommands(
 
   // crosvm_cmd.Cmd().AddParameter("--null-audio");
   crosvm_cmd.Cmd().AddParameter("--mem=", instance.memory_mb());
-  if (instance.mte()) {
+  if (instance.mte() == Mte::kOn) {
     crosvm_cmd.Cmd().AddParameter("--mte");
   }
 

--- a/base/cvd/cuttlefish/host/libs/vm_manager/qemu_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/qemu_manager.cpp
@@ -44,6 +44,7 @@
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 #include "cuttlefish/host/libs/config/external_network_mode.h"
 #include "cuttlefish/host/libs/config/gpu_mode.h"
+#include "cuttlefish/host/libs/config/mte.h"
 #include "cuttlefish/host/libs/feature/command_source.h"
 #include "cuttlefish/host/libs/vm_manager/vhost_user.h"
 #include "cuttlefish/process/command.h"
@@ -374,7 +375,7 @@ Result<std::vector<MonitorCommand>> QemuManager::StartCommands(
       CF_EXPECT(instance.cpus() <= 8, "CPUs must be no more than 8 with GICv2");
     }
   }
-  if (instance.mte()) {
+  if (instance.mte() == Mte::kOn) {
     machine += ",mte=on";
   }
   qemu_cmd.AddParameter("-machine");

--- a/base/cvd/cuttlefish/process/command.h
+++ b/base/cvd/cuttlefish/process/command.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "absl/log/check.h"
+#include "absl/strings/str_join.h"
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/process/subprocess.h"
@@ -158,6 +159,18 @@ class Command {
   template <typename... Args>
   Command AppendToLastParameter(Args... args) && {
     return std::move(AppendToLastParameter(std::forward<Args>(args)...));
+  }
+
+  template <typename Container, typename Separator = const char*>
+  Command& AddJoinedParameter(const Container& container,
+                              Separator separator = ",") & {
+    command_.push_back(absl::StrJoin(container, separator));
+    return *this;
+  }
+  template <typename Container, typename Separator = const char*>
+  Command AddJoinedParameter(const Container& container,
+                             Separator separator = ",") && {
+    return std::move(AddJoinedParameter(container, separator));
   }
 
   // Redirects the standard IO of the command.


### PR DESCRIPTION
Make the currently boolean `--mte` CVD flag accept the value `auto` to only enable guest MTE when supported.

Map it to CrosVM's new `--cpus mte=[auto]` flag (https://crrev.com/c/8137608) but keep supporting `--mte` when `true`.