### PR TITLE
Enforce clang-tidy lints on headers, and fix outstanding errors

### DIFF
--- a/base/cvd/cuttlefish/common/libs/security/confui_sign.h
+++ b/base/cvd/cuttlefish/common/libs/security/confui_sign.h
@@ -53,7 +53,7 @@ class ConfUiSignerImpl {
 
   // set the sign_status_ if there was an error
   // TODO(kwstephenkim@): use android::base::Result. aosp/1940753
-  bool Send(SharedFD output, const confui::SignMessageError error,
+  bool Send(SharedFD output, confui::SignMessageError error,
             const std::vector<uint8_t>& payload);
   std::optional<confui::SignRawMessage> Receive(SharedFD input);
 
@@ -75,8 +75,7 @@ class ConfUiSignSender {
 
   // note that the error is IO error
   std::optional<confui::SignRawMessage> Receive();
-  bool Send(const SignMessageError error,
-            const std::vector<uint8_t>& encoded_hmac);
+  bool Send(SignMessageError error, const std::vector<uint8_t>& encoded_hmac);
 
   bool IsOk() const { return impl_.IsOk(); }
   bool IsIoError() const { return impl_.IsIoError(); }

--- a/base/cvd/cuttlefish/common/libs/utils/random.h
+++ b/base/cvd/cuttlefish/common/libs/utils/random.h
@@ -20,6 +20,6 @@
 
 namespace cuttlefish {
 
-std::string GenerateRandomString(const std::string& alphabet, const int length);
+std::string GenerateRandomString(const std::string& alphabet, int length);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/bootconfig_args.h
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/bootconfig_args.h
@@ -27,7 +27,7 @@ namespace cuttlefish {
 Result<std::unordered_map<std::string, std::string>> BootconfigArgsFromConfig(
     const CuttlefishConfig& config,
     const CuttlefishConfig::InstanceSpecific& instance,
-    const std::map<std::string, std::string, std::less<void>>
+    std::map<std::string, std::string, std::less<void>>
         builtin_bootconfig_args);
 
 Result<std::string> BootconfigArgsString(

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/sem.h
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/sem.h
@@ -29,7 +29,7 @@ constexpr std::chrono::seconds kSemNoTimeout = std::chrono::seconds(0);
  *
  * Any other processes Wait'ing to read on the socket will be unblocked.
  */
-Result<void> Post(const SharedFD socket);
+Result<void> Post(SharedFD socket);
 
 /*
  * Wait on the socket.
@@ -38,6 +38,6 @@ Result<void> Post(const SharedFD socket);
  * shut down, or the timeout is reached. The Result is ok if the socket
  * can be successfully read from.
  */
-Result<void> Wait(const SharedFD socket, std::chrono::seconds timeout);
+Result<void> Wait(SharedFD socket, std::chrono::seconds timeout);
 
 }  // namespace cuttlefish::cvdalloc

--- a/base/cvd/cuttlefish/host/commands/modem_simulator/sim_service.h
+++ b/base/cvd/cuttlefish/host/commands/modem_simulator/sim_service.h
@@ -202,11 +202,11 @@ class SimService : public ModemService, public std::enable_shared_from_this<SimS
 
     bool CheckPasswordValid(std::string_view password);
 
-    bool VerifyPIN(const std::string_view pin);
-    bool VerifyPUK(const std::string_view puk);
-    bool ChangePIN(ChangeMode mode, const std::string_view pin_or_puk,
-                   const std::string_view new_pin);
-    bool ChangePUK(const std::string_view puk, const std::string_view new_puk);
+    bool VerifyPIN(std::string_view pin);
+    bool VerifyPUK(std::string_view puk);
+    bool ChangePIN(ChangeMode mode, std::string_view pin_or_puk,
+                   std::string_view new_pin);
+    bool ChangePUK(std::string_view puk, std::string_view new_puk);
   };
   PinStatus pin1_status_;
   PinStatus pin2_status_;

--- a/base/cvd/cuttlefish/host/commands/run_cvd/server_loop_impl.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/server_loop_impl.h
@@ -79,8 +79,7 @@ class ServerLoopImpl : public ServerLoop,
   Result<void> HandleScreenshotDisplay(
       const run_cvd::ScreenshotDisplay& request);
 
-  void HandleActionWithNoData(const LauncherAction action,
-                              const SharedFD& client,
+  void HandleActionWithNoData(LauncherAction action, const SharedFD& client,
                               ProcessMonitor& process_monitor);
 
   void DeleteFifos();

--- a/base/cvd/cuttlefish/host/commands/sensors_simulator/sensors_simulator.h
+++ b/base/cvd/cuttlefish/host/commands/sensors_simulator/sensors_simulator.h
@@ -54,7 +54,7 @@ class SensorsSimulator {
   // corresponding sensor should be included in the returned data. Assuming
   // accelerometer and gyroscope are specified, the returned string would be
   // formatted as "<acc.x>:<acc.y>:<acc.z> <gyro.x>:<gyro.y>:<gyro.z>".
-  std::string GetSensorsData(const SensorsMask mask);
+  std::string GetSensorsData(SensorsMask mask);
 
  private:
   void NotifySensorsChanged(SensorsMask changed);

--- a/base/cvd/cuttlefish/host/libs/command_util/snapshot_utils.h
+++ b/base/cvd/cuttlefish/host/libs/command_util/snapshot_utils.h
@@ -32,7 +32,7 @@ namespace cuttlefish {
  */
 Result<void> CopyDirectoryRecursively(
     const std::string& src_dir_path, const std::string& dest_dir_path,
-    const bool verify_dest_dir_empty = false,
+    bool verify_dest_dir_empty = false,
     std::function<bool(const std::string&)> predicate = [](const std::string&) {
       return true;
     });

--- a/base/cvd/cuttlefish/host/libs/config/config_utils.h
+++ b/base/cvd/cuttlefish/host/libs/config/config_utils.h
@@ -29,7 +29,7 @@ int GetDefaultVsockCid();
 
 // Calculates vsock server port number
 // return base + (vsock_guest_cid - 3)
-int GetVsockServerPort(const int base, const int vsock_guest_cid);
+int GetVsockServerPort(int base, int vsock_guest_cid);
 
 // Returns a path where the launcher puts a link to the config file which makes
 // it easily discoverable regardless of what vm manager is in use

--- a/base/cvd/cuttlefish/host/libs/config/custom_actions.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/custom_actions.cpp
@@ -267,7 +267,7 @@ class CustomActionConfigImpl : public CustomActionConfigProvider {
                   return {};
                 })) {}
 
-  const std::vector<CustomShellActionConfig> CustomShellActions(
+  std::vector<CustomShellActionConfig> CustomShellActions(
       const std::string& id_str = std::string()) const override {
     int instance_index = 0;
     if (instance_actions_.empty()) {
@@ -284,7 +284,7 @@ class CustomActionConfigImpl : public CustomActionConfigProvider {
     return instance_actions_[instance_index].custom_shell_actions_;
   }
 
-  const std::vector<CustomActionServerConfig> CustomActionServers(
+  std::vector<CustomActionServerConfig> CustomActionServers(
       const std::string& id_str = std::string()) const override {
     int instance_index = 0;
     if (instance_actions_.empty()) {
@@ -301,7 +301,7 @@ class CustomActionConfigImpl : public CustomActionConfigProvider {
     return instance_actions_[instance_index].custom_action_servers_;
   }
 
-  const std::vector<CustomDeviceStateActionConfig> CustomDeviceStateActions(
+  std::vector<CustomDeviceStateActionConfig> CustomDeviceStateActions(
       const std::string& id_str = std::string()) const override {
     int instance_index = 0;
     if (instance_actions_.empty()) {

--- a/base/cvd/cuttlefish/host/libs/config/custom_actions.h
+++ b/base/cvd/cuttlefish/host/libs/config/custom_actions.h
@@ -59,12 +59,12 @@ struct CustomDeviceStateActionConfig {
 
 class CustomActionConfigProvider : public FlagFeature, public ConfigFragment {
  public:
-  virtual const std::vector<CustomShellActionConfig> CustomShellActions(
+  virtual std::vector<CustomShellActionConfig> CustomShellActions(
       const std::string& id_str = std::string()) const = 0;
-  virtual const std::vector<CustomActionServerConfig> CustomActionServers(
+  virtual std::vector<CustomActionServerConfig> CustomActionServers(
       const std::string& id_str = std::string()) const = 0;
-  virtual const std::vector<CustomDeviceStateActionConfig>
-  CustomDeviceStateActions(const std::string& id_str = std::string()) const = 0;
+  virtual std::vector<CustomDeviceStateActionConfig> CustomDeviceStateActions(
+      const std::string& id_str = std::string()) const = 0;
 };
 
 fruit::Component<fruit::Required<ConfigFlag>, CustomActionConfigProvider>

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
@@ -649,14 +649,14 @@ class CuttlefishConfig {
     void set_start_wmediumd_instance(bool start);
     void set_mcu(const Json::Value& cfg);
     void set_ap_boot_flow(APBootFlow flow);
-    void set_crosvm_use_balloon(const bool use_balloon);
-    void set_crosvm_use_rng(const bool use_rng);
-    void set_crosvm_simple_media_device(const bool simple_media_device);
-    void set_crosvm_v4l2_proxy(const std::string v4l2_proxy);
-    void set_use_pmem(const bool use_pmem);
+    void set_crosvm_use_balloon(bool use_balloon);
+    void set_crosvm_use_rng(bool use_rng);
+    void set_crosvm_simple_media_device(bool simple_media_device);
+    void set_crosvm_v4l2_proxy(std::string v4l2_proxy);
+    void set_use_pmem(bool use_pmem);
     void set_enable_pkvm(bool enable_pkvm);
     // Wifi MAC address inside the guest
-    void set_wifi_mac_prefix(const int wifi_mac_prefix);
+    void set_wifi_mac_prefix(int wifi_mac_prefix);
     // Gnss grpc proxy server port inside the host
     void set_gnss_grpc_proxy_server_port(int gnss_grpc_proxy_server_port);
     // Gnss grpc proxy local file path
@@ -667,8 +667,8 @@ class CuttlefishConfig {
     void set_gem5_checkpoint_dir(const std::string& gem5_checkpoint_dir);
     // Serial console
     void set_console(bool console);
-    void set_enable_sandbox(const bool enable_sandbox);
-    void set_enable_virtiofs(const bool enable_virtiofs);
+    void set_enable_sandbox(bool enable_sandbox);
+    void set_enable_virtiofs(bool enable_virtiofs);
     void set_kgdb(bool kgdb);
     void set_device_type(DeviceType type);
     void set_target_arch(Arch target_arch);
@@ -696,8 +696,8 @@ class CuttlefishConfig {
     void set_domkey_mapping_config(
         const std::string& domkey_mapping_config_json_path);
     void set_enable_usb(bool enable);
-    void set_enable_gnss_grpc_proxy(const bool enable_gnss_grpc_proxy);
-    void set_enable_bootanimation(const bool enable_bootanimation);
+    void set_enable_gnss_grpc_proxy(bool enable_gnss_grpc_proxy);
+    void set_enable_bootanimation(bool enable_bootanimation);
     void set_extra_bootconfig_args(const std::string& extra_bootconfig_args);
     void set_record_screen(bool record_screen);
     void set_gem5_debug_file(const std::string& gem5_debug_file);
@@ -759,14 +759,14 @@ class CuttlefishConfig {
     void set_guest_uses_bgra_framebuffers(bool uses_bgra);
     void set_frames_socket_path(const std::string& frame_socket_path);
 
-    void set_enable_gpu_udmabuf(const bool enable_gpu_udmabuf);
-    void set_enable_gpu_vhost_user(const bool enable_gpu_vhost_user);
-    void set_enable_gpu_external_blob(const bool enable_gpu_external_blob);
-    void set_enable_gpu_system_blob(const bool enable_gpu_system_blob);
+    void set_enable_gpu_udmabuf(bool enable_gpu_udmabuf);
+    void set_enable_gpu_vhost_user(bool enable_gpu_vhost_user);
+    void set_enable_gpu_external_blob(bool enable_gpu_external_blob);
+    void set_enable_gpu_system_blob(bool enable_gpu_system_blob);
 
-    void set_has_vulkan_gfxstream_apex(const bool has_apex);
-    void set_has_vulkan_lavapipe_apex(const bool has_apex);
-    void set_has_vulkan_swiftshader_apex(const bool has_apex);
+    void set_has_vulkan_gfxstream_apex(bool has_apex);
+    void set_has_vulkan_lavapipe_apex(bool has_apex);
+    void set_has_vulkan_swiftshader_apex(bool has_apex);
 
     void set_hwcomposer(const std::string&);
 
@@ -904,14 +904,14 @@ class CuttlefishConfig {
 
    public:
     // wmediumd related configs
-    void set_enable_wifi(const bool enable_wifi);
+    void set_enable_wifi(bool enable_wifi);
     void set_start_wmediumd(bool start);
     void set_vhost_user_mac80211_hwsim(const std::string& path);
     void set_wmediumd_api_server_socket(const std::string& path);
     void set_wmediumd_config(const std::string& config_path);
     void set_wmediumd_mac_prefix(int mac_prefix);
 
-    void set_group_uuid(const int group_uuid);
+    void set_group_uuid(int group_uuid);
   };
 
  private:

--- a/base/cvd/cuttlefish/host/libs/confui/host_renderer.h
+++ b/base/cvd/cuttlefish/host/libs/confui/host_renderer.h
@@ -65,12 +65,12 @@ class ConfUiRenderer {
  public:
   INJECT(ConfUiRenderer(ScreenConnectorFrameRenderer& screen_connector));
   ~ConfUiRenderer();
-  Result<void> RenderDialog(const uint32_t display_num,
+  Result<void> RenderDialog(uint32_t display_num,
                             const std::string& prompt_text,
                             const std::string& locale,
                             const std::vector<teeui::UIOption>& ui_options);
-  bool IsInConfirm(const uint32_t x, const uint32_t y);
-  bool IsInCancel(const uint32_t x, const uint32_t y);
+  bool IsInConfirm(uint32_t x, uint32_t y);
+  bool IsInCancel(uint32_t x, uint32_t y);
 
  private:
   bool IsInverted(const std::vector<teeui::UIOption>& ui_options) const;

--- a/base/cvd/cuttlefish/host/libs/confui/host_server.h
+++ b/base/cvd/cuttlefish/host/libs/confui/host_server.h
@@ -58,7 +58,7 @@ class HostServer {
   virtual ~HostServer() {}
 
   // implement input interfaces. called by webRTC
-  void TouchEvent(const int x, const int y, const bool is_down);
+  void TouchEvent(int x, int y, bool is_down);
   void UserAbortEvent();
 
  private:

--- a/base/cvd/cuttlefish/host/libs/confui/host_utils.h
+++ b/base/cvd/cuttlefish/host/libs/confui/host_utils.h
@@ -38,9 +38,9 @@ namespace thread {
  *
  * When running a thread, use the global RunThread function
  */
-std::string GetName(const std::thread::id tid = std::this_thread::get_id());
+std::string GetName(std::thread::id tid = std::this_thread::get_id());
 std::optional<std::thread::id> GetId(const std::string& name);
-void Set(const std::string& name, const std::thread::id tid);
+void Set(const std::string& name, std::thread::id tid);
 
 /*
  * This is wrapping std::thread. However, we keep the bidirectional map
@@ -56,9 +56,9 @@ ThreadTracer& GetThreadTracer();
 
 class ThreadTracer {
   friend ThreadTracer& GetThreadTracer();
-  friend std::string GetName(const std::thread::id tid);
+  friend std::string GetName(std::thread::id tid);
   friend std::optional<std::thread::id> GetId(const std::string& name);
-  friend void Set(const std::string& name, const std::thread::id tid);
+  friend void Set(const std::string& name, std::thread::id tid);
 
   template <typename F, typename... Args>
   friend std::thread RunThread(const std::string& name, F&& f, Args&&... args);
@@ -75,12 +75,12 @@ class ThreadTracer {
     ConfUiLogDebug << name << "thread started.";
     return th;
   }
-  std::string Get(const std::thread::id id = std::this_thread::get_id());
+  std::string Get(std::thread::id id = std::this_thread::get_id());
   std::optional<std::thread::id> Get(const std::string& name);
 
   // add later on even though it wasn't started with RunThread
   // if tid is already added, update the name only
-  void Set(const std::string& name, const std::thread::id tid);
+  void Set(const std::string& name, std::thread::id tid);
 
   ThreadTracer() = default;
   std::map<std::thread::id, std::string> id2name_;

--- a/base/cvd/cuttlefish/host/libs/confui/secure_input.h
+++ b/base/cvd/cuttlefish/host/libs/confui/secure_input.h
@@ -34,7 +34,7 @@ namespace confui {
 class ConfUiSecureUserSelectionMessage : public ConfUiMessage {
  public:
   ConfUiSecureUserSelectionMessage(
-      std::unique_ptr<ConfUiUserSelectionMessage>&& msg, const bool secure);
+      std::unique_ptr<ConfUiUserSelectionMessage>&& msg, bool secure);
   ConfUiSecureUserSelectionMessage() = delete;
   virtual ~ConfUiSecureUserSelectionMessage() = default;
   std::string ToString() const override { return msg_->ToString(); }
@@ -53,7 +53,7 @@ class ConfUiSecureUserSelectionMessage : public ConfUiMessage {
 class ConfUiSecureUserTouchMessage : public ConfUiMessage {
  public:
   ConfUiSecureUserTouchMessage(std::unique_ptr<ConfUiUserTouchMessage>&& msg,
-                               const bool secure);
+                               bool secure);
   virtual ~ConfUiSecureUserTouchMessage() = default;
   std::string ToString() const override { return msg_->ToString(); }
   ConfUiCmd GetType() const override { return msg_->GetType(); }
@@ -68,8 +68,8 @@ class ConfUiSecureUserTouchMessage : public ConfUiMessage {
 };
 
 std::unique_ptr<ConfUiSecureUserSelectionMessage> ToSecureSelectionMessage(
-    std::unique_ptr<ConfUiUserSelectionMessage>&& msg, const bool secure);
+    std::unique_ptr<ConfUiUserSelectionMessage>&& msg, bool secure);
 std::unique_ptr<ConfUiSecureUserTouchMessage> ToSecureTouchMessage(
-    std::unique_ptr<ConfUiUserTouchMessage>&& msg, const bool secure);
+    std::unique_ptr<ConfUiUserTouchMessage>&& msg, bool secure);
 }  // end of namespace confui
 }  // end of namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/confui/server_common.h
+++ b/base/cvd/cuttlefish/host/libs/confui/server_common.h
@@ -52,6 +52,6 @@ std::string ToString(const MainLoopState& state);
 FsmInput ToFsmInput(const ConfUiMessage& msg);
 
 std::unique_ptr<ConfUiMessage> CreateFromUserSelection(
-    const std::string& session_id, const UserResponse::type user_selection);
+    const std::string& session_id, UserResponse::type user_selection);
 }  // end of namespace confui
 }  // end of namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/confui/session.h
+++ b/base/cvd/cuttlefish/host/libs/confui/session.h
@@ -44,7 +44,7 @@ namespace confui {
  */
 class Session {
  public:
-  Session(const std::string& session_name, const uint32_t display_num,
+  Session(const std::string& session_name, uint32_t display_num,
           ConfUiRenderer& host_renderer, HostModeCtrl& host_mode_ctrl,
           const std::string& locale = "en");
 
@@ -52,7 +52,7 @@ class Session {
 
   MainLoopState GetState() { return state_; }
 
-  MainLoopState Transition(SharedFD& hal_cli, const FsmInput fsm_input,
+  MainLoopState Transition(SharedFD& hal_cli, FsmInput fsm_input,
                            const ConfUiMessage& conf_ui_message);
 
   /**
@@ -100,12 +100,12 @@ class Session {
   //
   // when false is returned, the FSM must terminate
   // and, no need to let the guest know
-  bool HandleInit(SharedFD hal_cli, const FsmInput fsm_input,
+  bool HandleInit(SharedFD hal_cli, FsmInput fsm_input,
                   const ConfUiMessage& conf_ui_message);
 
-  bool HandleWaitStop(SharedFD hal_cli, const FsmInput fsm_input);
+  bool HandleWaitStop(SharedFD hal_cli, FsmInput fsm_input);
 
-  bool HandleInSession(SharedFD hal_cli, const FsmInput fsm_input,
+  bool HandleInSession(SharedFD hal_cli, FsmInput fsm_input,
                        const ConfUiMessage& conf_ui_msg);
 
   // report with an error ack to HAL, and reset the FSM

--- a/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_display_controller.h
+++ b/base/cvd/cuttlefish/host/libs/vm_manager/crosvm_display_controller.h
@@ -26,16 +26,16 @@ namespace vm_manager {
 class CrosvmDisplayController {
  public:
   CrosvmDisplayController(const CuttlefishConfig* config) : config_(config) {};
-  Result<int> Add(const int instance_num,
+  Result<int> Add(int instance_num,
                   const std::vector<CuttlefishConfig::DisplayConfig>&
                       display_configs) const;
-  Result<int> Remove(const int instance_num,
-                     const std::vector<std::string> display_ids) const;
-  Result<std::string> List(const int instance_num);
+  Result<int> Remove(int instance_num,
+                     std::vector<std::string> display_ids) const;
+  Result<std::string> List(int instance_num);
 
  private:
   const CuttlefishConfig* config_;
-  Result<int> RunCrosvmDisplayCommand(const int instance_num,
+  Result<int> RunCrosvmDisplayCommand(int instance_num,
                                       const std::vector<std::string>& args,
                                       std::string* stdout_str) const;
 };

--- a/base/cvd/tools/lint/linters.bzl
+++ b/base/cvd/tools/lint/linters.bzl
@@ -14,12 +14,14 @@ clang_tidy = lint_clang_tidy_aspect(
     binary = "@@//tools/lint:clang_tidy",
     global_config = ["@@//clang_tidy_configs:base_config"],
     rule_kinds = ["cc_binary", "cc_library", "cc_test"],
+    lint_target_headers = True,
 )
 
 clang_tidy_with_include_cleaner = lint_clang_tidy_aspect(
     binary = "@@//tools/lint:clang_tidy",
     global_config = ["@@//clang_tidy_configs:with_include_cleaner"],
     rule_kinds = ["cc_binary", "cc_library", "cc_test"],
+    lint_target_headers = True,
 )
 
 clang_tidy_test = lint_test(aspect = clang_tidy)


### PR DESCRIPTION
The issue reported was mostly `readability-avoid-const-params-in-decls`.

https://clang.llvm.org/extra/clang-tidy/checks/readability/avoid-const-params-in-decls.html

Bug: b/550620334