### PR TITLE
Add switches to the host init script to toggle legacy behaviour

### DIFF
--- a/base/debian/cuttlefish-base.cuttlefish-host-resources.default
+++ b/base/debian/cuttlefish-base.cuttlefish-host-resources.default
@@ -36,3 +36,20 @@
 #wifi_ipv6_prefix_length=
 #ethernet_ipv6_prefix=
 #ethernet_ipv6_prefix_length=
+
+# Behavioural settings during the transition to cvdalloc.
+#
+# allocate_static_resources sets up all of the resources
+# expected by the legacy flow. initialize_cvdalloc simply invokes
+# cvdalloc to perform its own per-install setup.
+# Note that for cvd itself to use cvdalloc, it will need the
+# use_cvdalloc flag to be set on its own end.
+#
+# Static resources are disjoint to those allocated by cvdalloc.
+# Thus, the legacy behaviour is maintained by the below defaults.
+#
+# The only invalid combination is `allocate_static_resources=0`
+# with the cvd flag `use_cvdalloc` flipped off.
+#
+#allocate_static_resources=1
+#initialize_cvdalloc=0

--- a/base/debian/cuttlefish-base.cuttlefish-host-resources.init
+++ b/base/debian/cuttlefish-base.cuttlefish-host-resources.init
@@ -44,6 +44,8 @@ ipv4_bridge=${ipv4_bridge:-1}
 ipv6_bridge=${ipv6_bridge:-1}
 dns_servers=${dns_servers:-8.8.8.8,8.8.4.4}
 dns6_servers=${dns6_servers:-2001:4860:4860::8888,2001:4860:4860::8844}
+allocate_static_resources=${allocate_static_resources:-1}
+initialize_cvdalloc=${initialize_cvdalloc:-0}
 
 readonly CUTTLEFISH_RUN_DIR="/run/cuttlefish"
 
