### PR TITLE
Fix slice panic in PolledClient.GetMessages for out-of-range start/count

### DIFF
--- a/frontend/src/liboperator/operator/clients.go
+++ b/frontend/src/liboperator/operator/clients.go
@@ -80,16 +80,17 @@ func (c *PolledClient) ToDevice(msg interface{}) error {
 func (c *PolledClient) GetMessages(start int, count int) []interface{} {
 	c.msgMtx.Lock()
 	defer c.msgMtx.Unlock()
-	if count < 0 {
+	if start < 0 {
+		start = 0
+	}
+	if start > len(c.messages) {
+		start = len(c.messages)
+	}
+	if count < 0 || count > len(c.messages)-start {
 		count = len(c.messages) - start
 	}
-	end := start + count
-	if end > len(c.messages) {
-		end = len(c.messages)
-		count = end - start
-	}
 	ret := make([]interface{}, count)
-	copy(ret, c.messages[start:end])
+	copy(ret, c.messages[start:start+count])
 	return ret
 }
 

--- a/frontend/src/liboperator/operator/clients_test.go
+++ b/frontend/src/liboperator/operator/clients_test.go
@@ -78,6 +78,30 @@ func TestMessages(t *testing.T) {
 	}
 }
 
+func TestGetMessagesBounds(t *testing.T) {
+	ps := NewPolledSet()
+	c := ps.NewConnection(newDevice("d1", nil, 0, ""))
+	c.Send("msg1")
+	c.Send("msg2")
+	c.Send("msg3")
+
+	// Negative start is clamped to the beginning of the buffer.
+	if msgs := c.GetMessages(-1, -1); len(msgs) != 3 {
+		t.Errorf("negative start: got %d messages, want 3", len(msgs))
+	}
+	// start past the end of the buffer returns an empty slice.
+	if msgs := c.GetMessages(10, -1); len(msgs) != 0 {
+		t.Errorf("start past end: got %d messages, want 0", len(msgs))
+	}
+	if msgs := c.GetMessages(10, 2); len(msgs) != 0 {
+		t.Errorf("start past end with count: got %d messages, want 0", len(msgs))
+	}
+	// A count larger than the remaining messages is clamped.
+	if msgs := c.GetMessages(2, 100); len(msgs) != 1 {
+		t.Errorf("oversized count: got %d messages, want 1", len(msgs))
+	}
+}
+
 func TestDestroy(t *testing.T) {
 	ps := NewPolledSet()
 	c := ps.NewConnection(newDevice("d1", nil, 0, ""))


### PR DESCRIPTION
## Problem

The `/polled_connections/{connId}/messages` HTTP endpoint parses `start` and `count` from the request query string and passes them to `PolledClient.GetMessages` without any range validation. A negative `start` (e.g. `?start=-1`) or a `start` beyond the number of buffered messages (e.g. `?start=100`) caused `make([]interface{}, count)` or `c.messages[start:end]` to panic with a slice out-of-range error, terminating the request handler.

## Change

Clamp `start` to `[0, len(messages)]` and `count` to the remaining messages (`len(messages)-start`) in `GetMessages`, so the method returns a sensible slice for any input:

- `start < 0` is treated as `0`
- `start > len(messages)` returns an empty slice
- `count < 0` (meaning "all remaining") or `count` larger than the remaining messages is clamped to the remaining count

This also avoids the `start + count` integer-overflow edge case for very large `count` values by using `len(messages)-start` instead of computing `end := start + count`.

## Verification

- Added `TestGetMessagesBounds` covering negative `start`, `start` past the end (with and without `count`), and an oversized `count`.
- Existing `TestMessages` behavior is preserved.