### PR TITLE
Golang static checks only run for Go changes.

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -17,6 +17,29 @@ permissions:
   contents: read
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-22.04
+    outputs:
+      go: ${{ steps.filter.outputs.go }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      with:
+        persist-credentials: false
+    - name: Detect file changes
+      uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
+      id: filter
+      with:
+        filters: |
+          go:
+            - '**/*.go'
+            - '**/go.mod'
+            - '**/go.sum'
+            - 'e2etests/**'
+            - 'container/src/podcvd/**'
+            - 'frontend/**'
+            - 'tools/baseimage/**'
+            - '.github/workflows/presubmit.yaml'
   buildozer:
     runs-on: ubuntu-22.04
     steps:
@@ -75,6 +98,8 @@ jobs:
           exit 1;
         fi
   staticcheck:
+    needs: [detect-changes]
+    if: ${{ needs.detect-changes.outputs.go == 'true' }}
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -103,6 +128,8 @@ jobs:
         install-go: false
         working-directory: ${{ matrix.dir }}
   run-frontend-unit-tests:
+    needs: [detect-changes]
+    if: ${{ needs.detect-changes.outputs.go == 'true' }}
     runs-on: ubuntu-22.04
     container:
       image: debian@sha256:9258a75a7e4323c9e5562b361effc84ee747920116d8adfc98a465a5cdc9150e # debian:bookworm-20250407 (amd64)
@@ -138,6 +165,8 @@ jobs:
           popd
         done
   run-frontend-api-documentation-check:
+    needs: [detect-changes]
+    if: ${{ needs.detect-changes.outputs.go == 'true' }}
     runs-on: ubuntu-22.04
     container:
       image: debian@sha256:9258a75a7e4323c9e5562b361effc84ee747920116d8adfc98a465a5cdc9150e # debian:bookworm-20250407 (amd64)


### PR DESCRIPTION
Use dorny/paths-filter to only run Go static checks for Go changes. This should improve presubmit signal-to-noise when making changes that don't touch Go code.