### PR TITLE
Support seccomp policies baked into crosvm

### DIFF
--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
@@ -28,6 +28,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/log/log.h"
 #include "absl/strings/str_join.h"
 #include "android-base/file.h"
 #include "json/json.h"
@@ -751,13 +752,12 @@ Result<std::vector<MonitorCommand>> CrosvmManager::StartCommands(
     const bool seccomp_exists = DirectoryExists(instance.seccomp_policy_dir());
     const std::string& var_empty_dir = kCrosvmVarEmptyDir;
     const bool var_empty_available = DirectoryExists(var_empty_dir);
-    CF_EXPECT(var_empty_available && seccomp_exists,
-              var_empty_dir << " is not an existing, empty directory."
-                            << "seccomp-policy-dir, "
-                            << instance.seccomp_policy_dir()
-                            << " does not exist");
-    crosvm_cmd.Cmd().AddParameter("--seccomp-policy-dir=",
-                                  instance.seccomp_policy_dir());
+    if (seccomp_exists && var_empty_available) {
+      crosvm_cmd.Cmd().AddParameter("--seccomp-policy-dir=",
+                                    instance.seccomp_policy_dir());
+    } else {
+      VLOG(0) << "Relying on crosvm built-in sandboxing";
+    }
   } else {
     crosvm_cmd.Cmd().AddParameter("--disable-sandbox");
   }


### PR DESCRIPTION
On Android, the seccomp policy files used for crosvm sandbox mode are not baked into the crosvm executable. We distribute them instead through `cvd-host_package.tar.gz`.

As we create our own crosvm build, we can bake these into the executable instead which is more convenient.

Bug: b/548053644