### PR TITLE
Always build crosvm in `opt` mode

### DIFF
--- a/base/cvd/build_external/crosvm/BUILD.bazel
+++ b/base/cvd/build_external/crosvm/BUILD.bazel
@@ -1,3 +1,18 @@
+load("//build_external/crosvm:transition_opt.bzl", "build_in_opt")
+
 exports_files([
     "crosvm.config.toml",
 ])
+
+# Build crosvm as if bazel was invoked with `-c opt`. Without this, observed
+# some errors that looked like
+# ```
+# fatal runtime error: IO Safety violation: owned file descriptor already closed
+# ```
+# Additionally, crosvm optimization affects VM performance more noticeably
+# than other executables involved in running Cuttlefish devices.
+build_in_opt(
+    name = "crosvm_bin_opt",
+    actual = "@crosvm_bin//:crosvm__crosvm",
+    visibility = ["//visibility:public"],
+)

--- a/base/cvd/build_external/crosvm/transition_opt.bzl
+++ b/base/cvd/build_external/crosvm/transition_opt.bzl
@@ -1,0 +1,41 @@
+def _file_from_label(l):
+    files = l.files.to_list()
+    if len(files) != 1:
+        fail(msg = "Unexpected number of files in target {}: {}".format(l, len(files)))
+    return files[0]
+
+def _build_in_opt_transition_impl(settings, attr):
+    return {"//command_line_option:compilation_mode": "opt"}
+
+# https://bazel.build/rules/lib/builtins/transition#transition
+build_in_opt_transition = transition(
+    implementation = _build_in_opt_transition_impl,
+    inputs = [],
+    outputs = ["//command_line_option:compilation_mode"],
+)
+
+def _build_in_opt_rule_impl(ctx):
+    input_file = _file_from_label(ctx.attr.actual)
+    output = ctx.actions.declare_file(ctx.attr.name)
+    ctx.actions.run_shell(
+        mnemonic = "CopyOutput",
+        inputs = [input_file],
+        outputs = [output],
+        command = " ".join(["cp", input_file.path, output.path])
+    )
+    return [
+        DefaultInfo(
+            executable = output,
+            files = depset([output])
+        ),
+    ]
+
+# https://bazel.build/extending/config#attaching-transitions
+build_in_opt = rule(
+    attrs = {
+        "actual": attr.label(),
+    },
+    implementation = _build_in_opt_rule_impl,
+    cfg = build_in_opt_transition,
+    executable = True,
+)

--- a/base/cvd/cuttlefish/package/BUILD.bazel
+++ b/base/cvd/cuttlefish/package/BUILD.bazel
@@ -160,7 +160,7 @@ package_files(
         "etc/modem_simulator/files/iccprofile_for_sim1.xml": "//cuttlefish/host/commands/modem_simulator:etc/files/iccprofile_for_sim1.xml",
         "etc/modem_simulator/files/numeric_operator.xml": "//cuttlefish/host/commands/modem_simulator:etc/files/numeric_operator.xml",
         # "bin/crosvm": "@crosvm_bin//:crosvm__crosvm", # TODO: b/402274999 - currently requires --enable_sandbox=false
-        "bin/prebuilts/crosvm": "@crosvm_bin//:crosvm__crosvm",  # TODO: b/402274999 - keep in bin and symlink to prebuilts
+        "bin/prebuilts/crosvm": "//build_external/crosvm:crosvm_bin_opt",  # TODO: b/402274999 - keep in bin and symlink to prebuilts
         "usr/share/webrtc/assets/client.html": "//cuttlefish/host/frontend/webrtc/html_client:client.html",
         "usr/share/webrtc/assets/controls.css": "//cuttlefish/host/frontend/webrtc/html_client:controls.css",
         "usr/share/webrtc/assets/custom.css": "//cuttlefish/host/frontend/webrtc/html_client:custom.css",


### PR DESCRIPTION
This has two effects:

- Disables debug assertions crash over an IO safety issue in sandbox mode.
- Improves VM runtime performance.

With this change, we are closer to being able to package crosvm in `//cuttlefish/package:common`.

Bug: b/402274999