### PR TITLE
broadcastradio: Add Virtual Tuner proto and state machine

### DIFF
--- a/base/cvd/cuttlefish/host/commands/virtual_tuner_daemon/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/commands/virtual_tuner_daemon/BUILD.bazel
@@ -1,0 +1,52 @@
+load("@grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("//cuttlefish/bazel:rules.bzl", "cf_cc_library", "cf_cc_test")
+
+package(
+    default_visibility = ["//:android_cuttlefish"],
+)
+
+proto_library(
+    name = "virtual_tuner_proto",
+    srcs = ["VirtualTuner.proto"],
+)
+
+cc_proto_library(
+    name = "virtual_tuner_cc_proto",
+    deps = [":virtual_tuner_proto"],
+)
+
+cc_grpc_library(
+    name = "libcvd_virtual_tuner",
+    srcs = [":virtual_tuner_proto"],
+    grpc_only = True,
+    deps = [
+        ":virtual_tuner_cc_proto",
+        "@grpc//:grpc++",
+    ],
+)
+
+cf_cc_library(
+    name = "tuner_state",
+    srcs = [
+        "tuner_state.cpp",
+    ],
+    hdrs = [
+        "tuner_state.h",
+    ],
+    deps = [
+        ":virtual_tuner_cc_proto",
+    ],
+)
+
+cf_cc_test(
+    name = "tuner_state_test",
+    srcs = [
+        "tuner_state_test.cpp",
+    ],
+    deps = [
+        ":tuner_state",
+        ":virtual_tuner_cc_proto",
+    ],
+)

--- a/base/cvd/cuttlefish/host/commands/virtual_tuner_daemon/VirtualTuner.proto
+++ b/base/cvd/cuttlefish/host/commands/virtual_tuner_daemon/VirtualTuner.proto
@@ -1,0 +1,32 @@
+syntax = "proto3";
+
+package cuttlefish.virtualtuner;
+
+enum RadioBand {
+    AM = 0;
+    FM = 1;
+    DAB = 2;
+}
+
+message TuneRequest {
+    RadioBand band = 1;
+    uint32 frequency_hz = 2;
+    uint32 hd_subchannel = 3;
+}
+
+message TuneResponse {
+    bool success = 1;
+    string message = 2;
+}
+
+message StopRequest {}
+
+message StopResponse {
+    bool success = 1;
+    string message = 2;
+}
+
+service VirtualTuner {
+    rpc Tune(TuneRequest) returns (TuneResponse) {}
+    rpc Stop(StopRequest) returns (StopResponse) {}
+}

--- a/base/cvd/cuttlefish/host/commands/virtual_tuner_daemon/tuner_state.cpp
+++ b/base/cvd/cuttlefish/host/commands/virtual_tuner_daemon/tuner_state.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/host/commands/virtual_tuner_daemon/tuner_state.h"
+
+#include <cstdint>
+#include <mutex>
+
+#include "cuttlefish/host/commands/virtual_tuner_daemon/VirtualTuner.pb.h"
+
+namespace cuttlefish {
+namespace virtualtuner {
+
+void TunerState::SetTune(RadioBand band, uint32_t frequency_hz,
+                         uint32_t hd_subchannel) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  state_.band = band;
+  state_.frequency_hz = frequency_hz;
+  state_.hd_subchannel = hd_subchannel;
+  state_.is_playing = true;
+}
+
+void TunerState::Stop() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  state_.frequency_hz = 0;
+  state_.is_playing = false;
+}
+
+TunerStateSnapshot TunerState::GetSnapshot() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return state_;
+}
+
+uint32_t TunerState::GetFrequency() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return state_.frequency_hz;
+}
+
+RadioBand TunerState::GetBand() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return state_.band;
+}
+
+uint32_t TunerState::GetSubchannel() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return state_.hd_subchannel;
+}
+
+bool TunerState::IsPlaying() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return state_.is_playing;
+}
+
+}  // namespace virtualtuner
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/virtual_tuner_daemon/tuner_state.h
+++ b/base/cvd/cuttlefish/host/commands/virtual_tuner_daemon/tuner_state.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <mutex>
+
+#include "cuttlefish/host/commands/virtual_tuner_daemon/VirtualTuner.pb.h"
+
+namespace cuttlefish {
+namespace virtualtuner {
+
+struct TunerStateSnapshot {
+  RadioBand band = RadioBand::FM;
+  uint32_t frequency_hz = 0;
+  uint32_t hd_subchannel = 0;
+  bool is_playing = false;
+};
+
+class TunerState {
+ public:
+  TunerState() = default;
+
+  void SetTune(RadioBand band, uint32_t frequency_hz, uint32_t hd_subchannel);
+  void Stop();
+
+  TunerStateSnapshot GetSnapshot() const;
+  uint32_t GetFrequency() const;
+  RadioBand GetBand() const;
+  uint32_t GetSubchannel() const;
+  bool IsPlaying() const;
+
+ private:
+  mutable std::mutex mutex_;
+  TunerStateSnapshot state_;
+};
+
+}  // namespace virtualtuner
+}  // namespace cuttlefish

