### PR TITLE
vhu_input: Add an endpoint to capture events

### DIFF
--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/input_paths_provider.cc
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/input_paths_provider.cc
@@ -48,6 +48,8 @@ namespace {
 
 // Holds all sockets related to a single vhost user input device process.
 struct DeviceSockets {
+  // Path to the events capture server socket.
+  std::string capture_server_path;
   // Path to the events server socket.
   std::string events_server_path;
   // The events server fd. It's created and held at the CommandSource level to
@@ -59,9 +61,11 @@ struct DeviceSockets {
   SharedFD vhu_server;
 };
 
-Result<DeviceSockets> NewDeviceSockets(const std::string& evt_server_path,
+Result<DeviceSockets> NewDeviceSockets(const std::string& capture_server_path,
+                                       const std::string& evt_server_path,
                                        const std::string& vhu_server_path) {
   DeviceSockets ret{
+      .capture_server_path = capture_server_path,
       .events_server_path = evt_server_path,
       .events_server = CF_EXPECT(
           Fd::SocketLocalServer(evt_server_path, false, SOCK_STREAM, 0600),
@@ -81,6 +85,8 @@ Command NewVhostUserInputCommand(const DeviceSockets& device_sockets,
   cmd.AddParameter("--socket-fd=", device_sockets.vhu_server);
   cmd.AddParameter("--device-config=", spec);
   cmd.AddParameter("--server-fd=", device_sockets.events_server);
+  cmd.AddParameter("--capture-server-path=",
+                   device_sockets.capture_server_path);
   return cmd;
 }
 
@@ -266,33 +272,39 @@ class VhostInputDevices : public CommandSource, public InputPathsProvider {
   std::unordered_set<SetupFeature*> Dependencies() const override { return {}; }
   Result<void> ResultSetup() override {
     rotary_sockets_ =
-        CF_EXPECT(NewDeviceSockets(RotaryEventsServerPath(instance_),
+        CF_EXPECT(NewDeviceSockets(RotaryCaptureServerPath(instance_),
+                                   RotaryEventsServerPath(instance_),
                                    RotarySocketPath(instance_)),
                   "Failed to setup sockets for rotary device");
     if (instance_.enable_mouse()) {
       mouse_sockets_ =
-          CF_EXPECT(NewDeviceSockets(MouseEventsServerPath(instance_),
+          CF_EXPECT(NewDeviceSockets(MouseCaptureServerPath(instance_),
+                                     MouseEventsServerPath(instance_),
                                      MouseSocketPath(instance_)),
                     "Failed to setup sockets for mouse device");
     }
     if (instance_.enable_gamepad()) {
       gamepad_sockets_ =
-          CF_EXPECT(NewDeviceSockets(GamepadEventsServerPath(instance_),
+          CF_EXPECT(NewDeviceSockets(GamepadCaptureServerPath(instance_),
+                                     GamepadEventsServerPath(instance_),
                                      GamepadSocketPath(instance_)),
                     "Failed to setup sockets for gamepad device");
     }
     keyboard_sockets_ =
-        CF_EXPECT(NewDeviceSockets(KeyboardEventsServerPath(instance_),
+        CF_EXPECT(NewDeviceSockets(KeyboardCaptureServerPath(instance_),
+                                   KeyboardEventsServerPath(instance_),
                                    KeyboardSocketPath(instance_)),
                   "Failed to setup sockets for keyboard device");
     switches_sockets_ =
-        CF_EXPECT(NewDeviceSockets(SwitchesEventsServerPath(instance_),
+        CF_EXPECT(NewDeviceSockets(SwitchesCaptureServerPath(instance_),
+                                   SwitchesEventsServerPath(instance_),
                                    SwitchesSocketPath(instance_)),
                   "Failed to setup sockets for switches device");
     touchscreen_sockets_.reserve(instance_.display_configs().size());
     for (int i = 0; i < instance_.display_configs().size(); ++i) {
       touchscreen_sockets_.emplace_back(
-          CF_EXPECTF(NewDeviceSockets(instance_.touch_events_server_path(i),
+          CF_EXPECTF(NewDeviceSockets(instance_.touch_capture_server_path(i),
+                                      instance_.touch_events_server_path(i),
                                       instance_.touch_socket_path(i)),
                      "Failed to setup sockets for touchscreen {}", i));
     }
@@ -300,7 +312,8 @@ class VhostInputDevices : public CommandSource, public InputPathsProvider {
     for (int i = 0; i < instance_.touchpad_configs().size(); ++i) {
       int idx = touchscreen_sockets_.size() + i;
       touchpad_sockets_.emplace_back(
-          CF_EXPECTF(NewDeviceSockets(instance_.touch_events_server_path(idx),
+          CF_EXPECTF(NewDeviceSockets(instance_.touch_capture_server_path(i),
+                                      instance_.touch_events_server_path(idx),
                                       instance_.touch_socket_path(idx)),
                      "Failed to setup sockets for touchpad {}", i));
     }

--- a/base/cvd/cuttlefish/host/commands/vhost_user_input/src/event_source.rs
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_input/src/event_source.rs
@@ -6,6 +6,8 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::{bail, Context, Result};
 use log::{error, warn};
+use nix::errno::Errno;
+use nix::poll::{poll, PollFd, PollFlags, PollTimeout};
 use vmm_sys_util::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
 
 use crate::buf_reader::EventReader;
@@ -76,6 +78,7 @@ pub struct UnixSocketEventSource {
     events_fd: UnixStream,
     events: Arc<Mutex<Vec<u8>>>,
     status: Arc<Mutex<Vec<u8>>>,
+    capture_sink: Arc<Mutex<Option<UnixStream>>>,
 }
 
 impl UnixSocketEventSource {
@@ -92,12 +95,33 @@ impl UnixSocketEventSource {
         let events_clone = events.clone();
         let status = Arc::new(Mutex::new(Vec::new()));
         let status_clone = events.clone();
-        std::thread::spawn(move || server_loop(listener, bg_events_fd, events_clone, status_clone));
+        let capture_sink = Arc::new(Mutex::new(None));
+        let capture_sink_clone = capture_sink.clone();
+        std::thread::spawn(move || {
+            server_loop(
+                listener,
+                bg_events_fd,
+                events_clone,
+                status_clone,
+                capture_sink_clone,
+            )
+        });
         Ok(Self {
             events_fd: fg_events_fd,
             events,
             status,
+            capture_sink,
         })
+    }
+
+    pub fn with_capture_server(
+        listener: UnixListener,
+        capture_server: UnixListener,
+    ) -> Result<Self> {
+        let res = Self::new(listener)?;
+        let sink_clone = res.capture_sink.clone();
+        std::thread::spawn(move || capture_loop(capture_server, sink_clone));
+        Ok(res)
     }
 }
 
@@ -131,6 +155,7 @@ impl EventSource for UnixSocketEventSource {
             events_fd: self.events_fd.try_clone()?,
             events: self.events.clone(),
             status: self.status.clone(),
+            capture_sink: self.capture_sink.clone(),
         })
     }
 }
@@ -140,6 +165,7 @@ fn server_loop(
     mut events_fd: UnixStream,
     events: Arc<Mutex<Vec<u8>>>,
     status: Arc<Mutex<Vec<u8>>>,
+    capture_sink: Arc<Mutex<Option<UnixStream>>>,
 ) {
     const SERVER_TOKEN: u64 = 0;
     const EVENT_TOKEN: u64 = 1;
@@ -230,6 +256,11 @@ fn server_loop(
                         .expect("epoll token is not associated to any fd");
                     match client.read_events() {
                         Ok(mut v) => {
+                            if let Some(ref mut s) = *capture_sink.lock().unwrap() {
+                                if let Err(e) = s.write_all(&v) {
+                                    error!("Failed to write events to capture client: {:?}", e);
+                                }
+                            }
                             events.lock().unwrap().append(&mut v);
                             events_fd
                                 .write_all(&[0u8; 1])
@@ -250,6 +281,47 @@ fn server_loop(
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+fn capture_loop(server: UnixListener, sink: Arc<Mutex<Option<UnixStream>>>) {
+    loop {
+        match server.accept() {
+            Err(e) => {
+                error!("Failed to accept connection on capture server: {:?}", e);
+            }
+            Ok((client, _)) => {
+                if let Err(e) = client.set_nonblocking(true) {
+                    error!(
+                        "Failed to set capture client connection non-blocking: {:?}",
+                        e
+                    );
+                    continue;
+                }
+                let client_clone = match client.try_clone() {
+                    Err(e) => {
+                        error!("Failed to clone capture client connection: {:?}", e);
+                        continue;
+                    }
+                    Ok(c) => c,
+                };
+                let _ = sink.lock().unwrap().insert(client_clone);
+                // Don't include POLLIN here, the peer could have closed its write channel
+                let mut poll_fds = [PollFd::new(client.as_fd(), PollFlags::POLLHUP)];
+                match poll(&mut poll_fds, PollTimeout::NONE) {
+                    Ok(_) => {
+                        continue;
+                    }
+                    Err(e) if e == Errno::EINTR => {
+                        continue;
+                    }
+                    Err(e) => {
+                        error!("Failed to poll capture client connection: {:?}", e);
+                    }
+                }
+                let _ = sink.lock().unwrap().take();
             }
         }
     }

--- a/base/cvd/cuttlefish/host/commands/vhost_user_input/src/main.rs
+++ b/base/cvd/cuttlefish/host/commands/vhost_user_input/src/main.rs
@@ -7,6 +7,7 @@ mod vhu_input;
 mod vio_input;
 
 use std::fs;
+use std::io::ErrorKind;
 use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
 use std::os::unix::net::UnixListener;
 use std::str::FromStr;
@@ -14,7 +15,7 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::{anyhow, bail, Context, Result};
 use clap::Parser;
-use log::{info, LevelFilter};
+use log::{error, info, LevelFilter};
 use vhost::vhost_user::{Error as VError, Listener};
 use vhost_user_backend::{Error as VHUError, VhostUserDaemon};
 use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
@@ -36,9 +37,12 @@ struct Args {
     /// Path to a file specifying the device's config in JSON format.
     #[arg(short, long, required = true)]
     device_config: String,
-    /// A file descriptor for the unix socket event sources will connect to.
+    /// File descriptor for the unix socket event sources will connect to.
     #[arg(long, default_value_t = -1i32)]
     server_fd: i32,
+    /// Path to the event capture unix socket.
+    #[arg(long, default_value_t = String::from(""))]
+    capture_server_path: String,
 }
 
 fn init_logging(verbosity: &str) -> Result<()> {
@@ -58,7 +62,9 @@ fn create_and_run_device<T: EventSource + 'static>(
     server_fd: OwnedFd,
 ) -> Result<()> {
     loop {
-        let event_source_clone = event_source.try_clone().context("Failed to clone event source")?;
+        let event_source_clone = event_source
+            .try_clone()
+            .context("Failed to clone event source")?;
         let event_source_fd = event_source_clone.as_fd().as_raw_fd();
         // vhost::vhost_user::Listener and UnixListener take ownership of the underlying fds and
         // close them when dropped, so dups of the original fds are used in each iteration.
@@ -138,9 +144,26 @@ fn main() -> Result<()> {
     if args.server_fd >= 0 {
         let server_fd = inherited_fd::take_fd_ownership(args.server_fd)
             .context("Failed to take ownership of socket fd")?;
-        let event_source = UnixSocketEventSource::new(UnixListener::from(server_fd))?;
+        let event_source = if args.capture_server_path.is_empty() {
+            UnixSocketEventSource::new(UnixListener::from(server_fd))?
+        } else {
+            match fs::remove_file(&args.capture_server_path) {
+                Err(e) if e.kind() != ErrorKind::NotFound => {
+                    error!("Failed to remove existing capture socket: {:?}", e);
+                }
+                _ => {}
+            }
+            UnixSocketEventSource::with_capture_server(
+                UnixListener::from(server_fd),
+                UnixListener::bind(&args.capture_server_path)
+                    .context("Failed to create capture server unix socket")?,
+            )?
+        };
         create_and_run_device(event_source, device_config, socket_fd)?;
     } else {
+        if !args.capture_server_path.is_empty() {
+            bail!("--capture_server_path is only supported with --server_fd");
+        }
         let event_source = StdioEventSource::new();
         create_and_run_device(event_source, device_config, socket_fd)?;
     };

--- a/base/cvd/cuttlefish/host/libs/config/config_instance_derived.cc
+++ b/base/cvd/cuttlefish/host/libs/config/config_instance_derived.cc
@@ -52,6 +52,11 @@ std::string GamepadEventsServerPath(
   return ins.PerInstanceInternalUdsPath("gamepad.events.in");
 }
 
+std::string GamepadCaptureServerPath(
+    const CuttlefishConfig::InstanceSpecific& ins) {
+  return ins.PerInstanceInternalUdsPath("gamepad.events.out");
+}
+
 std::string HwcomposerPmemPath(const CuttlefishConfig::InstanceSpecific& ins) {
   return AbsolutePath(ins.PerInstanceInternalPath("hwcomposer-pmem"));
 }
@@ -67,6 +72,11 @@ std::string KeyboardSocketPath(const CuttlefishConfig::InstanceSpecific& ins) {
 std::string KeyboardEventsServerPath(
     const CuttlefishConfig::InstanceSpecific& ins) {
   return ins.PerInstanceInternalUdsPath("keyboard.events.in");
+}
+
+std::string KeyboardCaptureServerPath(
+    const CuttlefishConfig::InstanceSpecific& ins) {
+  return ins.PerInstanceInternalUdsPath("keyboard.events.out");
 }
 
 std::string LauncherMonitorSocketPath(
@@ -91,6 +101,11 @@ std::string MouseEventsServerPath(
   return ins.PerInstanceInternalUdsPath("mouse.events.in");
 }
 
+std::string MouseCaptureServerPath(
+    const CuttlefishConfig::InstanceSpecific& ins) {
+  return ins.PerInstanceInternalUdsPath("mouse.events.out");
+}
+
 std::string PflashPath(const CuttlefishConfig::InstanceSpecific& ins) {
   return AbsolutePath(ins.PerInstancePath("pflash.img"));
 }
@@ -108,6 +123,11 @@ std::string RotaryEventsServerPath(
   return ins.PerInstanceInternalUdsPath("rotary.events.in");
 }
 
+std::string RotaryCaptureServerPath(
+    const CuttlefishConfig::InstanceSpecific& ins) {
+  return ins.PerInstanceInternalUdsPath("rotary.events.out");
+}
+
 std::string SwitchesSocketPath(const CuttlefishConfig::InstanceSpecific& ins) {
   return ins.PerInstanceInternalUdsPath("switches.sock");
 }
@@ -115,6 +135,11 @@ std::string SwitchesSocketPath(const CuttlefishConfig::InstanceSpecific& ins) {
 std::string SwitchesEventsServerPath(
     const CuttlefishConfig::InstanceSpecific& ins) {
   return ins.PerInstanceInternalUdsPath("switches.events.in");
+}
+
+std::string SwitchesCaptureServerPath(
+    const CuttlefishConfig::InstanceSpecific& ins) {
+  return ins.PerInstanceInternalUdsPath("switches.events.out");
 }
 
 std::string RestoreAdbdPipeName(const CuttlefishConfig::InstanceSpecific& ins) {

--- a/base/cvd/cuttlefish/host/libs/config/config_instance_derived.h
+++ b/base/cvd/cuttlefish/host/libs/config/config_instance_derived.h
@@ -28,22 +28,29 @@ std::string ConsolePath(const CuttlefishConfig::InstanceSpecific&);
 std::string ConsolePipePrefix(const CuttlefishConfig::InstanceSpecific&);
 std::string GamepadSocketPath(const CuttlefishConfig::InstanceSpecific&);
 std::string GamepadEventsServerPath(const CuttlefishConfig::InstanceSpecific&);
+std::string GamepadCaptureServerPath(const CuttlefishConfig::InstanceSpecific&);
 std::string HwcomposerPmemPath(const CuttlefishConfig::InstanceSpecific&);
 std::string KernelLogPipeName(const CuttlefishConfig::InstanceSpecific& ins);
 std::string KeyboardSocketPath(const CuttlefishConfig::InstanceSpecific&);
 std::string KeyboardEventsServerPath(const CuttlefishConfig::InstanceSpecific&);
+std::string KeyboardCaptureServerPath(
+    const CuttlefishConfig::InstanceSpecific&);
 std::string LauncherMonitorSocketPath(
     const CuttlefishConfig::InstanceSpecific&);
 std::string LogcatPath(const CuttlefishConfig::InstanceSpecific&);
 std::string LogcatPipeName(const CuttlefishConfig::InstanceSpecific&);
 std::string MouseSocketPath(const CuttlefishConfig::InstanceSpecific&);
 std::string MouseEventsServerPath(const CuttlefishConfig::InstanceSpecific&);
+std::string MouseCaptureServerPath(const CuttlefishConfig::InstanceSpecific&);
 std::string PflashPath(const CuttlefishConfig::InstanceSpecific&);
 std::string PstorePath(const CuttlefishConfig::InstanceSpecific&);
 std::string RotarySocketPath(const CuttlefishConfig::InstanceSpecific&);
 std::string RotaryEventsServerPath(const CuttlefishConfig::InstanceSpecific&);
+std::string RotaryCaptureServerPath(const CuttlefishConfig::InstanceSpecific&);
 std::string SwitchesSocketPath(const CuttlefishConfig::InstanceSpecific&);
 std::string SwitchesEventsServerPath(const CuttlefishConfig::InstanceSpecific&);
+std::string SwitchesCaptureServerPath(
+    const CuttlefishConfig::InstanceSpecific&);
 std::string RestoreAdbdPipeName(const CuttlefishConfig::InstanceSpecific&);
 
 }  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config.h
@@ -346,6 +346,8 @@ class CuttlefishConfig {
 
     std::string touch_events_server_path(int touch_dev_idx) const;
 
+    std::string touch_capture_server_path(int touch_dev_idx) const;
+
     std::string media_socket_path(int index) const;
 
     std::string launcher_log_path() const;

--- a/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/cuttlefish_config_instance.cpp
@@ -1931,6 +1931,12 @@ std::string CuttlefishConfig::InstanceSpecific::touch_events_server_path(
   return PerInstanceInternalUdsPath(name);
 }
 
+std::string CuttlefishConfig::InstanceSpecific::touch_capture_server_path(
+    int touch_dev_idx) const {
+  std::string name = absl::StrCat("touch_", touch_dev_idx, ".events.out");
+  return PerInstanceInternalUdsPath(name);
+}
+
 std::string CuttlefishConfig::InstanceSpecific::media_socket_path(
     int index) const {
   return PerInstanceInternalUdsPath(absl::StrCat("media_", index, ".sock"));


### PR DESCRIPTION
The vhost-user-input backend accepts connections on an extra unix
socket. Events received through the main server are sent to any client
connected to this server in addition to the frontend. At most one
connection is allowed through this server at a time.

Bug: b/554190370