### PR TITLE
Operator can now delegate its infra_config values.

### DIFF
--- a/frontend/src/liboperator/operator/operator.go
+++ b/frontend/src/liboperator/operator/operator.go
@@ -26,8 +26,11 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	apiv1 "github.com/google/android-cuttlefish/frontend/src/liboperator/api/v1"
 	"github.com/gorilla/mux"
@@ -101,6 +104,85 @@ func SetupControlEndpoint(pool *DevicePool, path string) (func() error, error) {
 	}, nil
 }
 
+type InfraConfigProvider interface {
+	Get() (apiv1.InfraConfig, error)
+}
+
+type StaticInfraConfigProvider struct {
+	config apiv1.InfraConfig
+}
+
+func NewStaticInfraConfigProvider(
+	config apiv1.InfraConfig,
+) *StaticInfraConfigProvider {
+	return &StaticInfraConfigProvider{config: config}
+}
+
+func (s *StaticInfraConfigProvider) Get() (apiv1.InfraConfig, error) {
+	return s.config, nil
+}
+
+const DefaultDelegateTimeout = 10 * time.Second
+
+type DelegateInfraConfigProvider struct {
+	staticConfig apiv1.InfraConfig
+	delegatePath string
+	defaultTTL   time.Duration
+	timeout      time.Duration
+
+	mu        sync.Mutex
+	cfg       apiv1.InfraConfig
+	expiresAt time.Time
+}
+
+func NewDelegateInfraConfigProvider(
+	staticConfig apiv1.InfraConfig,
+	delegatePath string,
+	defaultTTL, timeout time.Duration,
+) *DelegateInfraConfigProvider {
+	if timeout <= 0 {
+		timeout = DefaultDelegateTimeout
+	}
+	return &DelegateInfraConfigProvider{
+		staticConfig: staticConfig,
+		delegatePath: delegatePath,
+		defaultTTL:   defaultTTL,
+		timeout:      timeout,
+	}
+}
+
+func (p *DelegateInfraConfigProvider) Get() (apiv1.InfraConfig, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if time.Now().Before(p.expiresAt) {
+		return p.cfg, nil
+	}
+
+	p.cfg = p.runDelegate()
+	p.expiresAt = time.Now().Add(p.defaultTTL)
+	return p.cfg, nil
+}
+
+func (p *DelegateInfraConfigProvider) runDelegate() apiv1.InfraConfig {
+	ctx, cancel := context.WithTimeout(context.Background(), p.timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, p.delegatePath)
+	out, err := cmd.Output()
+	if err != nil {
+		log.Printf("runDelegate failed: %v", err)
+		return p.staticConfig
+	}
+
+	var cfg apiv1.InfraConfig
+	if err := json.Unmarshal(out, &cfg); err != nil {
+		log.Printf("runDelegate failed: %v", err)
+		return p.staticConfig
+	}
+	return cfg
+}
+
 // Creates a router with handlers for the following endpoints:
 // GET  /infra_config
 // GET  /devices
@@ -125,7 +207,7 @@ func SetupControlEndpoint(pool *DevicePool, path string) (func() error, error) {
 func CreateHttpHandlers(
 	pool *DevicePool,
 	polledSet *PolledSet,
-	config apiv1.InfraConfig,
+	infraConfigProvider InfraConfigProvider,
 	maybeIntercept func(string) *string) *mux.Router {
 	router := mux.NewRouter()
 	// The path parameter needs to include the leading '/'
@@ -172,7 +254,13 @@ func CreateHttpHandlers(
 		createPolledConnection(w, r, pool, polledSet)
 	}).Methods("POST")
 	router.HandleFunc("/infra_config", func(w http.ResponseWriter, r *http.Request) {
-		ReplyJSONOK(w, config)
+		cfg, err := infraConfigProvider.Get()
+		if err != nil {
+			ReplyJSONErr(w, err)
+			return
+		}
+		w.Header().Set("Cache-Control", "no-cache")
+		ReplyJSONOK(w, cfg)
 	}).Methods("GET")
 	return router
 }

