### PR TITLE
Print stderr message without any confusing logs

### DIFF
--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/BUILD.bazel
@@ -459,6 +459,7 @@ cf_cc_library(
     hdrs = ["streamer.h"],
     deps = [
         "//cuttlefish/common/libs/fs",
+        "//cuttlefish/common/libs/utils:environment",
         "//cuttlefish/common/libs/utils:files",
         "//cuttlefish/host/commands/run_cvd:reporting",
         "//cuttlefish/host/commands/run_cvd/launch:enable_multitouch",
@@ -477,6 +478,7 @@ cf_cc_library(
         "//cuttlefish/result",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/strings",
+        "@fmt",
         "@fruit",
     ],
 )

--- a/base/cvd/cuttlefish/host/commands/run_cvd/launch/streamer.cpp
+++ b/base/cvd/cuttlefish/host/commands/run_cvd/launch/streamer.cpp
@@ -18,7 +18,7 @@
 #include <errno.h>
 #include <sys/socket.h>
 
-#include <sstream>
+#include <optional>
 #include <string>
 #include <unordered_set>
 #include <utility>
@@ -26,11 +26,13 @@
 
 #include "absl/log/log.h"
 #include "absl/strings/str_join.h"
+#include "fmt/format.h"
 #include "fruit/component.h"
 #include "fruit/fruit_forward_decls.h"
 #include "fruit/macro.h"
 
 #include "cuttlefish/common/libs/fs/shared_fd.h"
+#include "cuttlefish/common/libs/utils/environment.h"
 #include "cuttlefish/common/libs/utils/files.h"
 #include "cuttlefish/host/commands/run_cvd/launch/enable_multitouch.h"
 #include "cuttlefish/host/commands/run_cvd/launch/input_paths_provider.h"
@@ -218,10 +220,21 @@ class WebRtcServer : public virtual CommandSource,
     if (!Enabled()) {
       return {};
     }
-    std::ostringstream out;
-    out << "Point your browser to https://localhost:"
-        << config_.sig_server_proxy_port() << " to interact with the device.";
-    return {out.str()};
+    std::string url;
+    if (StringFromEnv("CVD_INVOKER").value_or("") == "podcvd") {
+      // Container image used by podcvd always contains `cuttlefish-user` debian
+      // package. URL starting with `https://localhost:1443` is required as port
+      // 1443 in the container is exposed via port forwarding. When printing
+      // this message by run_cvd in the container, podcvd captures the message
+      // and modify URL with proper IP address and port.
+      url = fmt::format("https://localhost:1443/devices/{}/files/client.html",
+                        instance_.webrtc_device_id());
+    } else {
+      url =
+          fmt::format("https://localhost:{}", config_.sig_server_proxy_port());
+    }
+    return {fmt::format("Point your browser to {} to interact with the device.",
+                        url)};
   }
 
   // CommandSource

--- a/container/src/podcvd/internal/main.go
+++ b/container/src/podcvd/internal/main.go
@@ -112,8 +112,18 @@ func handleCreateOrStartExecution(ccm CuttlefishContainerManager, cvdArgs *CvdAr
 		args = append(args, fmt.Sprintf("--override=common.group_name:%s", cvdArgs.CommonArgs.GroupName))
 	}
 
+	groupNameIpAddrMap, err := Ipv4AddressesByGroupNames(ccm, false, false)
+	if err != nil {
+		return fmt.Errorf("failed to get IPv4 addresses for group names: %w", err)
+	}
+	ip, exists := groupNameIpAddrMap[cvdArgs.CommonArgs.GroupName]
+	if !exists {
+		return fmt.Errorf("failed to find IPv4 address for group name %q", cvdArgs.CommonArgs.GroupName)
+	}
+	rewriter := NewStderrRewriter(os.Stderr, ip)
+	defer rewriter.Flush()
 	var stdoutBuf bytes.Buffer
