### PR TITLE
Set networking mode before configuration.

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/flags.cc
@@ -1054,6 +1054,13 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
     }
     instance.set_mobile_tap_name(iface_config.mobile_tap.name);
 
+    auto external_network_mode = CF_EXPECT(
+        ParseExternalNetworkMode(device_external_network_vec[instance_index]));
+    CF_EXPECT(external_network_mode == ExternalNetworkMode::kTap ||
+                  external_network_mode == ExternalNetworkMode::kSlirp,
+              "Unknown external_network_mode");
+    instance.set_external_network_mode(external_network_mode);
+
     CF_EXPECT(ConfigureNetworkSettings(
         ril_dns_vec[instance_index], tmp_config_obj, const_instance, instance));
 
@@ -1330,13 +1337,6 @@ Result<CuttlefishConfig> InitializeCuttlefishConfiguration(
     } else {
       instance.set_modem_simulator_ports("");
     }
-
-    auto external_network_mode = CF_EXPECT(
-        ParseExternalNetworkMode(device_external_network_vec[instance_index]));
-    CF_EXPECT(external_network_mode == ExternalNetworkMode::kTap ||
-                  external_network_mode == ExternalNetworkMode::kSlirp,
-              "Unknown external_network_mode");
-    instance.set_external_network_mode(external_network_mode);
 
     instance.set_mcu(CF_EXPECT(mcu_config_paths.JsonForIndex(instance_index)));
 


### PR DESCRIPTION
ConfigureNetworkSettings reads external_network_mode, so if we override it, we should set it beforehand.