### PR TITLE
verify instance nums match snapshot on restore

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -76,6 +76,7 @@ cf_cc_binary(
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:fetcher_configs",
         "//cuttlefish/host/libs/config:file_source",
+        "//cuttlefish/host/libs/config:instance_nums",
         "//cuttlefish/host/libs/config:log_string_to_dir",
         "//cuttlefish/host/libs/config/adb",
         "//cuttlefish/host/libs/config/defaults",

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/assemble_cvd.cc
@@ -97,6 +97,7 @@
 #include "cuttlefish/host/libs/config/fastboot/fastboot.h"
 #include "cuttlefish/host/libs/config/fetcher_configs.h"
 #include "cuttlefish/host/libs/config/file_source.h"
+#include "cuttlefish/host/libs/config/instance_nums.h"
 #include "cuttlefish/host/libs/config/log_string_to_dir.h"
 #include "cuttlefish/host/libs/feature/feature.h"
 #include "cuttlefish/host/libs/feature/inject.h"
@@ -535,6 +536,23 @@ Result<void> VerifyConditionsOnSnapshotRestore(
                "--snapshot_path does not allow customizing --instance_dir");
   CF_EXPECT_EQ(assembly_dir, CF_DEFAULTS_ASSEMBLY_DIR,
                "--snapshot_path does not allow customizing --assembly_dir");
+
+  // We can't change the instance num as part of restore, so error early if it
+  // doesn't match.
+  const auto meta_json = CF_EXPECT(LoadMetaJson(snapshot_path));
+  CF_EXPECT(meta_json.isMember(kGuestSnapshotField),
+            "Snapshot meta json missing guest_snapshot field.");
+  const auto& guest_snapshot = meta_json[kGuestSnapshotField];
+  CF_EXPECT_EQ(guest_snapshot.size(), 1,
+               "Snapshot must contain exactly one instance");
+  const std::vector<int> target_nums =
+      CF_EXPECT(InstanceNumsCalculator().FromGlobalGflags().Calculate());
+  CF_EXPECT_EQ(target_nums.size(), 1,
+               "Restoring multiple instances is not supported");
+  const std::string snapshot_num = guest_snapshot.getMemberNames()[0];
+  const std::string target_num = std::to_string(target_nums[0]);
+  CF_EXPECT_EQ(target_num, snapshot_num,
+               "Requested instance num does not match snapshot");
   return {};
 }
 


### PR DESCRIPTION
We currently don't support changing the instance nums between snapshot and restore. If you mess it up, you get errors about disks changes that might lead you to debug in the wrong direction, so, add an explicit check.

Bug: b/310035418