### PR TITLE
Use TargetBin rather than hardcoded 'cvd' binary on E2E testing

### DIFF
--- a/e2etests/cvd/common/common.go
+++ b/e2etests/cvd/common/common.go
@@ -337,7 +337,7 @@ func (tc *TestContext) CVDCreateWithConfigFile(load LoadArgs) error {
 }
 
 func (tc *TestContext) GetMetricsDir() (string, error) {
-	res, err := tc.RunCmd("cvd", "fleet")
+	res, err := tc.RunCmd(tc.TargetBin(), "fleet")
 	if err != nil {
 		return "", fmt.Errorf("failed to run `cvd fleet`")
 	}


### PR DESCRIPTION
It seems one line is missed while 2 PRs were in progress at the almost same time.
- https://github.com/google/android-cuttlefish/pull/2300
- https://github.com/google/android-cuttlefish/pull/2498