### PR TITLE
Make FileInstance movable

### DIFF
--- a/base/cvd/cuttlefish/common/libs/fs/file_instance.cc
+++ b/base/cvd/cuttlefish/common/libs/fs/file_instance.cc
@@ -77,6 +77,22 @@ constexpr size_t kPreferredBufferSize = 8192;
 
 }  // namespace
 
+FileInstance::FileInstance() : FileInstance(-1, 0) {}
+
+FileInstance::FileInstance(FileInstance&& other) : FileInstance() {
+  std::swap(fd_, other.fd_);
+  std::swap(errno_, other.errno_);
+}
+
+FileInstance::~FileInstance() { Close(); }
+
+FileInstance& FileInstance::operator=(FileInstance&& other) {
+  Close();
+  std::swap(fd_, other.fd_);
+  std::swap(errno_, other.errno_);
+  return *this;
+}
+
 bool FileInstance::CopyFrom(FileInstance& in, size_t length,
                             FileInstance* stop) {
   LocalErrno record_errno(errno_);
@@ -280,10 +296,6 @@ void FileInstance::Set(fd_set* dest, int* max_index) const {
     *max_index = fd_ + 1;
   }
   FD_SET(fd_, dest);
-}
-
-/* static */ std::unique_ptr<FileInstance> FileInstance::ClosedInstance() {
-  return std::unique_ptr<FileInstance>(new FileInstance(-1, EBADF));
 }
 
 int FileInstance::Bind(const struct sockaddr* addr, socklen_t addrlen) {

--- a/base/cvd/cuttlefish/common/libs/fs/file_instance.h
+++ b/base/cvd/cuttlefish/common/libs/fs/file_instance.h
@@ -78,12 +78,10 @@ namespace cuttlefish {
  * number.
  *
  * FileInstances have two states: Open and Closed. They may start in either
- * state. However, once a FileIntance enters the Closed state it cannot be
- * reopened.
+ * state.
  *
  * Construction of FileInstances is limited to select classes to avoid
- * escaping file descriptors. At this point SharedFD is the only class
- * that has access. We may eventually have ScopedFD and WeakFD.
+ * escaping file descriptors.
  */
 class FileInstance : public ReaderSeeker {
   // Give SharedFD access to the aliasing constructor.
@@ -92,10 +90,12 @@ class FileInstance : public ReaderSeeker {
   friend class Epoll;
 
  public:
-  virtual ~FileInstance() { Close(); }
-
-  // This can't be a singleton because our shared_ptr's aren't thread safe.
-  static std::unique_ptr<FileInstance> ClosedInstance();
+  FileInstance();
+  FileInstance(FileInstance&) = delete;
+  FileInstance(FileInstance&&);
+  ~FileInstance();
+  FileInstance& operator=(FileInstance&) = delete;
+  FileInstance& operator=(FileInstance&&);
 
   int Bind(const struct sockaddr* addr, socklen_t addrlen);
   int Connect(const struct sockaddr* addr, socklen_t addrlen);

--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd.cpp
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd.cpp
@@ -117,6 +117,8 @@ int Select(SharedFDSet* read_set, SharedFDSet* write_set,
   return rval;
 }
 
+SharedFD::SharedFD() : value_(std::make_shared<FileInstance>()) {}
+
 SharedFD::SharedFD(SharedFD&& other) {
   value_ = std::move(other.value_);
   other.value_.reset(new FileInstance(-1, EBADF));

--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd.h
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd.h
@@ -127,7 +127,7 @@ class SharedFD {
   friend class WeakFD;
 
  public:
-  inline SharedFD();
+  SharedFD();
   SharedFD(const std::shared_ptr<FileInstance>& in) : value_(in) {}
   SharedFD(SharedFD const&) = default;
   SharedFD(SharedFD&& other);
@@ -241,11 +241,6 @@ struct PollSharedFd {
   short events;
   short revents;
 };
-
-/* Methods that need both a fully defined SharedFD and a fully defined
-   FileInstance. */
-
-SharedFD::SharedFD() : value_(FileInstance::ClosedInstance()) {}
 
 }  // namespace cuttlefish
 

--- a/base/cvd/cuttlefish/common/libs/fs/unique_fd.cc
+++ b/base/cvd/cuttlefish/common/libs/fs/unique_fd.cc
@@ -113,6 +113,8 @@ static void MakeAddress(const char* name, bool abstract,
   *len = namelen + offsetof(struct sockaddr_un, sun_path) + 1;
 }
 
+UniqueFd::UniqueFd() : value_(std::make_unique<FileInstance>()) {}
+
 UniqueFd UniqueFd::Accept(const FileInstance& listener, struct sockaddr* addr,
                           socklen_t* addrlen) {
   return UniqueFd(

--- a/base/cvd/cuttlefish/common/libs/fs/unique_fd.h
+++ b/base/cvd/cuttlefish/common/libs/fs/unique_fd.h
@@ -116,7 +116,7 @@ class UniqueFd {
   friend class SharedFD;
 
  public:
-  inline UniqueFd();
+  UniqueFd();
   UniqueFd(std::unique_ptr<FileInstance> in) : value_(std::move(in)) {}
   UniqueFd(UniqueFd&& other);
   UniqueFd& operator=(UniqueFd&& other);
@@ -202,8 +202,6 @@ class UniqueFd {
 
   std::unique_ptr<FileInstance> value_;
 };
-
-UniqueFd::UniqueFd() : value_(FileInstance::ClosedInstance()) {}
 
 }  // namespace cuttlefish
 


### PR DESCRIPTION
This removes the need for UniqueFd, as FileInstance can be used directly in cases where UniqueFd would be used otherwise.

Suggested by jemoreira@.

Bug: b/545794593