### PR TITLE
Revert `tools/*/cw/Containerfile` and fix kokoro testing for podcvd

### DIFF
--- a/.config/cache-config.env
+++ b/.config/cache-config.env
@@ -1,3 +1,3 @@
-CACHE_VERSION=v2
+CACHE_VERSION=v3
 BAZEL_REMOTE_CACHE="https://storage.googleapis.com/android-cuttlefish-cache"
 

--- a/.kokoro/presubmit.sh
+++ b/.kokoro/presubmit.sh
@@ -32,6 +32,7 @@ if [ -f "$CACHE_CONFIG_FILE" ]; then
     source "$CACHE_CONFIG_FILE"
 fi
 
+"${TOOL_DIR}/buildutils/build_packages.sh" -r "${BAZEL_REMOTE_CACHE}" -c "${CACHE_VERSION}"
 if [[ "${ANDROID_CUTTLEFISH_KOKORO_BUILD_SCRIPT_ARGS:-}" == *"-p"* ]]; then
     if [[ "${ANDROID_CUTTLEFISH_KOKORO_BUILD_SCRIPT_ARGS:-}" == *"-g"* ]]; then
         sudo install -m 0755 -d /etc/apt/keyrings
@@ -41,23 +42,10 @@ if [[ "${ANDROID_CUTTLEFISH_KOKORO_BUILD_SCRIPT_ARGS:-}" == *"-p"* ]]; then
         retry sudo apt update
         retry sudo apt-get install -y nvidia-container-toolkit
     fi
-    retry sudo apt-get install -y docker.io
-    sudo systemctl start docker || true
-
-    sudo docker build -t android-cuttlefish-build:latest -f "${TOOL_DIR}/buildutils/cw/Containerfile" "${REPO_DIR}"
-    sudo docker run --rm --network=host -v="${REPO_DIR}":/mnt/build -w /mnt/build android-cuttlefish-build:latest base -r "${BAZEL_REMOTE_CACHE}" -c "${CACHE_VERSION}"
-    sudo docker run --rm --network=host -v="${REPO_DIR}":/mnt/build -w /mnt/build android-cuttlefish-build:latest container
-    sudo docker run --rm --network=host -v="${REPO_DIR}":/mnt/build -w /mnt/build android-cuttlefish-build:latest frontend
-    # Clean up temporary packaging directories created during debuild
-    sudo rm -rf "${REPO_DIR}"/*/debian/tmp
-
+    retry sudo apt-get install -y podman
     "${TOOL_DIR}/testutils/prepare_host.sh" -d "${REPO_DIR}" -u testrunner -g kokoro -p
     sudo -u testrunner "${REPO_DIR}/container/image/image-builder.sh" -c podman -m dev -t localhost/cuttlefish-orchestration:latest
-
-    sudo "${TOOL_DIR}/buildutils/installbazel.sh"
 else
-    "${TOOL_DIR}/buildutils/build_packages.sh" -r "${BAZEL_REMOTE_CACHE}" -c "${CACHE_VERSION}"
-
     # Add test user to the kokoro group so it has access to the source dir
     "${TOOL_DIR}/testutils/prepare_host.sh" -d "${REPO_DIR}" -u testrunner -g kokoro
 fi

--- a/tools/buildutils/build_packages.sh
+++ b/tools/buildutils/build_packages.sh
@@ -19,5 +19,6 @@ BUILD_PACKAGE="$(dirname $0)/build_package.sh"
 command -v bazel &> /dev/null || sudo "${INSTALL_BAZEL}"
 install_debuild_dependencies
 
+"${BUILD_PACKAGE}" "${REPO_DIR}/container" $@
 "${BUILD_PACKAGE}" "${REPO_DIR}/base" $@
 "${BUILD_PACKAGE}" "${REPO_DIR}/frontend" $@

--- a/tools/buildutils/cw/Containerfile
+++ b/tools/buildutils/cw/Containerfile
@@ -1,9 +1,15 @@
-FROM mirror.gcr.io/library/debian:13 AS base
+FROM mirror.gcr.io/library/debian:bookworm-20250811 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt update -y && apt upgrade -y
 RUN apt install -y sudo devscripts
+
+# Download newer version of golang with keep using bookworm for building debian
+# packages.
+RUN echo "deb http://deb.debian.org/debian bookworm-backports main" > /etc/apt/sources.list.d/backports.list
+RUN apt update
+RUN apt install -t bookworm-backports -y golang
 
 COPY ./tools/buildutils/installbazel.sh /installbazel.sh
 RUN /installbazel.sh && rm /installbazel.sh

--- a/tools/testutils/cw/Containerfile
+++ b/tools/testutils/cw/Containerfile
@@ -1,4 +1,4 @@
-FROM mirror.gcr.io/library/debian:13 AS base
+FROM mirror.gcr.io/library/debian:bookworm-20250811 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV OVERRIDE_BAZEL_WRAPPER_DOWNLOAD_DIR=/tmp/cw_bazel


### PR DESCRIPTION
Predecessor of this PR: https://github.com/google/android-cuttlefish/pull/3133

However to pass all presubmit checks, more commits are required.