### PR TITLE
Add convenience overloads of WriteExact

### DIFF
--- a/base/cvd/cuttlefish/io/write_exact.cc
+++ b/base/cvd/cuttlefish/io/write_exact.cc
@@ -17,6 +17,10 @@
 
 #include <stddef.h>
 
+#include <string>
+#include <string_view>
+#include <vector>
+
 #include "cuttlefish/io/io.h"
 #include "cuttlefish/result/expect.h"
 #include "cuttlefish/result/result_type.h"
@@ -30,6 +34,21 @@ Result<void> WriteExact(Writer& writer, const char* buf, size_t size) {
     buf += data_written;
     size -= data_written;
   }
+  return {};
+}
+
+Result<void> WriteExact(Writer& writer, const std::string& str) {
+  CF_EXPECT(WriteExact(writer, str.data(), str.size()));
+  return {};
+}
+
+Result<void> WriteExact(Writer& writer, const std::string_view str) {
+  CF_EXPECT(WriteExact(writer, str.data(), str.size()));
+  return {};
+}
+
+Result<void> WriteExact(Writer& writer, const std::vector<char>& vec) {
+  CF_EXPECT(WriteExact(writer, vec.data(), vec.size()));
   return {};
 }
 

--- a/base/cvd/cuttlefish/io/write_exact.h
+++ b/base/cvd/cuttlefish/io/write_exact.h
@@ -17,6 +17,10 @@
 
 #include <stdint.h>
 
+#include <string>
+#include <string_view>
+#include <vector>
+
 #include "cuttlefish/io/io.h"
 #include "cuttlefish/result/expect.h"
 #include "cuttlefish/result/result_type.h"
@@ -24,6 +28,9 @@
 namespace cuttlefish {
 
 Result<void> WriteExact(Writer&, const char* buf, size_t size);
+Result<void> WriteExact(Writer&, const std::string&);
+Result<void> WriteExact(Writer&, std::string_view);
+Result<void> WriteExact(Writer&, const std::vector<char>&);
 
 template <typename T>
 Result<void> WriteExactBinary(Writer& writer, const T& data) {


### PR DESCRIPTION
This will make it more convenient to replace WriteAll from shared_buf.h.

Bug: b/545278508