### PR TITLE
ci: Eliminate pseudo-TTY CRLF

### DIFF
--- a/.github/actions/run-cw-sharded-e2e-test/action.yaml
+++ b/.github/actions/run-cw-sharded-e2e-test/action.yaml
@@ -72,7 +72,6 @@ runs:
         # Run tests
         targets=( $(echo ${runner_tests}) )
         for t in "${targets[@]}"; do
-          t="${t::-1}"
           echo "running test: ${t}"
           sudo podman rm -f tester
           sudo podman run --name tester -d  --privileged --pids-limit=8192 -v /tmp/cw_bazel:/tmp/cw_bazel -v .:/src/workspace -w /src/workspace/e2etests android-cuttlefish-e2etest:latest

--- a/.github/actions/run-cw-sharded-e2e-test/action.yaml
+++ b/.github/actions/run-cw-sharded-e2e-test/action.yaml
@@ -44,7 +44,7 @@ runs:
         sudo podman run --name tester -d  --privileged --pids-limit=8192 -v /tmp/cw_bazel:/tmp/cw_bazel -v .:/src/workspace -w /src/workspace/e2etests android-cuttlefish-e2etest:latest
 
         # Compute tests for this runner
-        all_tests=$( sudo podman exec --user=testrunner -it tester bazel --output_user_root=/tmp/cw_bazel/output query --noshow_progress 'kind("go_test", orchestration/...) except attr(flaky, 1, //...) except attr(tags, "[\[ ]host-ready-special[,\]]", //...)' | grep -e "^\/\/" | sort )
+        all_tests=$( sudo podman exec --user=testrunner tester bazel --output_user_root=/tmp/cw_bazel/output query --noshow_progress 'kind("go_test", orchestration/...) except attr(flaky, 1, //...) except attr(tags, "[\[ ]host-ready-special[,\]]", //...)' | grep -e "^\/\/" | sort )
         all_tests_count=$(echo "${all_tests}" | wc --lines)
         echo "ALL TESTS: ${all_tests_count}"
         echo "${all_tests}"
@@ -76,7 +76,7 @@ runs:
           echo "running test: ${t}"
           sudo podman rm -f tester
           sudo podman run --name tester -d  --privileged --pids-limit=8192 -v /tmp/cw_bazel:/tmp/cw_bazel -v .:/src/workspace -w /src/workspace/e2etests android-cuttlefish-e2etest:latest
-          sudo podman exec --user=testrunner -it tester bazel --output_user_root=/tmp/cw_bazel/output test --sandbox_writable_path=/home/testrunner $t
+          sudo podman exec --user=testrunner tester bazel --output_user_root=/tmp/cw_bazel/output test --sandbox_writable_path=/home/testrunner $t
         done
     - name: Upload test logs
       if: always()

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -407,7 +407,7 @@ jobs:
         # Flaky tests would be executed in clean container everytime, rather than using `cvd reset`
         # in a tainted container.
         sudo podman run --name tester -d  --privileged --pids-limit=8192 -v /tmp/cw_bazel:/tmp/cw_bazel -v .:/src/workspace -w /src/workspace/e2etests android-cuttlefish-e2etest:latest
-        targets=$(sudo podman exec --user=testrunner -it tester sh -c "stty -onlcr && bazel --output_user_root=/tmp/cw_bazel/output query --noshow_progress 'attr(flaky, 1, orchestration/...)' 2>/dev/null" | sort)
+        targets=$(sudo podman exec --user=testrunner tester bazel --output_user_root=/tmp/cw_bazel/output query --noshow_progress 'attr(flaky, 1, orchestration/...)' | sort)
         echo "FLAKY TARGETS:"                                                                                                                                                                                              
         echo "${targets}"                                                                                                                                                                                                  
         echo ""
@@ -419,7 +419,7 @@ jobs:
             echo "Attempt: ${attempt} of ${ATTEMPTS}"
             sudo podman rm -f tester
             sudo podman run --name tester -d  --privileged --pids-limit=8192 -v /tmp/cw_bazel:/tmp/cw_bazel -v .:/src/workspace -w /src/workspace/e2etests android-cuttlefish-e2etest:latest
