### PR TITLE
Parametrize metrics transmitter path.

### DIFF
--- a/base/cvd/cuttlefish/metrics/io/BUILD.bazel
+++ b/base/cvd/cuttlefish/metrics/io/BUILD.bazel
@@ -11,6 +11,7 @@ cf_cc_library(
     srcs = ["enabled.cc"],
     hdrs = ["enabled.h"],
     deps = [
+        "//cuttlefish/common/libs/utils:environment",
         "//cuttlefish/files:file_exists",
     ],
 )

--- a/base/cvd/cuttlefish/metrics/io/enabled.cc
+++ b/base/cvd/cuttlefish/metrics/io/enabled.cc
@@ -16,10 +16,17 @@
 
 #include "cuttlefish/metrics/io/enabled.h"
 
+#include <string>
+
+#include "cuttlefish/common/libs/utils/environment.h"
 #include "cuttlefish/files/file_exists.h"
 
 namespace cuttlefish {
 
-bool AreMetricsEnabled() { return FileExists(kTransmitterPath); }
+std::string TransmitterPath() {
+  return StringFromEnv("CUTTLEFISH_METRICS_TRANSMITTER_PATH", kTransmitterPath);
+}
+
+bool AreMetricsEnabled() { return FileExists(TransmitterPath()); }
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/metrics/io/enabled.h
+++ b/base/cvd/cuttlefish/metrics/io/enabled.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <string_view>
+#include <string>
 
 namespace cuttlefish {
 
@@ -25,5 +25,7 @@ inline constexpr char kTransmitterPath[] =
 
 // trigger check for v2 metrics
 bool AreMetricsEnabled();
+
+std::string TransmitterPath();
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/metrics/metrics_orchestration.cc
+++ b/base/cvd/cuttlefish/metrics/metrics_orchestration.cc
@@ -81,7 +81,7 @@ Result<void> OutputMetrics(std::string_view event_type_label,
   if (AreMetricsEnabled()) {
     const CuttlefishLogEvent cf_log_event =
         BuildCuttlefishLogEvent(metrics_data);
-    CF_EXPECT(TransmitMetrics(kTransmitterPath, cf_log_event));
+    CF_EXPECT(TransmitMetrics(TransmitterPath(), cf_log_event));
     CF_EXPECT(
         WriteMetricsEvent(event_type_label, metrics_directory, cf_log_event));
   }


### PR DESCRIPTION
Metrics are only written to disk when the transmitter binary exists. We only check a static path under /usr, the package destination. Thus, checking to see if metrics have been written to disk is only possible when the package is installed, and this requires root.

For testing purposes, we might want to have metrics written to disk but without having the entire package installed, or we might be running in environments where we cannot install the transmitter to /usr. Instead, allow us to override the location of the transmitter binary, so we could potentially fake it out for testing purposes.