### PR TITLE
cvd fetch: Extract pvmfw.img from system target files

### DIFF
--- a/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd.cc
+++ b/base/cvd/cuttlefish/host/commands/cvd/fetch/fetch_cvd.cc
@@ -284,10 +284,7 @@ Result<void> FetchSystemTarget(FetchBuildContext& context,
     }
 
     static constexpr std::string_view kSystemImageFiles[] = {
-        "init_boot",
-        "product",
-        "system_ext",
-        "vbmeta_system",
+        "init_boot", "product", "pvmfw", "system_ext", "vbmeta_system",
     };
     for (std::string_view system_image : kSystemImageFiles) {
       std::string member = fmt::format("IMAGES/{}.img", system_image);


### PR DESCRIPTION
The pvmfw partition is now chained under vbmeta_system for some targets. Add pvmfw to kSystemImageFiles to ensure it is extracted alongside other system images during mixed system builds.

Bug: 559321113