### PR TITLE
Hide warning from control_env_proxy_server/main.cpp

### DIFF
--- a/base/cvd/.bazelrc
+++ b/base/cvd/.bazelrc
@@ -7,6 +7,7 @@ build --test_output=errors
 build --test_summary=terse
 
 # files with warnings from files they depend upon
+build --per_file_copt=cuttlefish/host/commands/control_env_proxy_server/main\.cpp$@-Wno-deprecated-declarations
 build --per_file_copt=cuttlefish/host/graphics_detector/vulkan\.cpp$@-Wno-deprecated-declarations
 build --per_file_copt=cuttlefish/host/frontend/webrtc/libcommon/connection_controller\.cpp$@-Wno-thread-safety-reference-return
 build --per_file_copt=cuttlefish/host/frontend/webrtc/libcommon/connection_controller\.h$@-Wno-thread-safety-reference-return


### PR DESCRIPTION
This warning comes from grpc.
```
In file included from cuttlefish/host/commands/control_env_proxy_server/main.cpp:29:
In file included from external/grpc+/include/grpcpp/grpcpp.h:52:
In file included from external/grpc+/include/grpcpp/channel.h:23:
external/grpc+/include/grpcpp/completion_queue.h:390:31: warning: 'MutexLock' is deprecated: Use the constructor that takes a reference instead [-Wdeprecated-declarations]
  390 |     grpc::internal::MutexLock l(&server_list_mutex_);
      |                               ^
external/abseil-cpp+/absl/synchronization/mutex.h:620:5: note: 'MutexLock' has been explicitly marked deprecated here
  620 |   [[deprecated("Use the constructor that takes a reference instead")]]
      |     ^
```