### PR TITLE
vhost_user_media: Uprev vhost and vhost-user-backend

### DIFF
--- a/base/cvd/cuttlefish/host/commands/vhost_user_media/Cargo.toml
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_media/Cargo.toml
@@ -15,12 +15,12 @@ log = "0.4"
 nix = "0.29.0"
 thiserror = "2.0"
 v4l2r = { version = "0.0.6", features = ["arch64"] }
-vhost = { version = "0.16.0", features = ["vhost-user-backend"] }
-vhost-user-backend = {  version = "0.22.0" }
+vhost = { version = "0.17.0", features = ["vhost-user-backend"] }
+vhost-user-backend = {  version = "0.23.0" }
 vhu_media = { path = "vhu_media" }
-virtio-bindings = "0.2.6"
+virtio-bindings = "0.2.7"
 virtio-media = "0.0.7"
-virtio-queue = "0.17.0"
+virtio-queue = "0.18.0"
 vm-allocator = "0.1.3"
-vm-memory = "=0.17.1"
+vm-memory = "=0.18.0"
 vmm-sys-util = "0.15.0"


### PR DESCRIPTION
The vhost-user SHMEM protocol feature bit number was updated to rust-vmm/vhost (https://github.com/rust-vmm/vhost/pull/367) and adopted in crosvm (https://chromium-review.git.corp.google.com/c/crosvm/crosvm/+/8193826).

Uprev vhost to 0.17.0 and vhost-user-backend to 0.23.0, along with associated dependencies to match the new bit definition.

Bug: b/543144081
Test: bazel build //cuttlefish/host/commands/vhost_user_media/...
Test: v4l2-compliance -d1 -s