### PR TITLE
Support target configuration preset in Cuttlefish cvd load JSON

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/cf_configs_instances.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/cf_configs_instances.cpp
@@ -34,7 +34,30 @@
 
 namespace cuttlefish {
 
+namespace {
+
 using cvd::config::EnvironmentSpecification;
+using cvd::config::Instance;
+
+std::string ConfigFlag(const Instance& instance) {
+  if (instance.has_config()) {
+    return instance.config();
+  }
+  return "";
+}
+
+std::vector<std::string> GenerateConfigFlags(
+    const EnvironmentSpecification& cfg) {
+  for (const auto& instance : cfg.instances()) {
+    if (instance.has_config() && !instance.config().empty()) {
+      return std::vector<std::string>{
+          GenerateInstanceFlag("config", cfg, ConfigFlag)};
+    }
+  }
+  return {};
+}
+
+}  // namespace
 
 Result<std::vector<std::string>> GenerateInstancesFlags(
     const EnvironmentSpecification& cfg) {
@@ -46,6 +69,7 @@ Result<std::vector<std::string>> GenerateInstancesFlags(
   res = MergeResults(std::move(res), CF_EXPECT(GenerateVmFlags(cfg)));
   res = MergeResults(std::move(res), GenerateConnectivityFlags(cfg));
   res = MergeResults(std::move(res), CF_EXPECT(GenerateMediaFlags(cfg)));
+  res = MergeResults(std::move(res), GenerateConfigFlags(cfg));
   return res;
 }
 

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/flags_parser_test.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/flags_parser_test.cc
@@ -600,4 +600,85 @@ TEST(ConnectivityFlagsParserTest, ParseModemSimulatorSimTypeInvalidInt) {
       << "modem_simulator_sim_type flag is missing or wrongly formatted";
 }
 
+TEST(ConfigFlagsParserTest, ParseSingleInstanceConfig) {
+  const char* test_string = R""""(
+{
+    "instances" :
+    [
+        {
+          "config": "phone"
+        }
+    ]
+}
+  )"""";
+
+  Json::Value json_configs;
+  std::string json_text(test_string);
+
+  EXPECT_TRUE(ParseJsonString(json_text, json_configs))
+      << "Invalid Json string";
+  const Result<std::vector<std::string>> serialized_data =
+      LaunchCvdParserTester(json_configs);
+  ASSERT_THAT(serialized_data, IsOk());
+  EXPECT_TRUE(FindConfig(*serialized_data, "--config=phone"))
+      << "config flag is missing or wrongly formatted";
+}
+
+TEST(ConfigFlagsParserTest, ParseMultiInstanceConfig) {
+  const char* test_string = R""""(
+{
+    "instances" :
+    [
+        {
+          "config": "phone"
+        },
+        {
+          "config": "tv"
+        }
+    ]
+}
+  )"""";
+
+  Json::Value json_configs;
+  std::string json_text(test_string);
+
+  EXPECT_TRUE(ParseJsonString(json_text, json_configs))
+      << "Invalid Json string";
+  const Result<std::vector<std::string>> serialized_data =
+      LaunchCvdParserTester(json_configs);
+  ASSERT_THAT(serialized_data, IsOk());
+  EXPECT_TRUE(FindConfig(*serialized_data, "--config=phone,tv"))
+      << "config multi-instance flag is missing or wrongly formatted";
+}
+
+TEST(ConfigFlagsParserTest, ParseMultiInstanceConfigPartial) {
+  const char* test_string = R""""(
+{
+    "instances" :
+    [
+        {
+          "config": "phone"
+        },
+        {
+          "vm": {
+            "crosvm":{
+            }
+          }
+        }
+    ]
+}
+  )"""";
+
+  Json::Value json_configs;
+  std::string json_text(test_string);
+
+  EXPECT_TRUE(ParseJsonString(json_text, json_configs))
+      << "Invalid Json string";
+  const Result<std::vector<std::string>> serialized_data =
+      LaunchCvdParserTester(json_configs);
+  ASSERT_THAT(serialized_data, IsOk());
+  EXPECT_TRUE(FindConfig(*serialized_data, "--config=phone,"))
+      << "config partial multi-instance flag is missing or wrongly formatted";
+}
+
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_config.proto
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/parser/load_config.proto
@@ -95,6 +95,7 @@ message Instance {
   // TODO: b/337089452 - handle outside of proto logic
   optional string import_template = 9 [json_name = "@import"];
   optional Media media = 10;
+  optional string config = 11;
 }
 
 message Boot {


### PR DESCRIPTION
Backport of #3034 

## Summary
Adds support for specifying a target configuration preset in Cuttlefish cvd load JSON configurations.

* Adds optional string config = 11; to message Instance in load_config.proto.
* Updates cf_configs_instances.cpp to emit --config=<preset> per instance when configured, allowing cvd load and cloud orchestrators to pass configuration presets natively in JSON.
* Adds comprehensive unit test coverage in flags_parser_test.cc for single-instance, multi-instance, and partial multi-instance scenarios.

## Test
Added unit tests in flags_parser_test.cc:

* ConfigFlagsParserTest.ParseSingleInstanceConfig
* ConfigFlagsParserTest.ParseMultiInstanceConfig
* ConfigFlagsParserTest.ParseMultiInstanceConfigPartial