### PR TITLE
Initialize uninitialized variable

### DIFF
--- a/base/cvd/cuttlefish/host/libs/web/parse_time.cc
+++ b/base/cvd/cuttlefish/host/libs/web/parse_time.cc
@@ -30,7 +30,7 @@ namespace cuttlefish {
 
 Result<std::chrono::system_clock::time_point> ParseTime(std::string_view str) {
   std::stringstream stream = std::stringstream(std::string(str));
-  tm time_tm;
+  tm time_tm = {};
   stream >> std::get_time(&time_tm, "%Y-%m-%dT%H:%M:%S");
   CF_EXPECTF(!!stream, "Failed to parse time '{}'", str);
 


### PR DESCRIPTION
Initialize tm struct with zero values to prevent mktime from reading uninitialized memory (such as tm_isdst), resolving MSAN failure.

Bug: b/543844800
Test: bazel test //cuttlefish/host/libs/web:parse_time_test
Assisted-By: Antigravity:Gemini-Next