### PR TITLE
Capture fetched build safety levels for metrics

### DIFF
--- a/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/web/BUILD.bazel
@@ -12,6 +12,7 @@ cf_cc_library(
     hdrs = ["android_build.h"],
     deps = [
         "//cuttlefish/common/libs/utils:environment",
+        "//cuttlefish/host/libs/web:android_build_url",
         "@abseil-cpp//absl/strings",
         "@fmt",
     ],

--- a/base/cvd/cuttlefish/host/libs/web/android_build.h
+++ b/base/cvd/cuttlefish/host/libs/web/android_build.h
@@ -21,6 +21,8 @@
 #include <variant>
 #include <vector>
 
+#include "cuttlefish/host/libs/web/android_build_url.h"
+
 namespace cuttlefish {
 
 struct DeviceBuild {
@@ -32,6 +34,7 @@ struct DeviceBuild {
   // did retrieving build details block waiting for a terminal status
   bool status_blocked = false;
   std::optional<std::string> filepath;
+  SafeLevel safe_level;
 };
 
 std::ostream& operator<<(std::ostream&, const DeviceBuild&);

--- a/base/cvd/cuttlefish/host/libs/web/android_build_api.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_api.cpp
@@ -112,10 +112,12 @@ Result<Build> AndroidBuildApi::GetBuild(const DeviceBuildString& build_string) {
       build_string.target.has_value(),
       "Given build string must have a target with the branch or build id");
   std::string proposed_build_id = build_string.branch_or_id;
+  SafeLevel proposed_safe_level = SafeLevel::kSafeLevelUnspecified;
   const std::optional<CandidateBuild> latest_build_candidate =
       CF_EXPECT(LatestBuildCandidate(proposed_build_id, *build_string.target));
   if (latest_build_candidate) {
     proposed_build_id = latest_build_candidate->build_id;
+    proposed_safe_level = latest_build_candidate->safe_level;
     VLOG(0) << fmt::format(
         "Build id({}) to be fetched for branch({}), target({}).",
         proposed_build_id, build_string.branch_or_id, *build_string.target);
@@ -133,6 +135,7 @@ Result<Build> AndroidBuildApi::GetBuild(const DeviceBuildString& build_string) {
       .is_signed = build_info.is_signed,
       .status_blocked = blocked_on_status,
       .filepath = build_string.filepath,
+      .safe_level = proposed_safe_level,
   };
 }
 

--- a/base/cvd/cuttlefish/host/libs/web/android_build_api.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_api.cpp
@@ -112,10 +112,10 @@ Result<Build> AndroidBuildApi::GetBuild(const DeviceBuildString& build_string) {
       build_string.target.has_value(),
       "Given build string must have a target with the branch or build id");
   std::string proposed_build_id = build_string.branch_or_id;
-  auto latest_build_id =
-      CF_EXPECT(LatestBuildId(proposed_build_id, *build_string.target));
-  if (latest_build_id) {
-    proposed_build_id = *latest_build_id;
+  const std::optional<CandidateBuild> latest_build_candidate =
+      CF_EXPECT(LatestBuildCandidate(proposed_build_id, *build_string.target));
+  if (latest_build_candidate) {
+    proposed_build_id = latest_build_candidate->build_id;
     VLOG(0) << fmt::format(
         "Build id({}) to be fetched for branch({}), target({}).",
         proposed_build_id, build_string.branch_or_id, *build_string.target);
@@ -193,7 +193,7 @@ Result<AndroidBuildApi::BuildInfo> AndroidBuildApi::GetBuildInfo(
 
   std::string no_auth_error_message;
   if (credential_source_ == nullptr && response.http_code == 404) {
-    // In LatestBuildId we currently cannot distinguish between the cases:
+    // In LatestBuildCandidate we cannot distinguish between the cases:
     //    - user provided a build ID (not an error)
     //    - user provided a branch with a typo
     //    - user provided a branch without the necessary authentication
@@ -271,19 +271,16 @@ Result<std::vector<std::string>> AndroidBuildApi::Headers() {
   return headers;
 }
 
-Result<std::optional<std::string>> AndroidBuildApi::LatestBuildId(
-    const std::string& branch, const std::string& target) {
-  struct CandidateBuild {
-    std::string build_id;
-    std::chrono::system_clock::time_point creation_time;
-  };
+Result<std::optional<AndroidBuildApi::CandidateBuild>>
+AndroidBuildApi::LatestBuildCandidate(const std::string& branch,
+                                      const std::string& target) {
   // Find the latest build at every safe level
-  std::vector<CandidateBuild> candidates;
+  std::vector<AndroidBuildApi::CandidateBuild> candidates;
   for (const SafeLevel safe_level : kAllSafeLevels) {
     VLOG(0) << "Attempting to download build at safe level '" << safe_level
             << "' for branch '" << branch << "' and target '" << target << "'";
-    const std::string url =
-        android_build_url_.GetLatestBuildIdUrl(branch, target, safe_level);
+    const std::string url = android_build_url_.GetLatestBuildCandidateUrl(
+        branch, target, safe_level);
     const std::vector<std::string> headers = CF_EXPECT(Headers());
     const HttpResponse<Json::Value> response =
         CF_EXPECT(HttpGetToJson(http_client_, url, headers));
@@ -306,9 +303,10 @@ Result<std::optional<std::string>> AndroidBuildApi::LatestBuildId(
 
     const Json::Value& build = json["builds"][0];
     const std::string& completion = build["completionTimestamp"].asString();
-    candidates.emplace_back(CandidateBuild{
+    candidates.emplace_back(AndroidBuildApi::CandidateBuild{
         .build_id = build["buildId"].asString(),
         .creation_time = CF_EXPECT(ParseTime(completion)),
+        .safe_level = safe_level,
     });
   }
   if (candidates.empty()) {
@@ -325,7 +323,7 @@ Result<std::optional<std::string>> AndroidBuildApi::LatestBuildId(
   // Return the first valid build (which will have the highest safe level)
   auto it = std::find_if(candidates.begin(), candidates.end(), recent);
   CHECK(it != candidates.end());
-  return it->build_id;
+  return *it;
 }
 
 Result<std::unordered_set<std::string>> AndroidBuildApi::Artifacts(

--- a/base/cvd/cuttlefish/host/libs/web/android_build_api.h
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_api.h
@@ -63,6 +63,13 @@ class AndroidBuildApi : public BuildApi {
     std::string target;
     bool is_signed;
   };
+
+  struct CandidateBuild {
+    std::string build_id;
+    std::chrono::system_clock::time_point creation_time;
+    SafeLevel safe_level;
+  };
+
   Result<BuildInfo> GetBuildInfo(std::string_view build_id,
                                  std::string_view target);
   Result<bool> BlockUntilTerminalStatus(std::string_view initial_status,
@@ -70,8 +77,8 @@ class AndroidBuildApi : public BuildApi {
                                         std::string_view target);
   Result<std::vector<std::string>> Headers();
 
-  Result<std::optional<std::string>> LatestBuildId(const std::string& branch,
-                                                   const std::string& target);
+  Result<std::optional<CandidateBuild>> LatestBuildCandidate(
+      const std::string& branch, const std::string& target);
 
   Result<std::unordered_set<std::string>> Artifacts(
       const DeviceBuild& build,

--- a/base/cvd/cuttlefish/host/libs/web/android_build_url.cpp
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_url.cpp
@@ -34,7 +34,7 @@ namespace {
 
 class UrlBuilder {
  public:
-  static UrlBuilder GetLatestBuildIdBaseUrl(std::string_view api_base) {
+  static UrlBuilder GetLatestBuildCandidateUrl(std::string_view api_base) {
     return UrlBuilder(fmt::format("{}/builds", api_base));
   }
 
@@ -134,10 +134,10 @@ AndroidBuildUrl::AndroidBuildUrl(std::string api_base_url, std::string api_key,
       api_key_(std::move(api_key)),
       project_id_(std::move(project_id)) {}
 
-std::string AndroidBuildUrl::GetLatestBuildIdUrl(std::string_view branch,
-                                                 std::string_view target,
-                                                 SafeLevel safe_level) {
-  UrlBuilder builder = UrlBuilder::GetLatestBuildIdBaseUrl(api_base_url_);
+std::string AndroidBuildUrl::GetLatestBuildCandidateUrl(std::string_view branch,
+                                                        std::string_view target,
+                                                        SafeLevel safe_level) {
+  UrlBuilder builder = UrlBuilder::GetLatestBuildCandidateUrl(api_base_url_);
   builder.AddQueryParameter("buildAttemptStatus", "complete");
   builder.AddQueryParameter("buildType", "submitted");
   builder.AddQueryParameter("pageSize", "1");

--- a/base/cvd/cuttlefish/host/libs/web/android_build_url.h
+++ b/base/cvd/cuttlefish/host/libs/web/android_build_url.h
@@ -55,7 +55,7 @@ class AndroidBuildUrl {
   AndroidBuildUrl(std::string api_base_url, std::string api_key,
                   std::string project_id);
 
-  std::string GetLatestBuildIdUrl(
+  std::string GetLatestBuildCandidateUrl(
       std::string_view branch, std::string_view target,
       SafeLevel safe_level = SafeLevel::kSafeLevelUnspecified);
   std::string GetBuildUrl(std::string_view id, std::string_view target);


### PR DESCRIPTION
Not yet being transmitted, but available at the metrics message populating step `*conversion.cc::PopulateCuttlefishBuild` when we are ready to transmit.

Bug: 535685161