### PR TITLE
Define no-op presubmit_podcvd_gpu

### DIFF
--- a/.kokoro/presubmit_podcvd_gpu.cfg
+++ b/.kokoro/presubmit_podcvd_gpu.cfg
@@ -1,0 +1,1 @@
+build_file: "android-cuttlefish/.kokoro/no_op.sh"


### PR DESCRIPTION
Before doing integration of presubmit_podcvd_gpu, use no_op.sh for a while to make every check green.

Context: b/527644057