### PR TITLE
WebRTC streamer and vhost-user-input backend processes communicate with a client-server protocol

### DIFF
--- a/base/cvd/cuttlefish/host/commands/run_cvd/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/BUILD.bazel
@@ -80,7 +80,7 @@ cf_cc_binary(
         "//cuttlefish/host/commands/run_cvd/launch:cvdalloc",
         "//cuttlefish/host/commands/run_cvd/launch:echo_server",
         "//cuttlefish/host/commands/run_cvd/launch:gnss_grpc_proxy",
-        "//cuttlefish/host/commands/run_cvd/launch:input_connections_provider",
+        "//cuttlefish/host/commands/run_cvd/launch:input_paths_provider",
         "//cuttlefish/host/commands/run_cvd/launch:kernel_log_monitor",
         "//cuttlefish/host/commands/run_cvd/launch:logcat_receiver",
         "//cuttlefish/host/commands/run_cvd/launch:mcu",

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
@@ -172,9 +172,9 @@ cf_cc_library(
 )
 
 cf_cc_library(
-    name = "input_connections_provider",
-    srcs = ["input_connections_provider.cc"],
-    hdrs = ["input_connections_provider.h"],
+    name = "input_paths_provider",
+    srcs = ["input_paths_provider.cc"],
+    hdrs = ["input_paths_provider.h"],
     deps = [
         "//cuttlefish/common/libs/fs",
         "//cuttlefish/common/libs/fs:fd",
@@ -462,7 +462,7 @@ cf_cc_library(
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/commands/run_cvd:reporting",
         "//cuttlefish/host/commands/run_cvd/launch:enable_multitouch",
-        "//cuttlefish/host/commands/run_cvd/launch:input_connections_provider",
+        "//cuttlefish/host/commands/run_cvd/launch:input_paths_provider",
         "//cuttlefish/host/commands/run_cvd/launch:sensors_socket_pair",
         "//cuttlefish/host/commands/run_cvd/launch:webrtc_controller",
         "//cuttlefish/host/libs/config:config_utils",
@@ -476,6 +476,7 @@ cf_cc_library(
         "//cuttlefish/process:subprocess",
         "//cuttlefish/result",
         "@abseil-cpp//absl/log",
+        "@abseil-cpp//absl/strings",
         "@fruit",
     ],
 )

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/input_paths_provider.cc
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/input_paths_provider.cc
@@ -13,10 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "cuttlefish/host/commands/run_cvd/launch/input_connections_provider.h"
+#include "cuttlefish/host/commands/run_cvd/launch/input_paths_provider.h"
 
-#include <fcntl.h>
-#include <sys/socket.h>
+#include <sys/socket.h>  // IWYU pragma: keep: SOCK_STREAM
 
 #include <regex>
 #include <string>
@@ -49,40 +48,28 @@ namespace {
 
 // Holds all sockets related to a single vhost user input device process.
 struct DeviceSockets {
-  // Device end of the connection between device and streamer.
-  SharedFD device_end;
-  // Streamer end of the connection between device and streamer.
-  SharedFD streamer_end;
+  // Path to the events server socket.
+  std::string events_server_path;
+  // The events server fd. It's created and held at the CommandSource level to
+  // ensure it already exists by the time the streamer attempts to connect.
+  SharedFD events_server;
   // Unix socket for the server to which the VMM connects to. It's created and
   // held at the CommandSource level to ensure it already exists by the time the
   // VMM runs and attempts to connect.
   SharedFD vhu_server;
 };
 
-Result<DeviceSockets> NewDeviceSockets(const std::string& vhu_server_path) {
-  DeviceSockets ret;
-  CF_EXPECTF(
-      SharedFD::SocketPair(AF_UNIX, SOCK_STREAM, 0, &ret.device_end,
-                           &ret.streamer_end),
-      "Failed to create connection sockets (socket pair) for input device: {}",
-      ret.device_end->StrError());
-
-  // The webRTC process currently doesn't read status updates from input
-  // devices, so the vhost processes will write that to /dev/null.
-  // These calls shouldn't return errors since we already know these are a newly
-  // created socket pair.
-  CF_EXPECTF(ret.device_end->Shutdown(SHUT_WR) == 0,
-             "Failed to close input connection's device for writes: {}",
-             ret.device_end->StrError());
-  CF_EXPECTF(ret.streamer_end->Shutdown(SHUT_RD) == 0,
-             "Failed to close input connection's streamer end for reads: {}",
-             ret.streamer_end->StrError());
-
-  ret.vhu_server =
-      SharedFD::SocketLocalServer(vhu_server_path, false, SOCK_STREAM, 0600);
-  CF_EXPECTF(ret.vhu_server->IsOpen(),
-             "Failed to create vhost user socket for device: {}",
-             ret.vhu_server->StrError());
+Result<DeviceSockets> NewDeviceSockets(const std::string& evt_server_path,
+                                       const std::string& vhu_server_path) {
+  DeviceSockets ret{
+      .events_server_path = evt_server_path,
+      .events_server = CF_EXPECT(
+          Fd::SocketLocalServer(evt_server_path, false, SOCK_STREAM, 0600),
+          "Failed to create event server for device"),
+      .vhu_server = CF_EXPECT(
+          Fd::SocketLocalServer(vhu_server_path, false, SOCK_STREAM, 0600),
+          "Failed to create vhost user socket for device"),
+  };
 
   return ret;
 }
@@ -93,9 +80,7 @@ Command NewVhostUserInputCommand(const DeviceSockets& device_sockets,
   cmd.AddParameter("--verbosity=DEBUG");
   cmd.AddParameter("--socket-fd=", device_sockets.vhu_server);
   cmd.AddParameter("--device-config=", spec);
-  cmd.RedirectStdIO(Command::StdIoChannel::kStdIn, device_sockets.device_end);
-  cmd.RedirectStdIO(Command::StdIoChannel::kStdOut,
-                    Fd::Open("/dev/null", O_WRONLY).value_or(Fd()));
+  cmd.AddParameter("--server-fd=", device_sockets.events_server);
   return cmd;
 }
 
@@ -118,8 +103,7 @@ std::string BuildTouchSpec(const std::string& spec_template,
 }
 
 // Creates the commands for the vhost user input devices.
-class VhostInputDevices : public CommandSource,
-                          public InputConnectionsProvider {
+class VhostInputDevices : public CommandSource, public InputPathsProvider {
  public:
   INJECT(VhostInputDevices(const CuttlefishConfig::InstanceSpecific& instance,
                            LogTeeCreator& log_tee))
@@ -237,41 +221,41 @@ class VhostInputDevices : public CommandSource,
     return commands;
   }
 
-  // InputConnectionsProvider
-  SharedFD RotaryDeviceConnection() const override {
-    return rotary_sockets_.streamer_end;
+  // InputPathsProvider
+  std::string RotaryDevicePath() const override {
+    return rotary_sockets_.events_server_path;
   }
 
-  SharedFD MouseConnection() const override {
-    return mouse_sockets_.streamer_end;
+  std::string MousePath() const override {
+    return mouse_sockets_.events_server_path;
   }
 
-  SharedFD GamepadConnection() const override {
-    return gamepad_sockets_.streamer_end;
+  std::string GamepadPath() const override {
+    return gamepad_sockets_.events_server_path;
   }
 
-  SharedFD KeyboardConnection() const override {
-    return keyboard_sockets_.streamer_end;
+  std::string KeyboardPath() const override {
+    return keyboard_sockets_.events_server_path;
   }
 
-  SharedFD SwitchesConnection() const override {
-    return switches_sockets_.streamer_end;
+  std::string SwitchesPath() const override {
+    return switches_sockets_.events_server_path;
   }
 
-  std::vector<SharedFD> TouchscreenConnections() const override {
-    std::vector<SharedFD> conns;
+  std::vector<std::string> TouchscreenPaths() const override {
+    std::vector<std::string> conns;
     conns.reserve(touchscreen_sockets_.size());
     for (const DeviceSockets& sockets : touchscreen_sockets_) {
-      conns.emplace_back(sockets.streamer_end);
+      conns.emplace_back(sockets.events_server_path);
     }
     return conns;
   }
 
-  std::vector<SharedFD> TouchpadConnections() const override {
-    std::vector<SharedFD> conns;
+  std::vector<std::string> TouchpadPaths() const override {
+    std::vector<std::string> conns;
     conns.reserve(touchpad_sockets_.size());
     for (const DeviceSockets& sockets : touchpad_sockets_) {
-      conns.emplace_back(sockets.streamer_end);
+      conns.emplace_back(sockets.events_server_path);
     }
     return conns;
   }
@@ -281,34 +265,43 @@ class VhostInputDevices : public CommandSource,
   std::string Name() const override { return "VhostInputDevices"; }
   std::unordered_set<SetupFeature*> Dependencies() const override { return {}; }
   Result<void> ResultSetup() override {
-    rotary_sockets_ = CF_EXPECT(NewDeviceSockets(RotarySocketPath(instance_)),
-                                "Failed to setup sockets for rotary device");
+    rotary_sockets_ =
+        CF_EXPECT(NewDeviceSockets(RotaryEventsServerPath(instance_),
+                                   RotarySocketPath(instance_)),
+                  "Failed to setup sockets for rotary device");
     if (instance_.enable_mouse()) {
-      mouse_sockets_ = CF_EXPECT(NewDeviceSockets(MouseSocketPath(instance_)),
-                                 "Failed to setup sockets for mouse device");
+      mouse_sockets_ =
+          CF_EXPECT(NewDeviceSockets(MouseEventsServerPath(instance_),
+                                     MouseSocketPath(instance_)),
+                    "Failed to setup sockets for mouse device");
     }
     if (instance_.enable_gamepad()) {
       gamepad_sockets_ =
-          CF_EXPECT(NewDeviceSockets(GamepadSocketPath(instance_)),
+          CF_EXPECT(NewDeviceSockets(GamepadEventsServerPath(instance_),
+                                     GamepadSocketPath(instance_)),
                     "Failed to setup sockets for gamepad device");
     }
     keyboard_sockets_ =
-        CF_EXPECT(NewDeviceSockets(KeyboardSocketPath(instance_)),
+        CF_EXPECT(NewDeviceSockets(KeyboardEventsServerPath(instance_),
+                                   KeyboardSocketPath(instance_)),
                   "Failed to setup sockets for keyboard device");
     switches_sockets_ =
-        CF_EXPECT(NewDeviceSockets(SwitchesSocketPath(instance_)),
+        CF_EXPECT(NewDeviceSockets(SwitchesEventsServerPath(instance_),
+                                   SwitchesSocketPath(instance_)),
                   "Failed to setup sockets for switches device");
     touchscreen_sockets_.reserve(instance_.display_configs().size());
     for (int i = 0; i < instance_.display_configs().size(); ++i) {
       touchscreen_sockets_.emplace_back(
-          CF_EXPECTF(NewDeviceSockets(instance_.touch_socket_path(i)),
+          CF_EXPECTF(NewDeviceSockets(instance_.touch_events_server_path(i),
+                                      instance_.touch_socket_path(i)),
                      "Failed to setup sockets for touchscreen {}", i));
     }
     touchpad_sockets_.reserve(instance_.touchpad_configs().size());
     for (int i = 0; i < instance_.touchpad_configs().size(); ++i) {
       int idx = touchscreen_sockets_.size() + i;
       touchpad_sockets_.emplace_back(
-          CF_EXPECTF(NewDeviceSockets(instance_.touch_socket_path(idx)),
+          CF_EXPECTF(NewDeviceSockets(instance_.touch_events_server_path(idx),
+                                      instance_.touch_socket_path(idx)),
                      "Failed to setup sockets for touchpad {}", i));
     }
     return {};
@@ -327,10 +320,10 @@ class VhostInputDevices : public CommandSource,
 
 }  // namespace
 fruit::Component<fruit::Required<const CuttlefishConfig::InstanceSpecific>,
-                 InputConnectionsProvider, LogTeeCreator>
+                 InputPathsProvider, LogTeeCreator>
 VhostInputDevicesComponent() {
   return fruit::createComponent()
-      .bind<InputConnectionsProvider, VhostInputDevices>()
+      .bind<InputPathsProvider, VhostInputDevices>()
       .addMultibinding<CommandSource, VhostInputDevices>()
       .addMultibinding<SetupFeature, VhostInputDevices>();
 }

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/input_paths_provider.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/input_paths_provider.h
@@ -17,7 +17,6 @@
 
 #include <vector>
 
-#include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/host/commands/run_cvd/launch/log_tee_creator.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
 #include "cuttlefish/host/libs/feature/feature.h"
@@ -27,21 +26,21 @@ namespace cuttlefish {
 // Feature that provides access to the connections to the input devices.
 // Such connections are file descriptors over which (virtio_) input events can
 // be written to inject them to the VM and (virtio_) status updates can be read.
-class InputConnectionsProvider : public virtual SetupFeature {
+class InputPathsProvider : public virtual SetupFeature {
  public:
-  virtual ~InputConnectionsProvider() = default;
+  virtual ~InputPathsProvider() = default;
 
-  virtual SharedFD RotaryDeviceConnection() const = 0;
-  virtual SharedFD MouseConnection() const = 0;
-  virtual SharedFD GamepadConnection() const = 0;
-  virtual SharedFD KeyboardConnection() const = 0;
-  virtual SharedFD SwitchesConnection() const = 0;
-  virtual std::vector<SharedFD> TouchscreenConnections() const = 0;
-  virtual std::vector<SharedFD> TouchpadConnections() const = 0;
+  virtual std::string RotaryDevicePath() const = 0;
+  virtual std::string MousePath() const = 0;
+  virtual std::string GamepadPath() const = 0;
+  virtual std::string KeyboardPath() const = 0;
+  virtual std::string SwitchesPath() const = 0;
+  virtual std::vector<std::string> TouchscreenPaths() const = 0;
+  virtual std::vector<std::string> TouchpadPaths() const = 0;
 };
 
 fruit::Component<fruit::Required<const CuttlefishConfig::InstanceSpecific>,
-                 InputConnectionsProvider, LogTeeCreator>
+                 InputPathsProvider, LogTeeCreator>
 VhostInputDevicesComponent();
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/streamer.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/streamer.cpp
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "absl/log/log.h"
+#include "absl/strings/str_join.h"
 #include "fruit/component.h"
 #include "fruit/fruit_forward_decls.h"
 #include "fruit/macro.h"
@@ -32,7 +33,7 @@
 #include "cuttlefish/common/libs/fs/shared_fd.h"
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/commands/run_cvd/launch/enable_multitouch.h"
-#include "cuttlefish/host/commands/run_cvd/launch/input_connections_provider.h"
+#include "cuttlefish/host/commands/run_cvd/launch/input_paths_provider.h"
 #include "cuttlefish/host/commands/run_cvd/launch/sensors_socket_pair.h"
 #include "cuttlefish/host/commands/run_cvd/launch/webrtc_controller.h"
 #include "cuttlefish/host/commands/run_cvd/reporting.h"
@@ -104,48 +105,45 @@ std::vector<Command> LaunchCustomActionServers(
 class StreamerSockets : public virtual SetupFeature {
  public:
   INJECT(StreamerSockets(const CuttlefishConfig& config,
-                         InputConnectionsProvider& input_connections_provider,
+                         InputPathsProvider& input_paths_provider,
                          const CuttlefishConfig::InstanceSpecific& instance))
       : config_(config),
         instance_(instance),
-        input_connections_provider_(input_connections_provider) {}
+        input_paths_provider_(input_paths_provider) {}
 
   void AppendCommandArguments(Command& cmd) {
     const int touch_count = instance_.display_configs().size() +
                             instance_.touchpad_configs().size();
     if (touch_count > 0) {
       cmd.AddParameter("--multitouch=", ShouldEnableMultitouch(instance_));
-      std::vector<SharedFD> touch_connections =
-          input_connections_provider_.TouchscreenConnections();
-      for (const SharedFD& touchpad_connection :
-           input_connections_provider_.TouchpadConnections()) {
-        touch_connections.push_back(touchpad_connection);
+      std::vector<std::string> touch_paths =
+          input_paths_provider_.TouchscreenPaths();
+      for (const std::string& touchpad_path :
+           input_paths_provider_.TouchpadPaths()) {
+        touch_paths.push_back(touchpad_path);
       }
-      cmd.AddParameter("-touch_fds=", touch_connections[0]);
-      for (int i = 1; i < touch_connections.size(); ++i) {
-        cmd.AppendToLastParameter(",", touch_connections[i]);
-      }
+      cmd.AddParameter("-touch_server_paths=", absl::StrJoin(touch_paths, ","));
     }
     if (instance_.enable_mouse()) {
-      cmd.AddParameter("-mouse_fd=",
-                       input_connections_provider_.MouseConnection());
+      cmd.AddParameter("-mouse_server_path=",
+                       input_paths_provider_.MousePath());
     }
     if (instance_.enable_gamepad()) {
-      cmd.AddParameter("-gamepad_fd=",
-                       input_connections_provider_.GamepadConnection());
+      cmd.AddParameter("-gamepad_server_path=",
+                       input_paths_provider_.GamepadPath());
     }
-    cmd.AddParameter("-rotary_fd=",
-                     input_connections_provider_.RotaryDeviceConnection());
-    cmd.AddParameter("-keyboard_fd=",
-                     input_connections_provider_.KeyboardConnection());
+    cmd.AddParameter("-rotary_server_path=",
+                     input_paths_provider_.RotaryDevicePath());
+    cmd.AddParameter("-keyboard_server_path=",
+                     input_paths_provider_.KeyboardPath());
     cmd.AddParameter("-frame_server_fd=", frames_server_);
     if (instance_.enable_audio()) {
       cmd.AddParameter("--audio_server_fd=", audio_server_);
     }
     cmd.AddParameter("--confui_in_fd=", confui_in_fd_);
     cmd.AddParameter("--confui_out_fd=", confui_out_fd_);
-    cmd.AddParameter("-switches_fd=",
-                     input_connections_provider_.SwitchesConnection());
+    cmd.AddParameter("-switches_server_path=",
+                     input_paths_provider_.SwitchesPath());
   }
 
   // SetupFeature
@@ -157,7 +155,7 @@ class StreamerSockets : public virtual SetupFeature {
 
  private:
   std::unordered_set<SetupFeature*> Dependencies() const override {
-    return {&input_connections_provider_};
+    return {&input_paths_provider_};
   }
 
   Result<void> ResultSetup() override {
@@ -190,7 +188,7 @@ class StreamerSockets : public virtual SetupFeature {
 
   const CuttlefishConfig& config_;
   const CuttlefishConfig::InstanceSpecific instance_;
-  InputConnectionsProvider& input_connections_provider_;
+  InputPathsProvider& input_paths_provider_;
   SharedFD frames_server_;
   SharedFD audio_server_;
   SharedFD confui_in_fd_;   // host -> guest
@@ -300,7 +298,7 @@ class WebRtcServer : public virtual CommandSource,
 }  // namespace
 
 fruit::Component<fruit::Required<
-    const CuttlefishConfig, KernelLogPipeProvider, InputConnectionsProvider,
+    const CuttlefishConfig, KernelLogPipeProvider, InputPathsProvider,
     const CuttlefishConfig::InstanceSpecific, const CustomActionConfigProvider,
     WebRtcController>>
 launchStreamerComponent() {

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/streamer.h
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/streamer.h
@@ -17,7 +17,7 @@
 
 #include <fruit/fruit.h>
 
-#include "cuttlefish/host/commands/run_cvd/launch/input_connections_provider.h"
+#include "cuttlefish/host/commands/run_cvd/launch/input_paths_provider.h"
 #include "cuttlefish/host/commands/run_cvd/launch/webrtc_controller.h"
 #include "cuttlefish/host/libs/config/custom_actions.h"
 #include "cuttlefish/host/libs/config/cuttlefish_config.h"
@@ -26,7 +26,7 @@
 namespace cuttlefish {
 
 fruit::Component<fruit::Required<
-    const CuttlefishConfig, KernelLogPipeProvider, InputConnectionsProvider,
+    const CuttlefishConfig, KernelLogPipeProvider, InputPathsProvider,
     const CuttlefishConfig::InstanceSpecific, const CustomActionConfigProvider,
     WebRtcController>>
 launchStreamerComponent();

--- a/base/cvd/cuttlefish/host/commands/run_cvd/main.cc
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/main.cc
@@ -41,7 +41,7 @@
 #include "cuttlefish/host/commands/run_cvd/launch/cvdalloc.h"
 #include "cuttlefish/host/commands/run_cvd/launch/echo_server.h"
 #include "cuttlefish/host/commands/run_cvd/launch/gnss_grpc_proxy.h"
-#include "cuttlefish/host/commands/run_cvd/launch/input_connections_provider.h"
+#include "cuttlefish/host/commands/run_cvd/launch/input_paths_provider.h"
 #include "cuttlefish/host/commands/run_cvd/launch/kernel_log_monitor.h"
 #include "cuttlefish/host/commands/run_cvd/launch/logcat_receiver.h"
 #include "cuttlefish/host/commands/run_cvd/launch/mcu.h"

--- a/base/cvd/cuttlefish/host/commands/vhost_user_input/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_input/BUILD.bazel
@@ -11,6 +11,7 @@ rust_binary(
     name = "cf_vhost_user_input",
     srcs = [
         "src/buf_reader.rs",
+        "src/event_source.rs",
         "src/inherited_fd.rs",
         "src/main.rs",
         "src/vhu_input.rs",

--- a/base/cvd/cuttlefish/host/commands/vhost_user_input/src/buf_reader.rs
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_input/src/buf_reader.rs
@@ -1,56 +1,91 @@
-use std::io::{ErrorKind, Read};
+use std::io::{Error, ErrorKind, Read, Result};
 use std::os::fd::{AsFd, BorrowedFd};
 
-use anyhow::{bail, Context, Result};
 use log::trace;
+
+use crate::vio_input::{trim_to_event_size_multiple, VIRTIO_INPUT_EVENT_SIZE};
 
 /// Object to read and temporarily store virtio input events.
 /// An std::io::BufReader can't be used because it doesn't provide a way to read more bytes when
 /// only a partial event has been read.
 #[derive(Clone)]
-pub struct BufReader<R: Read + AsFd + Sync + Send> {
+pub struct EventReader<R: Read + AsFd + Send + Sync> {
     buf: [u8; 8192],
     size: usize,
     reader: R,
 }
 
-impl<R: Read + AsFd + Sync + Send> BufReader<R> {
-    /// Create a new BufReader.
-    pub fn new(reader: R) -> BufReader<R> {
-        BufReader {
+impl<R: Read + AsFd + Send + Sync> EventReader<R> {
+    /// Create a new EventReader.
+    pub fn new(reader: R) -> Self {
+        Self {
             buf: [0u8; 8192],
             size: 0,
             reader,
         }
     }
 
-    /// Reads available bytes from the underlying reader. Returns number of bytes read during this
+    /// Reads more bytes from the inner reader. Returns a list of events once a full event
+    /// group has been read, otherwise an empty list. Returns error if the underlying reader
+    /// produces an error or reaches end of file (ErrorKind::UnexpectedEof).
+    pub fn read_events(&mut self) -> Result<Vec<u8>> {
+        let read_len = self.read_ahead()?;
+        if read_len == 0 {
+            // EOF reached or error
+            return Err(Error::new(
+                ErrorKind::UnexpectedEof,
+                "Reached end of event stream",
+            ));
+        }
+        // These events were checked on previous calls.
+        let skip_len = trim_to_event_size_multiple(self.buffer().len() - read_len);
+        let mut len = trim_to_event_size_multiple(self.buffer().len());
+        // Search from the last fully read event for SYN_REPORT. Reading from the end ensures
+        // all fully read event groups are consumed. Stop searching at events checked on a previous
+        // read.
+        while len > skip_len {
+            // i >= previous_size because both previous_size and len are multiples of event size
+            let i = len - VIRTIO_INPUT_EVENT_SIZE;
+            // SYN_REPORT events have the first 4 bytes set to 0
+            if self.buffer()[i..i + 4] == [0u8; 4] {
+                // Consume events from the range [0..len]
+                return Ok(self.consume(len));
+            }
+            len -= VIRTIO_INPUT_EVENT_SIZE;
+        }
+        Ok(Vec::new())
+    }
+
+    pub fn inner(&mut self) -> &mut R {
+        &mut self.reader
+    }
+
+    /// Reads available bytes from the inner reader. Returns number of bytes read during this
     /// call (which may be less than the resulting size of the buffer) or 0 on EOF.
-    pub fn read_ahead(&mut self) -> Result<usize> {
+    fn read_ahead(&mut self) -> Result<usize> {
         if self.size == self.buf.len() {
             // The buffer may be full if SYN_REPORT events are not sent.
-            bail!("Event buffer is full");
+            return Err(Error::new(ErrorKind::OutOfMemory, "Event buffer is full"));
         }
         let read = loop {
             match self.reader.read(&mut self.buf[self.size..]) {
                 Err(e) if e.kind() == ErrorKind::Interrupted => continue,
                 res => break res,
             }
-        }
-        .context("Failed to read events")?;
+        }?;
         trace!("Read {} bytes", read);
         self.size += read;
         Ok(read)
     }
 
     /// Returns a slice with the available bytes.
-    pub fn buffer(&self) -> &[u8] {
+    fn buffer(&self) -> &[u8] {
         &self.buf[..self.size]
     }
 
     /// Remove consumed bytes from the buffer, making more space for future reads. Returns the
     /// consumed bytes in a vector.
-    pub fn consume(&mut self, count: usize) -> Vec<u8> {
+    fn consume(&mut self, count: usize) -> Vec<u8> {
         let v = self.buf[..count].to_vec();
         self.buf.copy_within(count..self.size, 0);
         self.size -= count;
@@ -58,7 +93,7 @@ impl<R: Read + AsFd + Sync + Send> BufReader<R> {
     }
 }
 
-impl<R: Read + AsFd + Send + Sync> AsFd for BufReader<R> {
+impl<R: Read + AsFd + Send + Sync> AsFd for EventReader<R> {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.reader.as_fd()
     }

--- a/base/cvd/cuttlefish/host/commands/vhost_user_input/src/buf_reader.rs
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_input/src/buf_reader.rs
@@ -17,7 +17,11 @@ pub struct BufReader<R: Read + AsFd + Sync + Send> {
 impl<R: Read + AsFd + Sync + Send> BufReader<R> {
     /// Create a new BufReader.
     pub fn new(reader: R) -> BufReader<R> {
-        BufReader { buf: [0u8; 8192], size: 0, reader }
+        BufReader {
+            buf: [0u8; 8192],
+            size: 0,
+            reader,
+        }
     }
 
     /// Reads available bytes from the underlying reader. Returns number of bytes read during this

--- a/base/cvd/cuttlefish/host/commands/vhost_user_input/src/buf_reader.rs
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_input/src/buf_reader.rs
@@ -1,4 +1,5 @@
 use std::io::{ErrorKind, Read};
+use std::os::fd::{AsFd, BorrowedFd};
 
 use anyhow::{bail, Context, Result};
 use log::trace;
@@ -7,23 +8,23 @@ use log::trace;
 /// An std::io::BufReader can't be used because it doesn't provide a way to read more bytes when
 /// only a partial event has been read.
 #[derive(Clone)]
-pub struct BufReader<R: Read + Sync + Send> {
+pub struct BufReader<R: Read + AsFd + Sync + Send> {
     buf: [u8; 8192],
     size: usize,
     reader: R,
 }
 
-impl<R: Read + Sync + Send> BufReader<R> {
+impl<R: Read + AsFd + Sync + Send> BufReader<R> {
     /// Create a new BufReader.
     pub fn new(reader: R) -> BufReader<R> {
         BufReader { buf: [0u8; 8192], size: 0, reader }
     }
 
-    /// Reads available bytes from the underlying reader.
-    pub fn read_ahead(&mut self) -> Result<()> {
+    /// Reads available bytes from the underlying reader. Returns number of bytes read during this
+    /// call (which may be less than the resulting size of the buffer) or 0 on EOF.
+    pub fn read_ahead(&mut self) -> Result<usize> {
         if self.size == self.buf.len() {
-            // The buffer may be full when the driver doesn't provide virtq buffers to receive the
-            // events.
+            // The buffer may be full if SYN_REPORT events are not sent.
             bail!("Event buffer is full");
         }
         let read = loop {
@@ -35,7 +36,7 @@ impl<R: Read + Sync + Send> BufReader<R> {
         .context("Failed to read events")?;
         trace!("Read {} bytes", read);
         self.size += read;
-        Ok(())
+        Ok(read)
     }
 
     /// Returns a slice with the available bytes.
@@ -43,9 +44,18 @@ impl<R: Read + Sync + Send> BufReader<R> {
         &self.buf[..self.size]
     }
 
-    /// Remove consumed bytes from the buffer, making more space for future reads.
-    pub fn consume(&mut self, count: usize) {
+    /// Remove consumed bytes from the buffer, making more space for future reads. Returns the
+    /// consumed bytes in a vector.
+    pub fn consume(&mut self, count: usize) -> Vec<u8> {
+        let v = self.buf[..count].to_vec();
         self.buf.copy_within(count..self.size, 0);
         self.size -= count;
+        v
+    }
+}
+
+impl<R: Read + AsFd + Send + Sync> AsFd for BufReader<R> {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.reader.as_fd()
     }
 }

--- a/base/cvd/cuttlefish/host/commands/vhost_user_input/src/buf_reader.rs
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_input/src/buf_reader.rs
@@ -1,4 +1,4 @@
-use std::io::Read;
+use std::io::{ErrorKind, Read};
 
 use anyhow::{bail, Context, Result};
 use log::trace;
@@ -26,11 +26,14 @@ impl<R: Read + Sync + Send> BufReader<R> {
             // events.
             bail!("Event buffer is full");
         }
-        let read = self.reader.read(&mut self.buf[self.size..]).context("Failed to read events")?;
-        trace!("Read {} bytes", read);
-        if read == 0 {
-            bail!("Event source closed");
+        let read = loop {
+            match self.reader.read(&mut self.buf[self.size..]) {
+                Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+                res => break res,
+            }
         }
+        .context("Failed to read events")?;
+        trace!("Read {} bytes", read);
         self.size += read;
         Ok(())
     }

--- a/base/cvd/cuttlefish/host/commands/vhost_user_input/src/event_source.rs
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_input/src/event_source.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::io::{ErrorKind, Read, Write};
+use std::io::{stdin, stdout, ErrorKind, Stdin, Write};
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::sync::{Arc, Mutex};
@@ -16,37 +16,38 @@ use crate::buf_reader::EventReader;
 /// when new events are available. No assumption should be made about the nature of this fd, in
 /// particular it should not be assumed this is an eventfd and the caller should never attempt to
 /// read from it directly.
-pub trait EventSource: Send + Sync + AsFd {
+pub trait EventSource: Send + Sync + AsFd + Sized {
     /// Gets all input events available in this source. Input events are always delivered in groups
     /// ending with the SYN_REPORT type event. The returned list may be empty if only a partial
     /// group was read.
     fn get_events(&mut self) -> Result<Vec<u8>>;
     /// Send status feedback such as keyboard LED states back to the source.
     fn send_status_feedback(&mut self, status_buffer: Vec<u8>);
+    /// Creates a new independenlty owned handle to the same underlying event source.
+    fn try_clone(&self) -> Result<Self>;
 }
 
-/// Reads events from a pipe
-pub struct PipeEventSource<R: Read + AsFd + Send + Sync, W: Write + Send + Sync> {
-    reader: EventReader<R>,
-    writer: W,
+/// Reads events from stdin, writes status feedback to stdout. Typically these channels will be
+/// pipes connected to other processes or just /dev/null.
+pub struct StdioEventSource {
+    reader: EventReader<Stdin>,
 }
 
-impl<R: Read + AsFd + Send + Sync, W: Write + Send + Sync> PipeEventSource<R, W> {
-    pub fn new(reader: R, writer: W) -> PipeEventSource<R, W> {
-        PipeEventSource::<R, W> {
-            reader: EventReader::new(reader),
-            writer,
+impl StdioEventSource {
+    pub fn new() -> StdioEventSource {
+        StdioEventSource {
+            reader: EventReader::new(stdin()),
         }
     }
 }
 
-impl<R: Read + AsFd + Send + Sync, W: Write + Send + Sync> AsFd for PipeEventSource<R, W> {
+impl AsFd for StdioEventSource {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.reader.as_fd()
     }
 }
 
-impl<R: Read + AsFd + Send + Sync, W: Write + Send + Sync> EventSource for PipeEventSource<R, W> {
+impl EventSource for StdioEventSource {
     fn get_events(&mut self) -> Result<Vec<u8>> {
         // This implementation can't recover from an errored or closed pipe
         self.reader
@@ -55,9 +56,13 @@ impl<R: Read + AsFd + Send + Sync, W: Write + Send + Sync> EventSource for PipeE
     }
 
     fn send_status_feedback(&mut self, status_buffer: Vec<u8>) {
-        if let Err(e) = self.writer.write_all(&status_buffer) {
+        if let Err(e) = stdout().write_all(&status_buffer) {
             warn!("Failed to send status feedback: {:?}", e);
         }
+    }
+
+    fn try_clone(&self) -> Result<Self> {
+        Ok(StdioEventSource::new())
     }
 }
 
@@ -119,6 +124,14 @@ impl EventSource for UnixSocketEventSource {
     fn send_status_feedback(&mut self, mut status_buffer: Vec<u8>) {
         self.status.lock().unwrap().append(&mut status_buffer);
         let _ = self.events_fd.write_all(&[0u8; 1]);
+    }
+
+    fn try_clone(&self) -> Result<Self> {
+        Ok(Self {
+            events_fd: self.events_fd.try_clone()?,
+            events: self.events.clone(),
+            status: self.status.clone(),
+        })
     }
 }
 

--- a/base/cvd/cuttlefish/host/commands/vhost_user_input/src/event_source.rs
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_input/src/event_source.rs
@@ -1,36 +1,40 @@
-use std::io::{Read, Write};
-use std::os::fd::{AsFd, BorrowedFd};
+use std::collections::HashMap;
+use std::io::{ErrorKind, Read, Write};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::sync::{Arc, Mutex};
 
+use anyhow::{bail, Context, Result};
 use log::{error, warn};
+use vmm_sys_util::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
 
-use crate::buf_reader::BufReader;
-use crate::vio_input::{trim_to_event_size_multiple, VIRTIO_INPUT_EVENT_SIZE};
+use crate::buf_reader::EventReader;
 
-/// Provides input events to the vhost-user backend. Implementations may can get these events from
-/// an event device (e.g /dev/input/event0), a pipe, a server, etc.
+/// Provides input events to the vhost-user backend. Implementations can get these events from an
+/// event device (e.g /dev/input/event0), a pipe, a server, etc.
 /// The fd returned by as_fd() can be watched with a poll-like function, it will become readable
 /// when new events are available. No assumption should be made about the nature of this fd, in
 /// particular it should not be assumed this is an eventfd and the caller should never attempt to
 /// read from it directly.
-pub trait EventSource: Sync + Send + AsFd {
+pub trait EventSource: Send + Sync + AsFd {
     /// Gets all input events available in this source. Input events are always delivered in groups
     /// ending with the SYN_REPORT type event. The returned list may be empty if only a partial
-    /// groups was read.
-    fn get_events(&mut self) -> Vec<u8>;
+    /// group was read.
+    fn get_events(&mut self) -> Result<Vec<u8>>;
     /// Send status feedback such as keyboard LED states back to the source.
-    fn send_status_feedback(&mut self, status_buffer: &[u8]);
+    fn send_status_feedback(&mut self, status_buffer: Vec<u8>);
 }
 
 /// Reads events from a pipe
-pub struct PipeEventSource<R: Read + AsFd + Sync + Send, W: Write + Send + Sync> {
-    reader: BufReader<R>,
+pub struct PipeEventSource<R: Read + AsFd + Send + Sync, W: Write + Send + Sync> {
+    reader: EventReader<R>,
     writer: W,
 }
 
 impl<R: Read + AsFd + Send + Sync, W: Write + Send + Sync> PipeEventSource<R, W> {
     pub fn new(reader: R, writer: W) -> PipeEventSource<R, W> {
         PipeEventSource::<R, W> {
-            reader: BufReader::new(reader),
+            reader: EventReader::new(reader),
             writer,
         }
     }
@@ -43,55 +47,197 @@ impl<R: Read + AsFd + Send + Sync, W: Write + Send + Sync> AsFd for PipeEventSou
 }
 
 impl<R: Read + AsFd + Send + Sync, W: Write + Send + Sync> EventSource for PipeEventSource<R, W> {
-    fn get_events(&mut self) -> Vec<u8> {
-        match read_events(&mut self.reader) {
-            // This implementation can't recover from an errored or closed pipe
-            ReadResult::SourceClosed => panic!("Event source pipe closed"),
-            ReadResult::Events(v) => v,
-        }
+    fn get_events(&mut self) -> Result<Vec<u8>> {
+        // This implementation can't recover from an errored or closed pipe
+        self.reader
+            .read_events()
+            .context("Event source pipe closed")
     }
 
-    fn send_status_feedback(&mut self, status_buffer: &[u8]) {
-        if let Err(e) = self.writer.write_all(status_buffer) {
+    fn send_status_feedback(&mut self, status_buffer: Vec<u8>) {
+        if let Err(e) = self.writer.write_all(&status_buffer) {
             warn!("Failed to send status feedback: {:?}", e);
         }
     }
 }
 
-enum ReadResult {
-    SourceClosed,
-    Events(Vec<u8>),
-}
-fn read_events<R: Read + AsFd + Send + Sync>(reader: &mut BufReader<R>) -> ReadResult {
-    let read_len = match reader.read_ahead() {
-        Ok(len) => len,
-        Err(e) => {
-            error!("Error reading from event source: {}", e);
-            0usize
-        }
-    };
-    if read_len == 0 {
-        // EOF reached or error
-        return ReadResult::SourceClosed;
-    }
-    // These events were checked on previous calls.
-    let skip_len = trim_to_event_size_multiple(reader.buffer().len() - read_len);
-    let mut len = trim_to_event_size_multiple(reader.buffer().len());
-    let mut v = Vec::<u8>::new();
-    // Search from the last fully read event for SYN_REPORT. Reading from the end ensures
-    // all fully read event groups are consumed. Stop searching at events checked on a previous
-    // read.
-    while len > skip_len {
-        // i >= previous_size because both previous_size and len are multiples of event size
-        let i = len - VIRTIO_INPUT_EVENT_SIZE;
-        // SYN_REPORT events have the first 4 bytes set to 0
-        if reader.buffer()[i..i + 4] == [0u8; 4] {
-            // Consume events from the range [0..len]
-            v = reader.consume(len);
-            break;
-        }
-        len -= VIRTIO_INPUT_EVENT_SIZE;
-    }
-    ReadResult::Events(v)
+/// Accepts connections on a unix socket and reads events from each client.
+/// Guarantees that events from different clients are always separated by a SYN_REPORT event, but
+/// events from multiple clients can still end up mixed in unexpected ways (such as a touch swipe
+/// gesture appearing to jump around the screen).
+pub struct UnixSocketEventSource {
+    // This will become readable when new events are available. It will also notify the background
+    // thread that it's time to stop when it closes on drop.
+    events_fd: UnixStream,
+    events: Arc<Mutex<Vec<u8>>>,
+    status: Arc<Mutex<Vec<u8>>>,
 }
 
+impl UnixSocketEventSource {
+    pub fn new(listener: UnixListener) -> Result<Self> {
+        let (fg_events_fd, bg_events_fd) =
+            UnixStream::pair().context("Failed to create notifications socket pair")?;
+        fg_events_fd
+            .set_nonblocking(true)
+            .context("Unable to set non-blocking")?;
+        bg_events_fd
+            .set_nonblocking(true)
+            .context("Unable to set non-blocking")?;
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let events_clone = events.clone();
+        let status = Arc::new(Mutex::new(Vec::new()));
+        let status_clone = events.clone();
+        std::thread::spawn(move || server_loop(listener, bg_events_fd, events_clone, status_clone));
+        Ok(Self {
+            events_fd: fg_events_fd,
+            events,
+            status,
+        })
+    }
+}
+
+impl AsFd for UnixSocketEventSource {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.events_fd.as_fd()
+    }
+}
+
+impl EventSource for UnixSocketEventSource {
+    fn get_events(&mut self) -> Result<Vec<u8>> {
+        match std::io::copy(&mut self.events_fd, &mut std::io::sink()) {
+            Err(e) if e.kind() == ErrorKind::WouldBlock => {}
+            Err(e) => {
+                bail!("Failed to read from background thread's channel: {:?}", e);
+            }
+            Ok(_) => {
+                bail!("Background thread's channel closed unexpectedly");
+            }
+        }
+        Ok(std::mem::take(&mut *self.events.lock().unwrap()))
+    }
+
+    fn send_status_feedback(&mut self, mut status_buffer: Vec<u8>) {
+        self.status.lock().unwrap().append(&mut status_buffer);
+        let _ = self.events_fd.write_all(&[0u8; 1]);
+    }
+}
+
+fn server_loop(
+    listener: UnixListener,
+    mut events_fd: UnixStream,
+    events: Arc<Mutex<Vec<u8>>>,
+    status: Arc<Mutex<Vec<u8>>>,
+) {
+    const SERVER_TOKEN: u64 = 0;
+    const EVENT_TOKEN: u64 = 1;
+    const FIRST_CLIENT_TOKEN: u64 = 2;
+    let mut clients = HashMap::<u64, EventReader<UnixStream>>::new();
+
+    let epoll = Epoll::new().expect("Failed to create epoll instance");
+    epoll
+        .ctl(
+            ControlOperation::Add,
+            listener.as_raw_fd(),
+            EpollEvent::new(EventSet::IN, SERVER_TOKEN),
+        )
+        .expect("Failed to add listener to epoll");
+    epoll
+        .ctl(
+            ControlOperation::Add,
+            events_fd.as_raw_fd(),
+            EpollEvent::new(EventSet::IN | EventSet::HANG_UP, EVENT_TOKEN),
+        )
+        .expect("Failed to add events fd to epoll");
+    let mut ready_events = [EpollEvent::default(); 16];
+    loop {
+        let num_ready = epoll
+            .wait(-1, &mut ready_events)
+            .expect("Failed to wait for events");
+        for event in &ready_events[..num_ready] {
+            match event.data() {
+                SERVER_TOKEN => {
+                    let client = match listener.accept() {
+                        Ok((c, _)) => c,
+                        Err(e) => {
+                            error!("Failed to accept on event source server: {:?}", e);
+                            continue;
+                        }
+                    };
+                    if let Err(e) = client.set_nonblocking(true) {
+                        error!("Failed to set events connection non-blocking: {:?}", e);
+                        continue;
+                    }
+                    // New client available
+                    let token = (FIRST_CLIENT_TOKEN
+                        ..FIRST_CLIENT_TOKEN + (clients.len() as u64) + 1)
+                        .find(|t| !clients.contains_key(t))
+                        // Safe because we check more tokens than the map contains, so at least one
+                        // isn't there.
+                        .unwrap();
+                    epoll
+                        .ctl(
+                            ControlOperation::Add,
+                            client.as_raw_fd(),
+                            EpollEvent::new(EventSet::IN | EventSet::HANG_UP, token),
+                        )
+                        .expect("Failed to add client stream to epoll");
+                    clients.insert(token, EventReader::new(client));
+                }
+                EVENT_TOKEN => {
+                    if event.event_set().contains(EventSet::HANG_UP) {
+                        // Exit on closed events fd.
+                        return;
+                    }
+                    match std::io::copy(&mut events_fd, &mut std::io::sink()) {
+                        Err(e) if e.kind() == ErrorKind::WouldBlock => {}
+                        Err(e) => {
+                            panic!("Failed to read from background thread's channel: {:?}", e);
+                        }
+                        Ok(_) => {
+                            // the other end of events_fd must be closed if io::copy succeeded
+                            return;
+                        }
+                    }
+                    let status = std::mem::take(&mut *status.lock().unwrap());
+                    for client in clients.values_mut() {
+                        // The client's inner reader is a UnixStream, so it can also write
+                        match client.inner().write_all(&status) {
+                            Err(e) if e.kind() != ErrorKind::WouldBlock => {
+                                // Ignore WouldBlock errors since those are likely due to the client
+                                // ignoring status feedback.
+                                error!("Failed to send status feedback to client: {:?}", e);
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                client_token => {
+                    let client = clients
+                        .get_mut(&client_token)
+                        .expect("epoll token is not associated to any fd");
+                    match client.read_events() {
+                        Ok(mut v) => {
+                            events.lock().unwrap().append(&mut v);
+                            events_fd
+                                .write_all(&[0u8; 1])
+                                .expect("Failed to notify backend or available events");
+                        }
+                        Err(e) => {
+                            if e.kind() != ErrorKind::UnexpectedEof {
+                                error!("Error reading events: {:?}", e);
+                            }
+                            epoll
+                                .ctl(
+                                    ControlOperation::Delete,
+                                    client.inner().as_raw_fd(),
+                                    EpollEvent::default(),
+                                )
+                                .expect("Failed to remove client from epoll");
+                            clients.remove(&client_token);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/base/cvd/cuttlefish/host/commands/vhost_user_input/src/event_source.rs
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_input/src/event_source.rs
@@ -1,0 +1,97 @@
+use std::io::{Read, Write};
+use std::os::fd::{AsFd, BorrowedFd};
+
+use log::{error, warn};
+
+use crate::buf_reader::BufReader;
+use crate::vio_input::{trim_to_event_size_multiple, VIRTIO_INPUT_EVENT_SIZE};
+
+/// Provides input events to the vhost-user backend. Implementations may can get these events from
+/// an event device (e.g /dev/input/event0), a pipe, a server, etc.
+/// The fd returned by as_fd() can be watched with a poll-like function, it will become readable
+/// when new events are available. No assumption should be made about the nature of this fd, in
+/// particular it should not be assumed this is an eventfd and the caller should never attempt to
+/// read from it directly.
+pub trait EventSource: Sync + Send + AsFd {
+    /// Gets all input events available in this source. Input events are always delivered in groups
+    /// ending with the SYN_REPORT type event. The returned list may be empty if only a partial
+    /// groups was read.
+    fn get_events(&mut self) -> Vec<u8>;
+    /// Send status feedback such as keyboard LED states back to the source.
+    fn send_status_feedback(&mut self, status_buffer: &[u8]);
+}
+
+/// Reads events from a pipe
+pub struct PipeEventSource<R: Read + AsFd + Sync + Send, W: Write + Send + Sync> {
+    reader: BufReader<R>,
+    writer: W,
+}
+
+impl<R: Read + AsFd + Send + Sync, W: Write + Send + Sync> PipeEventSource<R, W> {
+    pub fn new(reader: R, writer: W) -> PipeEventSource<R, W> {
+        PipeEventSource::<R, W> {
+            reader: BufReader::new(reader),
+            writer,
+        }
+    }
+}
+
+impl<R: Read + AsFd + Send + Sync, W: Write + Send + Sync> AsFd for PipeEventSource<R, W> {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.reader.as_fd()
+    }
+}
+
+impl<R: Read + AsFd + Send + Sync, W: Write + Send + Sync> EventSource for PipeEventSource<R, W> {
+    fn get_events(&mut self) -> Vec<u8> {
+        match read_events(&mut self.reader) {
+            // This implementation can't recover from an errored or closed pipe
+            ReadResult::SourceClosed => panic!("Event source pipe closed"),
+            ReadResult::Events(v) => v,
+        }
+    }
+
+    fn send_status_feedback(&mut self, status_buffer: &[u8]) {
+        if let Err(e) = self.writer.write_all(status_buffer) {
+            warn!("Failed to send status feedback: {:?}", e);
+        }
+    }
+}
+
+enum ReadResult {
+    SourceClosed,
+    Events(Vec<u8>),
+}
+fn read_events<R: Read + AsFd + Send + Sync>(reader: &mut BufReader<R>) -> ReadResult {
+    let read_len = match reader.read_ahead() {
+        Ok(len) => len,
+        Err(e) => {
+            error!("Error reading from event source: {}", e);
+            0usize
+        }
+    };
+    if read_len == 0 {
+        // EOF reached or error
+        return ReadResult::SourceClosed;
+    }
+    // These events were checked on previous calls.
+    let skip_len = trim_to_event_size_multiple(reader.buffer().len() - read_len);
+    let mut len = trim_to_event_size_multiple(reader.buffer().len());
+    let mut v = Vec::<u8>::new();
+    // Search from the last fully read event for SYN_REPORT. Reading from the end ensures
+    // all fully read event groups are consumed. Stop searching at events checked on a previous
+    // read.
+    while len > skip_len {
+        // i >= previous_size because both previous_size and len are multiples of event size
+        let i = len - VIRTIO_INPUT_EVENT_SIZE;
+        // SYN_REPORT events have the first 4 bytes set to 0
+        if reader.buffer()[i..i + 4] == [0u8; 4] {
+            // Consume events from the range [0..len]
+            v = reader.consume(len);
+            break;
+        }
+        len -= VIRTIO_INPUT_EVENT_SIZE;
+    }
+    ReadResult::Events(v)
+}
+

--- a/base/cvd/cuttlefish/host/commands/vhost_user_input/src/inherited_fd.rs
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_input/src/inherited_fd.rs
@@ -91,14 +91,20 @@ pub unsafe fn init_once() -> Result<(), std::io::Error> {
 
     INHERITED_FDS
         .set(Mutex::new(fds))
-        .or(Err(std::io::Error::other("Inherited fds were already initialized")))
+        .or(Err(std::io::Error::other(
+            "Inherited fds were already initialized",
+        )))
 }
 
 /// Take the ownership of the given `RawFd` and returns `OwnedFd` for it. The returned FD is set
 /// CLOEXEC. `Error` is returned when the ownership was already taken (by a prior call to this
 /// function with the same `RawFd`) or `RawFd` is not an inherited file descriptor.
 pub fn take_fd_ownership(raw_fd: RawFd) -> Result<OwnedFd, Error> {
-    let mut fds = INHERITED_FDS.get().ok_or(Error::NotInitialized)?.lock().unwrap();
+    let mut fds = INHERITED_FDS
+        .get()
+        .ok_or(Error::NotInitialized)?
+        .lock()
+        .unwrap();
 
     if let Some(value) = fds.get_mut(&raw_fd) {
         if let Some(owned_fd) = value.take() {
@@ -175,7 +181,10 @@ mod test {
         // this must run first to avoid it reusing a previously closed fd
         {
             let f_new = fixture.open_new_file()?;
-            assert_eq!(Some(Error::FileDescriptorNotInherited(f_new)), take_fd_ownership(f_new).err());
+            assert_eq!(
+                Some(Error::FileDescriptorNotInherited(f_new)),
+                take_fd_ownership(f_new).err()
+            );
         }
 
         // happy_case

--- a/base/cvd/cuttlefish/host/commands/vhost_user_input/src/main.rs
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_input/src/main.rs
@@ -19,7 +19,7 @@ use vhost::vhost_user::{Error as VError, Listener};
 use vhost_user_backend::{Error as VHUError, VhostUserDaemon};
 use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
 
-use event_source::{EventSource, PipeEventSource, UnixSocketEventSource};
+use event_source::{EventSource, StdioEventSource, UnixSocketEventSource};
 use vhu_input::{VhostUserInput, EVENTS_AVAILABLE};
 use vio_input::VirtioInputConfig;
 
@@ -57,53 +57,61 @@ fn create_and_run_device<T: EventSource + 'static>(
     device_config: VirtioInputConfig,
     server_fd: OwnedFd,
 ) -> Result<()> {
-    let event_source_fd = event_source.as_fd().as_raw_fd();
-    let backend = Arc::new(Mutex::new(VhostUserInput::new(device_config, event_source)));
-    let mut daemon = VhostUserDaemon::new(
-        "vhost-user-input".to_string(),
-        backend.clone(),
-        GuestMemoryAtomic::new(GuestMemoryMmap::new()),
-    )
-    .map_err(|e| anyhow!("Failed to create vhost user daemon: {:?}", e))?;
-
-    // Ideally, this registration would be done by the backend since it is the one that knows to
-    // read the event source when the EVENTS_AVAILABLE event is generated. This is not possible
-    // because register_listener attempts to lock the backend to call num_queues() which causes
-    // a deadlock if the backend lock is already held.
-    daemon
-        .get_epoll_handlers()
-        .first()
-        .context("Daemon created without epoll handler threads")?
-        .register_listener(
-            event_source_fd,
-            vmm_sys_util::epoll::EventSet::IN,
-            EVENTS_AVAILABLE as u64,
+    loop {
+        let event_source_clone = event_source.try_clone().context("Failed to clone event source")?;
+        let event_source_fd = event_source_clone.as_fd().as_raw_fd();
+        // vhost::vhost_user::Listener and UnixListener take ownership of the underlying fds and
+        // close them when dropped, so dups of the original fds are used in each iteration.
+        let server_dup = server_fd.try_clone().context("Failed to clone socket fd")?;
+        let backend = Arc::new(Mutex::new(VhostUserInput::new(
+            device_config.clone(),
+            event_source_clone,
+        )));
+        let mut daemon = VhostUserDaemon::new(
+            "vhost-user-input".to_string(),
+            backend.clone(),
+            GuestMemoryAtomic::new(GuestMemoryMmap::new()),
         )
-        .context("Failed to register epoll handler")?;
+        .map_err(|e| anyhow!("Failed to create vhost user daemon: {:?}", e))?;
 
-    let listener = {
-        // SAFETY: Safe because we just dupped this fd and don't use it anywhwere else.
-        // Listener takes ownership and ensures it's properly closed when finished with it.
-        // TODO: Use safe Listener::from<UnixStream> after updating to a version that implements it
-        unsafe { Listener::from_raw_fd(server_fd.into_raw_fd()) }
-    };
-    info!("Created vhost-user daemon");
-    daemon
-        .start(listener)
-        .map_err(|e| anyhow!("Failed to start vhost-user daemon: {:?}", e))?;
-    info!("Accepted connection in vhost-user daemon");
-    match daemon.wait() {
-        Err(VHUError::HandleRequest(VError::Disconnected)) => {
-            info!("Frontend disconnected");
-        }
-        Err(e) => {
-            bail!("Daemon exited with error: {:?}", e);
-        }
-        Ok(()) => {
-            info!("Daemon exited");
+        // Ideally, this registration would be done by the backend since it is the one that knows to
+        // read the event source when the EVENTS_AVAILABLE event is generated. This is not possible
+        // because register_listener attempts to lock the backend to call num_queues() which causes
+        // a deadlock if the backend lock is already held.
+        daemon
+            .get_epoll_handlers()
+            .first()
+            .context("Daemon created without epoll handler threads")?
+            .register_listener(
+                event_source_fd,
+                vmm_sys_util::epoll::EventSet::IN,
+                EVENTS_AVAILABLE as u64,
+            )
+            .context("Failed to register epoll handler")?;
+
+        let listener = {
+            // SAFETY: Safe because we just dupped this fd and don't use it anywhwere else.
+            // Listener takes ownership and ensures it's properly closed when finished with it.
+            // TODO: Use safe Listener::from<UnixStream> after updating to a version that implements it
+            unsafe { Listener::from_raw_fd(server_dup.into_raw_fd()) }
+        };
+        info!("Created vhost-user daemon");
+        daemon
+            .start(listener)
+            .map_err(|e| anyhow!("Failed to start vhost-user daemon: {:?}", e))?;
+        info!("Accepted connection in vhost-user daemon");
+        match daemon.wait() {
+            Err(VHUError::HandleRequest(VError::Disconnected)) => {
+                info!("Frontend disconnected");
+            }
+            Err(e) => {
+                bail!("Daemon exited with error: {:?}", e);
+            }
+            Ok(()) => {
+                info!("Daemon exited");
+            }
         }
     }
-    Ok(())
 }
 
 fn main() -> Result<()> {
@@ -127,28 +135,14 @@ fn main() -> Result<()> {
 
     let socket_fd = inherited_fd::take_fd_ownership(args.socket_fd)
         .context("Failed to take ownership of socket fd")?;
-    let server_fd = if args.server_fd >= 0 {
-        Some(
-            inherited_fd::take_fd_ownership(args.server_fd)
-                .context("Failed to take ownership of socket fd")?,
-        )
+    if args.server_fd >= 0 {
+        let server_fd = inherited_fd::take_fd_ownership(args.server_fd)
+            .context("Failed to take ownership of socket fd")?;
+        let event_source = UnixSocketEventSource::new(UnixListener::from(server_fd))?;
+        create_and_run_device(event_source, device_config, socket_fd)?;
     } else {
-        None
+        let event_source = StdioEventSource::new();
+        create_and_run_device(event_source, device_config, socket_fd)?;
     };
-    loop {
-        // vhost::vhost_user::Listener and UnixListener take ownership of the underlying fds and
-        // close them when dropped, so dups of the original fds are used in each iteration.
-        let socket_dup = socket_fd.try_clone().context("Failed to clone socket fd")?;
-        match server_fd {
-            Some(ref fd) => {
-                let server_dup = fd.try_clone().context("Failed to clone server fd")?;
-                let event_source = UnixSocketEventSource::new(UnixListener::from(server_dup))?;
-                create_and_run_device(event_source, device_config.clone(), socket_dup)?;
-            }
-            None => {
-                let event_source = PipeEventSource::new(std::io::stdin(), std::io::stdout());
-                create_and_run_device(event_source, device_config.clone(), socket_dup)?;
-            }
-        }
-    }
+    Ok(())
 }

--- a/base/cvd/cuttlefish/host/commands/vhost_user_input/src/main.rs
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_input/src/main.rs
@@ -7,18 +7,19 @@ mod vhu_input;
 mod vio_input;
 
 use std::fs;
-use std::os::fd::{AsFd, AsRawFd, FromRawFd, IntoRawFd};
+use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
+use std::os::unix::net::UnixListener;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
 use anyhow::{anyhow, bail, Context, Result};
 use clap::Parser;
-use log::{error, info, LevelFilter};
-use vhost::vhost_user::Listener;
-use vhost_user_backend::VhostUserDaemon;
+use log::{info, LevelFilter};
+use vhost::vhost_user::{Error as VError, Listener};
+use vhost_user_backend::{Error as VHUError, VhostUserDaemon};
 use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
 
-use event_source::PipeEventSource;
+use event_source::{EventSource, PipeEventSource, UnixSocketEventSource};
 use vhu_input::{VhostUserInput, EVENTS_AVAILABLE};
 use vio_input::VirtioInputConfig;
 
@@ -35,6 +36,9 @@ struct Args {
     /// Path to a file specifying the device's config in JSON format.
     #[arg(short, long, required = true)]
     device_config: String,
+    /// A file descriptor for the unix socket event sources will connect to.
+    #[arg(long, default_value_t = -1i32)]
+    server_fd: i32,
 }
 
 fn init_logging(verbosity: &str) -> Result<()> {
@@ -45,6 +49,60 @@ fn init_logging(verbosity: &str) -> Result<()> {
                 .with_context(|| format!("Invalid log level: {}", verbosity))?,
         )
         .init();
+    Ok(())
+}
+
+fn create_and_run_device<T: EventSource + 'static>(
+    event_source: T,
+    device_config: VirtioInputConfig,
+    server_fd: OwnedFd,
+) -> Result<()> {
+    let event_source_fd = event_source.as_fd().as_raw_fd();
+    let backend = Arc::new(Mutex::new(VhostUserInput::new(device_config, event_source)));
+    let mut daemon = VhostUserDaemon::new(
+        "vhost-user-input".to_string(),
+        backend.clone(),
+        GuestMemoryAtomic::new(GuestMemoryMmap::new()),
+    )
+    .map_err(|e| anyhow!("Failed to create vhost user daemon: {:?}", e))?;
+
+    // Ideally, this registration would be done by the backend since it is the one that knows to
+    // read the event source when the EVENTS_AVAILABLE event is generated. This is not possible
+    // because register_listener attempts to lock the backend to call num_queues() which causes
+    // a deadlock if the backend lock is already held.
+    daemon
+        .get_epoll_handlers()
+        .first()
+        .context("Daemon created without epoll handler threads")?
+        .register_listener(
+            event_source_fd,
+            vmm_sys_util::epoll::EventSet::IN,
+            EVENTS_AVAILABLE as u64,
+        )
+        .context("Failed to register epoll handler")?;
+
+    let listener = {
+        // SAFETY: Safe because we just dupped this fd and don't use it anywhwere else.
+        // Listener takes ownership and ensures it's properly closed when finished with it.
+        // TODO: Use safe Listener::from<UnixStream> after updating to a version that implements it
+        unsafe { Listener::from_raw_fd(server_fd.into_raw_fd()) }
+    };
+    info!("Created vhost-user daemon");
+    daemon
+        .start(listener)
+        .map_err(|e| anyhow!("Failed to start vhost-user daemon: {:?}", e))?;
+    info!("Accepted connection in vhost-user daemon");
+    match daemon.wait() {
+        Err(VHUError::HandleRequest(VError::Disconnected)) => {
+            info!("Frontend disconnected");
+        }
+        Err(e) => {
+            bail!("Daemon exited with error: {:?}", e);
+        }
+        Ok(()) => {
+            info!("Daemon exited");
+        }
+    }
     Ok(())
 }
 
@@ -67,55 +125,30 @@ fn main() -> Result<()> {
     let device_config = VirtioInputConfig::from_json(device_config_str.as_str())
         .context("Unable to parse config file")?;
 
-    // SAFETY: No choice but to trust the caller passed a valid fd representing a unix socket.
-    let server_fd = inherited_fd::take_fd_ownership(args.socket_fd)
+    let socket_fd = inherited_fd::take_fd_ownership(args.socket_fd)
         .context("Failed to take ownership of socket fd")?;
-    loop {
-        let event_source = PipeEventSource::new(std::io::stdin(), std::io::stdout());
-        let event_source_fd = event_source.as_fd().as_raw_fd();
-        let backend = Arc::new(Mutex::new(VhostUserInput::new(
-            device_config.clone(),
-            event_source,
-        )));
-        let mut daemon = VhostUserDaemon::new(
-            "vhost-user-input".to_string(),
-            backend.clone(),
-            GuestMemoryAtomic::new(GuestMemoryMmap::new()),
+    let server_fd = if args.server_fd >= 0 {
+        Some(
+            inherited_fd::take_fd_ownership(args.server_fd)
+                .context("Failed to take ownership of socket fd")?,
         )
-        .map_err(|e| anyhow!("Failed to create vhost user daemon: {:?}", e))?;
-
-        // Ideally, this registration would be done by the backend since it is the one that knows to
-        // read the event source when the EVENTS_AVAILABLE event is generated. This is not possible
-        // because register_listener attempts to lock the backend to call num_queues() which causes
-        // a deadlock if the backend lock is already held.
-        daemon
-            .get_epoll_handlers()
-            .first()
-            .context("Daemon created without epoll handler threads")?
-            .register_listener(
-                event_source_fd,
-                vmm_sys_util::epoll::EventSet::IN,
-                EVENTS_AVAILABLE as u64,
-            )
-            .context("Failed to register epoll handler")?;
-
-        let listener = {
-            // vhost::vhost_user::Listener takes ownership of the underlying fd and closes it when
-            // wait returns, so a dup of the original fd is passed to the constructor.
-            let server_dup = server_fd.try_clone().context("Failed to clone socket fd")?;
-            // SAFETY: Safe because we just dupped this fd and don't use it anywhwere else.
-            // Listener takes ownership and ensures it's properly closed when finished with it.
-            unsafe { Listener::from_raw_fd(server_dup.into_raw_fd()) }
-        };
-        info!("Created vhost-user daemon");
-        daemon
-            .start(listener)
-            .map_err(|e| anyhow!("Failed to start vhost-user daemon: {:?}", e))?;
-        info!("Accepted connection in vhost-user daemon");
-        if let Err(e) = daemon.wait() {
-            // This will print an error even when the frontend disconnects to do a restart.
-            error!("Error: {:?}", e);
-        };
-        info!("Daemon exited");
+    } else {
+        None
+    };
+    loop {
+        // vhost::vhost_user::Listener and UnixListener take ownership of the underlying fds and
+        // close them when dropped, so dups of the original fds are used in each iteration.
+        let socket_dup = socket_fd.try_clone().context("Failed to clone socket fd")?;
+        match server_fd {
+            Some(ref fd) => {
+                let server_dup = fd.try_clone().context("Failed to clone server fd")?;
+                let event_source = UnixSocketEventSource::new(UnixListener::from(server_dup))?;
+                create_and_run_device(event_source, device_config.clone(), socket_dup)?;
+            }
+            None => {
+                let event_source = PipeEventSource::new(std::io::stdin(), std::io::stdout());
+                create_and_run_device(event_source, device_config.clone(), socket_dup)?;
+            }
+        }
     }
 }

--- a/base/cvd/cuttlefish/host/commands/vhost_user_input/src/main.rs
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_input/src/main.rs
@@ -1,12 +1,13 @@
 //! vhost-user input device
 
 mod buf_reader;
+mod event_source;
 mod inherited_fd;
 mod vhu_input;
 mod vio_input;
 
 use std::fs;
-use std::os::fd::{FromRawFd, IntoRawFd};
+use std::os::fd::{AsFd, AsRawFd, FromRawFd, IntoRawFd};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
@@ -17,7 +18,8 @@ use vhost::vhost_user::Listener;
 use vhost_user_backend::VhostUserDaemon;
 use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
 
-use vhu_input::VhostUserInput;
+use event_source::PipeEventSource;
+use vhu_input::{VhostUserInput, EVENTS_AVAILABLE};
 use vio_input::VirtioInputConfig;
 
 /// Vhost-user input server.
@@ -69,8 +71,12 @@ fn main() -> Result<()> {
     let server_fd = inherited_fd::take_fd_ownership(args.socket_fd)
         .context("Failed to take ownership of socket fd")?;
     loop {
-        let backend =
-            Arc::new(Mutex::new(VhostUserInput::new(device_config.clone(), std::io::stdin())));
+        let event_source = PipeEventSource::new(std::io::stdin(), std::io::stdout());
+        let event_source_fd = event_source.as_fd().as_raw_fd();
+        let backend = Arc::new(Mutex::new(VhostUserInput::new(
+            device_config.clone(),
+            event_source,
+        )));
         let mut daemon = VhostUserDaemon::new(
             "vhost-user-input".to_string(),
             backend.clone(),
@@ -78,14 +84,20 @@ fn main() -> Result<()> {
         )
         .map_err(|e| anyhow!("Failed to create vhost user daemon: {:?}", e))?;
 
-        VhostUserInput::<std::io::Stdin>::register_handlers(
-            0i32, // stdin
-            daemon
-                .get_epoll_handlers()
-                .first()
-                .context("Daemon created without epoll handler threads")?,
-        )
-        .context("Failed to register epoll handler")?;
+        // Ideally, this registration would be done by the backend since it is the one that knows to
+        // read the event source when the EVENTS_AVAILABLE event is generated. This is not possible
+        // because register_listener attempts to lock the backend to call num_queues() which causes
+        // a deadlock if the backend lock is already held.
+        daemon
+            .get_epoll_handlers()
+            .first()
+            .context("Daemon created without epoll handler threads")?
+            .register_listener(
+                event_source_fd,
+                vmm_sys_util::epoll::EventSet::IN,
+                EVENTS_AVAILABLE as u64,
+            )
+            .context("Failed to register epoll handler")?;
 
         let listener = {
             // vhost::vhost_user::Listener takes ownership of the underlying fd and closes it when

--- a/base/cvd/cuttlefish/host/commands/vhost_user_input/src/vhu_input.rs
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_input/src/vhu_input.rs
@@ -145,7 +145,7 @@ impl<S: EventSource> VhostUserBackendMut for VhostUserInput<S> {
             }
             EVENTS_AVAILABLE => {
                 trace!("Source event");
-                self.read_input_events();
+                self.read_input_events().map_err(IoError::other)?;
                 self.send_pending_events(&vrings[EVENT_QUEUE as usize])
                     .map_err(IoError::other)?;
             }
@@ -225,8 +225,8 @@ impl<S: EventSource> VhostUserInput<S> {
         Ok(())
     }
 
-    fn read_input_events(&mut self) {
-        self.event_queue.extend(self.event_source.get_events());
+    fn read_input_events(&mut self) -> Result<()> {
+        Ok(self.event_queue.extend(self.event_source.get_events()?))
     }
 
     fn write_status_updates(&mut self, vring: &VringRwLock) -> Result<()> {
@@ -248,7 +248,7 @@ impl<S: EventSource> VhostUserInput<S> {
             let bytes = reader.available_bytes();
             let mut buf = vec![0u8; bytes];
             reader.read_exact(&mut buf)?;
-            self.event_source.send_status_feedback(&buf);
+            self.event_source.send_status_feedback(buf);
 
             vring_state
                 .add_used(head_index, bytes as u32)

--- a/base/cvd/cuttlefish/host/commands/vhost_user_input/src/vhu_input.rs
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_input/src/vhu_input.rs
@@ -1,7 +1,6 @@
+use std::collections::VecDeque;
 use std::fs::File;
-use std::io::{
-    stdout, Error as IoError, ErrorKind as IoErrorKind, Read, Result as IoResult, Write,
-};
+use std::io::{Error as IoError, ErrorKind as IoErrorKind, Read, Result as IoResult, Write};
 
 use anyhow::{bail, Context, Result};
 use log::{error, trace};
@@ -10,7 +9,7 @@ use vhost::vhost_user::message::{
     VhostUserVirtioFeatures,
 };
 use vhost_user_backend::{
-    VhostUserBackend, VhostUserBackendMut, VringEpollHandler, VringRwLock, VringT,
+    VhostUserBackendMut, VringRwLock, VringT,
 };
 use virtio_bindings::bindings::{
     virtio_config::VIRTIO_F_NOTIFY_ON_EMPTY, virtio_config::VIRTIO_F_VERSION_1,
@@ -20,7 +19,7 @@ use virtio_queue::QueueOwnedT;
 use vm_memory::{GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
 use vmm_sys_util::epoll::EventSet;
 
-use crate::buf_reader::BufReader;
+use crate::event_source::EventSource;
 use crate::vio_input::{trim_to_event_size_multiple, VirtioInputConfig};
 
 const VIRTIO_INPUT_NUM_QUEUES: usize = 2;
@@ -33,18 +32,19 @@ const FEATURES: u64 = 1 << VIRTIO_F_VERSION_1
 const EVENT_QUEUE: u16 = 0;
 const STATUS_QUEUE: u16 = 1;
 const EXIT_EVENT: u16 = 2;
-const STDIN_EVENT: u16 = 3;
+pub const EVENTS_AVAILABLE: u16 = 3;
 
 /// Vhost-user input backend implementation.
 #[derive(Clone)]
-pub struct VhostUserInput<R: Read + Sync + Send> {
+pub struct VhostUserInput<S: EventSource> {
     config: VirtioInputConfig,
-    event_reader: BufReader<R>,
+    event_source: S,
+    event_queue: VecDeque<u8>,
     event_idx: bool,
     mem: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
 }
 
-impl<R: Read + Sync + Send> VhostUserBackendMut for VhostUserInput<R> {
+impl<S: EventSource> VhostUserBackendMut for VhostUserInput<S> {
     type Bitmap = ();
     type Vring = VringRwLock;
     fn num_queues(&self) -> usize {
@@ -142,10 +142,11 @@ impl<R: Read + Sync + Send> VhostUserBackendMut for VhostUserInput<R> {
             EXIT_EVENT => {
                 trace!("Exit event");
             }
-            STDIN_EVENT => {
-                trace!("Stdin event");
-                self.read_input_events().map_err(IoError::other)?;
-                self.send_pending_events(&vrings[EVENT_QUEUE as usize]).map_err(IoError::other)?;
+            EVENTS_AVAILABLE => {
+                trace!("Source event");
+                self.read_input_events();
+                self.send_pending_events(&vrings[EVENT_QUEUE as usize])
+                    .map_err(IoError::other)?;
             }
             _ => {
                 error!("Unknown device event: {}", device_event);
@@ -155,20 +156,20 @@ impl<R: Read + Sync + Send> VhostUserBackendMut for VhostUserInput<R> {
     }
 }
 
-impl<R: Read + Sync + Send> VhostUserInput<R> {
+impl<S: EventSource> VhostUserInput<S> {
     /// Construct a new VhostUserInput backend.
-    pub fn new(device_config: VirtioInputConfig, reader: R) -> VhostUserInput<R> {
+    pub fn new(device_config: VirtioInputConfig, event_source: S) -> VhostUserInput<S> {
         VhostUserInput {
             config: device_config,
-            event_reader: BufReader::new(reader),
+            event_source,
+            event_queue: VecDeque::new(),
             event_idx: false,
             mem: None,
         }
     }
 
     fn send_pending_events(&mut self, vring: &VringRwLock) -> Result<()> {
-        // Only if can send at least one full event
-        if trim_to_event_size_multiple(self.event_reader.buffer().len()) == 0 {
+        if self.event_queue.is_empty() {
             return Ok(());
         }
         let mut vring_state = vring.get_mut();
@@ -183,19 +184,28 @@ impl<R: Read + Sync + Send> VhostUserInput<R> {
         {
             let mem = atomic_mem.memory();
             let head_index = avail_desc.head_index();
-            let mut writer = avail_desc.writer(&mem).context("Failed to get writable buffers")?;
-            let mut write_len =
-                std::cmp::min(self.event_reader.buffer().len(), writer.available_bytes());
-            // Send only full events
-            write_len = trim_to_event_size_multiple(write_len);
-            writer.write_all(&self.event_reader.buffer()[..write_len])?;
-            self.event_reader.consume(write_len);
+            let mut writer = avail_desc
+                .writer(&mem)
+                .context("Failed to get writable buffers")?;
+            // Trim to event size to send only full events
+            let write_len = trim_to_event_size_multiple(std::cmp::min(
+                writer.available_bytes(),
+                self.event_queue.len(),
+            ));
 
+            let (slice1, slice2) = self.event_queue.as_slices();
+            let write_len1 = std::cmp::min(write_len, slice1.len());
+            let write_len2 = write_len - write_len1;
+            writer.write_all(&slice1[..write_len1])?;
+            if write_len2 > 0 {
+                writer.write_all(&slice2[..write_len2])?;
+            }
+            self.event_queue.drain(..write_len);
             vring_state
                 .add_used(head_index, write_len as u32)
                 .context("Couldn't return used descriptor to the ring")?;
 
-            if trim_to_event_size_multiple(self.event_reader.buffer().len()) == 0 {
+            if self.event_queue.is_empty() {
                 // No more events available
                 break;
             }
@@ -214,9 +224,8 @@ impl<R: Read + Sync + Send> VhostUserInput<R> {
         Ok(())
     }
 
-    fn read_input_events(&mut self) -> Result<()> {
-        self.event_reader.read_ahead()?;
-        Ok(())
+    fn read_input_events(&mut self) {
+        self.event_queue.extend(self.event_source.get_events());
     }
 
     fn write_status_updates(&mut self, vring: &VringRwLock) -> Result<()> {
@@ -236,7 +245,7 @@ impl<R: Read + Sync + Send> VhostUserInput<R> {
             let bytes = reader.available_bytes();
             let mut buf = vec![0u8; bytes];
             reader.read_exact(&mut buf)?;
-            stdout().write_all(&buf)?;
+            self.event_source.send_status_feedback(&buf);
 
             vring_state
                 .add_used(head_index, bytes as u32)
@@ -254,13 +263,5 @@ impl<R: Read + Sync + Send> VhostUserInput<R> {
             vring_state.signal_used_queue().unwrap();
         }
         Ok(())
-    }
-
-    pub fn register_handlers<T: VhostUserBackend>(
-        fd: i32,
-        handler: &VringEpollHandler<T>,
-    ) -> IoResult<()> {
-        trace!("register_handlers");
-        handler.register_listener(fd, vmm_sys_util::epoll::EventSet::IN, STDIN_EVENT as u64)
     }
 }

--- a/base/cvd/cuttlefish/host/commands/vhost_user_input/src/vhu_input.rs
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_input/src/vhu_input.rs
@@ -8,9 +8,7 @@ use vhost::vhost_user::message::{
     VhostTransferStateDirection, VhostTransferStatePhase, VhostUserProtocolFeatures,
     VhostUserVirtioFeatures,
 };
-use vhost_user_backend::{
-    VhostUserBackendMut, VringRwLock, VringT,
-};
+use vhost_user_backend::{VhostUserBackendMut, VringRwLock, VringT};
 use virtio_bindings::bindings::{
     virtio_config::VIRTIO_F_NOTIFY_ON_EMPTY, virtio_config::VIRTIO_F_VERSION_1,
     virtio_ring::VIRTIO_RING_F_EVENT_IDX,
@@ -119,7 +117,9 @@ impl<S: EventSource> VhostUserBackendMut for VhostUserInput<S> {
 
     fn set_config(&mut self, offset: u32, buf: &[u8]) -> IoResult<()> {
         trace!("set_config: offset: {}, values: {:?}", offset, buf);
-        self.config.set_raw(offset, buf).map_err(|e| IoError::new(IoErrorKind::InvalidInput, e))
+        self.config
+            .set_raw(offset, buf)
+            .map_err(|e| IoError::new(IoErrorKind::InvalidInput, e))
     }
 
     fn handle_event(
@@ -132,7 +132,8 @@ impl<S: EventSource> VhostUserBackendMut for VhostUserInput<S> {
         match device_event {
             EVENT_QUEUE => {
                 trace!("event queue event");
-                self.send_pending_events(&vrings[EVENT_QUEUE as usize]).map_err(IoError::other)?;
+                self.send_pending_events(&vrings[EVENT_QUEUE as usize])
+                    .map_err(IoError::other)?;
             }
             STATUS_QUEUE => {
                 trace!("status queue event");
@@ -241,7 +242,9 @@ impl<S: EventSource> VhostUserInput<S> {
         {
             let mem = atomic_mem.memory();
             let head_index = avail_desc.head_index();
-            let mut reader = avail_desc.reader(&mem).context("Failed to get readable buffers")?;
+            let mut reader = avail_desc
+                .reader(&mem)
+                .context("Failed to get readable buffers")?;
             let bytes = reader.available_bytes();
             let mut buf = vec![0u8; bytes];
             reader.read_exact(&mut buf)?;

--- a/base/cvd/cuttlefish/host/commands/vhost_user_input/src/vio_input.rs
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_input/src/vio_input.rs
@@ -66,7 +66,10 @@ impl VirtioInputBitmap {
 
     /// Length of the minimum array that can hold all set bits in the map.
     pub fn min_size(&self) -> u8 {
-        self.bitmap.iter().rposition(|v| *v != 0).map_or(0, |i| i + 1) as u8
+        self.bitmap
+            .iter()
+            .rposition(|v| *v != 0)
+            .map_or(0, |i| i + 1) as u8
     }
 
     fn set(&mut self, idx: u16) -> Result<()> {

--- a/base/cvd/cuttlefish/host/frontend/webrtc/main.cpp
+++ b/base/cvd/cuttlefish/host/frontend/webrtc/main.cpp
@@ -58,13 +58,20 @@
 
 DEFINE_bool(multitouch, true,
             "Whether to send multi-touch or single-touch events");
-DEFINE_string(touch_fds, "",
-              "A list of fds to listen on for touch connections.");
-DEFINE_int32(mouse_fd, -1, "An fd to listen on for mouse connections.");
-DEFINE_int32(gamepad_fd, -1, "An fd to listen on for gamepad connections.");
-DEFINE_int32(rotary_fd, -1, "An fd to listen on for rotary connections.");
-DEFINE_int32(keyboard_fd, -1, "An fd to listen on for keyboard connections.");
-DEFINE_int32(switches_fd, -1, "An fd to listen on for switch connections.");
+DEFINE_string(touch_fds, "", "DEPRECATED: Use --touch_server_paths instead.");
+DEFINE_string(
+    touch_server_paths, "",
+    "A list of input server paths to connect to for touchscreen events.");
+DEFINE_int32(mouse_fd, -1, "DEPRECATED: Use --mouse_server_path instead.");
+DEFINE_string(mouse_server_path, "", "Mouse input server path.");
+DEFINE_int32(gamepad_fd, -1, "DEPRECATED: Use --gamepad_server_path instead.");
+DEFINE_string(gamepad_server_path, "", "Gamepad input server path.");
+DEFINE_int32(rotary_fd, -1, "DEPRECATED: Use --rotary_server_path instead.");
+DEFINE_string(rotary_server_path, "", "Rotary input server path.");
+DEFINE_int32(keyboard_fd, -1, "DEPRECATED: Use --rotary_server_path instead.");
+DEFINE_string(keyboard_server_path, "", "Keyboard input server path.");
+DEFINE_int32(switches_fd, -1, "DEPRECATED: Use --rotary_server_path instead.");
+DEFINE_string(switches_server_path, "", "Switches input server path.");
 DEFINE_int32(frame_server_fd, -1, "An fd to listen on for frame updates");
 DEFINE_int32(kernel_log_events_fd, -1,
              "An fd to listen on for kernel log events.");
@@ -316,49 +323,109 @@ int CuttlefishMain() {
   cuttlefish::InputConnectorBuilder inputs_builder;
 
   const auto display_count = instance.display_configs().size();
-  std::vector<std::string_view> touch_fds;
+  CHECK(FLAGS_touch_fds.empty() || FLAGS_touch_server_paths.empty())
+      << "Only one of --touch_fds or --touch_server_paths can be used at a "
+         "time";
   if (!FLAGS_touch_fds.empty()) {
-    touch_fds = absl::StrSplit(FLAGS_touch_fds, ',');
-  }
-  CHECK_EQ(touch_fds.size(), display_count + instance.touchpad_configs().size())
-      << "Number of touch FDs does not match the number of configured displays "
-         "and touchpads";
-  for (int i = 0; i < touch_fds.size(); i++) {
-    int touch_fd;
-    CHECK(absl::SimpleAtoi(touch_fds[i], &touch_fd))
-        << "Invalid touch_fd: " << touch_fds[i];
-    // Displays are listed first, then touchpads
-    auto label_prefix =
-        i < display_count ? kTouchscreenPrefix : kTouchpadPrefix;
-    auto device_idx = i < display_count ? i : i - display_count;
-    auto device_label = fmt::format("{}{}", label_prefix, device_idx);
-    auto touch_shared_fd = SharedFD::Dup(touch_fd);
-    if (FLAGS_multitouch) {
-      inputs_builder.WithMultitouchDevice(device_label, touch_shared_fd);
-    } else {
-      inputs_builder.WithTouchDevice(device_label, touch_shared_fd);
+    std::vector<std::string_view> touch_fds =
+        absl::StrSplit(FLAGS_touch_fds, ',');
+    CHECK_EQ(touch_fds.size(),
+             display_count + instance.touchpad_configs().size())
+        << "Number of touch FDs does not match the number of configured "
+           "displays "
+           "and touchpads";
+    for (int i = 0; i < touch_fds.size(); i++) {
+      int touch_fd;
+      CHECK(absl::SimpleAtoi(touch_fds[i], &touch_fd))
+          << "Invalid touch_fd: " << touch_fds[i];
+      // Displays are listed first, then touchpads
+      auto label_prefix =
+          i < display_count ? kTouchscreenPrefix : kTouchpadPrefix;
+      auto device_idx = i < display_count ? i : i - display_count;
+      auto device_label = fmt::format("{}{}", label_prefix, device_idx);
+      auto touch_shared_fd = SharedFD::Dup(touch_fd);
+      if (FLAGS_multitouch) {
+        inputs_builder.WithMultitouchDevice(device_label, touch_shared_fd);
+      } else {
+        inputs_builder.WithTouchDevice(device_label, touch_shared_fd);
+      }
+      close(touch_fd);
     }
-    close(touch_fd);
+  } else if (!FLAGS_touch_server_paths.empty()) {
+    std::vector<std::string> touch_paths =
+        absl::StrSplit(FLAGS_touch_server_paths, ',');
+    CHECK_EQ(touch_paths.size(),
+             display_count + instance.touchpad_configs().size())
+        << "Number of touch servers does not match the number of configured "
+           "displays and touchpads";
+    for (int i = 0; i < touch_paths.size(); i++) {
+      const std::string& touch_path = touch_paths[i];
+      // Displays are listed first, then touchpads
+      auto label_prefix =
+          i < display_count ? kTouchscreenPrefix : kTouchpadPrefix;
+      int device_idx = i < display_count ? i : i - display_count;
+      std::string device_label = fmt::format("{}{}", label_prefix, device_idx);
+      SharedFD touch_fd =
+          Fd::SocketLocalClient(touch_path, false, SOCK_STREAM).value_or(Fd());
+      if (FLAGS_multitouch) {
+        inputs_builder.WithMultitouchDevice(device_label, touch_fd);
+      } else {
+        inputs_builder.WithTouchDevice(device_label, touch_fd);
+      }
+    }
+  } else {
+    CHECK_EQ(0, display_count + instance.touchpad_configs().size())
+        << "Number of touch devices does not match the number of configured "
+           "displays and touchpads";
   }
-  if (FLAGS_rotary_fd >= 0) {
-    inputs_builder.WithRotary(SharedFD::Dup(FLAGS_rotary_fd));
-    close(FLAGS_rotary_fd);
-  }
+  CHECK(FLAGS_mouse_fd < 0 || FLAGS_mouse_server_path.empty())
+      << "Only one of --mouse_fd or --mouse_server_path can be used at a time";
   if (FLAGS_mouse_fd >= 0) {
     inputs_builder.WithMouse(SharedFD::Dup(FLAGS_mouse_fd));
     close(FLAGS_mouse_fd);
+  } else if (!FLAGS_mouse_server_path.empty()) {
+    inputs_builder.WithMouse(SharedFD::SocketLocalClient(
+        FLAGS_mouse_server_path, false, SOCK_STREAM));
   }
+  CHECK(FLAGS_gamepad_fd < 0 || FLAGS_gamepad_server_path.empty())
+      << "Only one of --gamepad_fd or --gamepad_server_path can be used at a "
+         "time";
   if (FLAGS_gamepad_fd >= 0) {
     inputs_builder.WithGamepad(SharedFD::Dup(FLAGS_gamepad_fd));
     close(FLAGS_gamepad_fd);
+  } else if (!FLAGS_gamepad_server_path.empty()) {
+    inputs_builder.WithGamepad(SharedFD::SocketLocalClient(
+        FLAGS_gamepad_server_path, false, SOCK_STREAM));
   }
+  CHECK(FLAGS_rotary_fd < 0 || FLAGS_rotary_server_path.empty())
+      << "Only one of --rotary_fd or --rotary_server_path can be used at a "
+         "time";
+  if (FLAGS_rotary_fd >= 0) {
+    inputs_builder.WithRotary(SharedFD::Dup(FLAGS_rotary_fd));
+    close(FLAGS_rotary_fd);
+  } else if (!FLAGS_rotary_server_path.empty()) {
+    inputs_builder.WithRotary(SharedFD::SocketLocalClient(
+        FLAGS_rotary_server_path, false, SOCK_STREAM));
+  }
+  CHECK(FLAGS_keyboard_fd < 0 || FLAGS_keyboard_server_path.empty())
+      << "Only one of --keyboard_fd or --keyboard_server_path can be used at a "
+         "time";
   if (FLAGS_keyboard_fd >= 0) {
     inputs_builder.WithKeyboard(SharedFD::Dup(FLAGS_keyboard_fd));
     close(FLAGS_keyboard_fd);
+  } else if (!FLAGS_keyboard_server_path.empty()) {
+    inputs_builder.WithKeyboard(SharedFD::SocketLocalClient(
+        FLAGS_keyboard_server_path, false, SOCK_STREAM));
   }
+  CHECK(FLAGS_switches_fd < 0 || FLAGS_switches_server_path.empty())
+      << "Only one of --switches_fd or --switches_server_path can be used at a "
+         "time";
   if (FLAGS_switches_fd >= 0) {
     inputs_builder.WithSwitches(SharedFD::Dup(FLAGS_switches_fd));
     close(FLAGS_switches_fd);
+  } else if (!FLAGS_switches_server_path.empty()) {
+    inputs_builder.WithSwitches(SharedFD::SocketLocalClient(
+        FLAGS_switches_server_path, false, SOCK_STREAM));
   }
 
   auto input_connector = std::move(inputs_builder).Build();

--- a/base/cvd/cuttlefish/host/libs/config/config_instance_derived.cc
+++ b/base/cvd/cuttlefish/host/libs/config/config_instance_derived.cc
@@ -47,6 +47,11 @@ std::string GamepadSocketPath(const CuttlefishConfig::InstanceSpecific& ins) {
   return ins.PerInstanceInternalUdsPath("gamepad.sock");
 }
 
+std::string GamepadEventsServerPath(
+    const CuttlefishConfig::InstanceSpecific& ins) {
+  return ins.PerInstanceInternalUdsPath("gamepad.events.in");
+}
+
 std::string HwcomposerPmemPath(const CuttlefishConfig::InstanceSpecific& ins) {
   return AbsolutePath(ins.PerInstanceInternalPath("hwcomposer-pmem"));
 }
@@ -57,6 +62,11 @@ std::string KernelLogPipeName(const CuttlefishConfig::InstanceSpecific& ins) {
 
 std::string KeyboardSocketPath(const CuttlefishConfig::InstanceSpecific& ins) {
   return ins.PerInstanceInternalUdsPath("keyboard.sock");
+}
+
+std::string KeyboardEventsServerPath(
+    const CuttlefishConfig::InstanceSpecific& ins) {
+  return ins.PerInstanceInternalUdsPath("keyboard.events.in");
 }
 
 std::string LauncherMonitorSocketPath(
@@ -76,6 +86,11 @@ std::string MouseSocketPath(const CuttlefishConfig::InstanceSpecific& ins) {
   return ins.PerInstanceInternalUdsPath("mouse.sock");
 }
 
+std::string MouseEventsServerPath(
+    const CuttlefishConfig::InstanceSpecific& ins) {
+  return ins.PerInstanceInternalUdsPath("mouse.events.in");
+}
+
 std::string PflashPath(const CuttlefishConfig::InstanceSpecific& ins) {
   return AbsolutePath(ins.PerInstancePath("pflash.img"));
 }
@@ -88,8 +103,18 @@ std::string RotarySocketPath(const CuttlefishConfig::InstanceSpecific& ins) {
   return ins.PerInstanceInternalUdsPath("rotary.sock");
 }
 
+std::string RotaryEventsServerPath(
+    const CuttlefishConfig::InstanceSpecific& ins) {
+  return ins.PerInstanceInternalUdsPath("rotary.events.in");
+}
+
 std::string SwitchesSocketPath(const CuttlefishConfig::InstanceSpecific& ins) {
   return ins.PerInstanceInternalUdsPath("switches.sock");
+}
+
+std::string SwitchesEventsServerPath(
+    const CuttlefishConfig::InstanceSpecific& ins) {
+  return ins.PerInstanceInternalUdsPath("switches.events.in");
 }
 
 std::string RestoreAdbdPipeName(const CuttlefishConfig::InstanceSpecific& ins) {

--- a/base/cvd/cuttlefish/host/libs/config/config_instance_derived.h
+++ b/base/cvd/cuttlefish/host/libs/config/config_instance_derived.h
@@ -27,18 +27,23 @@ std::string ConsoleOutPipeName(const CuttlefishConfig::InstanceSpecific&);
 std::string ConsolePath(const CuttlefishConfig::InstanceSpecific&);
 std::string ConsolePipePrefix(const CuttlefishConfig::InstanceSpecific&);
 std::string GamepadSocketPath(const CuttlefishConfig::InstanceSpecific&);
+std::string GamepadEventsServerPath(const CuttlefishConfig::InstanceSpecific&);
 std::string HwcomposerPmemPath(const CuttlefishConfig::InstanceSpecific&);
 std::string KernelLogPipeName(const CuttlefishConfig::InstanceSpecific& ins);
 std::string KeyboardSocketPath(const CuttlefishConfig::InstanceSpecific&);
+std::string KeyboardEventsServerPath(const CuttlefishConfig::InstanceSpecific&);
 std::string LauncherMonitorSocketPath(
     const CuttlefishConfig::InstanceSpecific&);
 std::string LogcatPath(const CuttlefishConfig::InstanceSpecific&);
 std::string LogcatPipeName(const CuttlefishConfig::InstanceSpecific&);
 std::string MouseSocketPath(const CuttlefishConfig::InstanceSpecific&);
+std::string MouseEventsServerPath(const CuttlefishConfig::InstanceSpecific&);
 std::string PflashPath(const CuttlefishConfig::InstanceSpecific&);
 std::string PstorePath(const CuttlefishConfig::InstanceSpecific&);
 std::string RotarySocketPath(const CuttlefishConfig::InstanceSpecific&);
+std::string RotaryEventsServerPath(const CuttlefishConfig::InstanceSpecific&);
 std::string SwitchesSocketPath(const CuttlefishConfig::InstanceSpecific&);
+std::string SwitchesEventsServerPath(const CuttlefishConfig::InstanceSpecific&);
 std::string RestoreAdbdPipeName(const CuttlefishConfig::InstanceSpecific&);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
@@ -344,6 +344,8 @@ class CuttlefishConfig {
 
     std::string touch_socket_path(int touch_dev_idx) const;
 
+    std::string touch_events_server_path(int touch_dev_idx) const;
+
     std::string media_socket_path(int index) const;
 
     std::string launcher_log_path() const;

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
@@ -1925,6 +1925,12 @@ std::string CuttlefishConfig::InstanceSpecific::touch_socket_path(
   return PerInstanceInternalUdsPath(name);
 }
 
+std::string CuttlefishConfig::InstanceSpecific::touch_events_server_path(
+    int touch_dev_idx) const {
+  std::string name = absl::StrCat("touch_", touch_dev_idx, ".events.in");
+  return PerInstanceInternalUdsPath(name);
+}
+
 std::string CuttlefishConfig::InstanceSpecific::media_socket_path(
     int index) const {
   return PerInstanceInternalUdsPath(absl::StrCat("media_", index, ".sock"));


### PR DESCRIPTION
`cf_vhost_user_input` listens on a UNIX socket server it inherits from `run_cvd`. `webRTC` connects to this server to inject input events (mouse, touch, keyboard, etc) to the device backends. This enables the input backend to receive events from sources outside the streamer process.

In addition to the protocol change, the device backend ensures all groups of events sent to the guest driver end in a `SYN_REPORT`. These `SYN_REPORT` events are used to group events from multiple sources so that the driver receives a valid flow of events.

The behavior is enabled by run_cvd by the flags it launches `webRTC` and `cf_vhost_user_input` with. When the `run_cvd` binary is not substituted, events are sent via a socket pair as before. It would be a problem if `run_cvd` was substituted but `webRTC` or `cf_vhost_user_input` was not, but this situation is extremely unlikely since the latter have been substituted for a while now.

Bug: b/552079861