### PR TITLE
Update boringssl to support newer glibc

### DIFF
--- a/base/cvd/MODULE.bazel
+++ b/base/cvd/MODULE.bazel
@@ -8,7 +8,7 @@ bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
 
 bazel_dep(name = "abseil-cpp", version = "20260107.0")
 bazel_dep(name = "aspect_bazel_lib", version = "2.22.0")
-bazel_dep(name = "boringssl", version = "0.20241024.0")
+bazel_dep(name = "boringssl", version = "0.20260813.0")
 bazel_dep(name = "brotli")
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2")
 bazel_dep(name = "crc32c")


### PR DESCRIPTION
Fixes error
```
In file included from external/boringssl+/crypto/fipsmodule/bcm.c:33:
external/boringssl+/crypto/fipsmodule/../internal.h:1052:10: error: returning 'const void *' from a function with result type 'void *' discards qualifiers [-Werror,-Wincompatible-pointer-types-discards-qualifiers]
 1052 |   return memchr(s, c, n);
      |          ^~~~~~~~~~~~~~~
/usr/include/string.h:122:3: note: expanded from macro 'memchr'
  122 |   __glibc_const_generic (S, const void *, memchr (S, C, N))
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/x86_64-linux-gnu/sys/cdefs.h:838:3: note: expanded from macro '__glibc_const_generic'
  838 |   _Generic (0 ? (PTR) : (void *) 1,                     \
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  839 |             const void *: (CTYPE) (CALL),               \
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  840 |             default: CALL)
      |             ~~~~~~~~~~~~~~
1 error generated.
```

Bug: b/557338478