### PR TITLE
Convert `@avb` into a proper bazel module with full isolation

### DIFF
--- a/base/cvd/MODULE.bazel
+++ b/base/cvd/MODULE.bazel
@@ -8,6 +8,7 @@ bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
 
 bazel_dep(name = "abseil-cpp", version = "20260107.0")
 bazel_dep(name = "aspect_bazel_lib", version = "2.22.0")
+bazel_dep(name = "avb")
 bazel_dep(name = "boringssl", version = "0.20260813.0")
 bazel_dep(name = "brotli")
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2")

--- a/base/cvd/build_external/avb/BUILD.avb.bazel
+++ b/base/cvd/build_external/avb/BUILD.avb.bazel
@@ -1,7 +1,7 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(
-    default_visibility = ["@//:android_cuttlefish"],
+    default_visibility = ["//visibility:public"],
 )
 
 cc_library(

--- a/base/cvd/build_external/avb/avb.MODULE.bazel
+++ b/base/cvd/build_external/avb/avb.MODULE.bazel
@@ -1,8 +1,18 @@
-git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-
-git_repository(
-    name = "avb",
+git_override(
+    module_name = "avb",
     build_file = "@//build_external/avb:BUILD.avb.bazel",
     commit = "761178607206f4cb2af79ed9eec52d8cbd814adb",
+    patch_cmds = [
+        """cat << 'EOF' > MODULE.bazel
+module(
+    name = "avb",
+    version = "0.1",
+)
+
+bazel_dep(name = "boringssl", version = "0.20260813.0")
+bazel_dep(name = "rules_cc", version = "0.2.19")
+EOF
+""",
+    ],
     remote = "https://android.googlesource.com/platform/external/avb",
 )


### PR DESCRIPTION
This is a trial for converting the crosvm build, which has isolation issues.

Bug: b/559825860 