### PR TITLE
More clauses for avoiding tap devices.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/BUILD.bazel
@@ -544,6 +544,7 @@ cf_cc_library(
     deps = [
         "//cuttlefish/host/commands/cvdalloc:interface",
         "//cuttlefish/host/libs/config:cuttlefish_config",
+        "//cuttlefish/host/libs/config:external_network_mode",
         "//cuttlefish/result",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/strings",

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -1054,8 +1054,8 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
     }
     instance.set_mobile_tap_name(iface_config.mobile_tap.name);
 
-    CF_EXPECT(ConfigureNetworkSettings(ril_dns_vec[instance_index],
-                                       const_instance, instance));
+    CF_EXPECT(ConfigureNetworkSettings(
+        ril_dns_vec[instance_index], tmp_config_obj, const_instance, instance));
 
     bool use_non_bridged_wireless =
         (NetworkInterfaceExists(iface_config.non_bridged_wireless_tap.name) ||

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/network_flags.cpp
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/network_flags.cpp
@@ -30,6 +30,7 @@
 
 #include "cuttlefish/host/commands/cvdalloc/interface.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/external_network_mode.h"
 #include "cuttlefish/result/result.h"
 
 namespace cuttlefish {
@@ -139,13 +140,16 @@ class NetConfig {
 }  // namespace
 
 Result<void> ConfigureNetworkSettings(
-    const std::string& ril_dns_arg,
+    const std::string& ril_dns_arg, const CuttlefishConfig& config,
     const CuttlefishConfig::InstanceSpecific& const_instance,
     CuttlefishConfig::MutableInstanceSpecific& instance) {
   // We can't introspect the tap interfaces using cvdalloc because
   // they're not set up yet. However, we can expect the following
   // instance to address scheme for the mtap interfaces.
-  if (const_instance.use_cvdalloc()) {
+  bool crosvm_slirp =
+      VmManagerIsCrosvm(config) &&
+      const_instance.external_network_mode() == ExternalNetworkMode::kSlirp;
+  if (const_instance.use_cvdalloc() || crosvm_slirp) {
     int num;
     CF_EXPECT(absl::SimpleAtoi(const_instance.id(), &num));
 

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/network_flags.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/network_flags.h
@@ -21,7 +21,7 @@
 namespace cuttlefish {
 
 Result<void> ConfigureNetworkSettings(
-    const std::string& ril_dns_arg,
+    const std::string& ril_dns_arg, const CuttlefishConfig& config,
     const CuttlefishConfig::InstanceSpecific& const_instance,
     CuttlefishConfig::MutableInstanceSpecific& instance);
 

--- a/base/cvd/cuttlefish/host/commands/run_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/BUILD.bazel
@@ -181,6 +181,7 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:in_sandbox",
         "//cuttlefish/common/libs/utils:network",
         "//cuttlefish/host/libs/config:cuttlefish_config",
+        "//cuttlefish/host/libs/config:external_network_mode",
         "//cuttlefish/host/libs/vm_manager",
         "//cuttlefish/posix:strerror",
         "//cuttlefish/result",

--- a/base/cvd/cuttlefish/host/commands/run_cvd/validate.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/validate.cpp
@@ -29,6 +29,7 @@
 #include "allocd/alloc_utils.h"
 #include "cuttlefish/common/libs/utils/in_sandbox.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/external_network_mode.h"
 #include "cuttlefish/host/libs/vm_manager/host_configuration.h"
 #include "cuttlefish/posix/strerror.h"
 #include "cuttlefish/result/result.h"
@@ -38,9 +39,9 @@ namespace cuttlefish {
 static Result<void> TestTapDevices(
     const CuttlefishConfig::InstanceSpecific& instance) {
 #ifdef __linux__
-  if (InSandbox() ||
-      instance.use_cvdalloc()) {  // cvdalloc owns its own resources. those
-                                  // resources can't be validated this way.
+  if (InSandbox() || instance.use_cvdalloc() ||
+      instance.external_network_mode() == ExternalNetworkMode::kSlirp ||
+      !instance.enable_tap_devices()) {
     return {};
   }
   auto wifi = instance.wifi_tap_name();


### PR DESCRIPTION
cvdalloc defines an addressing scheme for configuring the RIL early because tap devices are not preconfigured. This scheme should also be used when tap devices are disabled or when (eventually) user-mode networking should be configured for crosvm.

To ensure that this addressing scheme doesn't conflict with qemu's usermode networking, we need to introspect the vmm, which necessitates adding an extra argument to ConfigureNetworkSettings.

Likewise, run_cvd tests if the existing tap devices are usable. This is unnecessary when using cvdalloc, but this is also unnecessary for user-mode networking for qemu or crosvm.