### PR TITLE
run `adb connect` before `adb wait-for-device` when restoring a VM

### DIFF
--- a/base/cvd/cuttlefish/host/commands/run_cvd/boot_state_machine.cc
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/boot_state_machine.cc
@@ -420,6 +420,13 @@ class CvdBootStateMachine : public SetupFeature, public KernelLogPipeConsumer {
               }
               return subtool_path;
             };
+            // Connect adb.
+            Command adb_connect(SubtoolPath("adb"));
+            adb_connect.SetWorkingDirectory("/");
+            adb_connect.AddParameter("connect").AddParameter(
+                instance_.adb_ip_and_port());
+            CHECK_EQ(adb_connect.Start().Wait(), 0)
+                << "Failed to run adb connect";
             // Run the in-guest post-restore script.
             Command adb_command(SubtoolPath("adb"));
             // Avoid the adb server being started in the runtime directory and


### PR DESCRIPTION
Similar to https://r.android.com/3285054: In some environments adb_connector isn't running, so `wait-for-device` will get stuck. Additionally, even when it is running, adb_connector seems to use the IP 127.0.0.1, which doesn't match the IP 0.0.0.0 used by default in instance_.adb_host_port().