--- a/base/cvd/cuttlefish/host/commands/virtual_tuner_daemon/tuner_state_test.cpp
+++ b/base/cvd/cuttlefish/host/commands/virtual_tuner_daemon/tuner_state_test.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuttlefish/host/commands/virtual_tuner_daemon/tuner_state.h"
+
+#include <gtest/gtest.h>
+
+#include "cuttlefish/host/commands/virtual_tuner_daemon/VirtualTuner.pb.h"
+
+namespace cuttlefish {
+namespace virtualtuner {
+namespace {
+
+TEST(TunerStateTest, InitialStateIsUntuned) {
+  TunerState state;
+  TunerStateSnapshot snapshot = state.GetSnapshot();
+
+  EXPECT_FALSE(snapshot.is_playing);
+  EXPECT_EQ(snapshot.frequency_hz, 0u);
+  EXPECT_FALSE(state.IsPlaying());
+  EXPECT_EQ(state.GetFrequency(), 0u);
+}
+
+TEST(TunerStateTest, SetTuneUpdatesState) {
+  TunerState state;
+  state.SetTune(RadioBand::FM, 98500000, 1);
+
+  TunerStateSnapshot snapshot = state.GetSnapshot();
+  EXPECT_TRUE(snapshot.is_playing);
+  EXPECT_EQ(snapshot.band, RadioBand::FM);
+  EXPECT_EQ(snapshot.frequency_hz, 98500000u);
+  EXPECT_EQ(snapshot.hd_subchannel, 1u);
+
+  EXPECT_TRUE(state.IsPlaying());
+  EXPECT_EQ(state.GetBand(), RadioBand::FM);
+  EXPECT_EQ(state.GetFrequency(), 98500000u);
+  EXPECT_EQ(state.GetSubchannel(), 1u);
+}
+
+TEST(TunerStateTest, StopResetsState) {
+  TunerState state;
+  state.SetTune(RadioBand::AM, 1000000, 0);
+  EXPECT_TRUE(state.IsPlaying());
+
+  state.Stop();
+  TunerStateSnapshot snapshot = state.GetSnapshot();
+  EXPECT_FALSE(snapshot.is_playing);
+  EXPECT_EQ(snapshot.frequency_hz, 0u);
+  EXPECT_FALSE(state.IsPlaying());
+}
+
+}  // namespace
+}  // namespace virtualtuner
+}  // namespace cuttlefish


### PR DESCRIPTION
Introduce the gRPC protocol definition (VirtualTuner.proto) and thread-safe TunerState state machine for the Cuttlefish Virtual Tuner daemon. This defines the control RPCs (Tune, Stop) and provides atomic state tracking for virtual broadcast radio emulation.

Includes standalone unit tests for TunerState.

Test: bazel test //cuttlefish/host/commands/virtual_tuner_daemon:tuner_state_test 
Bug: 521329213
TAG=agy
CONV=809829e8-ac68-4c32-b9b7-632f61743e47