### PR TITLE
Support StrongBox KeyMint jcardsim JVM lookup in container images

### DIFF
--- a/container/image/Containerfile
+++ b/container/image/Containerfile
@@ -26,11 +26,13 @@ RUN apt update
 RUN apt install -y --no-install-recommends \
     ca-certificates \
     curl \
+    default-jre-headless \
     libvulkan1 \
     mesa-utils \
     nginx \
     sudo
 RUN update-ca-certificates
+ENV JAVA_HOME=/usr/lib/jvm/default-java
 
 # When setting `auto` value, nginx spawns worker processes as the number of CPU
 # cores. It's discouraged in any multiple container scenarios, as it spawns too


### PR DESCRIPTION
When launching Cuttlefish with --enable_jcard_simulator=true, secure_env attempts to load libjvm.so to run the StrongBox KeyMint Java Card simulator applet. Inside rootless container environments like podcvd, this fails because the base image lacks a JRE runtime and JAVA_HOME is not set.

This commit resolves the issue by:
1. Installing openjdk-21-jre-headless in runner-base.
2. Setting ENV JAVA_HOME=/usr/lib/jvm/default-java so secure_env automatically locates libjvm.so via getenv("JAVA_HOME").