### PR TITLE
build_test, DWYU, include-cleaner for defaults, cvdalloc

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvdalloc/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/BUILD.bazel
@@ -1,8 +1,10 @@
-load("//cuttlefish/bazel:rules.bzl", "cf_cc_binary", "cf_cc_library")
+load("//cuttlefish/bazel:rules.bzl", "cf_build_test", "cf_cc_binary", "cf_cc_library")
 
 package(
     default_visibility = ["//:android_cuttlefish"],
 )
+
+cf_build_test(name = "cvdalloc_build_test")
 
 cf_cc_library(
     name = "interface",
@@ -10,7 +12,6 @@ cf_cc_library(
         "interface.cpp",
     ],
     hdrs = ["interface.h"],
-    include_cleaner_enabled = False,
     deps = [
         "@abseil-cpp//absl/strings:str_format",
     ],
@@ -22,11 +23,11 @@ cf_cc_library(
         "sem.cpp",
     ],
     hdrs = ["sem.h"],
-    include_cleaner_enabled = False,
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/host/libs/command_util",
-        "//cuttlefish/result",
+        "//cuttlefish/result:expect",
+        "//cuttlefish/result:result_type",
     ],
 )
 
@@ -34,12 +35,10 @@ cf_cc_library(
     name = "privilege",
     srcs = ["privilege.cpp"],
     hdrs = ["privilege.h"],
-    depend_on_what_you_use_enabled = False,
-    include_cleaner_enabled = False,
     deps = [
         "//cuttlefish/posix:strerror",
-        "//cuttlefish/result",
-        "//libbase",
+        "//cuttlefish/result:expect",
+        "//cuttlefish/result:result_type",
         "@abseil-cpp//absl/log",
     ],
 )
@@ -47,8 +46,6 @@ cf_cc_library(
 cf_cc_binary(
     name = "cvdalloc",
     srcs = ["cvdalloc.cpp"],
-    depend_on_what_you_use_enabled = False,
-    include_cleaner_enabled = False,
     deps = [
         ":interface",
         ":privilege",
@@ -56,12 +53,11 @@ cf_cc_binary(
         "//allocd:alloc_utils",
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/posix:strerror",
-        "//cuttlefish/result",
-        "//libbase",
+        "//cuttlefish/result:expect",
+        "//cuttlefish/result:result_type",
         "@abseil-cpp//absl/cleanup:cleanup",
         "@abseil-cpp//absl/flags:flag",
         "@abseil-cpp//absl/flags:parse",
         "@abseil-cpp//absl/log",
-        "@abseil-cpp//absl/strings:str_format",
     ],
 )

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/cvdalloc.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/cvdalloc.cpp
@@ -13,9 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include <string_view>
+#include <utility>
+#include <vector>
 
 #include "absl/cleanup/cleanup.h"
 #include "absl/flags/flag.h"
@@ -28,6 +34,8 @@
 #include "cuttlefish/host/commands/cvdalloc/privilege.h"
 #include "cuttlefish/host/commands/cvdalloc/sem.h"
 #include "cuttlefish/posix/strerror.h"
+#include "cuttlefish/result/expect.h"
+#include "cuttlefish/result/result_type.h"
 
 ABSL_FLAG(int, id, 0, "Id");
 ABSL_FLAG(int, socket, 0, "Socket");

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/interface.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/interface.cpp
@@ -15,6 +15,8 @@
  */
 #include "cuttlefish/host/commands/cvdalloc/interface.h"
 
+#include <string>
+
 #include "absl/strings/str_format.h"
 
 namespace cuttlefish {

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/privilege.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/privilege.cpp
@@ -17,7 +17,9 @@
 
 #include <errno.h>
 #include <fcntl.h>
-#include <string.h>
+#include <stddef.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #if defined(__linux__)
 #include <linux/capability.h>
 #include <linux/prctl.h>
@@ -27,11 +29,14 @@
 #include <sys/types.h>
 #include <sys/xattr.h>
 #endif
-#include <sys/stat.h>
+
+#include <string_view>
 
 #include "absl/log/log.h"
 
 #include "cuttlefish/posix/strerror.h"
+#include "cuttlefish/result/expect.h"
+#include "cuttlefish/result/result_type.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/privilege.h
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/privilege.h
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <unistd.h>
+#include <sys/types.h>
 
 #include <string_view>
 
-#include "cuttlefish/result/result.h"
+#include "cuttlefish/result/result_type.h"
 
 namespace cuttlefish {
 

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/sem.cpp
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/sem.cpp
@@ -15,7 +15,14 @@
  */
 #include "cuttlefish/host/commands/cvdalloc/sem.h"
 
+#include <stdint.h>
+
+#include <chrono>
+
+#include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/host/libs/command_util/util.h"
+#include "cuttlefish/result/expect.h"
+#include "cuttlefish/result/result_type.h"
 
 namespace cuttlefish::cvdalloc {
 

--- a/base/cvd/cuttlefish/host/commands/cvdalloc/sem.h
+++ b/base/cvd/cuttlefish/host/commands/cvdalloc/sem.h
@@ -18,7 +18,7 @@
 #include <chrono>
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
-#include "cuttlefish/result/result.h"
+#include "cuttlefish/result/result_type.h"
 
 namespace cuttlefish::cvdalloc {
 

--- a/base/cvd/cuttlefish/host/commands/defaults/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/defaults/BUILD.bazel
@@ -1,20 +1,20 @@
-load("//cuttlefish/bazel:rules.bzl", "cf_cc_binary")
+load("//cuttlefish/bazel:rules.bzl", "cf_build_test", "cf_cc_binary")
 
 package(
     default_visibility = ["//:android_cuttlefish"],
 )
 
+cf_build_test(name = "defaults_build_test")
+
 cf_cc_binary(
     name = "cf_defaults",
     srcs = ["defaults.cpp"],
-    depend_on_what_you_use_enabled = False,
-    include_cleaner_enabled = False,
     deps = [
         "//cuttlefish/common/libs/key_equals_value",
         "//cuttlefish/host/libs/web/http_client:curl_http_client",
         "//cuttlefish/host/libs/web/http_client:http_string",
-        "//cuttlefish/result",
-        "@abseil-cpp//absl/cleanup:cleanup",
+        "//cuttlefish/result:expect",
+        "//cuttlefish/result:result_type",
         "@abseil-cpp//absl/flags:flag",
         "@abseil-cpp//absl/flags:parse",
         "@abseil-cpp//absl/log",

--- a/base/cvd/cuttlefish/host/commands/defaults/defaults.cpp
+++ b/base/cvd/cuttlefish/host/commands/defaults/defaults.cpp
@@ -13,10 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <unistd.h>
+
+#include <stdlib.h>
 
 #include <functional>
+#include <map>
+#include <optional>
+#include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
@@ -26,6 +32,8 @@
 #include "cuttlefish/common/libs/key_equals_value/key_equals_value.h"
 #include "cuttlefish/host/libs/web/http_client/curl_http_client.h"
 #include "cuttlefish/host/libs/web/http_client/http_string.h"
+#include "cuttlefish/result/expect.h"
+#include "cuttlefish/result/result_type.h"
 
 ABSL_FLAG(std::string, filename, "/usr/lib/cuttlefish-common/etc/cf_defaults",
           "Output filename.");


### PR DESCRIPTION
Also replaced some `result.h` uses with `result_type.h` and `expect.h`.

Bug: b/523396865
Bug: b/532697459
Bug: b/534499070