### PR TITLE
Always run snapshot_hook_* as root

### DIFF
--- a/base/cvd/cuttlefish/host/commands/run_cvd/boot_state_machine.cc
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/boot_state_machine.cc
@@ -424,9 +424,11 @@ class CvdBootStateMachine : public SetupFeature, public KernelLogPipeConsumer {
                 instance_.adb_ip_and_port());
             adb_command.AddParameter("wait-for-device");
             adb_command.AddParameter("shell");
-            adb_command.AddParameter("/vendor/bin/snapshot_hook_post_resume");
+            adb_command.AddParameter(
+                "su root /vendor/bin/snapshot_hook_post_resume");
             CHECK_EQ(adb_command.Start().Wait(), 0)
-                << "Failed to run /vendor/bin/snapshot_hook_post_resume";
+                << "Failed to run su root "
+                   "/vendor/bin/snapshot_hook_post_resume";
             // Done last so that adb is more likely to be ready.
             CHECK(cuttlefish::WriteAll(restore_complete_pipe_write, "1") == 1)
                 << "Error writing to restore complete pipe: "

--- a/base/cvd/cuttlefish/host/commands/run_cvd/server_loop_impl_snapshot.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/server_loop_impl_snapshot.cpp
@@ -190,8 +190,8 @@ static Result<void> RunAdbShellCommand(
 Result<void> ServerLoopImpl::HandleSuspend(ProcessMonitor& process_monitor) {
   // right order: guest -> host
   VLOG(0) << "Suspending the guest..";
-  CF_EXPECT(
-      RunAdbShellCommand(instance_, {"/vendor/bin/snapshot_hook_pre_suspend"}));
+  CF_EXPECT(RunAdbShellCommand(
+      instance_, {"su", "root", "/vendor/bin/snapshot_hook_pre_suspend"}));
   CF_EXPECT(SuspendGuest());
   VLOG(0) << "The guest is suspended.";
   CF_EXPECT(process_monitor.SuspendMonitoredProcesses(),
@@ -207,8 +207,8 @@ Result<void> ServerLoopImpl::HandleResume(ProcessMonitor& process_monitor) {
   VLOG(0) << "The host processes are resumed.";
   VLOG(0) << "Resuming the guest..";
   CF_EXPECT(ResumeGuest());
-  CF_EXPECT(
-      RunAdbShellCommand(instance_, {"/vendor/bin/snapshot_hook_post_resume"}));
+  CF_EXPECT(RunAdbShellCommand(
+      instance_, {"su", "root", "/vendor/bin/snapshot_hook_post_resume"}));
   VLOG(0) << "The guest resumed.";
   return {};
 }


### PR DESCRIPTION
Backport of #2860 (and finish matching the `1.56` mirror of #2979)

When not run as root, this produces errors like
```
+ /system/bin/cmd nfc status
+ grep -q disabled
/vendor/bin/snapshot_hook_pre_suspend[40]: grep: inaccessible or not found
+ sleep 0.1
/vendor/bin/snapshot_hook_pre_suspend[40]: sleep: inaccessible or not found
```

This may have worked intermittently before depending on whether the runtime environment was also using `adb root`.

Bug: b/534832487