### PR TITLE
Bumping cache version so release branches can build fully

### DIFF
--- a/.config/cache-config.env
+++ b/.config/cache-config.env
@@ -1,3 +1,3 @@
-CACHE_VERSION=v1
+CACHE_VERSION=v2
 BAZEL_REMOTE_CACHE="https://storage.googleapis.com/android-cuttlefish-cache"
 


### PR DESCRIPTION
Release branch builds fail to link correctly since the main cache has progressed forward.

Going forward this cache version should be bumped everytime the load_config.proto gets updated.