### PR TITLE
Revert "Golang static checks only run for Go changes."

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -17,29 +17,6 @@ permissions:
   contents: read
 
 jobs:
-  detect-changes:
-    runs-on: ubuntu-22.04
-    outputs:
-      go: ${{ steps.filter.outputs.go }}
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
-      with:
-        persist-credentials: false
-    - name: Detect file changes
-      uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
-      id: filter
-      with:
-        filters: |
-          go:
-            - '**/*.go'
-            - '**/go.mod'
-            - '**/go.sum'
-            - 'e2etests/**'
-            - 'container/src/podcvd/**'
-            - 'frontend/**'
-            - 'tools/baseimage/**'
-            - '.github/workflows/presubmit.yaml'
   buildozer:
     runs-on: ubuntu-22.04
     steps:
@@ -98,8 +75,6 @@ jobs:
           exit 1;
         fi
   staticcheck:
-    needs: [detect-changes]
-    if: ${{ needs.detect-changes.outputs.go == 'true' }}
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -128,8 +103,6 @@ jobs:
         install-go: false
         working-directory: ${{ matrix.dir }}
   run-frontend-unit-tests:
-    needs: [detect-changes]
-    if: ${{ needs.detect-changes.outputs.go == 'true' }}
     runs-on: ubuntu-22.04
     container:
       image: debian@sha256:9258a75a7e4323c9e5562b361effc84ee747920116d8adfc98a465a5cdc9150e # debian:bookworm-20250407 (amd64)
@@ -165,8 +138,6 @@ jobs:
           popd
         done
   run-frontend-api-documentation-check:
-    needs: [detect-changes]
-    if: ${{ needs.detect-changes.outputs.go == 'true' }}
     runs-on: ubuntu-22.04
     container:
       image: debian@sha256:9258a75a7e4323c9e5562b361effc84ee747920116d8adfc98a465a5cdc9150e # debian:bookworm-20250407 (amd64)


### PR DESCRIPTION
Reverts google/android-cuttlefish#3101

In PRs with non-Go changes I'm seeing these actions stuck with the status

Expected — Waiting for status to be reported

e.g.

- https://www.github.com/google/android-cuttlefish/pull/3105
- https://www.github.com/google/android-cuttlefish/pull/3106
- https://www.github.com/google/android-cuttlefish/pull/3107

but they're still "Required" so it's blocking submission.

GitHub community discussion on this issue: https://www.github.com/orgs/community/discussions/26092