### PR TITLE
Revert "Disable media tests blocking kokoro presubmit"

### DIFF
--- a/e2etests/cvd/media_tests/cts/BUILD.bazel
+++ b/e2etests/cvd/media_tests/cts/BUILD.bazel
@@ -12,21 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# load("@rules_go//go:def.bzl", "go_test")
+load("@rules_go//go:def.bzl", "go_test")
 
-# TODO(b/543144081): re-enable this test
-# go_test(
-#     name = "media_tests",
-#     srcs = ["main_test.go"],
-#     deps = [
-#         "//cvd/common:common",
-#     ],
-#     size = "large",
-#     tags = [
-#         "exclusive",
-#         "external",
-#         "no-sandbox",
-#         "requires_ab",
-#         "supports-graceful-termination",
-#     ],
-# )
+go_test(
+    name = "media_tests",
+    srcs = ["main_test.go"],
+    deps = [
+        "//cvd/common:common",
+    ],
+    size = "large",
+    tags = [
+        "exclusive",
+        "external",
+        "no-sandbox",
+        "requires_ab",
+        "supports-graceful-termination",
+    ],
+)

--- a/e2etests/cvd/media_tests/v4l2compliance/BUILD.bazel
+++ b/e2etests/cvd/media_tests/v4l2compliance/BUILD.bazel
@@ -12,23 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# load("@rules_go//go:def.bzl", "go_test")
+load("@rules_go//go:def.bzl", "go_test")
 
-# TODO(b/543144081): re-enable this test
-# go_test(
-#     name = "media_tests",
-#     size = "large",
-#     srcs = ["main_test.go"],
-#     data = ["//:debian_substitution_marker"],
-#     env = {"LOCAL_DEBIAN_SUBSTITUTION_MARKER_FILE": "$(rlocationpath //:debian_substitution_marker)"},
-#     tags = [
-#         "exclusive",
-#         "external",
-#         "no-sandbox",
-#         "requires_ab",
-#         "supports-graceful-termination",
-#     ],
-#     deps = [
-#         "//cvd/common",
-#     ],
-# )
+go_test(
+    name = "media_tests",
+    size = "large",
+    srcs = ["main_test.go"],
+    data = ["//:debian_substitution_marker"],
+    env = {"LOCAL_DEBIAN_SUBSTITUTION_MARKER_FILE": "$(rlocationpath //:debian_substitution_marker)"},
+    tags = [
+        "exclusive",
+        "external",
+        "no-sandbox",
+        "requires_ab",
+        "supports-graceful-termination",
+    ],
+    deps = [
+        "//cvd/common",
+    ],
+)


### PR DESCRIPTION
Revert commit 26e8fe7633395d46a86ab260b81fcd015d6286bc as the issue was fixed by https://github.com/google/android-cuttlefish/pull/3033.

Bug: b/543144081