@@ -109,18 +111,30 @@ destroy_tap() {
 setup_nftables() {
     mkdir -p "$CUTTLEFISH_RUN_DIR"
 
-    # Ensure nftables tables and chains exist.
-    nft add table ip cuttlefish_nat
-    nft add chain ip cuttlefish_nat postrouting '{ type nat hook postrouting priority 100 ; }'
+    if [ "${initialize_cvdalloc}" = "1" ] && [ -x /usr/lib/cuttlefish-common/bin/cvdalloc ]; then
+        /usr/lib/cuttlefish-common/bin/cvdalloc --setup
+    fi
 
-    nft add table bridge cuttlefish_bridge
-    nft add chain bridge cuttlefish_bridge prerouting '{ type filter hook prerouting priority -250 ; }'
-    nft add chain bridge cuttlefish_bridge forward '{ type filter hook forward priority 0 ; }'
+    if [ "${allocate_static_resources}" = "1" ]; then
+        # Ensure nftables tables and chains exist.
+        nft add table ip cuttlefish_nat
+        nft add chain ip cuttlefish_nat postrouting '{ type nat hook postrouting priority 100 ; }'
+
+        nft add table bridge cuttlefish_bridge
+        nft add chain bridge cuttlefish_bridge prerouting '{ type filter hook prerouting priority -250 ; }'
+        nft add chain bridge cuttlefish_bridge forward '{ type filter hook forward priority 0 ; }'
+    fi
 }
 
 delete_nftables() {
-    nft delete table ip cuttlefish_nat
-    nft delete table bridge cuttlefish_bridge
+    if [ "${initialize_cvdalloc}" = "1" ] && [ -x /usr/lib/cuttlefish-common/bin/cvdalloc ]; then
+        /usr/lib/cuttlefish-common/bin/cvdalloc --teardown
+    fi
+
+    if [ "${allocate_static_resources}" = "1" ]; then
+        nft delete table ip cuttlefish_nat
+        nft delete table bridge cuttlefish_bridge
+    fi
 }
 
 
@@ -331,43 +345,44 @@ start() {
 
     setup_nftables
 
+    if [ "${allocate_static_resources}" = "1" ]; then
+        # Ethernet
+        # 192.168.98.X for cvd-ebr and cvd-etap-XX
+        create_bridged_interfaces \
+          192.168.98 "${ethernet_bridge_interface}" cvd-etap \
+          "${ethernet_ipv6_prefix}" "${ethernet_ipv6_prefix_length}"
 
-    # Ethernet
-    # 192.168.98.X for cvd-ebr and cvd-etap-XX
-    create_bridged_interfaces \
-      192.168.98 "${ethernet_bridge_interface}" cvd-etap \
-      "${ethernet_ipv6_prefix}" "${ethernet_ipv6_prefix_length}"
+        # Mobile Network
+        # 192.168.97.X from cvd-mtap-01 to cvd-mtap-64
+        # 192.168.93.X from cvd-mtap-65 to cvd-mtap-128
+        for i in $(seq ${num_cvd_accounts}); do
+            tap="$(printf cvd-mtap-%02d $i)"
+            if [ $i -lt 65 ]; then
+                create_interface $tap 192.168.97 $i
+            elif [ $i -lt 129 ]; then
+                create_interface $tap 192.168.93 $(($i - 64))
+            fi
+        done
 
-    # Mobile Network
-    # 192.168.97.X from cvd-mtap-01 to cvd-mtap-64
-    # 192.168.93.X from cvd-mtap-65 to cvd-mtap-128
-    for i in $(seq ${num_cvd_accounts}); do
-        tap="$(printf cvd-mtap-%02d $i)"
-        if [ $i -lt 65 ]; then
-            create_interface $tap 192.168.97 $i
-        elif [ $i -lt 129 ]; then
-            create_interface $tap 192.168.93 $(($i - 64))
-        fi
-    done
-
-    # Wireless Network
-    # cvd-wbr and cvd-wtap-XX for legacy wireless network without distinguished
-    # subnet between tap interfaces, cvd-wifiap-XX with distinguished subnet for
-    # running several OpenWRT instances simultaneously.
-    # 192.168.96.X for cvd-wbr and cvd-wtap-XX
-    # 192.168.94.X from cvd-wifiap-01 to cvd-wifiap-64
-    # 192.168.95.X from cvd-wifiap-65 to cvd-wifiap-128
-    create_bridged_interfaces \
-      192.168.96 "${wifi_bridge_interface}" cvd-wtap \
-      "${wifi_ipv6_prefix}" "${wifi_ipv6_prefix_length}"
-    for i in $(seq ${num_cvd_accounts}); do
-        tap="$(printf cvd-wifiap-%02d $i)"
-        if [ $i -lt 65 ]; then
-            create_interface $tap 192.168.94 $i
-        elif [ $i -lt 129 ]; then
-            create_interface $tap 192.168.95 $(($i - 64))
-        fi
-    done
+        # Wireless Network
+        # cvd-wbr and cvd-wtap-XX for legacy wireless network without distinguished
+        # subnet between tap interfaces, cvd-wifiap-XX with distinguished subnet for
+        # running several OpenWRT instances simultaneously.
+        # 192.168.96.X for cvd-wbr and cvd-wtap-XX
+        # 192.168.94.X from cvd-wifiap-01 to cvd-wifiap-64
+        # 192.168.95.X from cvd-wifiap-65 to cvd-wifiap-128
+        create_bridged_interfaces \
+          192.168.96 "${wifi_bridge_interface}" cvd-wtap \
+          "${wifi_ipv6_prefix}" "${wifi_ipv6_prefix_length}"
+        for i in $(seq ${num_cvd_accounts}); do
+            tap="$(printf cvd-wifiap-%02d $i)"
+            if [ $i -lt 65 ]; then
+                create_interface $tap 192.168.94 $i
+            elif [ $i -lt 129 ]; then
+                create_interface $tap 192.168.95 $(($i - 64))
+            fi
+        done
+    fi
 
     # When running inside a privileged container, set the ownership and access
     # of these device nodes.
@@ -385,33 +400,35 @@ start() {
 }
 
 stop() {
-    # Ethernet
-    destroy_bridged_interfaces \
-      192.168.98 "${ethernet_bridge_interface}" cvd-etap \
-      "${ethernet_ipv6_prefix}" "${ethernet_ipv6_prefix_length}"
+    if [ "${allocate_static_resources}" = "1" ]; then
+        # Ethernet
+        destroy_bridged_interfaces \
+          192.168.98 "${ethernet_bridge_interface}" cvd-etap \
+          "${ethernet_ipv6_prefix}" "${ethernet_ipv6_prefix_length}"
 
-    # Mobile Network
-    for i in $(seq ${num_cvd_accounts}); do
-        tap="$(printf cvd-mtap-%02d $i)"
-        if [ $i -lt 65 ]; then
-            destroy_interface $tap 192.168.97 $i
-        elif [ $i -lt 129 ]; then
-            destroy_interface $tap 192.168.93 $(($i - 64))
-        fi
-    done
+        # Mobile Network
+        for i in $(seq ${num_cvd_accounts}); do
+            tap="$(printf cvd-mtap-%02d $i)"
+            if [ $i -lt 65 ]; then
+                destroy_interface $tap 192.168.97 $i
+            elif [ $i -lt 129 ]; then
+                destroy_interface $tap 192.168.93 $(($i - 64))
+            fi
+        done
 
-    # Wireless Network
-    destroy_bridged_interfaces \
-      192.168.96 "${wifi_bridge_interface}" cvd-wtap \
-      "${wifi_ipv6_prefix}" "${wifi_ipv6_prefix_length}"
-    for i in $(seq ${num_cvd_accounts}); do
-        tap="$(printf cvd-wifiap-%02d $i)"
-        if [ $i -lt 65 ]; then
-            destroy_interface $tap 192.168.94 $i
-        elif [ $i -lt 129 ]; then
-            destroy_interface $tap 192.168.95 $(($i - 64))
-        fi
-    done
+        # Wireless Network
+        destroy_bridged_interfaces \
+          192.168.96 "${wifi_bridge_interface}" cvd-wtap \
+          "${wifi_ipv6_prefix}" "${wifi_ipv6_prefix_length}"
+        for i in $(seq ${num_cvd_accounts}); do
+            tap="$(printf cvd-wifiap-%02d $i)"
+            if [ $i -lt 65 ]; then
+                destroy_interface $tap 192.168.94 $i
+            elif [ $i -lt 129 ]; then
+                destroy_interface $tap 192.168.95 $(($i - 64))
+            fi
+        done
+    fi
     delete_nftables
 }
 


### PR DESCRIPTION
add two new flags for toggling static resource initialization as well as running cvdalloc's init (which is to be implemented in the final PR in this series). 

due to the way nftables works, cvdalloc also needs to do a small amount of install-time init (namely, creating its tables and chains). that code is better off living inside the cvdalloc binary, so we have the init script, which is our one hook point into install and uninstall, invoke it at exactly those times.

this change, as is, should be a no-op. the code enclosed within the `if [ "${allocate_static_resources}" = "1" ]; then` branches is the code we hope to delete one day, but until that day it will remain. 