### PR TITLE
Downstream infra expects serial 0.0.0.0:port connected.

### DIFF
--- a/base/cvd/cuttlefish/host/libs/config/adb/BUILD.bazel
+++ b/base/cvd/cuttlefish/host/libs/config/adb/BUILD.bazel
@@ -23,6 +23,7 @@ cf_cc_library(
         "//cuttlefish/host/libs/config:cuttlefish_config",
         "//cuttlefish/host/libs/config:known_paths",
         "//cuttlefish/host/libs/feature",
+        "//cuttlefish/metrics/host:invoker",
         "//cuttlefish/process:command",
         "//cuttlefish/result",
         "@abseil-cpp//absl/log",

--- a/base/cvd/cuttlefish/host/libs/config/adb/launch.cpp
+++ b/base/cvd/cuttlefish/host/libs/config/adb/launch.cpp
@@ -30,6 +30,7 @@
 #include "cuttlefish/host/libs/feature/command_source.h"
 #include "cuttlefish/host/libs/feature/feature.h"
 #include "cuttlefish/host/libs/feature/kernel_log_pipe_provider.h"
+#include "cuttlefish/metrics/host/invoker.h"
 #include "cuttlefish/process/command.h"
 #include "cuttlefish/result/result.h"
 
@@ -48,6 +49,10 @@ class AdbHelper {
 
   std::string ConnectorTcpArg() const {
     return "127.0.0.1:" + std::to_string(instance_.adb_host_port());
+  }
+
+  std::string LegacyConnectorTcpArg() const {
+    return "0.0.0.0:" + std::to_string(instance_.adb_host_port());
   }
 
   std::string ConnectorVsockArg() const {
@@ -89,7 +94,13 @@ class AdbConnector : public CommandSource {
 
     if (helper_.TcpConnectorEnabled()) {
       addresses.insert(helper_.ConnectorTcpArg());
+      // TODO(b/556848408): Downstream infra expects serial 0.0.0.0:port
+      // connected.
+      if (GetInvoker() == Invoker::HostOrchestrator) {
+        addresses.insert(helper_.LegacyConnectorTcpArg());
+      }
     }
+
     if (helper_.VsockConnectorEnabled()) {
       addresses.insert(helper_.ConnectorVsockArg());
     }


### PR DESCRIPTION
Bug: b/556848408
Test: CVD_INVOKER=host_orchestrator bazel run //cuttlefish/package:cvd -- create