--- a/frontend/src/operator/main.go
+++ b/frontend/src/operator/main.go
@@ -24,20 +24,23 @@ import (
 	"net/url"
 	"os"
 	"sync"
+	"time"
 
 	apiv1 "github.com/google/android-cuttlefish/frontend/src/liboperator/api/v1"
 	"github.com/google/android-cuttlefish/frontend/src/liboperator/operator"
 )
 
 const (
-	DefaultSocketPath        = "/run/cuttlefish/operator"
-	DefaultControlSocketPath = "/run/cuttlefish/operator_control"
-	DefaultHttpPort          = 1080
-	DefaultTLSCertDir        = "/etc/cuttlefish-common/operator/cert"
-	DefaultStaticFilesDir    = "static"    // relative path
-	DefaultInterceptDir      = "intercept" // relative path
-	DefaultWebUIUrl          = ""
-	DefaultListenAddress     = "127.0.0.1"
+	DefaultSocketPath         = "/run/cuttlefish/operator"
+	DefaultControlSocketPath  = "/run/cuttlefish/operator_control"
+	DefaultHttpPort           = 1080
+	DefaultTLSCertDir         = "/etc/cuttlefish-common/operator/cert"
+	DefaultStaticFilesDir     = "static"    // relative path
+	DefaultInterceptDir       = "intercept" // relative path
+	DefaultWebUIUrl           = ""
+	DefaultListenAddress      = "127.0.0.1"
+	DefaultInfraConfigTTL     = 6 * time.Hour
+	DefaultInfraConfigTimeout = 10 * time.Second
 )
 
 func startHttpServer(address string, port int) error {
@@ -91,6 +94,9 @@ func main() {
 	webUiUrlStr := flag.String("webui_url", DefaultWebUIUrl, "WebUI URL.")
 	address := flag.String("listen_addr", DefaultListenAddress, "IP address to listen for requests.")
 	logFile := flag.String("log_file", "", "Path to file to write logs to.")
+	infraConfigDelegate := flag.String("infra_config_delegate", "", "Path to delegate binary returning infrastructure config JSON.")
+	infraConfigTTL := flag.Duration("infra_config_ttl", DefaultInfraConfigTTL, "Default TTL for cached infrastructure config.")
+	infraConfigTimeout := flag.Duration("infra_config_timeout", DefaultInfraConfigTimeout, "Timeout for executing infrastructure config delegate.")
 
 	flag.Parse()
 
@@ -116,7 +122,13 @@ func main() {
 		},
 	}
 
-	r := operator.CreateHttpHandlers(pool, polledSet, config, maybeIntercept)
+	var infraConfigProvider operator.InfraConfigProvider = operator.NewStaticInfraConfigProvider(config)
+	if *infraConfigDelegate != "" {
+		infraConfigProvider = operator.NewDelegateInfraConfigProvider(
+			config, *infraConfigDelegate, *infraConfigTTL, *infraConfigTimeout)
+	}
+
+	r := operator.CreateHttpHandlers(pool, polledSet, infraConfigProvider, maybeIntercept)
 	if *webUiUrlStr != "" {
 		webUiUrl, _ := url.Parse(*webUiUrlStr)
 		proxy := httputil.NewSingleHostReverseProxy(webUiUrl)


### PR DESCRIPTION
Instead of statically allocating the output of the infra_config handler, we allow the operator to optionally delegate its contents to a sidecar command that can supply the values returned by this handler. This means that if a user wishes to supply alternate STUN or TURN servers for running webRTC, it can do so.

Why not a static configuration loaded from a file? For TURN for example, the credential returned from the TURN server may have a limited TTL, so we need to be able to request the TURN credential on-demand. We default however to letting the operator set the credential TTL for the moment, and may revisit that behavior in the future.

If the delegate is specified and fails for whatever reason, then we fall back to the existing, static configuration so as not to break existing clients.

TURN support is particularly useful, since it means that large port-forward ranges are no longer necessary.