### PR TITLE
base: cvd: packed structure member access

### DIFF
--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_image/boot_image.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_image/boot_image.cc
@@ -61,7 +61,8 @@ Result<BootImage> BootImage::Read(std::unique_ptr<ReaderSeeker> rd) {
     case 4:
       return BootImage(std::move(rd), *reinterpret_cast<boot_img_hdr_v4*>(&v2));
     default:
-      return CF_ERRF("Unknown header version '{}'", v2.header_version);
+      return CF_ERRF("Unknown header version '{}'",
+                     static_cast<uint32_t>(v2.header_version));
   }
 }
 

--- a/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_image/vendor_boot_image.cc
+++ b/base/cvd/cuttlefish/host/commands/assemble_cvd/boot_image/vendor_boot_image.cc
@@ -51,7 +51,8 @@ static_assert(sizeof(vendor_boot_img_hdr_v4) >= sizeof(vendor_boot_img_hdr_v3));
     case 4:
       return VendorBootImage(std::move(rd), v4);
     default:
-      return CF_ERRF("Unknown header version '{}'", v4.header_version);
+      return CF_ERRF("Unknown header version '{}'",
+                     static_cast<uint32_t>(v4.header_version));
   }
 }
 

--- a/base/cvd/cuttlefish/host/libs/image_aggregator/image_aggregator.cc
+++ b/base/cvd/cuttlefish/host/libs/image_aggregator/image_aggregator.cc
@@ -29,7 +29,6 @@
 #include <memory>
 #include <random>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "google/protobuf/util/message_differencer.h"
@@ -244,7 +243,9 @@ class CompositeDiskBuilder {
     gpt.footer = head.header;
     gpt.footer.partition_entries_lba =
         (DiskSize() - sizeof(gpt.entries)) / kSectorSize - 1;
-    std::swap(gpt.footer.current_lba, gpt.footer.backup_lba);
+    auto tmp_lba = gpt.footer.current_lba;
+    gpt.footer.current_lba = gpt.footer.backup_lba;
+    gpt.footer.backup_lba = tmp_lba;
     gpt.footer.header_crc32 = 0;
     gpt.footer.header_crc32 =
         crc32(0, (uint8_t*)&gpt.footer, sizeof(GptHeader));


### PR DESCRIPTION
Hi. I made 2 patches for access the packed structure member. The issue is we cannot use reference or pointer to point to a member inside the packed structure. Otherwise it might causes alignment issues. So we need to copy its value out and avoid reference it.