### PR TITLE
Add missing 'unset' in config flag vectorizing

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -230,7 +230,9 @@ Result<std::vector<bool>> GetFlagBoolValueForInstances(
       if (flag_vec[instance_index] == "unset" ||
           flag_vec[instance_index] == "\"unset\"") {
         std::string_view default_value = default_value_vec[0];
-        if (instance_index < default_value_vec.size()) {
+        if (instance_index < default_value_vec.size() &&
+            default_value_vec[instance_index] != "unset" &&
+            default_value_vec[instance_index] != "\"unset\"") {
           default_value = default_value_vec[instance_index];
         }
         value_vec[instance_index] =
@@ -264,7 +266,9 @@ Result<std::vector<int>> GetFlagIntValueForInstances(
       if (flag_vec[instance_index] == "unset" ||
           flag_vec[instance_index] == "\"unset\"") {
         std::string_view default_value = default_value_vec[0];
-        if (instance_index < default_value_vec.size()) {
+        if (instance_index < default_value_vec.size() &&
+            default_value_vec[instance_index] != "unset" &&
+            default_value_vec[instance_index] != "\"unset\"") {
           default_value = default_value_vec[instance_index];
         }
         CF_EXPECTF(absl::SimpleAtoi(default_value, &value_vec[instance_index]),
@@ -304,7 +308,9 @@ Result<std::vector<std::string>> GetFlagStrValueForInstances(
       if (flag_vec[instance_index] == "unset" ||
           flag_vec[instance_index] == "\"unset\"") {
         std::string_view default_value = default_value_vec[0];
-        if (instance_index < default_value_vec.size()) {
+        if (instance_index < default_value_vec.size() &&
+            default_value_vec[instance_index] != "unset" &&
+            default_value_vec[instance_index] != "\"unset\"") {
           default_value = default_value_vec[instance_index];
         }
         value_vec[instance_index] = default_value;

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/resolve_instance_files.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/resolve_instance_files.cc
@@ -82,7 +82,9 @@ Result<void> ResolveInstanceFiles(
         comma_str + cur_system_image_dir + "/vbmeta_system_dlkm.img";
 
     if (instance_index < default_vvmtruststore_file_name.size()) {
-      if (default_vvmtruststore_file_name[instance_index].empty()) {
+      if (default_vvmtruststore_file_name[instance_index].empty() ||
+          default_vvmtruststore_file_name[instance_index] == "unset" ||
+          default_vvmtruststore_file_name[instance_index] == "\"unset\"") {
         vvmtruststore_path += comma_str;
       } else {
         vvmtruststore_path +=

--- a/base/cvd/cuttlefish/host/libs/config/config_flag.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/config_flag.cpp
@@ -30,6 +30,7 @@
 #include <vector>
 
 #include "absl/log/log.h"
+#include "absl/strings/match.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/strip.h"
@@ -111,6 +112,31 @@ class ConfigReader : public FlagFeature {
   std::set<std::string> allowed_config_presets_;
 };
 
+bool ShouldPadWithUnset(const std::string& flag) {
+  static const std::unordered_set<std::string> kNonVectorizedFlags = {
+      "custom_actions",
+      "extra_bootconfig_args",
+      "extra_kernel_cmdline",
+      "gem5_debug_flags",
+      "group_id",
+      "secure_hals",
+      "straced_host_executables",
+      "touchpad",
+  };
+  if (kNonVectorizedFlags.find(flag) != kNonVectorizedFlags.end()) {
+    return false;
+  }
+  // Flags starting with "display" (e.g. display, display0, display1) use
+  // internal comma-separated key=value pairs (width=...,height=...) and cannot
+  // be comma-vectorized. Flags starting with "webrtc_" or "ap_" are also
+  // non-vectorized.
+  if (absl::StartsWith(flag, "display") || absl::StartsWith(flag, "webrtc_") ||
+      absl::StartsWith(flag, "ap_")) {
+    return false;
+  }
+  return true;
+}
+
 class ConfigFlagImpl : public ConfigFlag {
  public:
   INJECT(ConfigFlagImpl(ConfigReader& cr, SystemImageDirFlag& s))
@@ -167,7 +193,19 @@ class ConfigFlagImpl : public ConfigFlag {
         } else {
           value = config_values[flag].asString();
         }
-        flags[flag].push_back(value);
+        if (ShouldPadWithUnset(flag)) {
+          CF_EXPECTF(
+              value.find(',') == std::string::npos,
+              "Flag '--{}' contains commas in its preset value; vectorizing "
+              "with 'unset' across instances creates invalid syntax.",
+              flag);
+          auto [flag_values_it, _] =
+              flags.try_emplace(flag, configs_.size(), "unset");
+          auto& flag_values = flag_values_it->second;
+          flag_values[i] = value;
+        } else {
+          flags[flag].push_back(value);
+        }
       }
     }
     for (const auto& [flag, values] : flags) {


### PR DESCRIPTION
Fix multi-instance default flag resolution in config_flag.cpp by populating missing instance flags with "unset". This ensures that unspecified instance flags fall back to their per-instance defaults rather than inadvertently replicating the primary instance's settings.

Bug: 354927775, 543955575