### PR TITLE
Enable podcvd E2E tests with GPU on merge queue

### DIFF
--- a/.kokoro/continuous_podcvd_gpu.cfg
+++ b/.kokoro/continuous_podcvd_gpu.cfg
@@ -1,0 +1,1 @@
+presubmit_podcvd_gpu.cfg


### PR DESCRIPTION
This will be marked as 'Required' check, when we can see sufficient number of E2E test trial are passed without flakiness.

Context: b/527644057