-	if err := ccm.ExecOnContainer(context.Background(), ContainerName(cvdArgs.CommonArgs.GroupName), args, os.Stdin, &stdoutBuf, os.Stderr); err != nil {
+	if err := ccm.ExecOnContainer(context.Background(), ContainerName(cvdArgs.CommonArgs.GroupName), args, os.Stdin, &stdoutBuf, rewriter); err != nil {
 		return err
 	}
 	var instanceGroup *InstanceGroup
@@ -128,14 +138,6 @@ func handleCreateOrStartExecution(ccm CuttlefishContainerManager, cvdArgs *CvdAr
 		var res map[string]any
 		if err := json.Unmarshal(stdoutBuf.Bytes(), &res); err != nil {
 			return fmt.Errorf("failed to unmarshal json: %w", err)
-		}
-		groupNameIpAddrMap, err := Ipv4AddressesByGroupNames(ccm, false, false)
-		if err != nil {
-			return fmt.Errorf("failed to get IPv4 addresses for group names: %w", err)
-		}
-		ip, exists := groupNameIpAddrMap[cvdArgs.CommonArgs.GroupName]
-		if !exists {
-			return fmt.Errorf("failed to find IPv4 address for group name %q", cvdArgs.CommonArgs.GroupName)
 		}
 		containerInfo, err := ccm.InspectContainer(context.Background(), ContainerName(cvdArgs.CommonArgs.GroupName))
 		if err != nil {

--- a/container/src/podcvd/internal/stderr_rewriter.go
+++ b/container/src/podcvd/internal/stderr_rewriter.go
@@ -1,0 +1,70 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"bytes"
+	"io"
+	"strings"
+)
+
+// StderrRewriter intercepts container stderr in real time and rewrites
+// cvd-specific outputs (such as `cvd logs` and internal WebRTC addresses)
+// into podcvd-compatible guidance for host users.
+type StderrRewriter struct {
+	out io.Writer
+	ip  string
+	buf []byte
+}
+
+func NewStderrRewriter(out io.Writer, ip string) *StderrRewriter {
+	if out == nil {
+		out = io.Discard
+	}
+	return &StderrRewriter{
+		out: out,
+		ip:  ip,
+	}
+}
+
+func (r *StderrRewriter) Write(p []byte) (int, error) {
+	r.buf = append(r.buf, p...)
+	idx := bytes.LastIndexByte(r.buf, '\n')
+	if idx < 0 {
+		return len(p), nil
+	}
+	if _, err := io.WriteString(r.out, r.rewrite(string(r.buf[:idx+1]))); err != nil {
+		return 0, err
+	}
+	r.buf = r.buf[idx+1:]
+	return len(p), nil
+}
+
+func (r *StderrRewriter) Flush() error {
+	if len(r.buf) > 0 {
+		_, err := io.WriteString(r.out, r.rewrite(string(r.buf)))
+		r.buf = nil
+		return err
+	}
+	return nil
+}
+
+func (r *StderrRewriter) rewrite(s string) string {
+	s = strings.ReplaceAll(s, "`cvd logs`", "`podcvd logs`")
+	if r.ip != "" {
+		s = updateIPAndPortString(s, r.ip)
+	}
+	return s
+}


### PR DESCRIPTION
So far, `podcvd create` printed some stderr messages however it doesn't fit to `podcvd` UX. This PR aims to modify stderr message, to make users & agents understand the log better.

Before:
```
  Run `cvd logs` to report paths to device logs.
  Point your browser to https://localhost:8443 to interact with the device.
  Serial console is disabled; use -console=true to enable it.
  Launcher Build ID:
```

After:
```
  Run `podcvd logs` to report paths to device logs.
  Point your browser to https://192.168.112.1:11443/devices/cvd_1-1-1/files/client.html to interact with the device.
  Serial console is disabled; use -console=true to enable it.
  Launcher Build ID: 
```

Context: b/555922254