### PR TITLE
Create a common wrapper function for stat(2)

### DIFF
--- a/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/utils/BUILD.bazel
@@ -125,6 +125,7 @@ cf_cc_library(
         "//cuttlefish/posix:realpath",
         "//cuttlefish/posix:remove",
         "//cuttlefish/posix:rename",
+        "//cuttlefish/posix:stat",
         "//cuttlefish/posix:strerror",
         "//cuttlefish/result",
         "//libbase",

--- a/base/cvd/cuttlefish/common/libs/utils/files.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/files.cpp
@@ -61,6 +61,7 @@
 #include "cuttlefish/posix/realpath.h"
 #include "cuttlefish/posix/remove.h"
 #include "cuttlefish/posix/rename.h"
+#include "cuttlefish/posix/stat.h"
 #include "cuttlefish/posix/strerror.h"
 #include "cuttlefish/result/result.h"
 
@@ -210,19 +211,12 @@ std::string AbsolutePath(std::string_view path) {
 }
 
 off_t FileSize(const std::string& path) {
-  struct stat st{};
-  if (stat(path.c_str(), &st) == -1) {
-    return 0;
-  }
-  return st.st_size;
+  static auto get_size = [](const struct stat& st) { return st.st_size; };
+  return Stat(path).transform(get_size).value_or(0);
 }
 
 Result<uid_t> FileOwner(const std::string& path) {
-  struct stat st{};
-  if (stat(path.c_str(), &st) == -1) {
-    return CF_ERRF("Failed to stat file '{}' : {}", path, StrError(errno));
-  }
-  return st.st_uid;
+  return CF_EXPECT(Stat(path)).st_uid;
 }
 
 bool MakeFileExecutable(const std::string& path) {
@@ -232,11 +226,7 @@ bool MakeFileExecutable(const std::string& path) {
 
 Result<std::chrono::system_clock::time_point> FileModificationTime(
     const std::string& path) {
-  struct stat st;
-  CF_EXPECTF(stat(path.c_str(), &st) == 0,
-             "stat() failed retrieving file modification time on \"{}\" with "
-             "error: {}",
-             path, strerror(errno));
+  struct stat st = CF_EXPECT(Stat(path));
 #ifdef __linux__
   std::chrono::seconds seconds(st.st_mtim.tv_sec);
 #elif defined(__APPLE__)
@@ -407,21 +397,18 @@ Result<std::string> Search(const std::vector<std::string>& path,
 
 Result<SharedFD> CreateOrReuseAndDrainFifo(const std::string& path,
                                            mode_t mode) {
-  struct stat st{};
-  bool existed = false;
-  if (TEMP_FAILURE_RETRY(stat(path.c_str(), &st)) != 0) {
-    CF_EXPECTF(TEMP_FAILURE_RETRY(mkfifo(path.c_str(), mode)) == 0,
-               "Failed to mkfifo('{}', {:o}): {}", path, mode,
-               ::cuttlefish::StrError(errno));
-  } else {
-    CF_EXPECTF(S_ISFIFO(st.st_mode), "File at '{}' exists but is not a FIFO",
+  Result<struct stat> st = Stat(path);
+  if (st.has_value()) {
+    CF_EXPECTF(S_ISFIFO(st->st_mode), "File at '{}' exists but is not a FIFO",
                path);
-    existed = true;
+  } else {
+    CF_EXPECTF(TEMP_FAILURE_RETRY(mkfifo(path.c_str(), mode)) == 0,
+               "Failed to mkfifo('{}', {:o}): {}", path, mode, StrError(errno));
   }
 
   Fd ret = CF_EXPECT(Fd::Open(path, O_RDWR));
 
-  if (existed) {
+  if (st.has_value()) {
     int flags = ret.Fcntl(F_GETFL, 0);
     if (flags >= 0) {
       ret.Fcntl(F_SETFL, flags | O_NONBLOCK);

--- a/base/cvd/cuttlefish/files/BUILD.bazel
+++ b/base/cvd/cuttlefish/files/BUILD.bazel
@@ -12,7 +12,7 @@ cf_cc_library(
     hdrs = ["are_hard_linked.h"],
     deps = [
         "//cuttlefish/files:file_device_id",
-        "//cuttlefish/posix:strerror",
+        "//cuttlefish/posix:stat",
         "//cuttlefish/result:expect",
         "//cuttlefish/result:result_type",
     ],
@@ -35,6 +35,7 @@ cf_cc_library(
     hdrs = ["copy_with_attributes.h"],
     deps = [
         "//cuttlefish/files:copy",
+        "//cuttlefish/posix:stat",
         "//cuttlefish/posix:strerror",
         "//cuttlefish/result:expect",
         "//cuttlefish/result:result_type",
@@ -62,7 +63,7 @@ cf_cc_library(
     srcs = ["file_device_id.cc"],
     hdrs = ["file_device_id.h"],
     deps = [
-        "//cuttlefish/posix:strerror",
+        "//cuttlefish/posix:stat",
         "//cuttlefish/result:expect",
         "//cuttlefish/result:result_type",
     ],
@@ -78,6 +79,9 @@ cf_cc_library(
     name = "file_is_socket",
     srcs = ["file_is_socket.cc"],
     hdrs = ["file_is_socket.h"],
+    deps = [
+        "//cuttlefish/posix:stat",
+    ],
 )
 
 cf_cc_library(

--- a/base/cvd/cuttlefish/files/are_hard_linked.cc
+++ b/base/cvd/cuttlefish/files/are_hard_linked.cc
@@ -16,14 +16,13 @@
 
 #include "cuttlefish/files/are_hard_linked.h"
 
-#include <errno.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
 #include <string>
 
 #include "cuttlefish/files/file_device_id.h"
-#include "cuttlefish/posix/strerror.h"
+#include "cuttlefish/posix/stat.h"
 #include "cuttlefish/result/expect.h"
 #include "cuttlefish/result/result_type.h"
 
@@ -31,13 +30,7 @@ namespace cuttlefish {
 namespace {
 
 Result<ino_t> FileInodeNumber(const std::string& path) {
-  struct stat out;
-  CF_EXPECTF(
-      stat(path.c_str(), &out) == 0,
-      "stat() failed trying to retrieve inode num information for \"{}\" "
-      "with error: {}",
-      path, StrError(errno));
-  return out.st_ino;
+  return CF_EXPECT(Stat(path)).st_ino;
 }
 
 }  // namespace

--- a/base/cvd/cuttlefish/files/file_device_id.cc
+++ b/base/cvd/cuttlefish/files/file_device_id.cc
@@ -16,26 +16,19 @@
 
 #include "cuttlefish/files/file_device_id.h"
 
-#include <errno.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
 #include <string>
 
-#include "cuttlefish/posix/strerror.h"
+#include "cuttlefish/posix/stat.h"
 #include "cuttlefish/result/expect.h"
 #include "cuttlefish/result/result_type.h"
 
 namespace cuttlefish {
 
 Result<dev_t> FileDeviceId(const std::string& path) {
-  struct stat out;
-  CF_EXPECTF(
-      stat(path.c_str(), &out) == 0,
-      "stat() failed trying to retrieve device ID information for \"{}\" "
-      "with error: {}",
-      path, StrError(errno));
-  return out.st_dev;
+  return CF_EXPECT(Stat(path)).st_dev;
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/files/file_is_socket.cc
+++ b/base/cvd/cuttlefish/files/file_is_socket.cc
@@ -20,11 +20,13 @@
 
 #include <string>
 
+#include "cuttlefish/posix/stat.h"
+
 namespace cuttlefish {
 
 bool FileIsSocket(const std::string& path) {
-  struct stat st{};
-  return stat(path.c_str(), &st) == 0 && S_ISSOCK(st.st_mode);
+  static auto sock = [](const struct stat& st) { return S_ISSOCK(st.st_mode); };
+  return Stat(path).transform(sock).value_or(false);
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -189,6 +189,7 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:in_sandbox",
         "//cuttlefish/files:directory_contents",
         "//cuttlefish/host/libs/config:config_utils",
+        "//cuttlefish/posix:stat",
         "//cuttlefish/posix:strerror",
         "//cuttlefish/process:proc_file_utils",
         "//cuttlefish/result",

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/clean.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/clean.cc
@@ -36,6 +36,7 @@
 #include "cuttlefish/common/libs/utils/in_sandbox.h"
 #include "cuttlefish/files/directory_contents.h"
 #include "cuttlefish/host/libs/config/config_utils.h"
+#include "cuttlefish/posix/stat.h"
 #include "cuttlefish/posix/strerror.h"
 #include "cuttlefish/process/proc_file_utils.h"
 #include "cuttlefish/result/result.h"
@@ -149,14 +150,14 @@ Result<void> CleanPriorFiles(const std::vector<std::string>& paths,
   std::set<std::string> prior_dirs;
   std::set<std::string> prior_files;
   for (const auto& path : paths) {
-    struct stat statbuf;
-    if (stat(path.c_str(), &statbuf) < 0) {
+    Result<struct stat> statbuf = Stat(path);
+    if (!statbuf.has_value()) {
       if (errno == ENOENT) {
         continue;  // it doesn't exist yet, so there is no work to do
       }
       return CF_ERRNO("Could not stat \"" << path << "\"");
     }
-    bool is_directory = (statbuf.st_mode & S_IFMT) == S_IFDIR;
+    bool is_directory = (statbuf->st_mode & S_IFMT) == S_IFDIR;
     (is_directory ? prior_dirs : prior_files).emplace(path);
   }
   VLOG(0) << fmt::format("Prior dirs: {}", fmt::join(prior_dirs, ", "));

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/BUILD.bazel
@@ -36,6 +36,7 @@ cf_cc_library(
     srcs = ["privilege.cpp"],
     hdrs = ["privilege.h"],
     deps = [
+        "//cuttlefish/posix:stat",
         "//cuttlefish/posix:strerror",
         "//cuttlefish/result:expect",
         "//cuttlefish/result:result_type",

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/privilege.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/privilege.cpp
@@ -17,8 +17,6 @@
 
 #include <errno.h>
 #include <fcntl.h>
-#include <stddef.h>
-#include <sys/stat.h>
 #include <unistd.h>
 #if defined(__linux__)
 #include <linux/capability.h>
@@ -34,6 +32,7 @@
 
 #include "absl/log/log.h"
 
+#include "cuttlefish/posix/stat.h"
 #include "cuttlefish/posix/strerror.h"
 #include "cuttlefish/result/expect.h"
 #include "cuttlefish/result/result_type.h"
@@ -92,11 +91,9 @@ static int SetAmbientCapabilities() {
 #endif
 
 Result<void> ValidateCvdallocBinary(std::string_view path) {
-  struct stat st;
-  int r = stat(path.data(), &st);
-  CF_EXPECTF(r == 0, "Could not stat the cvdalloc binary at '{}': '{}'", path,
-             StrError(errno));
+  struct stat st = CF_EXPECT(Stat(path));
 #if defined(__linux__)
+  (void)st;
   /* Try and determine if the cvdalloc binary has any capabilities. */
   struct vfs_cap_data cap;
   ssize_t s = getxattr(path.data(), XATTR_NAME_CAPS, &cap, sizeof(cap));

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
@@ -125,7 +125,7 @@ cf_cc_library(
         "//cuttlefish/host/libs/config:known_paths",
         "//cuttlefish/host/libs/feature",
         "//cuttlefish/host/libs/vm_manager",
-        "//cuttlefish/posix:strerror",
+        "//cuttlefish/posix:stat",
         "//cuttlefish/process:command",
         "//cuttlefish/process:subprocess",
         "//cuttlefish/result",

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/cvdalloc.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/cvdalloc.cpp
@@ -15,9 +15,7 @@
 
 #include "cuttlefish/host/commands/run_cvd/launch/cvdalloc.h"
 
-#include <errno.h>
 #include <sys/socket.h>
-#include <sys/stat.h>
 
 #include <chrono>
 #include <mutex>
@@ -39,7 +37,7 @@
 #include "cuttlefish/host/libs/feature/command_source.h"
 #include "cuttlefish/host/libs/feature/feature.h"
 #include "cuttlefish/host/libs/vm_manager/vm_manager.h"
-#include "cuttlefish/posix/strerror.h"
+#include "cuttlefish/posix/stat.h"
 #include "cuttlefish/process/command.h"
 #include "cuttlefish/process/subprocess.h"
 #include "cuttlefish/result/result.h"
@@ -103,10 +101,7 @@ Result<void> Cvdalloc::ResultSetup() {
 }
 
 Result<void> Cvdalloc::BinaryIsValid(std::string_view path) {
-  struct stat st;  // NOLINT(misc-include-cleaner): sys/stat.h
-  int r = stat(path.data(), &st);
-  CF_EXPECT(r == 0, "Could not stat the cvdalloc binary at "
-                        << path << ": " << StrError(errno));
+  CF_EXPECT(Stat(path));
   CF_EXPECT(ValidateCvdallocBinary(path));
   return {};
 }

--- a/base/cvd/cuttlefish/host/libs/directories/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/directories/BUILD.bazel
@@ -19,6 +19,7 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/common/libs/utils:users",
         "//cuttlefish/posix:rename",
+        "//cuttlefish/posix:stat",
         "//cuttlefish/posix:strerror",
         "//cuttlefish/result",
         "//libbase",

--- a/base/cvd/cuttlefish/host/libs/directories/xdg.cpp
+++ b/base/cvd/cuttlefish/host/libs/directories/xdg.cpp
@@ -30,6 +30,7 @@
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/common/libs/utils/users.h"
 #include "cuttlefish/posix/rename.h"
+#include "cuttlefish/posix/stat.h"
 #include "cuttlefish/posix/strerror.h"
 #include "cuttlefish/result/result.h"
 
@@ -134,12 +135,12 @@ Result<std::string> ReadCvdDataFile(std::string_view path) {
 Result<std::vector<std::string>> FindCvdDataFiles(std::string_view path) {
   std::vector<std::string> results;
   for (const std::string& dir : CF_EXPECT(CvdDataDirs())) {
-    struct stat statbuf;
     std::string test_path = fmt::format("{}/{}", dir, path);
-    if (stat(test_path.c_str(), &statbuf) != 0) {
+    Result<struct stat> statbuf = Stat(test_path);
+    if (!statbuf.has_value()) {
       continue;
     }
-    if (!S_ISDIR(statbuf.st_mode)) {
+    if (!S_ISDIR(statbuf->st_mode)) {
       results.emplace_back(std::move(test_path));
       continue;
     }

--- a/base/cvd/cuttlefish/io/BUILD.bazel
+++ b/base/cvd/cuttlefish/io/BUILD.bazel
@@ -301,7 +301,7 @@ cf_cc_library(
         "//cuttlefish/io",
         "//cuttlefish/io:filesystem",
         "//cuttlefish/posix:remove",
-        "//cuttlefish/posix:strerror",
+        "//cuttlefish/posix:stat",
         "//cuttlefish/result:expect",
         "//cuttlefish/result:result_type",
     ],

--- a/base/cvd/cuttlefish/io/native_filesystem.cc
+++ b/base/cvd/cuttlefish/io/native_filesystem.cc
@@ -15,19 +15,16 @@
 
 #include "cuttlefish/io/native_filesystem.h"
 
-#include <errno.h>
 #include <fcntl.h>
 #include <stdint.h>
-#include <sys/stat.h>
 
 #include <memory>
-#include <string>
 #include <string_view>
 
 #include "cuttlefish/common/libs/fs/fd.h"
 #include "cuttlefish/io/io.h"
 #include "cuttlefish/posix/remove.h"
-#include "cuttlefish/posix/strerror.h"
+#include "cuttlefish/posix/stat.h"
 #include "cuttlefish/result/expect.h"
 #include "cuttlefish/result/result_type.h"
 
@@ -40,9 +37,7 @@ Result<std::unique_ptr<ReaderWriterSeeker>> NativeFilesystem::CreateFile(
 }
 
 Result<uint32_t> NativeFilesystem::FileAttributes(std::string_view path) const {
-  struct stat st;
-  CF_EXPECT_GE(stat(std::string(path).c_str(), &st), 0, StrError(errno));
-  return st.st_mode;
+  return CF_EXPECT(Stat(path)).st_mode;
 }
 
 Result<void> NativeFilesystem::DeleteFile(std::string_view path) {

--- a/base/cvd/cuttlefish/io/native_filesystem.h
+++ b/base/cvd/cuttlefish/io/native_filesystem.h
@@ -17,6 +17,7 @@
 
 #include <stdint.h>
 
+#include <memory>
 #include <string_view>
 
 #include "cuttlefish/io/filesystem.h"

--- a/base/cvd/cuttlefish/package/BUILD.bazel
+++ b/base/cvd/cuttlefish/package/BUILD.bazel
@@ -10,7 +10,7 @@ cf_cc_binary(
         "//cuttlefish/files:link_or_copy",
         "//cuttlefish/files:recursively_remove_directory",
         "//cuttlefish/flag_parser",
-        "//cuttlefish/posix:strerror",
+        "//cuttlefish/posix:stat",
         "//cuttlefish/posix:symlink",
         "//cuttlefish/result:expect",
         "//cuttlefish/result:result_type",

--- a/base/cvd/cuttlefish/package/packager.cc
+++ b/base/cvd/cuttlefish/package/packager.cc
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <errno.h>
 #include <stddef.h>
 #include <sys/stat.h>
 
@@ -37,7 +36,7 @@
 #include "cuttlefish/files/recursively_remove_directory.h"
 #include "cuttlefish/flag_parser/flag.h"
 #include "cuttlefish/flag_parser/gflags_compat.h"
-#include "cuttlefish/posix/strerror.h"
+#include "cuttlefish/posix/stat.h"
 #include "cuttlefish/posix/symlink.h"
 #include "cuttlefish/result/expect.h"
 #include "cuttlefish/result/result_type.h"
@@ -121,9 +120,7 @@ Result<void> PackagerMain(std::vector<std::string> args_strs) {
   for (const auto& [pkg_path, src_path] : args.PackageToSrc()) {
     const std::string base_pkg = absl::StrCat(args.BaseDir(), "/", pkg_path);
     CF_EXPECT(EnsureDirectoryExists(android::base::Dirname(base_pkg)));
-    struct stat st;
-    CF_EXPECTF(stat(src_path.c_str(), &st) == 0, "Failed to stat('{}'): {}",
-               src_path, StrError(errno));
+    struct stat st = CF_EXPECT(Stat(src_path));
     // bin/cvd is sensitive to location, uses readlink("/proc/self/exe").
     // Otherwise, the input may be either a file in the source tree or a bazel
     // artifact. If we hard link the file in the source tree, bazel will try to

--- a/base/cvd/cuttlefish/posix/BUILD.bazel
+++ b/base/cvd/cuttlefish/posix/BUILD.bazel
@@ -65,3 +65,14 @@ cf_cc_library(
         "@abseil-cpp//absl/log",
     ],
 )
+
+cf_cc_library(
+    name = "stat",
+    srcs = ["stat.cc"],
+    hdrs = ["stat.h"],
+    deps = [
+        "//cuttlefish/posix:strerror",
+        "//cuttlefish/result:expect",
+        "//cuttlefish/result:result_type",
+    ],
+)

--- a/base/cvd/cuttlefish/posix/BUILD.bazel
+++ b/base/cvd/cuttlefish/posix/BUILD.bazel
@@ -72,7 +72,13 @@ cf_cc_library(
     hdrs = ["stat.h"],
     deps = [
         "//cuttlefish/posix:strerror",
+        "//cuttlefish/posix:temp_failure_retry",
         "//cuttlefish/result:expect",
         "//cuttlefish/result:result_type",
     ],
+)
+
+cf_cc_library(
+    name = "temp_failure_retry",
+    hdrs = ["temp_failure_retry.h"],
 )

--- a/base/cvd/cuttlefish/posix/stat.cc
+++ b/base/cvd/cuttlefish/posix/stat.cc
@@ -24,6 +24,7 @@
 #include <string_view>
 
 #include "cuttlefish/posix/strerror.h"
+#include "cuttlefish/posix/temp_failure_retry.h"  // IWYU pragma: keep
 #include "cuttlefish/result/expect.h"
 #include "cuttlefish/result/result_type.h"
 

--- a/base/cvd/cuttlefish/posix/stat.cc
+++ b/base/cvd/cuttlefish/posix/stat.cc
@@ -14,29 +14,34 @@
  * limitations under the License.
  */
 
-#include "cuttlefish/files/copy_with_attributes.h"
+#include "cuttlefish/posix/stat.h"
 
 #include <errno.h>
 #include <sys/stat.h>
-#include <sys/types.h>
+#include <unistd.h>
 
 #include <string>
+#include <string_view>
 
-#include "cuttlefish/files/copy.h"
-#include "cuttlefish/posix/stat.h"
 #include "cuttlefish/posix/strerror.h"
 #include "cuttlefish/result/expect.h"
 #include "cuttlefish/result/result_type.h"
 
 namespace cuttlefish {
 
-Result<void> CopyWithAttributes(const std::string& from,
-                                const std::string& to) {
-  CF_EXPECTF(Copy(from, to), "Failed to copy '{}' to '{}'", from, to);
-  mode_t mode = CF_EXPECT(Stat(from)).st_mode;
-  CF_EXPECTF(chmod(to.c_str(), mode) >= 0, "Failed to chmod '{}': {}", to,
-             StrError(errno));
-  return {};
+Result<struct stat> Stat(const char* path) {
+  struct stat ret;
+  int success = TEMP_FAILURE_RETRY(stat(path, &ret));
+  CF_EXPECTF(success == 0, "Stat('{}') failed: ", path, StrError(errno));
+  return ret;
+}
+
+Result<struct stat> Stat(const std::string& path) {
+  return CF_EXPECT(Stat(path.c_str()));
+}
+
+Result<struct stat> Stat(std::string_view path) {
+  return CF_EXPECT(Stat(std::string(path)));
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/posix/stat.h
+++ b/base/cvd/cuttlefish/posix/stat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 The Android Open Source Project
+ * Copyright (C) 2026 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,30 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#pragma once
 
-#include "cuttlefish/files/copy_with_attributes.h"
-
-#include <errno.h>
 #include <sys/stat.h>
-#include <sys/types.h>
 
 #include <string>
+#include <string_view>
 
-#include "cuttlefish/files/copy.h"
-#include "cuttlefish/posix/stat.h"
-#include "cuttlefish/posix/strerror.h"
-#include "cuttlefish/result/expect.h"
 #include "cuttlefish/result/result_type.h"
 
 namespace cuttlefish {
 
-Result<void> CopyWithAttributes(const std::string& from,
-                                const std::string& to) {
-  CF_EXPECTF(Copy(from, to), "Failed to copy '{}' to '{}'", from, to);
-  mode_t mode = CF_EXPECT(Stat(from)).st_mode;
-  CF_EXPECTF(chmod(to.c_str(), mode) >= 0, "Failed to chmod '{}': {}", to,
-             StrError(errno));
-  return {};
-}
+Result<struct stat> Stat(const char*);
+Result<struct stat> Stat(const std::string&);
+Result<struct stat> Stat(std::string_view);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/posix/temp_failure_retry.h
+++ b/base/cvd/cuttlefish/posix/temp_failure_retry.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <errno.h>
+
+// glibc-ism, not guaranteed by posix
+#ifndef TEMP_FAILURE_RETRY
+// https://cs.android.com/android/platform/superproject/+/android-latest-release:bionic/libc/include/unistd.h;l=479;drc=3f4f1697e89d3904f441db4977920448d3861a10
+/* Used to retry syscalls that can return EINTR. */
+#define TEMP_FAILURE_RETRY(exp)            \
+  ({                                       \
+    __typeof__(exp) _rc;                   \
+    do {                                   \
+      _rc = (exp);                         \
+    } while (_rc == -1 && errno == EINTR); \
+    _rc;                                   \
+  })
+#endif

--- a/base/cvd/cuttlefish/process/BUILD.bazel
+++ b/base/cvd/cuttlefish/process/BUILD.bazel
@@ -73,6 +73,7 @@ cf_cc_library(
         "//cuttlefish/files:directory_contents",
         "//cuttlefish/files:directory_exists",
         "//cuttlefish/posix:readlink",
+        "//cuttlefish/posix:stat",
         "//cuttlefish/result",
         "//libbase",
         "@abseil-cpp//absl/log",

--- a/base/cvd/cuttlefish/process/proc_file_utils.cc
+++ b/base/cvd/cuttlefish/process/proc_file_utils.cc
@@ -43,6 +43,7 @@
 #include "cuttlefish/files/directory_contents.h"
 #include "cuttlefish/files/directory_exists.h"
 #include "cuttlefish/posix/readlink.h"
+#include "cuttlefish/posix/stat.h"
 #include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
@@ -50,10 +51,7 @@ namespace cuttlefish {
 // sometimes, files under /proc/<pid> owned by a different user
 // e.g. /proc/<pid>/exe
 static Result<uid_t> FileOwnerUid(const std::string& file_path) {
-  // NOLINTNEXTLINE(misc-include-cleaner): <sys/stat.h>
-  struct stat buf;
-  CF_EXPECT_EQ(::stat(file_path.data(), &buf), 0);
-  return buf.st_uid;
+  return CF_EXPECT(Stat(file_path)).st_uid;
 }
 
 struct ProcStatusUids {


### PR DESCRIPTION
This guarantees that TEMP_FAILURE_RETRY is called, and puts the error formatting text in a common place.

Bug: b/546692445