### PR TITLE
Update the go version used in the buildozer action

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Install go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.23.1'
+        go-version: '1.26.6'
     - name: Install buildozer
       run: go install github.com/bazelbuild/buildtools/buildozer@latest
     - name: Validate formatting


### PR DESCRIPTION
Addresses the error
```
$ go install github.com/bazelbuild/buildtools/buildozer@latest
go: downloading github.com/bazelbuild/buildtools v0.0.0-20260819135130-5d08cfd22031
go: downloading github.com/golang/protobuf v1.5.0
go: downloading google.golang.org/protobuf v1.33.0
go: downloading github.com/google/safeopen v0.0.0-20260327150837-43626d6f4685
go: finding module for package golang.org/x/sys/unix
go: downloading golang.org/x/sys v0.47.0
go: toolchain upgrade needed to resolve golang.org/x/sys/unix
go: golang.org/x/sys@v0.47.0 requires go >= 1.25.0 (running go 1.23.1; GOTOOLCHAIN=local)
Error: Process completed with exit code 1.
```