### PR TITLE
Disable v4l2compliance test for now

### DIFF
--- a/e2etests/cvd/media_tests/v4l2_stream_proxy/v4l2compliance/BUILD.bazel
+++ b/e2etests/cvd/media_tests/v4l2_stream_proxy/v4l2compliance/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
     tags = [
         "exclusive",
         "external",
+        "manual",
         "no-sandbox",
         "requires_ab",
         "supports-graceful-termination",


### PR DESCRIPTION
It's been flaking. Converting it to "manual" still allows running it explicitly for development.