### PR TITLE
bazel: Enable --incompatible_strict_action_env by default

### DIFF
--- a/base/cvd/.bazelrc
+++ b/base/cvd/.bazelrc
@@ -1,5 +1,6 @@
 common --vendor_dir=vendor_src
 
+build --incompatible_strict_action_env
 build --build_tag_filters=-clang_tidy,-clang-tidy
 build --copt=-fdiagnostics-color=always
 build --output_filter='^//((?!(external/libarchive|external/libevent|external/rules_flex|external/rules_m4):).)*$'


### PR DESCRIPTION
Enables `--incompatible_strict_action_env` in `.bazelrc` to prevent spurious cache invalidations and full rebuilds when switching between different client environments (such as interactive terminal shells and IDE / language server subshells).

Without this option, Bazel inherits client environment variables like `PATH` and `LD_LIBRARY_PATH` into action cache keys, causing full cache invalidations when environment variables differ between clients.

When enabled, Bazel uses a static, hermetic value for `PATH` (`/bin:/usr/bin:/usr/local/bin`) and strips `LD_LIBRARY_PATH` across all build actions.

Reference:
http://bazel.build/reference/command-line-reference#param-no-incompatible-strict-action-env

Assisted-by: Jetski:GeminiNext
Bug: b/555354159