### PR TITLE
Rename FileInstance to Fd

### DIFF
--- a/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
@@ -21,9 +21,9 @@ cf_cc_library(
 )
 
 cf_cc_library(
-    name = "file_instance",
-    srcs = ["file_instance.cc"],
-    hdrs = ["file_instance.h"],
+    name = "fd",
+    srcs = ["fd.cc"],
+    hdrs = ["fd.h"],
     include_cleaner_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs:scoped_mmap",
@@ -54,7 +54,7 @@ cf_cc_library(
         "//conditions:default": [],
     }),
     deps = [
-        "//cuttlefish/common/libs/fs:file_instance",
+        "//cuttlefish/common/libs/fs:fd",
         "//cuttlefish/common/libs/fs:unique_fd",
         "//cuttlefish/posix:strerror",
         "//cuttlefish/result",
@@ -78,7 +78,7 @@ cf_cc_library(
     srcs = ["recv_all.cc"],
     hdrs = ["recv_all.h"],
     deps = [
-        "//cuttlefish/common/libs/fs:file_instance",
+        "//cuttlefish/common/libs/fs:fd",
         "//cuttlefish/result:expect",
         "//cuttlefish/result:result_type",
     ],
@@ -106,7 +106,7 @@ cf_cc_library(
     hdrs = ["unique_fd.h"],
     include_cleaner_enabled = False,
     deps = [
-        "//cuttlefish/common/libs/fs:file_instance",
+        "//cuttlefish/common/libs/fs:fd",
         "//cuttlefish/common/libs/utils:environment",
         "//cuttlefish/posix:strerror",
         "//cuttlefish/result",

--- a/base/cvd/cuttlefish/common/libs/fs/epoll.cpp
+++ b/base/cvd/cuttlefish/common/libs/fs/epoll.cpp
@@ -35,7 +35,7 @@ Result<Epoll> Epoll::Create() {
   if (fd == -1) {
     return CF_ERRNO("Failed to create epoll");
   }
-  SharedFD shared{std::shared_ptr<FileInstance>(new FileInstance(fd, 0))};
+  SharedFD shared{std::shared_ptr<Fd>(new Fd(fd, 0))};
   return Epoll(shared);
 }
 

--- a/base/cvd/cuttlefish/common/libs/fs/fd.cc
+++ b/base/cvd/cuttlefish/common/libs/fs/fd.cc
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "cuttlefish/common/libs/fs/file_instance.h"
+#include "cuttlefish/common/libs/fs/fd.h"
 
 #include <arpa/inet.h>
 #include <errno.h>
@@ -77,24 +77,23 @@ constexpr size_t kPreferredBufferSize = 8192;
 
 }  // namespace
 
-FileInstance::FileInstance() : FileInstance(-1, 0) {}
+Fd::Fd() : Fd(-1, 0) {}
 
-FileInstance::FileInstance(FileInstance&& other) : FileInstance() {
+Fd::Fd(Fd&& other) : Fd() {
   std::swap(fd_, other.fd_);
   std::swap(errno_, other.errno_);
 }
 
-FileInstance::~FileInstance() { Close(); }
+Fd::~Fd() { Close(); }
 
-FileInstance& FileInstance::operator=(FileInstance&& other) {
+Fd& Fd::operator=(Fd&& other) {
   Close();
   std::swap(fd_, other.fd_);
   std::swap(errno_, other.errno_);
   return *this;
 }
 
-bool FileInstance::CopyFrom(FileInstance& in, size_t length,
-                            FileInstance* stop) {
+bool Fd::CopyFrom(Fd& in, size_t length, Fd* stop) {
   LocalErrno record_errno(errno_);
   std::vector<char> buffer(kPreferredBufferSize);
   while (length > 0) {
@@ -149,8 +148,8 @@ bool FileInstance::CopyFrom(FileInstance& in, size_t length,
   return true;
 }
 
-bool FileInstance::CopyAllFrom(FileInstance& in, FileInstance* stop) {
-  // FileInstance may have been constructed with a non-zero errno_ value because
+bool Fd::CopyAllFrom(Fd& in, Fd* stop) {
+  // Fd may have been constructed with a non-zero errno_ value because
   // the errno variable is not zeroed out before.
   errno_ = 0;
   in.errno_ = 0;
@@ -160,7 +159,7 @@ bool FileInstance::CopyAllFrom(FileInstance& in, FileInstance* stop) {
   return !GetErrno() && !in.GetErrno();
 }
 
-bool FileInstance::SendFile(FileInstance& in, off_t* offset, size_t count) {
+bool Fd::SendFile(Fd& in, off_t* offset, size_t count) {
   LocalErrno record_errno(errno_);
   while (count > 0) {
 #ifdef __linux__
@@ -183,7 +182,7 @@ bool FileInstance::SendFile(FileInstance& in, off_t* offset, size_t count) {
   return true;
 }
 
-void FileInstance::Close() {
+void Fd::Close() {
   std::stringstream message;
   if (fd_ == -1) {
     errno_ = EBADF;
@@ -205,15 +204,14 @@ void FileInstance::Close() {
   fd_ = -1;
 }
 
-bool FileInstance::Chmod(mode_t mode) {
+bool Fd::Chmod(mode_t mode) {
   LocalErrno record_errno(errno_);
 
   return fchmod(fd_, mode) == 0;
 }
 
-int FileInstance::ConnectWithTimeout(const struct sockaddr* addr,
-                                     socklen_t addrlen,
-                                     struct timeval* timeout) {
+int Fd::ConnectWithTimeout(const struct sockaddr* addr, socklen_t addrlen,
+                           struct timeval* timeout) {
   int original_flags = Fcntl(F_GETFL, 0);
   if (original_flags == -1) {
     LOG(ERROR) << "Could not get current file descriptor flags: " << StrError();
@@ -275,7 +273,7 @@ int FileInstance::ConnectWithTimeout(const struct sockaddr* addr,
   return 0;
 }
 
-bool FileInstance::IsSet(fd_set* in) const {
+bool Fd::IsSet(fd_set* in) const {
   if (IsOpen() && FD_ISSET(fd_, in)) {
     return true;
   }
@@ -283,12 +281,12 @@ bool FileInstance::IsSet(fd_set* in) const {
 }
 
 #if ENABLE_GCE_SHARED_FD_LOGGING
-void FileInstance::Log(const char* message) { LOG(INFO) << message; }
+void Fd::Log(const char* message) { LOG(INFO) << message; }
 #else
-void FileInstance::Log(const char*) {}
+void Fd::Log(const char*) {}
 #endif
 
-void FileInstance::Set(fd_set* dest, int* max_index) const {
+void Fd::Set(fd_set* dest, int* max_index) const {
   if (!IsOpen()) {
     return;
   }
@@ -298,31 +296,31 @@ void FileInstance::Set(fd_set* dest, int* max_index) const {
   FD_SET(fd_, dest);
 }
 
-int FileInstance::Bind(const struct sockaddr* addr, socklen_t addrlen) {
+int Fd::Bind(const struct sockaddr* addr, socklen_t addrlen) {
   LocalErrno record_errno(errno_);
 
   return bind(fd_, addr, addrlen);
 }
 
-int FileInstance::Connect(const struct sockaddr* addr, socklen_t addrlen) {
+int Fd::Connect(const struct sockaddr* addr, socklen_t addrlen) {
   LocalErrno record_errno(errno_);
 
   return connect(fd_, addr, addrlen);
 }
 
-int FileInstance::UNMANAGED_Dup() {
+int Fd::UNMANAGED_Dup() {
   LocalErrno record_errno(errno_);
 
   return TEMP_FAILURE_RETRY(dup(fd_));
 }
 
-int FileInstance::UNMANAGED_Dup2(int newfd) {
+int Fd::UNMANAGED_Dup2(int newfd) {
   LocalErrno record_errno(errno_);
 
   return TEMP_FAILURE_RETRY(dup2(fd_, newfd));
 }
 
-int FileInstance::Fchdir() {
+int Fd::Fchdir() {
   if (fd_ < 0) {
     return -1;
   }
@@ -331,19 +329,19 @@ int FileInstance::Fchdir() {
   return TEMP_FAILURE_RETRY(fchdir(fd_));
 }
 
-int FileInstance::Fcntl(int command, int value) {
+int Fd::Fcntl(int command, int value) {
   LocalErrno record_errno(errno_);
 
   return TEMP_FAILURE_RETRY(fcntl(fd_, command, value));
 }
 
-int FileInstance::Fsync() {
+int Fd::Fsync() {
   LocalErrno record_errno(errno_);
 
   return TEMP_FAILURE_RETRY(fsync(fd_));
 }
 
-Result<void> FileInstance::Flock(int operation) {
+Result<void> Fd::Flock(int operation) {
   LocalErrno record_errno(errno_);
 
   CF_EXPECT(TEMP_FAILURE_RETRY(flock(fd_, operation)) == 0,
@@ -351,14 +349,14 @@ Result<void> FileInstance::Flock(int operation) {
   return {};
 }
 
-int FileInstance::GetSockName(struct sockaddr* addr, socklen_t* addrlen) {
+int Fd::GetSockName(struct sockaddr* addr, socklen_t* addrlen) {
   LocalErrno record_errno(errno_);
 
   return TEMP_FAILURE_RETRY(getsockname(fd_, addr, addrlen));
 }
 
 #ifdef __linux__
-unsigned int FileInstance::VsockServerPort() {
+unsigned int Fd::VsockServerPort() {
   struct sockaddr_vm vm_socket;
   socklen_t length = sizeof(vm_socket);
   GetSockName(reinterpret_cast<struct sockaddr*>(&vm_socket), &length);
@@ -366,13 +364,13 @@ unsigned int FileInstance::VsockServerPort() {
 }
 #endif
 
-int FileInstance::Ioctl(int request, void* val) {
+int Fd::Ioctl(int request, void* val) {
   LocalErrno record_errno(errno_);
 
   return TEMP_FAILURE_RETRY(ioctl(fd_, request, val));
 }
 
-int FileInstance::LinkAtCwd(const std::string& path) {
+int Fd::LinkAtCwd(const std::string& path) {
   LocalErrno record_errno(errno_);
 
   std::string name = "/proc/self/fd/";
@@ -381,31 +379,31 @@ int FileInstance::LinkAtCwd(const std::string& path) {
                 AT_SYMLINK_FOLLOW);
 }
 
-int FileInstance::Listen(int backlog) {
+int Fd::Listen(int backlog) {
   LocalErrno record_errno(errno_);
 
   return listen(fd_, backlog);
 }
 
-off_t FileInstance::LSeek(off_t offset, int whence) {
+off_t Fd::LSeek(off_t offset, int whence) {
   LocalErrno record_errno(errno_);
 
   return TEMP_FAILURE_RETRY(lseek(fd_, offset, whence));
 }
 
-ssize_t FileInstance::Recv(void* buf, size_t len, int flags) {
+ssize_t Fd::Recv(void* buf, size_t len, int flags) {
   LocalErrno record_errno(errno_);
 
   return TEMP_FAILURE_RETRY(recv(fd_, buf, len, flags));
 }
 
-ssize_t FileInstance::RecvMsg(struct msghdr* msg, int flags) {
+ssize_t Fd::RecvMsg(struct msghdr* msg, int flags) {
   LocalErrno record_errno(errno_);
 
   return TEMP_FAILURE_RETRY(recvmsg(fd_, msg, flags));
 }
 
-Result<uint64_t> FileInstance::Read(void* buf, uint64_t count) {
+Result<uint64_t> Fd::Read(void* buf, uint64_t count) {
   LocalErrno record_errno(errno_);
 
   ssize_t res = TEMP_FAILURE_RETRY(read(fd_, buf, count));
@@ -414,8 +412,7 @@ Result<uint64_t> FileInstance::Read(void* buf, uint64_t count) {
   return static_cast<uint64_t>(res);
 }
 
-Result<uint64_t> FileInstance::PRead(void* buf, size_t count,
-                                     size_t offset) const {
+Result<uint64_t> Fd::PRead(void* buf, size_t count, size_t offset) const {
   LocalErrno record_errno(const_cast<int&>(errno_));
 
   ssize_t res = TEMP_FAILURE_RETRY(pread(fd_, buf, count, offset));
@@ -425,64 +422,63 @@ Result<uint64_t> FileInstance::PRead(void* buf, size_t count,
 }
 
 #ifdef __linux__
-int FileInstance::EventfdRead(eventfd_t* value) {
+int Fd::EventfdRead(eventfd_t* value) {
   LocalErrno record_errno(errno_);
 
   return eventfd_read(fd_, value);
 }
 #endif
 
-ssize_t FileInstance::Send(const void* buf, size_t len, int flags) {
+ssize_t Fd::Send(const void* buf, size_t len, int flags) {
   LocalErrno record_errno(errno_);
 
   return TEMP_FAILURE_RETRY(send(fd_, buf, len, flags));
 }
 
-ssize_t FileInstance::SendMsg(const struct msghdr* msg, int flags) {
+ssize_t Fd::SendMsg(const struct msghdr* msg, int flags) {
   LocalErrno record_errno(errno_);
 
   return TEMP_FAILURE_RETRY(sendmsg(fd_, msg, flags));
 }
 
-Result<uint64_t> FileInstance::SeekSet(uint64_t offset) {
+Result<uint64_t> Fd::SeekSet(uint64_t offset) {
   off_t ret = LSeek(static_cast<off_t>(offset), SEEK_SET);
   CF_EXPECT_GE(ret, 0, StrError());
   return ret;
 }
 
-Result<uint64_t> FileInstance::SeekCur(int64_t offset) {
+Result<uint64_t> Fd::SeekCur(int64_t offset) {
   off_t ret = LSeek(static_cast<off_t>(offset), SEEK_CUR);
   CF_EXPECT_GE(ret, 0, StrError());
   return ret;
 }
 
-Result<uint64_t> FileInstance::SeekEnd(int64_t offset) {
+Result<uint64_t> Fd::SeekEnd(int64_t offset) {
   off_t ret = LSeek(static_cast<off_t>(offset), SEEK_END);
   CF_EXPECT_GE(ret, 0, StrError());
   return ret;
 }
 
-int FileInstance::Shutdown(int how) {
+int Fd::Shutdown(int how) {
   LocalErrno record_errno(errno_);
 
   return shutdown(fd_, how);
 }
 
-int FileInstance::SetSockOpt(int level, int optname, const void* optval,
-                             socklen_t optlen) {
+int Fd::SetSockOpt(int level, int optname, const void* optval,
+                   socklen_t optlen) {
   LocalErrno record_errno(errno_);
 
   return setsockopt(fd_, level, optname, optval, optlen);
 }
 
-int FileInstance::GetSockOpt(int level, int optname, void* optval,
-                             socklen_t* optlen) {
+int Fd::GetSockOpt(int level, int optname, void* optval, socklen_t* optlen) {
   LocalErrno record_errno(errno_);
 
   return getsockopt(fd_, level, optname, optval, optlen);
 }
 
-int FileInstance::SetTerminalRaw() {
+int Fd::SetTerminalRaw() {
   LocalErrno record_errno(errno_);
 
   termios terminal_settings;
@@ -507,20 +503,20 @@ int FileInstance::SetTerminalRaw() {
   return 0;
 }
 
-std::string FileInstance::StrError() const {
+std::string Fd::StrError() const {
   errno = 0;
   return std::string(::cuttlefish::StrError(errno_));
 }
 
-ScopedMMap FileInstance::MMap(void* addr, size_t length, int prot, int flags,
-                              off_t offset) {
+ScopedMMap Fd::MMap(void* addr, size_t length, int prot, int flags,
+                    off_t offset) {
   LocalErrno record_errno(errno_);
 
   auto ptr = mmap(addr, length, prot, flags, fd_, offset);
   return ScopedMMap(ptr, length);
 }
 
-Result<void> FileInstance::Truncate(uint64_t length) {
+Result<void> Fd::Truncate(uint64_t length) {
   LocalErrno record_errno(errno_);
 
   ssize_t res = TEMP_FAILURE_RETRY(ftruncate(fd_, length));
@@ -529,7 +525,7 @@ Result<void> FileInstance::Truncate(uint64_t length) {
   return {};
 }
 
-Result<uint64_t> FileInstance::Write(const void* buf, size_t count) {
+Result<uint64_t> Fd::Write(const void* buf, size_t count) {
   if (count == 0 && !IsRegular()) {
     return 0;
   }
@@ -542,8 +538,7 @@ Result<uint64_t> FileInstance::Write(const void* buf, size_t count) {
   return static_cast<uint64_t>(res);
 }
 
-Result<uint64_t> FileInstance::PWrite(const void* buf, size_t count,
-                                      size_t offset) {
+Result<uint64_t> Fd::PWrite(const void* buf, size_t count, size_t offset) {
   LocalErrno record_errno(errno_);
 
   ssize_t res = TEMP_FAILURE_RETRY(pwrite(fd_, buf, count, offset));
@@ -553,35 +548,35 @@ Result<uint64_t> FileInstance::PWrite(const void* buf, size_t count,
 }
 
 #ifdef __linux__
-int FileInstance::EventfdWrite(eventfd_t value) {
+int Fd::EventfdWrite(eventfd_t value) {
   LocalErrno record_errno(errno_);
 
   return eventfd_write(fd_, value);
 }
 #endif
 
-bool FileInstance::IsATTY() {
+bool Fd::IsATTY() {
   LocalErrno record_errno(errno_);
 
   return isatty(fd_);
 }
 
-int FileInstance::Futimens(const struct timespec times[2]) {
+int Fd::Futimens(const struct timespec times[2]) {
   LocalErrno record_errno(errno_);
 
   return TEMP_FAILURE_RETRY(futimens(fd_, times));
 }
 
 // inotify related functions
-int FileInstance::InotifyAddWatch(const std::string& pathname, uint32_t mask) {
+int Fd::InotifyAddWatch(const std::string& pathname, uint32_t mask) {
   return inotify_add_watch(fd_, pathname.c_str(), mask);
 }
 
-void FileInstance::InotifyRmWatch(int watch) { inotify_rm_watch(fd_, watch); }
+void Fd::InotifyRmWatch(int watch) { inotify_rm_watch(fd_, watch); }
 
-FileInstance::FileInstance(int fd, int in_errno)
+Fd::Fd(int fd, int in_errno)
     : fd_(fd), errno_(in_errno), is_regular_file_(IsRegularFile(fd_)) {
-  // Ensure every file descriptor managed by a FileInstance has the CLOEXEC
+  // Ensure every file descriptor managed by a Fd has the CLOEXEC
   // flag
   TEMP_FAILURE_RETRY(fcntl(fd, F_SETFD, FD_CLOEXEC));
   std::stringstream identity;
@@ -589,13 +584,12 @@ FileInstance::FileInstance(int fd, int in_errno)
   identity_ = identity.str();
 }
 
-FileInstance* FileInstance::Accept(struct sockaddr* addr,
-                                   socklen_t* addrlen) const {
+Fd* Fd::Accept(struct sockaddr* addr, socklen_t* addrlen) const {
   int fd = TEMP_FAILURE_RETRY(accept(fd_, addr, addrlen));
   if (fd == -1) {
-    return new FileInstance(fd, errno);
+    return new Fd(fd, errno);
   } else {
-    return new FileInstance(fd, 0);
+    return new Fd(fd, 0);
   }
 }
 

--- a/base/cvd/cuttlefish/common/libs/fs/fd.h
+++ b/base/cvd/cuttlefish/common/libs/fs/fd.h
@@ -77,25 +77,25 @@ namespace cuttlefish {
  * callers to use the file without knowledge of the underlying descriptor
  * number.
  *
- * FileInstances have two states: Open and Closed. They may start in either
+ * Fds have two states: Open and Closed. They may start in either
  * state.
  *
- * Construction of FileInstances is limited to select classes to avoid
+ * Construction of Fds is limited to select classes to avoid
  * escaping file descriptors.
  */
-class FileInstance : public ReaderWriterSeeker {
+class Fd : public ReaderWriterSeeker {
   // Give SharedFD access to the aliasing constructor.
   friend class SharedFD;
   friend class UniqueFd;
   friend class Epoll;
 
  public:
-  FileInstance();
-  FileInstance(FileInstance&) = delete;
-  FileInstance(FileInstance&&);
-  ~FileInstance();
-  FileInstance& operator=(FileInstance&) = delete;
-  FileInstance& operator=(FileInstance&&);
+  Fd();
+  Fd(Fd&) = delete;
+  Fd(Fd&&);
+  ~Fd();
+  Fd& operator=(Fd&) = delete;
+  Fd& operator=(Fd&&);
 
   int Bind(const struct sockaddr* addr, socklen_t addrlen);
   int Connect(const struct sockaddr* addr, socklen_t addrlen);
@@ -109,10 +109,10 @@ class FileInstance : public ReaderWriterSeeker {
   // Otherwise an error will be set either on this file or the input.
   // The non-const reference is needed to avoid binding this to a particular
   // reference type.
-  bool CopyFrom(FileInstance& in, size_t length, FileInstance* stop = nullptr);
+  bool CopyFrom(Fd& in, size_t length, Fd* stop = nullptr);
   // Same as CopyFrom, but reads from input until EOF is reached.
-  bool CopyAllFrom(FileInstance& in, FileInstance* stop = nullptr);
-  bool SendFile(FileInstance& in, off_t* offset, size_t count);
+  bool CopyAllFrom(Fd& in, Fd* stop = nullptr);
+  bool SendFile(Fd& in, off_t* offset, size_t count);
 
   int UNMANAGED_Dup();
   int UNMANAGED_Dup2(int newfd);
@@ -207,8 +207,8 @@ class FileInstance : public ReaderWriterSeeker {
   void InotifyRmWatch(int watch);
 
  private:
-  FileInstance(int fd, int in_errno);
-  FileInstance* Accept(struct sockaddr* addr, socklen_t* addrlen) const;
+  Fd(int fd, int in_errno);
+  Fd* Accept(struct sockaddr* addr, socklen_t* addrlen) const;
 
   int fd_;
   int errno_;

--- a/base/cvd/cuttlefish/common/libs/fs/recv_all.cc
+++ b/base/cvd/cuttlefish/common/libs/fs/recv_all.cc
@@ -21,13 +21,13 @@
 #include <memory>
 #include <string>
 
-#include "cuttlefish/common/libs/fs/file_instance.h"
+#include "cuttlefish/common/libs/fs/fd.h"
 #include "cuttlefish/result/expect.h"
 #include "cuttlefish/result/result_type.h"
 
 namespace cuttlefish {
 
-Result<std::string> RecvAll(FileInstance& sock, const uint64_t count) {
+Result<std::string> RecvAll(Fd& sock, const uint64_t count) {
   uint64_t total_read{};
   CF_EXPECT(sock.IsOpen());
   std::unique_ptr<char[]> data(new char[count]);

--- a/base/cvd/cuttlefish/common/libs/fs/recv_all.h
+++ b/base/cvd/cuttlefish/common/libs/fs/recv_all.h
@@ -19,7 +19,7 @@
 
 #include <string>
 
-#include "cuttlefish/common/libs/fs/file_instance.h"
+#include "cuttlefish/common/libs/fs/fd.h"
 #include "cuttlefish/result/result_type.h"
 
 namespace cuttlefish {
@@ -29,6 +29,6 @@ namespace cuttlefish {
  *
  * On successful Recv, returns a string containing the received data
  */
-Result<std::string> RecvAll(FileInstance& sock, uint64_t count);
+Result<std::string> RecvAll(Fd& sock, uint64_t count);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd.cpp
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd.cpp
@@ -95,25 +95,25 @@ int Select(SharedFDSet* read_set, SharedFDSet* write_set,
 
   int rval = TEMP_FAILURE_RETRY(
       select(max_index, &readfds, &writefds, &errorfds, timeout));
-  FileInstance::Log("select\n");
+  Fd::Log("select\n");
   CheckMarked(&readfds, read_set);
   CheckMarked(&writefds, write_set);
   CheckMarked(&errorfds, error_set);
   return rval;
 }
 
-SharedFD::SharedFD() : value_(std::make_shared<FileInstance>()) {}
+SharedFD::SharedFD() : value_(std::make_shared<Fd>()) {}
 
 SharedFD::SharedFD(SharedFD&& other) {
   value_ = std::move(other.value_);
-  other.value_.reset(new FileInstance(-1, EBADF));
+  other.value_.reset(new Fd(-1, EBADF));
 }
 
 SharedFD::SharedFD(UniqueFd other) { value_ = std::move(other.value_); }
 
 SharedFD& SharedFD::operator=(SharedFD&& other) {
   value_ = std::move(other.value_);
-  other.value_.reset(new FileInstance(-1, EBADF));
+  other.value_.reset(new Fd(-1, EBADF));
   return *this;
 }
 
@@ -150,8 +150,8 @@ bool SharedFD::Pipe(SharedFD* fd0, SharedFD* fd1) {
   int rval = pipe(fds);
 #endif
   if (rval != -1) {
-    (*fd0) = std::shared_ptr<FileInstance>(new FileInstance(fds[0], errno));
-    (*fd1) = std::shared_ptr<FileInstance>(new FileInstance(fds[1], errno));
+    (*fd0) = std::shared_ptr<Fd>(new Fd(fds[0], errno));
+    (*fd1) = std::shared_ptr<Fd>(new Fd(fds[1], errno));
     return true;
   }
   return false;
@@ -231,8 +231,7 @@ Result<std::pair<SharedFD, std::string>> SharedFD::Mkostemp(
   const int fd = mkostemp(temp_path.data(), flags);
   CF_EXPECTF(fd != -1, "Error creating temporary file: {}",
              ::cuttlefish::StrError(errno));
-  auto shared_fd =
-      SharedFD(std::shared_ptr<FileInstance>(new FileInstance(fd, 0)));
+  auto shared_fd = SharedFD(std::shared_ptr<Fd>(new Fd(fd, 0)));
   return std::make_pair<SharedFD, std::string>(std::move(shared_fd),
                                                std::move(temp_path));
 }

--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd.h
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd.h
@@ -48,7 +48,7 @@
 #include <utility>
 #include <vector>
 
-#include "cuttlefish/common/libs/fs/file_instance.h"
+#include "cuttlefish/common/libs/fs/fd.h"
 #include "cuttlefish/common/libs/fs/unique_fd.h"
 #include "cuttlefish/result/result.h"
 
@@ -75,28 +75,28 @@ namespace cuttlefish {
 
 struct PollSharedFd;
 class Epoll;
-class FileInstance;
+class Fd;
 struct VhostUserVsockCid;
 struct VsockCid;
 
 /**
- * Counted reference to a FileInstance.
+ * Counted reference to a Fd.
  *
- * This is also the place where most new FileInstances are created. The creation
+ * This is also the place where most new Fds are created. The creation
  * methods correspond to the underlying POSIX calls.
  *
  * SharedFDs can be compared and stored in STL containers. The semantics are
  * slightly different from POSIX file descriptors:
  *
- * o The value of the SharedFD is the identity of its underlying FileInstance.
+ * o The value of the SharedFD is the identity of its underlying Fd.
  *
- * o Each newly created SharedFD has a unique, closed FileInstance:
+ * o Each newly created SharedFD has a unique, closed Fd:
  *    SharedFD a, b;
  *    assert (a != b);
  *    a = b;
  *    assert(a == b);
  *
- * o The identity of the FileInstance is not affected by closing the file:
+ * o The identity of the Fd is not affected by closing the file:
  *   SharedFD a, b;
  *   set<SharedFD> s;
  *   s.insert(a);
@@ -106,21 +106,21 @@ struct VsockCid;
  *   assert(s.count(a) == 1);
  *   assert(s.count(b) == 0);
  *
- * o FileInstances are never visibly recycled.
+ * o Fds are never visibly recycled.
  *
- * o If all of the SharedFDs referring to a FileInstance go out of scope the
- *   file is closed and the FileInstance is recycled.
+ * o If all of the SharedFDs referring to a Fd go out of scope the
+ *   file is closed and the Fd is recycled.
  *
  * Creation methods must ensure that no references to the new file descriptor
- * escape. The underlying FileInstance should have the only reference to the
+ * escape. The underlying Fd should have the only reference to the
  * file descriptor. Any method that needs to know the fd must be in either
- * SharedFD or FileInstance.
+ * SharedFD or Fd.
  *
- * SharedFDs always have an underlying FileInstance, so all of the method
+ * SharedFDs always have an underlying Fd, so all of the method
  * calls are safe in accordance with the null object pattern.
  *
- * Errors on system calls that create new FileInstances, such as Open, are
- * reported with a new, closed FileInstance with the errno set.
+ * Errors on system calls that create new Fds, such as Open, are
+ * reported with a new, closed Fd with the errno set.
  */
 class SharedFD {
   // Give WeakFD access to the underlying shared_ptr.
@@ -128,7 +128,7 @@ class SharedFD {
 
  public:
   SharedFD();
-  SharedFD(const std::shared_ptr<FileInstance>& in) : value_(in) {}
+  SharedFD(const std::shared_ptr<Fd>& in) : value_(in) {}
   SharedFD(SharedFD const&) = default;
   SharedFD(SharedFD&& other);
   SharedFD(UniqueFd other);
@@ -203,22 +203,22 @@ class SharedFD {
 
   auto operator<=>(const SharedFD&) const = default;
 
-  std::shared_ptr<FileInstance> operator->() const { return value_; }
+  std::shared_ptr<Fd> operator->() const { return value_; }
 
-  const FileInstance& operator*() const { return *value_; }
+  const Fd& operator*() const { return *value_; }
 
-  FileInstance& operator*() { return *value_; }
+  Fd& operator*() { return *value_; }
 
  private:
   static SharedFD ErrorFD(int error);
 
-  std::shared_ptr<FileInstance> value_;
+  std::shared_ptr<Fd> value_;
 };
 
 /**
- * A non-owning reference to a FileInstance. The referenced FileInstance needs
+ * A non-owning reference to a Fd. The referenced Fd needs
  * to be managed by a SharedFD. A WeakFD needs to be converted to a SharedFD to
- * access the underlying FileInstance.
+ * access the underlying Fd.
  */
 class WeakFD {
  public:
@@ -229,7 +229,7 @@ class WeakFD {
   SharedFD lock() const;
 
  private:
-  std::weak_ptr<FileInstance> value_;
+  std::weak_ptr<Fd> value_;
 };
 
 struct PollSharedFd {

--- a/base/cvd/cuttlefish/common/libs/fs/unique_fd.cc
+++ b/base/cvd/cuttlefish/common/libs/fs/unique_fd.cc
@@ -78,12 +78,12 @@ int memfd_create_wrapper(const char* name, unsigned int flags) {
 
 UniqueFd::UniqueFd(UniqueFd&& other) {
   value_ = std::move(other.value_);
-  other.value_.reset(new FileInstance(-1, EBADF));
+  other.value_.reset(new Fd(-1, EBADF));
 }
 
 UniqueFd& UniqueFd::operator=(UniqueFd&& other) {
   value_ = std::move(other.value_);
-  other.value_.reset(new FileInstance(-1, EBADF));
+  other.value_.reset(new Fd(-1, EBADF));
   return *this;
 }
 
@@ -113,23 +113,21 @@ static void MakeAddress(const char* name, bool abstract,
   *len = namelen + offsetof(struct sockaddr_un, sun_path) + 1;
 }
 
-UniqueFd::UniqueFd() : value_(std::make_unique<FileInstance>()) {}
+UniqueFd::UniqueFd() : value_(std::make_unique<Fd>()) {}
 
-UniqueFd UniqueFd::Accept(const FileInstance& listener, struct sockaddr* addr,
+UniqueFd UniqueFd::Accept(const Fd& listener, struct sockaddr* addr,
                           socklen_t* addrlen) {
-  return UniqueFd(
-      std::unique_ptr<FileInstance>(listener.Accept(addr, addrlen)));
+  return UniqueFd(std::unique_ptr<Fd>(listener.Accept(addr, addrlen)));
 }
 
-UniqueFd UniqueFd::Accept(const FileInstance& listener) {
+UniqueFd UniqueFd::Accept(const Fd& listener) {
   return UniqueFd::Accept(listener, NULL, NULL);
 }
 
 UniqueFd UniqueFd::Dup(int unmanaged_fd) {
   int fd = fcntl(unmanaged_fd, F_DUPFD_CLOEXEC, 3);
   int error_num = errno;
-  return UniqueFd(
-      std::unique_ptr<FileInstance>(new FileInstance(fd, error_num)));
+  return UniqueFd(std::unique_ptr<Fd>(new Fd(fd, error_num)));
 }
 
 bool UniqueFd::Pipe(UniqueFd* fd0, UniqueFd* fd1) {
@@ -140,8 +138,8 @@ bool UniqueFd::Pipe(UniqueFd* fd0, UniqueFd* fd1) {
   int rval = pipe(fds);
 #endif
   if (rval != -1) {
-    (*fd0) = std::unique_ptr<FileInstance>(new FileInstance(fds[0], errno));
-    (*fd1) = std::unique_ptr<FileInstance>(new FileInstance(fds[1], errno));
+    (*fd0) = std::unique_ptr<Fd>(new Fd(fds[0], errno));
+    (*fd1) = std::unique_ptr<Fd>(new Fd(fds[1], errno));
     return true;
   }
   return false;
@@ -150,21 +148,21 @@ bool UniqueFd::Pipe(UniqueFd* fd0, UniqueFd* fd1) {
 #ifdef __linux__
 UniqueFd UniqueFd::Event(int initval, int flags) {
   int fd = eventfd(initval, flags);
-  return std::unique_ptr<FileInstance>(new FileInstance(fd, errno));
+  return std::unique_ptr<Fd>(new Fd(fd, errno));
 }
 
 UniqueFd UniqueFd::ShmOpen(const std::string& name, int oflag, int mode) {
   errno = 0;
   int fd = shm_open(name.c_str(), oflag, mode);
   int error_num = errno;
-  return std::unique_ptr<FileInstance>(new FileInstance(fd, error_num));
+  return std::unique_ptr<Fd>(new Fd(fd, error_num));
 }
 #endif
 
 UniqueFd UniqueFd::MemfdCreate(const std::string& name, unsigned int flags) {
   int fd = memfd_create_wrapper(name.c_str(), flags);
   int error_num = errno;
-  return std::unique_ptr<FileInstance>(new FileInstance(fd, error_num));
+  return std::unique_ptr<Fd>(new Fd(fd, error_num));
 }
 
 bool UniqueFd::SocketPair(int domain, int type, int protocol, UniqueFd* fd0,
@@ -172,8 +170,8 @@ bool UniqueFd::SocketPair(int domain, int type, int protocol, UniqueFd* fd0,
   int fds[2];
   int rval = socketpair(domain, type, protocol, fds);
   if (rval != -1) {
-    (*fd0) = std::unique_ptr<FileInstance>(new FileInstance(fds[0], errno));
-    (*fd1) = std::unique_ptr<FileInstance>(new FileInstance(fds[1], errno));
+    (*fd0) = std::unique_ptr<Fd>(new Fd(fds[0], errno));
+    (*fd1) = std::unique_ptr<Fd>(new Fd(fds[1], errno));
     return true;
   }
   return false;
@@ -195,16 +193,16 @@ UniqueFd UniqueFd::Open(const std::string& path, int flags, mode_t mode) {
 UniqueFd UniqueFd::Open(const char* path, int flags, mode_t mode) {
   int fd = TEMP_FAILURE_RETRY(open(path, flags, mode));
   if (fd == -1) {
-    return UniqueFd(std::unique_ptr<FileInstance>(new FileInstance(fd, errno)));
+    return UniqueFd(std::unique_ptr<Fd>(new Fd(fd, errno)));
   } else {
-    return UniqueFd(std::unique_ptr<FileInstance>(new FileInstance(fd, 0)));
+    return UniqueFd(std::unique_ptr<Fd>(new Fd(fd, 0)));
   }
 }
 
 UniqueFd UniqueFd::InotifyFd(void) {
   errno = 0;
   int fd = TEMP_FAILURE_RETRY(inotify_init1(IN_CLOEXEC));
-  return UniqueFd(std::unique_ptr<FileInstance>(new FileInstance(fd, errno)));
+  return UniqueFd(std::unique_ptr<Fd>(new Fd(fd, errno)));
 }
 
 UniqueFd UniqueFd::Creat(const std::string& path, mode_t mode) {
@@ -229,18 +227,18 @@ Result<UniqueFd> UniqueFd::Fifo(const std::string& path, mode_t mode) {
 UniqueFd UniqueFd::Socket(int domain, int socket_type, int protocol) {
   int fd = TEMP_FAILURE_RETRY(socket(domain, socket_type, protocol));
   if (fd == -1) {
-    return UniqueFd(std::unique_ptr<FileInstance>(new FileInstance(fd, errno)));
+    return UniqueFd(std::unique_ptr<Fd>(new Fd(fd, errno)));
   } else {
-    return UniqueFd(std::unique_ptr<FileInstance>(new FileInstance(fd, 0)));
+    return UniqueFd(std::unique_ptr<Fd>(new Fd(fd, 0)));
   }
 }
 
 UniqueFd UniqueFd::Mkstemp(std::string* path) {
   int fd = mkstemp(path->data());
   if (fd == -1) {
-    return UniqueFd(std::unique_ptr<FileInstance>(new FileInstance(fd, errno)));
+    return UniqueFd(std::unique_ptr<Fd>(new Fd(fd, errno)));
   } else {
-    return UniqueFd(std::unique_ptr<FileInstance>(new FileInstance(fd, 0)));
+    return UniqueFd(std::unique_ptr<Fd>(new Fd(fd, 0)));
   }
 }
 
@@ -251,14 +249,13 @@ Result<std::pair<UniqueFd, std::string>> UniqueFd::Mkostemp(
   const int fd = mkostemp(temp_path.data(), flags);
   CF_EXPECTF(fd != -1, "Error creating temporary file: {}",
              ::cuttlefish::StrError(errno));
-  auto shared_fd =
-      UniqueFd(std::unique_ptr<FileInstance>(new FileInstance(fd, 0)));
+  auto shared_fd = UniqueFd(std::unique_ptr<Fd>(new Fd(fd, 0)));
   return std::make_pair<UniqueFd, std::string>(std::move(shared_fd),
                                                std::move(temp_path));
 }
 
 UniqueFd UniqueFd::ErrorFD(int error) {
-  return UniqueFd(std::unique_ptr<FileInstance>(new FileInstance(-1, error)));
+  return UniqueFd(std::unique_ptr<Fd>(new Fd(-1, error)));
 }
 
 UniqueFd UniqueFd::SocketLocalClient(const std::string& name, bool abstract,

--- a/base/cvd/cuttlefish/common/libs/fs/unique_fd.h
+++ b/base/cvd/cuttlefish/common/libs/fs/unique_fd.h
@@ -48,7 +48,7 @@
 #include <utility>
 #include <vector>
 
-#include "cuttlefish/common/libs/fs/file_instance.h"
+#include "cuttlefish/common/libs/fs/fd.h"
 #include "cuttlefish/result/result.h"
 
 /**
@@ -74,42 +74,42 @@ namespace cuttlefish {
 
 struct PollSharedFd;
 class Epoll;
-class FileInstance;
+class Fd;
 struct VhostUserVsockCid;
 struct VsockCid;
 
 /**
- * Counted reference to a FileInstance.
+ * Counted reference to a Fd.
  *
- * This is also the place where most new FileInstances are created. The creation
+ * This is also the place where most new Fds are created. The creation
  * methods correspond to the underlying POSIX calls.
  *
  * UniqueFds can be compared and stored in STL containers. The semantics are
  * slightly different from POSIX file descriptors:
  *
- * o The value of the UniqueFd is the identity of its underlying FileInstance.
+ * o The value of the UniqueFd is the identity of its underlying Fd.
  *
- * o Each newly created UniqueFd has a unique, closed FileInstance:
+ * o Each newly created UniqueFd has a unique, closed Fd:
  *    UniqueFd a, b;
  *    assert (a != b);
  *    a = b;
  *    assert(a == b);
  *
- * o FileInstances are never visibly recycled.
+ * o Fds are never visibly recycled.
  *
- * o If the UniqueFd referring to a FileInstance goes out of scope the file is
- *   closed and the FileInstance is recycled.
+ * o If the UniqueFd referring to a Fd goes out of scope the file is
+ *   closed and the Fd is recycled.
  *
  * Creation methods must ensure that no references to the new file descriptor
- * escape. The underlying FileInstance should have the only reference to the
+ * escape. The underlying Fd should have the only reference to the
  * file descriptor. Any method that needs to know the fd must be in either
- * UniqueFd or FileInstance.
+ * UniqueFd or Fd.
  *
- * UniqueFds always have an underlying FileInstance, so all of the method
+ * UniqueFds always have an underlying Fd, so all of the method
  * calls are safe in accordance with the null object pattern.
  *
- * Errors on system calls that create new FileInstances, such as Open, are
- * reported with a new, closed FileInstance with the errno set.
+ * Errors on system calls that create new Fds, such as Open, are
+ * reported with a new, closed Fd with the errno set.
  */
 class UniqueFd {
   // Give SharedFD access to the underlying unique_ptr.
@@ -117,13 +117,13 @@ class UniqueFd {
 
  public:
   UniqueFd();
-  UniqueFd(std::unique_ptr<FileInstance> in) : value_(std::move(in)) {}
+  UniqueFd(std::unique_ptr<Fd> in) : value_(std::move(in)) {}
   UniqueFd(UniqueFd&& other);
   UniqueFd& operator=(UniqueFd&& other);
-  // Reference the listener as a FileInstance to make this FD type agnostic.
-  static UniqueFd Accept(const FileInstance& listener, struct sockaddr* addr,
+  // Reference the listener as a Fd to make this FD type agnostic.
+  static UniqueFd Accept(const Fd& listener, struct sockaddr* addr,
                          socklen_t* addrlen);
-  static UniqueFd Accept(const FileInstance& listener);
+  static UniqueFd Accept(const Fd& listener);
   static UniqueFd Dup(int unmanaged_fd);
   // All UniqueFds have the O_CLOEXEC flag after creation. To remove use the
   // Fcntl or Dup functions.
@@ -190,16 +190,16 @@ class UniqueFd {
 
   auto operator<=>(const UniqueFd&) const = default;
 
-  const std::unique_ptr<FileInstance>& operator->() const { return value_; }
+  const std::unique_ptr<Fd>& operator->() const { return value_; }
 
-  const FileInstance& operator*() const { return *value_; }
+  const Fd& operator*() const { return *value_; }
 
-  FileInstance& operator*() { return *value_; }
+  Fd& operator*() { return *value_; }
 
  private:
   static UniqueFd ErrorFD(int error);
 
-  std::unique_ptr<FileInstance> value_;
+  std::unique_ptr<Fd> value_;
 };
 
 }  // namespace cuttlefish


### PR DESCRIPTION
An earlier commit introduced UniqueFd as a std::unique_ptr equivalent to std::shared_ptr for SharedFD. However, Making `FileInstance` movable makes `UniqueFd` redundant. Before using `FileInstance` everywhere, this is the best time to rename it something more ergonomic.

Bug: b/545278508