### PR TITLE
Update composite disk mtime when disk spec matches existing

### DIFF
--- a/base/cvd/cuttlefish/host/libs/image_aggregator/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/image_aggregator/BUILD.bazel
@@ -99,6 +99,7 @@ cf_cc_library(
         "//cuttlefish/io",
         "//cuttlefish/io:write_exact",
         "//cuttlefish/result",
+        "@abseil-cpp//absl/log",
         "@protobuf",
         "@protobuf//:differencer",
         "@zlib",

--- a/base/cvd/cuttlefish/host/libs/image_aggregator/image_aggregator.cc
+++ b/base/cvd/cuttlefish/host/libs/image_aggregator/image_aggregator.cc
@@ -23,6 +23,7 @@
 #include <fcntl.h>
 #include <stdint.h>
 #include <string.h>
+#include <sys/stat.h>
 
 #include <fstream>
 #include <ios>
@@ -31,6 +32,7 @@
 #include <string>
 #include <vector>
 
+#include "absl/log/log.h"
 #include "google/protobuf/util/message_differencer.h"
 #include <zlib.h>
 
@@ -361,7 +363,12 @@ Result<void> CreateOrUpdateCompositeDisk(
       google::protobuf::util::MessageDifferencer::Equals(
           composite_proto, composite_image_res->GetCompositeDisk())) {
     // The existing composite disk matches the given partitions, no need to
-    // regenerate
+    // regenerate, but update its modification time so it is not older than
+    // any recently updated component images.
+    if (utimensat(AT_FDCWD, output_composite_path.c_str(), nullptr, 0) != 0) {
+      PLOG(WARNING) << "Failed to update modification time for \""
+                    << output_composite_path << "\"";
+    }
     return {};
   }
 


### PR DESCRIPTION
When CreateOrUpdateCompositeDisk determines that an existing composite disk already matches the target partition layout, it skips regenerating the disk file. However, if a component partition (such as persistent_vbmeta.img) was regenerated or touched during instance setup, the composite disk's modification time would remain older than that component. This causes subsequent assemble_cvd checks to falsely detect that a component was updated and fail with an mtime mismatch error.

Update the modification time of output_composite_path using utimensat when the existing disk spec is retained, ensuring the composite disk mtime remains up to date.

Bug: 554545294