### PR TITLE
Sort result by GroupName for ExecOnAllCuttlefishHosts

### DIFF
--- a/container/src/podcvd/internal/host.go
+++ b/container/src/podcvd/internal/host.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -168,6 +169,9 @@ func ExecOnAllCuttlefishHosts(ccm CuttlefishContainerManager, subcommandArgs []s
 	for res := range resCh {
 		results = append(results, res)
 	}
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].GroupName < results[j].GroupName
+	})
 	return results, nil
 }
 


### PR DESCRIPTION
To show same result for aggerated podcvd results among podcvd runs.

Like `podcvd ps`, `podcvd fleet`

ExecOnAllCuttlefishHosts aggerates results using channel, so ordering is not deterministic. To show consistent result for running `podcvd ps` and `podcvd fleet`, sort result by GroupName after receiving all results.