### PR TITLE
Use passt for user-mode networking on crosvm.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -1334,8 +1334,8 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
     auto external_network_mode = CF_EXPECT(
         ParseExternalNetworkMode(device_external_network_vec[instance_index]));
     CF_EXPECT(external_network_mode == ExternalNetworkMode::kTap ||
-                  VmManagerIsQemu(vm_manager_flag),
-              "TODO(b/286284441): slirp only works on QEMU");
+                  external_network_mode == ExternalNetworkMode::kSlirp,
+              "Unknown external_network_mode");
     instance.set_external_network_mode(external_network_mode);
 
     instance.set_mcu(CF_EXPECT(mcu_config_paths.JsonForIndex(instance_index)));

--- a/base/cvd/cuttlefish/host/libs/vm_manager/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/BUILD.bazel
@@ -16,6 +16,7 @@ cf_cc_library(
         "pci.cpp",
         "qemu_manager.cpp",
         "vhost_user_block.cpp",
+        "vhost_user_net.cpp",
         "vm_manager.cpp",
     ],
     hdrs = [
@@ -58,6 +59,7 @@ cf_cc_library(
         "//cuttlefish/host/libs/config:vmm_mode",
         "//cuttlefish/host/libs/feature",
         "//cuttlefish/host/libs/feature:inject",
+        "//cuttlefish/posix:remove",
         "//cuttlefish/posix:strerror",
         "//cuttlefish/process:command",
         "//cuttlefish/process:execute",
@@ -68,6 +70,7 @@ cf_cc_library(
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/log:check",
         "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/strings:str_format",
         "@fmt",
         "@fruit",
         "@jsoncpp",

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_manager.cpp
@@ -49,6 +49,7 @@
 #include "cuttlefish/host/libs/config/config_constants.h"
 #include "cuttlefish/host/libs/config/config_instance_derived.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/external_network_mode.h"
 #include "cuttlefish/host/libs/config/gpu_mode.h"
 #include "cuttlefish/host/libs/config/guest_hwui_renderer.h"
 #include "cuttlefish/host/libs/config/guest_renderer_preload.h"
@@ -234,6 +235,21 @@ void ConfigureTapDevices(CrosvmBuilder& crosvm_cmd,
       crosvm_cmd.AddTap(instance.wifi_tap_name());
     }
   }
+}
+
+Result<void> ConfigureVhostUserNet(
+    CrosvmBuilder& crosvm_cmd, const CuttlefishConfig& config,
+    const CuttlefishConfig::InstanceSpecific& instance,
+    std::vector<MonitorCommand>& commands) {
+  auto net = CF_EXPECT(VhostUserNetDevice(
+      config, "mobile", instance.ril_ipaddr(), instance.ril_prefixlen(),
+      instance.ril_gateway(), instance.ril_dns()));
+  commands.emplace_back(std::move(net.device_cmd));
+  commands.emplace_back(std::move(net.device_logs_cmd));
+
+  crosvm_cmd.AddVhostUser("net", net.socket_path, /*max_queue_size=*/256);
+
+  return {};
 }
 #endif
 
@@ -746,6 +762,9 @@ Result<std::vector<MonitorCommand>> CrosvmManager::StartCommands(
   switch (instance.external_network_mode()) {
     case ExternalNetworkMode::kTap:
       ConfigureTapDevices(crosvm_cmd, config, instance);
+      break;
+    case ExternalNetworkMode::kSlirp:
+      CF_EXPECT(ConfigureVhostUserNet(crosvm_cmd, config, instance, commands));
       break;
     default:
       return CF_ERR("Unexpected network mode "

--- a/base/cvd/cuttlefish/host/libs/vm_manager/vhost_user.h
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/vhost_user.h
@@ -33,5 +33,10 @@ struct VhostUserDeviceCommands {
 Result<VhostUserDeviceCommands> VhostUserBlockDevice(
     const CuttlefishConfig& config, int num, std::string_view disk_path);
 
+Result<VhostUserDeviceCommands> VhostUserNetDevice(
+    const CuttlefishConfig& config, const std::string& name,
+    const std::string& ipaddr, int prefixlen, const std::string& gateway,
+    const std::string& dns);
+
 }  // namespace vm_manager
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/vm_manager/vhost_user_net.cpp
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/vhost_user_net.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <csignal>
+#include <string>
+#include <utility>
+
+#include "absl/strings/str_format.h"
+
+#include "cuttlefish/common/libs/fs/fd.h"
+#include "cuttlefish/common/libs/utils/files.h"
+#include "cuttlefish/files/file_exists.h"
+#include "cuttlefish/host/libs/config/cuttlefish_config.h"
+#include "cuttlefish/host/libs/config/known_paths.h"
+#include "cuttlefish/host/libs/vm_manager/vhost_user.h"
+#include "cuttlefish/posix/remove.h"
+#include "cuttlefish/process/command.h"
+#include "cuttlefish/result/result.h"
+
+namespace cuttlefish {
+namespace vm_manager {
+
+Result<VhostUserDeviceCommands> VhostUserNetDevice(
+    const CuttlefishConfig& config, const std::string& name,
+    const std::string& ipaddr, int prefixlen, const std::string& gateway,
+    const std::string& dns) {
+  const auto& instance = config.ForDefaultInstance();
+  const std::string logs_path =
+      instance.PerInstanceInternalPath(absl::StrFormat("passt_%s.fifo", name));
+  SharedFD logs = CF_EXPECT(Fd::Fifo(logs_path, 0666));
+
+  Command logs_cmd(HostBinaryPath("log_tee"));
+  logs_cmd.AddParameter(absl::StrFormat("--process_name=passt_%s", name));
+  logs_cmd.AddParameter("--log_fd_in=", logs);
+  logs_cmd.SetStopper(KillSubprocessFallback([](Subprocess* proc) {
+    bool res = kill(proc->pid(), SIGINT) == 0;
+    return res ? StopperResult::kSuccess : StopperResult::kFailure;
+  }));
+
+  const std::string socket_path = instance.PerInstanceInternalUdsPath(
+      absl::StrFormat("vhost_user_net_%s.sock", name));
+  if (FileExists(socket_path)) {
+    CF_EXPECT(RemoveFile(socket_path));
+  }
+
+  const std::string passt_binary = CF_EXPECT(Search(Path(), "passt"));
+
+  Command passt_cmd(ProcessRestarterBinary());
+  passt_cmd.AddParameter("-when_dumped");
+  passt_cmd.AddParameter("-when_killed");
+  passt_cmd.AddParameter("-when_exited_with_failure");
+  passt_cmd.SetStopper(KillSubprocessFallback([](Subprocess* proc) {
+    bool res = kill(proc->pid(), SIGINT) == 0;
+    return res ? StopperResult::kSuccess : StopperResult::kFailure;
+  }));
+  passt_cmd.AddParameter("--");
+  passt_cmd.AddParameter(passt_binary);
+  passt_cmd.AddParameter("--vhost-user");
+  passt_cmd.AddParameter("--foreground");
+  passt_cmd.AddParameter("-s");
+  passt_cmd.AddParameter(socket_path);
+  passt_cmd.AddParameter("--repair-path");
+  passt_cmd.AddParameter("none");
+  passt_cmd.AddParameter("-4");
+  passt_cmd.AddParameter("-a");
+  passt_cmd.AddParameter(ipaddr);
+  passt_cmd.AddParameter("-n");
+  passt_cmd.AddParameter(prefixlen);
+  passt_cmd.AddParameter("-g");
+  passt_cmd.AddParameter(gateway);
+  passt_cmd.AddParameter("--map-host-loopback");
+  passt_cmd.AddParameter(gateway);
+  if (!dns.empty()) {
+    passt_cmd.AddParameter("-D");
+    passt_cmd.AddParameter(dns);
+  }
+  passt_cmd.RedirectStdIO(Command::StdIoChannel::kStdOut, logs);
+  passt_cmd.RedirectStdIO(Command::StdIoChannel::kStdErr, logs);
+
+  return (VhostUserDeviceCommands){
+      .device_cmd = std::move(passt_cmd),
+      .device_logs_cmd = std::move(logs_cmd),
+      .socket_path = socket_path,
+  };
+}
+
+}  // namespace vm_manager
+}  // namespace cuttlefish


### PR DESCRIPTION
Currenly, for cuttlefish guest network access, the host requires tap
devices to be preconfigured or dynamically configured with cvdalloc.
Both require some manner of elevated privileges in the execution
environment, which can be inconvenient for external network access, or
prevents network access entirely in some execution environments.

User-mode networking is the typical mechanism to work around this
requirement, and slirp is the typical implementation for this. However,
while slirp is available in qemu, it is not available on all platforms
for crosvm.

To work around this, for now we use vhost-user and passt. If slirp is
supported in crosvm on more platforms in the future, then we can pivot.
Currently, only the mobile interface is set up with passt. Doing this
correctly for Wi-Fi will require more care, and for now, having some
basic user-mode networking is better than none.


Bug: 286284441

---

To expedite things, I'm sending this for review now while dependent prs covering the other commits are now being merged in #3056 and #3057. Once landed, I'll rebase this branch. For now, you can focus your attention on the changes in ccd35515bd53945e436a6888e78e449699880be2.