### PR TITLE
base: cvd: cuttlefish: Explicitly include absl/strings/numbers.h

### DIFF
--- a/base/cvd/cuttlefish/host/commands/stop/main.cc
+++ b/base/cvd/cuttlefish/host/commands/stop/main.cc
@@ -30,6 +30,7 @@
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/strings/match.h"
+#include "absl/strings/numbers.h"
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/environment.h"


### PR DESCRIPTION
absl::SimpleAtoi is used in StopCvdMain to parse instance IDs, which is defined in "absl/strings/numbers.h".

Include it explicitly to follow IWYU (Include What You Use) principles and avoid relying on transitive header inclusions.