### PR TITLE
Fd static function overhaul

### DIFF
--- a/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
+++ b/base/cvd/cuttlefish/common/libs/fs/BUILD.bazel
@@ -35,6 +35,7 @@ cf_cc_library(
         "//libbase",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/log:check",
+        "@fmt",
     ],
 )
 

--- a/base/cvd/cuttlefish/common/libs/fs/fd.cc
+++ b/base/cvd/cuttlefish/common/libs/fs/fd.cc
@@ -38,6 +38,8 @@
 
 #include "absl/log/check.h"
 #include "absl/log/log.h"
+#include "fmt/chrono.h"  // IWYU pragma: keep
+#include "fmt/format.h"
 
 #include "cuttlefish/common/libs/fs/scoped_mmap.h"
 #include "cuttlefish/common/libs/utils/known_paths.h"
@@ -66,13 +68,18 @@ class LocalErrno {
   int preserved_;
 };
 
-int memfd_create_wrapper(const char* name, unsigned int flags) {
+Result<int> MemfdCreateWrapper(const std::string& name, unsigned int flags) {
 #ifdef __linux__
-  return memfd_create(name, flags);
+  int fd = TEMP_FAILURE_RETRY(memfd_create(name.c_str(), flags));
+  CF_EXPECTF(fd >= 0, "memfd_create('{}', {}) failed: {}", name, flags,
+             StrError(errno));
 #else
   (void)flags;
-  return shm_open(name, O_RDWR);
+  int fd = TEMP_FAILURE_RETRY(shm_open(name.c_str(), O_RDWR));
+  CF_EXPECTF(fd >= 0, "shm_open('{}', O_RDWR) failed: {}", name,
+             StrError(errno));
 #endif
+  return fd;
 }
 
 bool IsRegularFile(const int fd) {
@@ -129,206 +136,174 @@ Fd& Fd::operator=(Fd&& other) {
   return *this;
 }
 
-Fd Fd::Accept(const Fd& listener, struct sockaddr* addr, socklen_t* addrlen) {
-  return listener.AcceptInternal(addr, addrlen);
+Result<Fd> Fd::Accept(const Fd& listener) {
+  const int fd = TEMP_FAILURE_RETRY(accept(listener.fd_, nullptr, nullptr));
+  CF_EXPECTF(fd >= 0, "accept(..., nullptr, nullptr) failed: '{}",
+             ::cuttlefish::StrError(errno));
+  return Fd(fd, 0);
 }
 
-Fd Fd::Accept(const Fd& listener) { return Fd::Accept(listener, NULL, NULL); }
-
-Fd Fd::Dup(int unmanaged_fd) {
-  int fd = fcntl(unmanaged_fd, F_DUPFD_CLOEXEC, 3);
-  int error_num = errno;
-  return Fd(fd, error_num);
+Result<Fd> Fd::Dup(int unmanaged_fd) {
+  const int fd = TEMP_FAILURE_RETRY(fcntl(unmanaged_fd, F_DUPFD_CLOEXEC, 3));
+  CF_EXPECTF(fd >= 0, "fcntl(..., F_DUPFD_CLOEXEC, 3) failed: {}",
+             ::cuttlefish::StrError(errno));
+  return Fd(fd, 0);
 }
 
-bool Fd::Pipe(Fd* fd0, Fd* fd1) {
+Result<std::pair<Fd, Fd>> Fd::Pipe() {
   int fds[2];
 #ifdef __linux__
-  int rval = pipe2(fds, O_CLOEXEC);
+  const int rval = TEMP_FAILURE_RETRY(pipe2(fds, O_CLOEXEC));
+  CF_EXPECTF(rval != -1, "pipe2(..., O_CLOEXEC) failed: {}",
+             ::cuttlefish::StrError(errno));
 #else
-  int rval = pipe(fds);
+  const int rval = TEMP_FAILURE_RETRY(pipe(fds));
+  CF_EXPECTF(rval != -1, "pipe(...) failed: {}", ::cuttlefish::StrError(errno));
 #endif
-  if (rval != -1) {
-    (*fd0) = Fd(fds[0], errno);
-    (*fd1) = Fd(fds[1], errno);
-    return true;
-  }
-  return false;
+  return std::make_pair(Fd(fds[0], 0), Fd(fds[1], 0));
 }
 
 #ifdef __linux__
-Fd Fd::Event(int initval, int flags) {
-  int fd = eventfd(initval, flags);
-  return Fd(fd, errno);
+Result<Fd> Fd::Event(int initval, int flags) {
+  int fd = TEMP_FAILURE_RETRY(eventfd(initval, flags));
+  CF_EXPECTF(fd >= 0, "eventfd({}, {}) failed: {}", initval, flags,
+             ::cuttlefish::StrError(errno));
+  return Fd(fd, 0);
 }
 
-Fd Fd::ShmOpen(const std::string& name, int oflag, int mode) {
-  errno = 0;
-  int fd = shm_open(name.c_str(), oflag, mode);
-  int error_num = errno;
-  return Fd(fd, error_num);
+Result<Fd> Fd::ShmOpen(std::string_view name, int oflag, int mode) {
+  std::string name_str(name);
+  const int fd = TEMP_FAILURE_RETRY(shm_open(name_str.c_str(), oflag, mode));
+  CF_EXPECTF(fd >= 0, "shm_open('{}', {}, {}) failed: {}", name, oflag, mode,
+             ::cuttlefish::StrError(errno));
+  return Fd(fd, 0);
 }
 #endif
 
-Fd Fd::MemfdCreate(const std::string& name, unsigned int flags) {
-  int fd = memfd_create_wrapper(name.c_str(), flags);
-  int error_num = errno;
-  return Fd(fd, error_num);
-}
-
-bool Fd::SocketPair(int domain, int type, int protocol, Fd* fd0, Fd* fd1) {
-  int fds[2];
-  int rval = socketpair(domain, type, protocol, fds);
-  if (rval != -1) {
-    (*fd0) = Fd(fds[0], errno);
-    (*fd1) = Fd(fds[1], errno);
-    return true;
-  }
-  return false;
+Result<Fd> Fd::MemfdCreate(std::string_view name, unsigned int flags) {
+  return Fd(CF_EXPECT(MemfdCreateWrapper(std::string(name), flags)), 0);
 }
 
 Result<std::pair<Fd, Fd>> Fd::SocketPair(int domain, int type, int protocol) {
-  Fd a, b;
-  if (!Fd::SocketPair(domain, type, protocol, &a, &b)) {
-    return CF_ERR("socketpair failed: " << ::cuttlefish::StrError(errno));
-  }
-  return std::make_pair(std::move(a), std::move(b));
+  int fds[2];
+  int rval = TEMP_FAILURE_RETRY(socketpair(domain, type, protocol, fds));
+  CF_EXPECTF(rval != -1, "socketpair({}, {}, {}) failed: {}", domain, type,
+             protocol, ::cuttlefish::StrError(errno));
+  return std::make_pair(Fd(fds[0], 0), Fd(fds[1], 0));
 }
 
-Fd Fd::Open(const std::string& path, int flags, mode_t mode) {
-  return Open(path.c_str(), flags, mode);
+Result<Fd> Fd::Open(std::string_view path, int flags, mode_t mode) {
+  const int fd =
+      TEMP_FAILURE_RETRY(open(std::string(path).c_str(), flags, mode));
+  CF_EXPECTF(fd >= 0, "open('{}', {}, {}) failed: {}", path, flags, mode,
+             ::cuttlefish::StrError(errno));
+  return Fd(fd, 0);
 }
 
-Fd Fd::Open(const char* path, int flags, mode_t mode) {
-  int fd = TEMP_FAILURE_RETRY(open(path, flags, mode));
-  if (fd == -1) {
-    return Fd(fd, errno);
-  } else {
-    return Fd(fd, 0);
-  }
+Result<Fd> Fd::InotifyFd(void) {
+  const int fd = TEMP_FAILURE_RETRY(inotify_init1(IN_CLOEXEC));
+  CF_EXPECTF(fd >= 0, "inotify_init1(IN_CLOEXEC) failed: {}",
+             ::cuttlefish::StrError(errno));
+  return Fd(fd, 0);
 }
 
-Fd Fd::InotifyFd(void) {
-  errno = 0;
-  int fd = TEMP_FAILURE_RETRY(inotify_init1(IN_CLOEXEC));
-  return Fd(fd, errno);
+Result<Fd> Fd::Creat(std::string_view path, mode_t mode) {
+  return CF_EXPECT(Fd::Open(path, O_CREAT | O_WRONLY | O_TRUNC, mode));
 }
 
-Result<Fd> Fd::Creat(const std::string& path, mode_t mode) {
-  Fd fd = Fd::Open(path, O_CREAT | O_WRONLY | O_TRUNC, mode);
-  CF_EXPECTF(fd.IsOpen(), "Failed to open '{}' with mode {:o}: {}", path, mode,
-             fd.StrError());
-  return fd;
-}
-
-Result<Fd> Fd::Fifo(const std::string& path, mode_t mode) {
+Result<Fd> Fd::Fifo(std::string_view path, mode_t mode) {
   struct stat st{};
-  if (TEMP_FAILURE_RETRY(stat(path.c_str(), &st)) == 0) {
-    CF_EXPECTF(TEMP_FAILURE_RETRY(remove(path.c_str())) == 0,
+  std::string path_str(path);
+  if (TEMP_FAILURE_RETRY(stat(path_str.c_str(), &st)) == 0) {
+    CF_EXPECTF(TEMP_FAILURE_RETRY(remove(path_str.c_str())) == 0,
                "Failed to delete old file at '{}': '{}'", path,
                ::cuttlefish::StrError(errno));
   }
 
-  CF_EXPECTF(TEMP_FAILURE_RETRY(mkfifo(path.c_str(), mode)) == 0,
+  CF_EXPECTF(TEMP_FAILURE_RETRY(mkfifo(path_str.c_str(), mode)) == 0,
              "Failed to mkfifo('{}', {:o})", path, mode);
-  auto ret = Open(path, O_RDWR);
-  CF_EXPECTF(ret.IsOpen(), "Failed to open '{}': '{}'", path, ret.StrError());
-  return ret;
+  return CF_EXPECT(Open(path, O_RDWR));
 }
 
-Fd Fd::Socket(int domain, int socket_type, int protocol) {
-  int fd = TEMP_FAILURE_RETRY(socket(domain, socket_type, protocol));
-  if (fd == -1) {
-    return Fd(fd, errno);
-  } else {
-    return Fd(fd, 0);
-  }
-}
-
-Fd Fd::Mkstemp(std::string* path) {
-  int fd = mkstemp(path->data());
-  if (fd == -1) {
-    return Fd(fd, errno);
-  } else {
-    return Fd(fd, 0);
-  }
+Result<Fd> Fd::Socket(int domain, int socket_type, int protocol) {
+  const int fd = TEMP_FAILURE_RETRY(socket(domain, socket_type, protocol));
+  CF_EXPECTF(fd >= 0, "socket({}, {}, {}) failed: {}", domain, socket_type,
+             protocol, ::cuttlefish::StrError(errno));
+  return Fd(fd, 0);
 }
 
 Result<std::pair<Fd, std::string>> Fd::Mkostemp(const std::string_view path,
                                                 const int flags) {
   // mkostemp replaces the Xs with random selections to make a unique filename
-  auto temp_path = fmt::format("{}XXXXXX", path);
-  const int fd = mkostemp(temp_path.data(), flags);
-  CF_EXPECTF(fd != -1, "Error creating temporary file: {}",
+  std::string temp_path = fmt::format("{}XXXXXX", path);
+  const int fd = TEMP_FAILURE_RETRY(mkostemp(temp_path.data(), flags));
+  CF_EXPECTF(fd != -1, "mkostemp('{}', {}) failed: {}", path, flags,
              ::cuttlefish::StrError(errno));
-  auto shared_fd = Fd(fd, 0);
-  return std::make_pair<Fd, std::string>(std::move(shared_fd),
-                                         std::move(temp_path));
+  return std::make_pair<Fd, std::string>(Fd(fd, 0), std::move(temp_path));
 }
 
 Fd Fd::ErrorFD(int error) { return Fd(-1, error); }
 
-Fd Fd::SocketLocalClient(const std::string& name, bool abstract, int in_type) {
-  return SocketLocalClient(name, abstract, in_type, 0);
+Result<Fd> Fd::SocketLocalClient(std::string_view name, bool abstract,
+                                 int in_type) {
+  return CF_EXPECT(SocketLocalClient(name, abstract, in_type, 0));
 }
 
-Fd Fd::SocketLocalClient(const std::string& name, bool abstract, int in_type,
-                         int timeout_seconds) {
+Result<Fd> Fd::SocketLocalClient(std::string_view name, bool abstract,
+                                 int in_type, int timeout_seconds) {
+  std::string name_str(name);
+
   struct sockaddr_un addr;
   socklen_t addrlen;
-  MakeAddress(name.c_str(), abstract, &addr, &addrlen);
-  Fd rval = Fd::Socket(PF_UNIX, in_type, 0);
-  if (!rval.IsOpen()) {
-    return rval;
-  }
+  MakeAddress(name_str.c_str(), abstract, &addr, &addrlen);
+  Fd rval = CF_EXPECT(Fd::Socket(PF_UNIX, in_type, 0));
+
   struct timeval timeout = {timeout_seconds, 0};
   auto casted_addr = reinterpret_cast<sockaddr*>(&addr);
-  if (rval.ConnectWithTimeout(casted_addr, addrlen, &timeout) == -1) {
-    return Fd::ErrorFD(rval.GetErrno());
-  }
+  CF_EXPECTF(rval.ConnectWithTimeout(casted_addr, addrlen, &timeout) != -1,
+             "ConnectWithTimeout failed: {}", rval.StrError());
   return rval;
 }
 
-Fd Fd::SocketLocalClient(int port, int type) {
+Result<Fd> Fd::SocketLocalClient(int port, int type) {
   sockaddr_in addr{};
   addr.sin_family = AF_INET;
   addr.sin_port = htons(port);
   addr.sin_addr.s_addr = htonl(INADDR_ANY);
-  auto rval = Fd::Socket(AF_INET, type, 0);
-  if (!rval.IsOpen()) {
-    return rval;
-  }
-  if (rval.Connect(reinterpret_cast<const sockaddr*>(&addr), sizeof addr) < 0) {
-    return Fd::ErrorFD(rval.GetErrno());
-  }
+  Fd rval = CF_EXPECT(Fd::Socket(AF_INET, type, 0));
+
+  auto addr_ptr = reinterpret_cast<const sockaddr*>(&addr);
+  CF_EXPECTF(rval.Connect(addr_ptr, sizeof addr) >= 0,
+             "Connect failed to port {} with type {}: {}", port, type,
+             rval.StrError());
+
   return rval;
 }
 
-Fd Fd::SocketClient(const std::string& host, int port, int type,
-                    std::chrono::seconds timeout) {
+Result<Fd> Fd::SocketClient(std::string_view host, int port, int type,
+                            std::chrono::seconds timeout) {
   sockaddr_in addr{};
   addr.sin_family = AF_INET;
   addr.sin_port = htons(port);
-  addr.sin_addr.s_addr = inet_addr(host.c_str());
-  auto rval = Fd::Socket(AF_INET, type, 0);
-  if (!rval.IsOpen()) {
-    return rval;
-  }
-  struct timeval timeout_timeval = {static_cast<time_t>(timeout.count()), 0};
-  if (rval.ConnectWithTimeout(reinterpret_cast<const sockaddr*>(&addr),
-                              sizeof addr, &timeout_timeval) < 0) {
-    return Fd::ErrorFD(rval.GetErrno());
-  }
+  addr.sin_addr.s_addr = inet_addr(std::string(host).c_str());
+  Fd rval = CF_EXPECT(Fd::Socket(AF_INET, type, 0));
+
+  struct timeval timeout_tval = {static_cast<time_t>(timeout.count()), 0};
+  auto addr_ptr = reinterpret_cast<const sockaddr*>(&addr);
+  CF_EXPECTF(
+      rval.ConnectWithTimeout(addr_ptr, sizeof addr, &timeout_tval) >= 0,
+      "ConnectWithTimeout to host {} and port {} with type {} failed in {}: {}",
+      host, port, type, timeout, rval.StrError());
   return rval;
 }
 
-Fd Fd::Socket6Client(const std::string& host, const std::string& interface,
-                     int port, int type, std::chrono::seconds timeout) {
+Result<Fd> Fd::Socket6Client(std::string_view host, std::string_view interface,
+                             int port, int type, std::chrono::seconds timeout) {
   sockaddr_in6 addr{};
   addr.sin6_family = AF_INET6;
   addr.sin6_port = htons(port);
-  inet_pton(AF_INET6, host.c_str(), &addr.sin6_addr);
-  auto rval = Fd::Socket(AF_INET6, type, 0);
+  inet_pton(AF_INET6, std::string(host).c_str(), &addr.sin6_addr);
+  Fd rval = CF_EXPECT(Fd::Socket(AF_INET6, type, 0));
   if (!rval.IsOpen()) {
     return rval;
   }
@@ -336,82 +311,70 @@ Fd Fd::Socket6Client(const std::string& host, const std::string& interface,
   if (!interface.empty()) {
 #ifdef __linux__
     ifreq ifr{};
-    snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", interface.c_str());
+    snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s",
+             std::string(interface).c_str());
 
-    if (rval.SetSockOpt(SOL_SOCKET, SO_BINDTODEVICE, &ifr, sizeof(ifr)) == -1) {
-      return Fd::ErrorFD(rval.GetErrno());
-    }
+    CF_EXPECTF(
+        rval.SetSockOpt(SOL_SOCKET, SO_BINDTODEVICE, &ifr, sizeof(ifr)) >= 0,
+        "SetSockOpt(SOL_SOCKET, SO_BINDTODEVICE, ...) failed: {}",
+        rval.StrError());
 #elif defined(__APPLE__)
-    int idx = if_nametoindex(interface.c_str());
-    if (rval->SetSockOpt(IPPROTO_IP, IP_BOUND_IF, &idx, sizeof(idx)) == -1) {
-      return Fd::ErrorFD(rval->GetErrno());
-    }
+    int idx = if_nametoindex(std::string(interface).c_str());
+    CF_EXPECTF(rval.SetSockOpt(IPPROTO_IP, IP_BOUND_IF, &idx, sizeof(idx)) >= 0,
+               "SetSockOpt(IPPROTO_IP, IP_BOUND_IF, {}, ...) failed: {}", idx,
+               rval.StrError());
 #else
 #error "Unsupported operating system"
 #endif
   }
 
   struct timeval timeout_timeval = {static_cast<time_t>(timeout.count()), 0};
-  if (rval.ConnectWithTimeout(reinterpret_cast<const sockaddr*>(&addr),
-                              sizeof addr, &timeout_timeval) < 0) {
-    return Fd::ErrorFD(rval.GetErrno());
-  }
+  CF_EXPECTF(rval.ConnectWithTimeout(reinterpret_cast<const sockaddr*>(&addr),
+                                     sizeof addr, &timeout_timeval) >= 0,
+             "ConnectWithTimeout failed: {}", rval.StrError());
   return rval;
 }
 
-Fd Fd::SocketLocalServer(int port, int type) {
+Result<Fd> Fd::SocketLocalServer(int port, int type) {
   struct sockaddr_in addr;
   memset(&addr, 0, sizeof(addr));
   addr.sin_family = AF_INET;
   addr.sin_port = htons(port);
   addr.sin_addr.s_addr = htonl(INADDR_ANY);
-  Fd rval = Fd::Socket(AF_INET, type, 0);
-  if (!rval.IsOpen()) {
-    return rval;
-  }
+  Fd rval = CF_EXPECT(Fd::Socket(AF_INET, type, 0));
+
   int n = 1;
-  if (rval.SetSockOpt(SOL_SOCKET, SO_REUSEADDR, &n, sizeof(n)) == -1) {
-    LOG(ERROR) << "SetSockOpt failed " << rval.StrError();
-    return Fd::ErrorFD(rval.GetErrno());
-  }
-  if (rval.Bind(reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
-    LOG(ERROR) << "Bind failed " << rval.StrError();
-    return Fd::ErrorFD(rval.GetErrno());
-  }
+  CF_EXPECTF(rval.SetSockOpt(SOL_SOCKET, SO_REUSEADDR, &n, sizeof(n)) >= 0,
+             "SetSockOpt failed: {}", rval.StrError());
+
+  CF_EXPECTF(rval.Bind(reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) >= 0,
+             "Bind failed: {}", rval.StrError());
+
   if (type == SOCK_STREAM || type == SOCK_SEQPACKET) {
-    if (rval.Listen(4) < 0) {
-      LOG(ERROR) << "Listen failed " << rval.StrError();
-      return Fd::ErrorFD(rval.GetErrno());
-    }
+    CF_EXPECTF(rval.Listen(4) >= 0, "Listen failed: {}", rval.StrError());
   }
   return rval;
 }
 
-Fd Fd::SocketLocalServer(const std::string& name, bool abstract, int in_type,
-                         mode_t mode) {
+Result<Fd> Fd::SocketLocalServer(std::string_view name, bool abstract,
+                                 int in_type, mode_t mode) {
   // DO NOT UNLINK addr.sun_path. It does NOT have to be null-terminated.
   // See man 7 unix for more details.
+  std::string name_str(name);
   if (!abstract) {
-    (void)unlink(name.c_str());
+    (void)TEMP_FAILURE_RETRY(unlink(name_str.c_str()));
   }
 
   struct sockaddr_un addr;
   socklen_t addrlen;
-  MakeAddress(name.c_str(), abstract, &addr, &addrlen);
-  Fd rval = Fd::Socket(PF_UNIX, in_type, 0);
-  if (!rval.IsOpen()) {
-    return rval;
-  }
+  MakeAddress(name_str.c_str(), abstract, &addr, &addrlen);
+  Fd rval = CF_EXPECT(Fd::Socket(PF_UNIX, in_type, 0));
 
   int n = 1;
-  if (rval.SetSockOpt(SOL_SOCKET, SO_REUSEADDR, &n, sizeof(n)) == -1) {
-    LOG(ERROR) << "SetSockOpt failed " << rval.StrError();
-    return Fd::ErrorFD(rval.GetErrno());
-  }
-  if (rval.Bind(reinterpret_cast<sockaddr*>(&addr), addrlen) == -1) {
-    LOG(ERROR) << "Bind failed; name=" << name << ": " << rval.StrError();
-    return Fd::ErrorFD(rval.GetErrno());
-  }
+  CF_EXPECTF(rval.SetSockOpt(SOL_SOCKET, SO_REUSEADDR, &n, sizeof(n)) >= 0,
+             "SetSockOpt failed: {}", rval.StrError());
+  CF_EXPECTF(rval.Bind(reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) >= 0,
+             "Bind failed: {}", rval.StrError());
 
   /* Only the bottom bits are really the socket type; there are flags too. */
   constexpr int SOCK_TYPE_MASK = 0xf;
@@ -420,14 +383,11 @@ Fd Fd::SocketLocalServer(const std::string& name, bool abstract, int in_type,
   // Connection oriented sockets: start listening.
   if (socket_type == SOCK_STREAM || socket_type == SOCK_SEQPACKET) {
     // Follows the default from socket_local_server
-    if (rval.Listen(1) == -1) {
-      LOG(ERROR) << "Listen failed: " << rval.StrError();
-      return Fd::ErrorFD(rval.GetErrno());
-    }
+    CF_EXPECTF(rval.Listen(4) >= 0, "Listen failed: {}", rval.StrError());
   }
 
   if (!abstract) {
-    if (TEMP_FAILURE_RETRY(chmod(name.c_str(), mode)) == -1) {
+    if (TEMP_FAILURE_RETRY(chmod(name_str.c_str(), mode)) == -1) {
       LOG(ERROR) << "chmod failed: " << ::cuttlefish::StrError(errno);
       // However, continue since we do have a listening socket
     }
@@ -436,42 +396,36 @@ Fd Fd::SocketLocalServer(const std::string& name, bool abstract, int in_type,
 }
 
 #ifdef __linux__
-Fd Fd::VsockServer(unsigned int port, int type,
-                   std::optional<int> vhost_user_vsock_listening_cid,
-                   unsigned int cid) {
+Result<Fd> Fd::VsockServer(unsigned int port, int type,
+                           std::optional<int> vhost_user_vsock_listening_cid,
+                           unsigned int cid) {
   if (vhost_user_vsock_listening_cid) {
-    return Fd::SocketLocalServer(
+    return CF_EXPECT(Fd::SocketLocalServer(
         GetVhostUserVsockServerAddr(port, *vhost_user_vsock_listening_cid),
-        false /* abstract */, type, 0666 /* mode */);
+        false /* abstract */, type, 0666 /* mode */));
   }
 
-  auto vsock = Fd::Socket(AF_VSOCK, type, 0);
-  if (!vsock.IsOpen()) {
-    return vsock;
-  }
+  Fd vsock = CF_EXPECT(Fd::Socket(AF_VSOCK, type, 0));
+
   sockaddr_vm addr{};
   addr.svm_family = AF_VSOCK;
   addr.svm_port = port;
   addr.svm_cid = cid;
   auto casted_addr = reinterpret_cast<sockaddr*>(&addr);
-  if (vsock.Bind(casted_addr, sizeof(addr)) == -1) {
-    LOG(ERROR) << "Port " << port << " Bind failed (" << vsock.StrError()
-               << ")";
-    return Fd::ErrorFD(vsock.GetErrno());
-  }
+  CF_EXPECTF(vsock.Bind(casted_addr, sizeof(addr)) >= 0,
+             "Bind failed port {}: {}", port, vsock.StrError());
+
   if (type == SOCK_STREAM || type == SOCK_SEQPACKET) {
-    if (vsock.Listen(4) < 0) {
-      LOG(ERROR) << "Port" << port << " Listen failed (" << vsock.StrError()
-                 << ")";
-      return Fd::ErrorFD(vsock.GetErrno());
-    }
+    CF_EXPECTF(vsock.Listen(4) >= 0, "Listen on port {} failed: {}", port,
+               vsock.StrError());
   }
   return vsock;
 }
 
-Fd Fd::VsockServer(int type,
-                   std::optional<int> vhost_user_vsock_listening_cid) {
-  return VsockServer(VMADDR_PORT_ANY, type, vhost_user_vsock_listening_cid);
+Result<Fd> Fd::VsockServer(int type,
+                           std::optional<int> vhost_user_vsock_listening_cid) {
+  return CF_EXPECT(
+      VsockServer(VMADDR_PORT_ANY, type, vhost_user_vsock_listening_cid));
 }
 
 std::string Fd::GetVhostUserVsockServerAddr(
@@ -978,15 +932,6 @@ Fd::Fd(int fd, int in_errno)
   std::stringstream identity;
   identity << "fd=" << fd << " @" << this;
   identity_ = identity.str();
-}
-
-Fd Fd::AcceptInternal(struct sockaddr* addr, socklen_t* addrlen) const {
-  int fd = TEMP_FAILURE_RETRY(accept(fd_, addr, addrlen));
-  if (fd == -1) {
-    return Fd(fd, errno);
-  } else {
-    return Fd(fd, 0);
-  }
 }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/common/libs/fs/fd.h
+++ b/base/cvd/cuttlefish/common/libs/fs/fd.h
@@ -45,6 +45,7 @@
 #include <chrono>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "android-base/cmsg.h"
@@ -101,42 +102,37 @@ class Fd : public ReaderWriterSeeker {
   // All Fds have the O_CLOEXEC flag after creation. To remove use the
   // Fcntl or Dup functions.
 
-  static Fd Accept(const Fd& listener, struct sockaddr* addr,
-                   socklen_t* addrlen);
-  static Fd Accept(const Fd& listener);
-  static Result<Fd> Creat(const std::string& path, mode_t mode);
-  static Fd Dup(int unmanaged_fd);
-  static Result<Fd> Fifo(const std::string& pathname, mode_t mode);
-  static Fd MemfdCreate(const std::string& name, unsigned int flags = 0);
-  static Fd Mkstemp(std::string* path);
+  static Result<Fd> Accept(const Fd& listener);
+  static Result<Fd> Creat(std::string_view path, mode_t mode);
+  static Result<Fd> Dup(int unmanaged_fd);
+  static Result<Fd> Fifo(std::string_view pathname, mode_t mode);
+  static Result<Fd> MemfdCreate(std::string_view name, unsigned int flags = 0);
   static Result<std::pair<Fd, std::string>> Mkostemp(std::string_view path,
                                                      int flags = O_CLOEXEC);
-  static Fd Open(const char* pathname, int flags, mode_t mode = 0);
-  static Fd Open(const std::string& pathname, int flags, mode_t mode = 0);
-  static bool Pipe(Fd* fd0, Fd* fd1);
-  static bool SocketPair(int domain, int type, int protocol, Fd* fd0, Fd* fd1);
-  static Fd Socket(int domain, int socket_type, int protocol);
-  static Fd Socket6Client(
-      const std::string& host, const std::string& interface, int port, int type,
-      std::chrono::seconds timeout = std::chrono::seconds(0));
-  static Fd SocketClient(
-      const std::string& host, int port, int type,
-      std::chrono::seconds timeout = std::chrono::seconds(0));
-  static Fd SocketLocalClient(const std::string& name, bool is_abstract,
-                              int in_type);
-  static Fd SocketLocalClient(const std::string& name, bool is_abstract,
-                              int in_type, int timeout_seconds);
-  static Fd SocketLocalClient(int port, int type);
-  static Fd SocketLocalServer(const std::string& name, bool is_abstract,
-                              int in_type, mode_t mode);
-  static Fd SocketLocalServer(int port, int type);
+  static Result<Fd> Open(std::string_view pathname, int flags, mode_t mode = 0);
+  static Result<std::pair<Fd, Fd>> Pipe();
   static Result<std::pair<Fd, Fd>> SocketPair(int domain, int type,
                                               int protocol);
+  static Result<Fd> Socket(int domain, int socket_type, int protocol);
+  static Result<Fd> Socket6Client(
+      std::string_view host, std::string_view interface, int port, int type,
+      std::chrono::seconds timeout = std::chrono::seconds(0));
+  static Result<Fd> SocketClient(
+      std::string_view host, int port, int type,
+      std::chrono::seconds timeout = std::chrono::seconds(0));
+  static Result<Fd> SocketLocalClient(std::string_view name, bool is_abstract,
+                                      int in_type);
+  static Result<Fd> SocketLocalClient(std::string_view name, bool is_abstract,
+                                      int in_type, int timeout_seconds);
+  static Result<Fd> SocketLocalClient(int port, int type);
+  static Result<Fd> SocketLocalServer(std::string_view name, bool is_abstract,
+                                      int in_type, mode_t mode);
+  static Result<Fd> SocketLocalServer(int port, int type);
 
 #ifdef __linux__
-  static Fd Event(int initval = 0, int flags = 0);
-  static Fd InotifyFd();
-  static Fd ShmOpen(const std::string& name, int oflag, int mode);
+  static Result<Fd> Event(int initval = 0, int flags = 0);
+  static Result<Fd> InotifyFd();
+  static Result<Fd> ShmOpen(std::string_view name, int oflag, int mode);
   // For binding in vsock, svm_cid from `cid` param would be either
   // VMADDR_CID_ANY, VMADDR_CID_LOCAL, VMADDR_CID_HOST or their own CID, and it
   // is used for indicating connections which it accepts from.
@@ -154,11 +150,12 @@ class Fd : public ReaderWriterSeeker {
   static std::string GetVhostUserVsockServerAddr(
       unsigned int port, int vhost_user_vsock_listening_cid);
   static std::string GetVhostUserVsockClientAddr(int cid);
-  static Fd VsockServer(unsigned int port, int type,
-                        std::optional<int> vhost_user_vsock_listening_cid,
-                        unsigned int cid = VMADDR_CID_ANY);
-  static Fd VsockServer(int type,
-                        std::optional<int> vhost_user_vsock_listening_cid);
+  static Result<Fd> VsockServer(
+      unsigned int port, int type,
+      std::optional<int> vhost_user_vsock_listening_cid,
+      unsigned int cid = VMADDR_CID_ANY);
+  static Result<Fd> VsockServer(
+      int type, std::optional<int> vhost_user_vsock_listening_cid);
 #endif
 
   int Bind(const struct sockaddr* addr, socklen_t addrlen);
@@ -272,7 +269,6 @@ class Fd : public ReaderWriterSeeker {
 
  private:
   Fd(int fd, int in_errno);
-  Fd AcceptInternal(struct sockaddr* addr, socklen_t* addrlen) const;
 
   static Fd ErrorFD(int error);
 

--- a/base/cvd/cuttlefish/common/libs/fs/shared_fd.cpp
+++ b/base/cvd/cuttlefish/common/libs/fs/shared_fd.cpp
@@ -142,7 +142,9 @@ int SharedFD::Poll(PollSharedFd* fds, size_t num_fds, int timeout) {
   return ret;
 }
 
-SharedFD SharedFD::Dup(int unmanaged_fd) { return Fd::Dup(unmanaged_fd); }
+SharedFD SharedFD::Dup(int unmanaged_fd) {
+  return Fd::Dup(unmanaged_fd).value_or(Fd());
+}
 
 bool SharedFD::Pipe(SharedFD* fd0, SharedFD* fd1) {
   int fds[2];
@@ -161,18 +163,18 @@ bool SharedFD::Pipe(SharedFD* fd0, SharedFD* fd1) {
 
 #ifdef __linux__
 SharedFD SharedFD::Event(int initval, int flags) {
-  return Fd::Event(initval, flags);
+  return Fd::Event(initval, flags).value_or(Fd());
 }
 
 SharedFD SharedFD::ShmOpen(const std::string& name, int oflag, int mode) {
-  return Fd::ShmOpen(name, oflag, mode);
+  return Fd::ShmOpen(name, oflag, mode).value_or(Fd());
 }
 #endif
 
 SharedFD SharedFD::MemfdCreateWithData(const std::string& name,
                                        const std::string& data,
                                        unsigned int flags) {
-  SharedFD memfd = Fd::MemfdCreate(name, flags);
+  SharedFD memfd = Fd::MemfdCreate(name, flags).value_or(Fd());
   if (WriteAll(memfd, data) != data.size()) {
     return ErrorFD(errno);
   }
@@ -187,13 +189,12 @@ SharedFD SharedFD::MemfdCreateWithData(const std::string& name,
 
 bool SharedFD::SocketPair(int domain, int type, int protocol, SharedFD* fd0,
                           SharedFD* fd1) {
-  Fd unique_fd0;
-  Fd unique_fd1;
-  if (!Fd::SocketPair(domain, type, protocol, &unique_fd0, &unique_fd1)) {
+  Result<std::pair<Fd, Fd>> res = Fd::SocketPair(domain, type, protocol);
+  if (!res.has_value()) {
     return false;
   }
-  *fd0 = std::move(unique_fd0);
-  *fd1 = std::move(unique_fd1);
+  *fd0 = std::move(res->first);
+  *fd1 = std::move(res->second);
   return true;
 }
 
@@ -207,70 +208,67 @@ Result<std::pair<SharedFD, SharedFD>> SharedFD::SocketPair(int domain, int type,
 }
 
 SharedFD SharedFD::Open(const std::string& path, int flags, mode_t mode) {
-  return Fd::Open(path, flags, mode);
+  return Fd::Open(path, flags, mode).value_or(Fd());
 }
 
 SharedFD SharedFD::Open(const char* path, int flags, mode_t mode) {
-  return Fd::Open(path, flags, mode);
+  return Fd::Open(path, flags, mode).value_or(Fd());
 }
 
 SharedFD SharedFD::Socket(int domain, int socket_type, int protocol) {
-  return Fd::Socket(domain, socket_type, protocol);
+  return Fd::Socket(domain, socket_type, protocol).value_or(Fd());
 }
 
 Result<std::pair<SharedFD, std::string>> SharedFD::Mkostemp(
     const std::string_view path, const int flags) {
-  // mkostemp replaces the Xs with random selections to make a unique filename
-  auto temp_path = fmt::format("{}XXXXXX", path);
-  const int fd = mkostemp(temp_path.data(), flags);
-  CF_EXPECTF(fd != -1, "Error creating temporary file: {}",
-             ::cuttlefish::StrError(errno));
-  auto shared_fd = SharedFD(std::shared_ptr<Fd>(new Fd(fd, 0)));
-  return std::make_pair<SharedFD, std::string>(std::move(shared_fd),
-                                               std::move(temp_path));
+  std::pair<Fd, std::string> fd_path = CF_EXPECT(Fd::Mkostemp(path, flags));
+  return std::make_pair<SharedFD, std::string>(std::move(fd_path.first),
+                                               std::move(fd_path.second));
 }
 
 SharedFD SharedFD::ErrorFD(int error) { return Fd::ErrorFD(error); }
 
 SharedFD SharedFD::SocketLocalClient(const std::string& name, bool abstract,
                                      int in_type) {
-  return Fd::SocketLocalClient(name, abstract, in_type);
+  return Fd::SocketLocalClient(name, abstract, in_type).value_or(Fd());
 }
 
 SharedFD SharedFD::SocketLocalClient(const std::string& name, bool abstract,
                                      int in_type, int timeout_seconds) {
-  return Fd::SocketLocalClient(name, abstract, in_type, timeout_seconds);
+  return Fd::SocketLocalClient(name, abstract, in_type, timeout_seconds)
+      .value_or(Fd());
 }
 
 SharedFD SharedFD::SocketLocalClient(int port, int type) {
-  return Fd::SocketLocalClient(port, type);
+  return Fd::SocketLocalClient(port, type).value_or(Fd());
 }
 
 SharedFD SharedFD::SocketClient(const std::string& host, int port, int type,
                                 std::chrono::seconds timeout) {
-  return Fd::SocketClient(host, port, type, timeout);
+  return Fd::SocketClient(host, port, type, timeout).value_or(Fd());
 }
 
 SharedFD SharedFD::Socket6Client(const std::string& host,
                                  const std::string& interface, int port,
                                  int type, std::chrono::seconds timeout) {
-  return Fd::Socket6Client(host, interface, port, type, timeout);
+  return Fd::Socket6Client(host, interface, port, type, timeout).value_or(Fd());
 }
 
 SharedFD SharedFD::SocketLocalServer(int port, int type) {
-  return Fd::SocketLocalServer(port, type);
+  return Fd::SocketLocalServer(port, type).value_or(Fd());
 }
 
 SharedFD SharedFD::SocketLocalServer(const std::string& name, bool abstract,
                                      int in_type, mode_t mode) {
-  return Fd::SocketLocalServer(name, abstract, in_type, mode);
+  return Fd::SocketLocalServer(name, abstract, in_type, mode).value_or(Fd());
 }
 
 #ifdef __linux__
 SharedFD SharedFD::VsockServer(
     unsigned int port, int type,
     std::optional<int> vhost_user_vsock_listening_cid, unsigned int cid) {
-  return Fd::VsockServer(port, type, vhost_user_vsock_listening_cid, cid);
+  return Fd::VsockServer(port, type, vhost_user_vsock_listening_cid, cid)
+      .value_or(Fd());
 }
 
 SharedFD SharedFD::VsockServer(

--- a/base/cvd/cuttlefish/common/libs/utils/socket2socket_proxy.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/socket2socket_proxy.cpp
@@ -152,7 +152,7 @@ ProxyServer::ProxyServer(SharedFD server,
 
       // Server fd is available to read, so we can accept the
       // connection without blocking on that
-      SharedFD client = Fd::Accept(*server_fd);
+      SharedFD client = Fd::Accept(*server_fd).value_or(Fd());
       if (!client->IsOpen()) {
         LOG(ERROR) << "Failed to accept incoming connection: "
                    << client->StrError();

--- a/base/cvd/cuttlefish/common/libs/utils/unix_sockets_test.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/unix_sockets_test.cpp
@@ -37,7 +37,7 @@
 namespace cuttlefish {
 
 SharedFD CreateMemFDWithData(const std::string& data) {
-  SharedFD memfd = Fd::MemfdCreate("");
+  SharedFD memfd = Fd::MemfdCreate("").value_or(Fd());
   CHECK(WriteAll(memfd, data) == data.size()) << memfd->StrError();
   CHECK(memfd->LSeek(0, SEEK_SET) == 0);
   return memfd;

--- a/base/cvd/cuttlefish/common/libs/utils/vsock_connection.cpp
+++ b/base/cvd/cuttlefish/common/libs/utils/vsock_connection.cpp
@@ -244,7 +244,7 @@ bool VsockServerConnection::Connect(unsigned int port, unsigned int cid,
                                                    vhost_user_vsock_cid, cid);
   }
   if (server_fd_->IsOpen()) {
-    fd_ = Fd::Accept(*server_fd_);
+    fd_ = Fd::Accept(*server_fd_).value_or(Fd());
     return fd_->IsOpen();
   } else {
     return false;

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/file_monitor_source.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/file_monitor_source.cc
@@ -113,7 +113,7 @@ FileMonitorSource::FileMonitorSource(
       file_io_(std::move(file_io)),
       colorize_line_(std::move(colorize_line)),
       filter_line_(std::move(filter_line)) {
-  inotify_fd_ = Fd::InotifyFd();
+  inotify_fd_ = Fd::InotifyFd().value_or(Fd());
   CHECK(inotify_fd_->IsOpen()) << inotify_fd_->StrError();
   CHECK_GE(inotify_fd_->InotifyAddWatch(path_, IN_DELETE_SELF | IN_MODIFY), 0);
   const int flags = inotify_fd_->Fcntl(F_GETFL, 0);

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/monitor.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/monitor/monitor.cc
@@ -60,8 +60,7 @@ Result<void> MonitorLogs(const LocalInstance& instance, SharedFD stop_eventfd,
   std::unique_ptr<MonitorSource> launcher_monitor_source;
   std::unique_ptr<MonitorSource> logcat_monitor_source;
 
-  const SharedFD dir_inotify_fd = Fd::InotifyFd();
-  CF_EXPECT(dir_inotify_fd->IsOpen(), "Failed to create inotify fd");
+  const SharedFD dir_inotify_fd = CF_EXPECT(Fd::InotifyFd());
   const int flags = dir_inotify_fd->Fcntl(F_GETFL, 0);
   CF_EXPECT(dir_inotify_fd->Fcntl(F_SETFL, flags | O_NONBLOCK) != -1,
             "Failed to set inotify fd to non-blocking");

--- a/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvd/cli/commands/start.cpp
@@ -421,9 +421,7 @@ Result<void> CvdStartCommandHandler::Handle(const CommandRequest& request) {
   SharedFD memfd;
   SharedFD stop_eventfd;
   if (!own_flags_.daemon) {
-    memfd = Fd::MemfdCreate("cvd_internal_start_output");
-    CF_EXPECT(memfd->IsOpen(), "Failed to create memfd for subprocess output: "
-                                   << memfd->StrError());
+    memfd = CF_EXPECT(Fd::MemfdCreate("cvd_internal_start_output"));
 
     stop_eventfd = SharedFD::Event();
     CF_EXPECT(stop_eventfd->IsOpen(),

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/channel_monitor.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/channel_monitor.cpp
@@ -69,7 +69,7 @@ ClientId ChannelMonitor::SetRemoteClient(SharedFD client, bool is_accepted) {
 }
 
 void ChannelMonitor::AcceptIncomingConnection() {
-  SharedFD client_fd = Fd::Accept(*server_);
+  SharedFD client_fd = Fd::Accept(*server_).value_or(Fd());
   if (!client_fd->IsOpen()) {
     LOG(ERROR) << "Error accepting connection on socket: "
                << client_fd->StrError();

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/main.cpp
@@ -141,7 +141,7 @@ int ModemSimulatorMain(int argc, char** argv) {
     if (num_fds <= 0) {  // Ignore select error
       LOG(ERROR) << "Select call returned error : " << strerror(errno);
     } else if (read_set.IsSet(monitor_socket)) {
-      SharedFD conn = Fd::Accept(*monitor_socket);
+      SharedFD conn = Fd::Accept(*monitor_socket).value_or(Fd());
       std::string buf(4, ' ');
       auto read = ReadExact(conn, &buf);
       if (read <= 0) {

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/ti50_emulator.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/ti50_emulator.cpp
@@ -87,7 +87,7 @@ class Ti50Emulator : public vm_manager::VmmDependencyCommand {
     }
 
     // Wait for control socket sending "READY".
-    SharedFD sock = Fd::Accept(*ctrl_sock_);
+    SharedFD sock = Fd::Accept(*ctrl_sock_).value_or(Fd());
     const char kExpectedReadyStr[] = "READY";
     char buf[std::size(kExpectedReadyStr)];
     Result<uint64_t> data_read = sock->Read(buf, sizeof(buf));

--- a/base/cvd/cuttlefish/host/commands/run_cvd/server_loop_impl.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/server_loop_impl.cpp
@@ -129,7 +129,7 @@ Result<void> ServerLoopImpl::Run() {
     }
 
     CF_EXPECT(read_set.IsSet(server_));
-    SharedFD client = Fd::Accept(*server_);
+    SharedFD client = Fd::Accept(*server_).value_or(Fd());
     while (client->IsOpen()) {
       auto launcher_action_with_info_result = ReadLauncherActionFromFd(client);
       if (!launcher_action_with_info_result.has_value()) {
@@ -448,7 +448,7 @@ void ServerLoopImpl::RestartRunCvd(int notification_fd) {
     CHECK(RemoveFile(config_.AssemblyPath("restore")).has_value());
   }
   auto config_path = config_.AssemblyPath("cuttlefish_config.json");
-  SharedFD followup_stdin = Fd::MemfdCreate("pseudo_stdin");
+  SharedFD followup_stdin = Fd::MemfdCreate("pseudo_stdin").value_or(Fd());
   WriteAll(followup_stdin, config_path + "\n");
   // NOLINTNEXTLINE(misc-include-cleaner): unistd.h provides SEEK_SET
   followup_stdin->LSeek(0, SEEK_SET);

--- a/base/cvd/cuttlefish/host/commands/tombstone_receiver/main.cpp
+++ b/base/cvd/cuttlefish/host/commands/tombstone_receiver/main.cpp
@@ -90,7 +90,7 @@ int TombstoneReceiverMain(int argc, char** argv) {
 
   // Server loop
   while (true) {
-    SharedFD conn = Fd::Accept(*server_fd);
+    SharedFD conn = Fd::Accept(*server_fd).value_or(Fd());
     std::ofstream file(next_tombstone_path(tombstone_dir),
                        std::ofstream::out | std::ofstream::binary);
     auto acc = 0;

--- a/base/cvd/cuttlefish/host/libs/audio_connector/server.cpp
+++ b/base/cvd/cuttlefish/host/libs/audio_connector/server.cpp
@@ -43,7 +43,7 @@ namespace cuttlefish {
 namespace {
 
 ScopedMMap AllocateShm(size_t size, const std::string& name, SharedFD* shm_fd) {
-  *shm_fd = Fd::MemfdCreate(name, 0);
+  *shm_fd = Fd::MemfdCreate(name, 0).value_or(Fd());
   if (!(*shm_fd)->IsOpen()) {
     LOG(FATAL) << "Unable to allocate create file for " << name << ": "
                << (*shm_fd)->StrError();
@@ -114,7 +114,7 @@ std::function<void(AudioStatus, uint32_t, uint32_t)> SendStatusCallback(
 std::unique_ptr<AudioClientConnection> AudioServer::AcceptClient(
     uint32_t num_streams, uint32_t num_jacks, uint32_t num_chmaps,
     uint32_t num_controls, size_t tx_shm_len, size_t rx_shm_len) {
-  SharedFD conn_fd = Fd::Accept(*server_socket_, nullptr, 0);
+  SharedFD conn_fd = Fd::Accept(*server_socket_).value_or(Fd());
   if (!conn_fd->IsOpen()) {
     LOG(ERROR) << "Connection failed on audio server: " << conn_fd->StrError();
     return nullptr;

--- a/base/cvd/cuttlefish/host/libs/web/oauth2_consent.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/oauth2_consent.cpp
@@ -85,8 +85,7 @@ class HttpServer {
   uint16_t Port() { return 8888; }
 
   Result<std::string> CodeFromClient() {
-    SharedFD client = Fd::Accept(*server_);
-    CF_EXPECT(client->IsOpen(), client->StrError());
+    SharedFD client = CF_EXPECT(Fd::Accept(*server_));
 
     std::stringstream request;
     char buffer[512];

--- a/base/cvd/cuttlefish/io/BUILD.bazel
+++ b/base/cvd/cuttlefish/io/BUILD.bazel
@@ -230,7 +230,6 @@ cf_cc_library(
     hdrs = ["lazily_loaded_file.h"],
     deps = [
         "//cuttlefish/common/libs/fs",
-        "//cuttlefish/common/libs/fs:fd",
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/io",
         "//cuttlefish/io:disjoint_range_set",

--- a/base/cvd/cuttlefish/io/lazily_loaded_file.cc
+++ b/base/cvd/cuttlefish/io/lazily_loaded_file.cc
@@ -30,7 +30,6 @@
 
 #include "absl/log/log.h"
 
-#include "cuttlefish/common/libs/fs/fd.h"
 #include "cuttlefish/common/libs/fs/shared_buf.h"
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/files.h"
@@ -134,16 +133,15 @@ Result<void> LazilyLoadedFile::Impl::ReadMetadata() {
 }
 
 Result<void> LazilyLoadedFile::Impl::WriteMetadata() {
-  std::string new_metadata_name = MetadataFile() + ".XXXXXX";
-  SharedFD new_metadata = Fd::Mkstemp(&new_metadata_name);
-  CF_EXPECT(new_metadata->IsOpen(), new_metadata->StrError());
-  CF_EXPECT(new_metadata->Chmod(0644));
+  std::pair<SharedFD, std::string> fd_name =
+      CF_EXPECT(SharedFD::Mkostemp(MetadataFile() + "."));
+  CF_EXPECT(fd_name.first->Chmod(0644));
 
   std::string data = Serialize(already_downloaded_);
-  CF_EXPECT_EQ(WriteAll(new_metadata, data), data.size(),
-               new_metadata->StrError());
+  CF_EXPECT_EQ(WriteAll(fd_name.first, data), data.size(),
+               fd_name.first->StrError());
 
-  CF_EXPECT(RenameFile(new_metadata_name, MetadataFile()));
+  CF_EXPECT(RenameFile(fd_name.second, MetadataFile()));
 
   return {};
 }


### PR DESCRIPTION
This is a good time to revisit some of these functions before introducing more callers.

- `const std::string&` -> `std::string_view` in arguments
- `Result` in return values
- Output parameters -> complex return types
- Use TEMP_FAILURE_RETRY more

SharedFD now invokes these internally. When deleting the corresponding members from `SharedFD`, the callers will have to be migrated to the improved versions.

Bug: b/545278508