### PR TITLE
Include secure_env in the debian package, and disable the weaver HAL

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -421,7 +421,7 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
                                    "_openwrt");
 
   static constexpr char kDefaultSecure[] =
-      "oemlock,guest_keymint_insecure,guest_gatekeeper_insecure,weaver";
+      "oemlock,guest_keymint_insecure,guest_gatekeeper_insecure";
   SetCommandLineOptionWithMode("secure_hals", kDefaultSecure,
                                google::FlagSettingMode::SET_FLAGS_DEFAULT);
   auto secure_hals = CF_EXPECT(ParseSecureHals(FLAGS_secure_hals));

--- a/base/cvd/cuttlefish/host/commands/secure_env/secure_env_only_oemlock.cpp
+++ b/base/cvd/cuttlefish/host/commands/secure_env/secure_env_only_oemlock.cpp
@@ -186,6 +186,24 @@ Result<void> SecureEnvMain(int argc, char** argv) {
         }
       });
 
+  std::vector<SharedFD> stub_snapshot_handlers = {
+      rust_snapshot_socket2,
+      keymaster_snapshot_socket2,
+      gatekeeper_snapshot_socket2,
+      weaver_snapshot_socket2,
+  };
+  for (SharedFD snapshot_socket : stub_snapshot_handlers) {
+    threads.emplace_back([snapshot_socket]() {
+      while (true) {
+        // infinite loop that returns if resetting responder is needed
+        Result<void> result = secure_env_impl::WorkerStubLoop(snapshot_socket);
+        if (!result.has_value()) {
+          LOG(FATAL) << "oemlock worker failed: " << result.error();
+        }
+      }
+    });
+  }
+
   auto kernel_events_fd = DupFdFlag(FLAGS_kernel_events_fd);
   threads.emplace_back(StartKernelEventMonitor(kernel_events_fd, oemlock_lock));
 

--- a/base/cvd/cuttlefish/host/commands/secure_env/worker_thread_loop_body.cpp
+++ b/base/cvd/cuttlefish/host/commands/secure_env/worker_thread_loop_body.cpp
@@ -23,6 +23,33 @@
 
 namespace cuttlefish {
 namespace secure_env_impl {
+namespace {
+
+Result<void> StubHandleSuspendRequest(SharedFD snapshot_socket) {
+  // Read the suspend request.
+  SnapshotSocketMessage suspend_request;
+  CF_EXPECT_EQ(sizeof(suspend_request),
+               snapshot_socket->Read(&suspend_request, sizeof(suspend_request))
+                   .value_or(0),
+               "socket read failed: " << snapshot_socket->StrError());
+  CF_EXPECT_EQ(SnapshotSocketMessage::kSuspend, suspend_request);
+  // Send the ACK response.
+  const SnapshotSocketMessage ack_response = SnapshotSocketMessage::kSuspendAck;
+  uint64_t written =
+      CF_EXPECT(snapshot_socket->Write(&ack_response, sizeof(ack_response)));
+  CF_EXPECT_EQ(sizeof(ack_response), written,
+               "socket write failed: " << snapshot_socket->StrError());
+  // Block until resumed.
+  SnapshotSocketMessage resume_request;
+  CF_EXPECT_EQ(sizeof(resume_request),
+               snapshot_socket->Read(&resume_request, sizeof(resume_request))
+                   .value_or(0),
+               "socket read failed: " << snapshot_socket->StrError());
+  CF_EXPECT_EQ(SnapshotSocketMessage::kResume, resume_request);
+  return {};
+}
+
+}  // namespace
 
 Result<void> WorkerInnerLoop(std::function<bool()> process_callback,
                              SharedFD read_fd, SharedFD snapshot_socket) {
@@ -50,29 +77,26 @@ Result<void> WorkerInnerLoop(std::function<bool()> process_callback,
     }
 
     if (readable_fds.IsSet(snapshot_socket)) {
-      // Read the suspend request.
-      SnapshotSocketMessage suspend_request;
-      CF_EXPECT_EQ(
-          sizeof(suspend_request),
-          snapshot_socket->Read(&suspend_request, sizeof(suspend_request))
-              .value_or(0),
-          "socket read failed: " << snapshot_socket->StrError());
-      CF_EXPECT_EQ(SnapshotSocketMessage::kSuspend, suspend_request);
-      // Send the ACK response.
-      const SnapshotSocketMessage ack_response =
-          SnapshotSocketMessage::kSuspendAck;
-      uint64_t written = CF_EXPECT(
-          snapshot_socket->Write(&ack_response, sizeof(ack_response)));
-      CF_EXPECT_EQ(sizeof(ack_response), written,
-                   "socket write failed: " << snapshot_socket->StrError());
-      // Block until resumed.
-      SnapshotSocketMessage resume_request;
-      CF_EXPECT_EQ(
-          sizeof(resume_request),
-          snapshot_socket->Read(&resume_request, sizeof(resume_request))
-              .value_or(0),
-          "socket read failed: " << snapshot_socket->StrError());
-      CF_EXPECT_EQ(SnapshotSocketMessage::kResume, resume_request);
+      CF_EXPECT(StubHandleSuspendRequest(snapshot_socket));
+    }
+  }
+
+  return {};
+}
+
+Result<void> WorkerStubLoop(SharedFD snapshot_socket) {
+  for (;;) {
+    SharedFDSet readable_fds;
+    readable_fds.Set(snapshot_socket);
+
+    int num_fds = Select(&readable_fds, nullptr, nullptr, nullptr);
+    if (num_fds < 0) {
+      LOG(FATAL) << "Select() returned a negative value: " << num_fds
+                 << StrError(errno);
+    }
+
+    if (readable_fds.IsSet(snapshot_socket)) {
+      CF_EXPECT(StubHandleSuspendRequest(snapshot_socket));
     }
   }
 

--- a/base/cvd/cuttlefish/host/commands/secure_env/worker_thread_loop_body.h
+++ b/base/cvd/cuttlefish/host/commands/secure_env/worker_thread_loop_body.h
@@ -26,5 +26,7 @@ namespace secure_env_impl {
 Result<void> WorkerInnerLoop(std::function<bool()> process_callback,
                              SharedFD read_fd, SharedFD snapshot_socket);
 
+Result<void> WorkerStubLoop(SharedFD snapshot_socket);
+
 }  // namespace secure_env_impl
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/package/BUILD.bazel
+++ b/base/cvd/cuttlefish/package/BUILD.bazel
@@ -113,7 +113,7 @@ package_files(
         "bin/rootcanal": "@rootcanal",
         "bin/run_cvd": "//cuttlefish/host/commands/run_cvd",
         "bin/screen_recording_server": "//cuttlefish/host/commands/screen_recording_server",
-        # "bin/secure_env": "//cuttlefish/host/commands/secure_env", # TODO: schuffelen - make this more complete
+        "bin/secure_env": "//cuttlefish/host/commands/secure_env",  # TODO: schuffelen - make this more complete
         "bin/sefcontext_compile": "@selinux//:sefcontext_compile",
         "bin/sensors_simulator": "//cuttlefish/host/commands/sensors_simulator",
         "bin/simg2img": "@android_system_core//:simg2img",


### PR DESCRIPTION
The Weaver HAL is missing from secure_env_only_oemlock, and it is nontrivial to include because it requires importing the WeaverTa dependency from AOSP.

Bug: b/548056221