-            sudo podman exec --user=testrunner -it tester bazel --output_user_root=/tmp/cw_bazel/output test --test_timeout 600 --sandbox_writable_path=/home/testrunner --flaky_test_attempts=1 ${t} && break || true 
+            sudo podman exec --user=testrunner tester bazel --output_user_root=/tmp/cw_bazel/output test --test_timeout 600 --sandbox_writable_path=/home/testrunner --flaky_test_attempts=1 ${t} && break || true 
             attempt=$((attempt+1))                                                                                                                                                                                         
           done
           if [[ ${attempt} -gt ${ATTEMPTS}  ]]; then
@@ -431,14 +431,14 @@ jobs:
         # Run verify_access_token_test
         sudo podman run --name tester -d  --privileged --pids-limit=8192 -v /tmp/cw_bazel:/tmp/cw_bazel -v .:/src/workspace -w /src/workspace/e2etests android-cuttlefish-e2etest:latest
         sleep 30s # Add delay before restarting cuttlefish-host_orchestrator service.
-        sudo podman exec -it tester sh -c 'echo "orchestrator_android_build_url=http://localhost:8090" >> /etc/default/cuttlefish-host_orchestrator && service cuttlefish-host_orchestrator restart'
-        sudo podman exec --user=testrunner -it tester bazel --output_user_root=/tmp/cw_bazel/output test //orchestration/verify_access_token_test:verify_access_token_test_test
+        sudo podman exec tester sh -c 'echo "orchestrator_android_build_url=http://localhost:8090" >> /etc/default/cuttlefish-host_orchestrator && service cuttlefish-host_orchestrator restart'
+        sudo podman exec --user=testrunner tester bazel --output_user_root=/tmp/cw_bazel/output test //orchestration/verify_access_token_test:verify_access_token_test_test
         sudo podman rm -f tester
         # Run create_with_gce_metadata_credentials_test
         sudo podman run --name tester -d  --privileged --pids-limit=8192 -v /tmp/cw_bazel:/tmp/cw_bazel -v .:/src/workspace -w /src/workspace/e2etests android-cuttlefish-e2etest:latest
         sleep 30s # Add delay before restarting cuttlefish-host_orchestrator service.
-        sudo podman exec -it tester sh -c 'echo "build_api_credentials_use_gce_metadata=true" >> /etc/default/cuttlefish-host_orchestrator && service cuttlefish-host_orchestrator restart'
-        sudo podman exec --user=testrunner -it tester bazel --output_user_root=/tmp/cw_bazel/output test //orchestration/create_with_gce_metadata_credentials_test:create_with_gce_metadata_credentials_test_test
+        sudo podman exec tester sh -c 'echo "build_api_credentials_use_gce_metadata=true" >> /etc/default/cuttlefish-host_orchestrator && service cuttlefish-host_orchestrator restart'
+        sudo podman exec --user=testrunner tester bazel --output_user_root=/tmp/cw_bazel/output test //orchestration/create_with_gce_metadata_credentials_test:create_with_gce_metadata_credentials_test_test
         sudo podman rm -f tester
     - name: Upload test logs
       if: always()


### PR DESCRIPTION
When `podman exec -it` was executed in CI scripts, pseudo-terminal allocation (-t) caused stdout lines to be emitted with CRLF (\r\n). In `runner-special`, capturing this into bash passed carriage returns to `bazel test`, which failed with:
  invalid target name '... \r': target names may not end with carriage returns

In `run-cw-sharded-e2e-test`, this was previously worked around by `${t::-1}` string slice.

Furthermore, `runner-special` attempted to mitigate this using `sh -c "stty -onlcr && bazel query ..." 2>/dev/null`. On runner VMs where standard input was non-interactive, `stty` failed silently, short-circuiting the `&&` and skipping flaky tests altogether.

This change:
1. Removes `-it` from all `podman exec` calls in both `presubmit.yaml` and `run-cw-sharded-e2e-test/action.yaml`.
2. Removes the `${t::-1}` slicing workaround in `run-cw-sharded-e2e-test`.

Test: Verified `bazel query` and target loops parse cleanly without trailing \r.
Assisted-By: Antigravity:Gemini-Next
Bug: b/550908119